### PR TITLE
Refine Showcase UI for macOS and tvOS

### DIFF
--- a/Showcase/SwiftVLCShowcase/Demos/AudioPlayerDemo.swift
+++ b/Showcase/SwiftVLCShowcase/Demos/AudioPlayerDemo.swift
@@ -97,7 +97,7 @@ struct AudioPlayerDemo: View {
         artworkPlaceholder
       }
     }
-    .frame(maxWidth: 280, maxHeight: 280)
+    .frame(maxWidth: 200, maxHeight: 200)
     .clipShape(.rect(cornerRadius: 16))
     .shadow(radius: 8)
   }
@@ -200,39 +200,41 @@ struct AudioPlayerDemo: View {
           in: -20...20
         )
 
-        VStack(spacing: 2) {
-          HStack(alignment: .bottom, spacing: 4) {
-            ForEach(0..<Equalizer.bandCount, id: \.self) { band in
-              VStack(spacing: 2) {
-                bandSlider(band: band)
-                Text(bandLabel(band))
-                  .font(.caption2)
-                  .foregroundStyle(.tertiary)
-              }
-            }
-          }
-          .frame(height: 140)
+        // Band sliders — horizontal rows
+        ForEach(0..<Equalizer.bandCount, id: \.self) { band in
+          bandRow(band: band, equalizer: equalizer)
         }
-        .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
       }
     } header: {
       Text("Equalizer")
     }
   }
 
-  private func bandSlider(band: Int) -> some View {
-    Slider(
-      value: Binding(
-        get: { Double(equalizer?.amplification(forBand: band) ?? 0) },
-        set: {
-          try? equalizer?.setAmplification(Float($0), forBand: band)
-          applyEqualizer()
-        }
-      ),
-      in: -20...20
-    )
-    .rotationEffect(.degrees(-90))
-    .frame(width: 20, height: 100)
+  private func bandRow(band: Int, equalizer: Equalizer) -> some View {
+    HStack(spacing: 8) {
+      Text(bandLabel(band))
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .frame(width: 36, alignment: .trailing)
+        .monospacedDigit()
+
+      Slider(
+        value: Binding(
+          get: { Double(equalizer.amplification(forBand: band)) },
+          set: {
+            try? equalizer.setAmplification(Float($0), forBand: band)
+            applyEqualizer()
+          }
+        ),
+        in: -20...20
+      )
+
+      Text("\(equalizer.amplification(forBand: band), specifier: "%+.0f")")
+        .font(.caption)
+        .foregroundStyle(.tertiary)
+        .frame(width: 28, alignment: .trailing)
+        .monospacedDigit()
+    }
   }
 
   private func bandLabel(_ band: Int) -> String {

--- a/Showcase/SwiftVLCShowcase/Demos/AudioPlayerDemo.swift
+++ b/Showcase/SwiftVLCShowcase/Demos/AudioPlayerDemo.swift
@@ -35,6 +35,8 @@ struct AudioPlayerDemo: View {
     #if os(iOS)
     .listStyle(.insetGrouped)
     #endif
+    .frame(maxWidth: 700)
+    .frame(maxWidth: .infinity)
     .navigationTitle("Audio Player")
     #if os(iOS)
       .navigationBarTitleDisplayMode(.inline)

--- a/Showcase/SwiftVLCShowcase/Demos/DebugConsoleDemo.swift
+++ b/Showcase/SwiftVLCShowcase/Demos/DebugConsoleDemo.swift
@@ -98,6 +98,8 @@ struct DebugConsoleDemo: View {
     #if os(iOS)
     .listStyle(.insetGrouped)
     #endif
+    .frame(maxWidth: 900)
+    .frame(maxWidth: .infinity)
     .navigationTitle("Debug Console")
     #if os(iOS)
       .navigationBarTitleDisplayMode(.inline)
@@ -150,17 +152,17 @@ struct DebugConsoleDemo: View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
           Text("[\(entry.entry.level.description)]")
             .foregroundStyle(levelColor(entry.entry.level))
-            .font(.caption2)
+            .font(logFont)
             .frame(width: 60, alignment: .leading)
           if let module = entry.entry.module {
             Text(module)
               .foregroundStyle(.tertiary)
-              .font(.caption2)
-              .frame(width: 60, alignment: .leading)
+              .font(logFont)
+              .frame(width: 80, alignment: .leading)
           }
           Text(entry.entry.message)
-            .font(.caption2)
-            .lineLimit(2)
+            .font(logFont)
+            .lineLimit(3)
         }
       }
     } header: {
@@ -187,6 +189,14 @@ struct DebugConsoleDemo: View {
   }
 
   // MARK: - Helpers
+
+  private var logFont: Font {
+    #if targetEnvironment(macCatalyst)
+    .caption
+    #else
+    .caption2
+    #endif
+  }
 
   private func stateLabel(_ state: PlayerState) -> String {
     switch state {

--- a/Showcase/SwiftVLCShowcase/Demos/PiPDemo.swift
+++ b/Showcase/SwiftVLCShowcase/Demos/PiPDemo.swift
@@ -82,6 +82,8 @@ struct PiPDemo: View {
     #if os(iOS)
     .listStyle(.insetGrouped)
     #endif
+    .frame(maxWidth: 700)
+    .frame(maxWidth: .infinity)
     .navigationTitle("Picture in Picture")
     #if os(iOS)
       .navigationBarTitleDisplayMode(.inline)

--- a/Showcase/SwiftVLCShowcase/Demos/PlaylistDemo.swift
+++ b/Showcase/SwiftVLCShowcase/Demos/PlaylistDemo.swift
@@ -11,9 +11,33 @@ struct PlaylistDemo: View {
   @State private var error: Error?
 
   var body: some View {
+    Group {
+      #if os(tvOS)
+      tvOSBody
+      #else
+      defaultBody
+      #endif
+    }
+    .task {
+      await setupPlaylist()
+    }
+    .onDisappear {
+      listPlayer?.stop()
+    }
+    .onChange(of: player?.currentMedia?.mrl) { _, newMRL in
+      guard let newMRL else { return }
+      if let match = items.first(where: { $0.mrl == newMRL }) {
+        currentIndex = match.index
+      }
+    }
+  }
+
+  // MARK: - iOS / macOS
+
+  #if !os(tvOS)
+  private var defaultBody: some View {
     VStack(spacing: .zero) {
       if let player {
-        // Video view
         VideoView(player)
           .aspectRatio(16 / 9, contentMode: .fit)
           .clipShape(.rect(cornerRadius: 12))
@@ -33,109 +57,146 @@ struct PlaylistDemo: View {
           .frame(height: 200)
       }
 
-      // Playlist
-      List(items) { item in
-        Button {
-          playItem(at: item.index)
-        } label: {
-          HStack {
-            if item.index == currentIndex {
-              Image(systemName: "speaker.wave.2.fill")
-                .foregroundStyle(.tint)
-            } else {
-              Image(systemName: "music.note")
-                .foregroundStyle(.secondary)
-            }
-            VStack(alignment: .leading) {
-              Text(item.title)
-                .font(.body)
-                .foregroundStyle(item.index == currentIndex ? .primary : .secondary)
-              if let duration = item.duration {
-                Text(duration.formatted)
-                  .font(.caption)
-                  .foregroundStyle(.tertiary)
-              }
-            }
-          }
-        }
-        #if !os(tvOS)
-        .buttonStyle(.plain)
-        #endif
-      }
-      #if os(iOS)
-      .listStyle(.insetGrouped)
-      #endif
+      trackList
 
-      // Transport + mode
       if let player, let listPlayer {
-        VStack(spacing: 8) {
-          HStack(spacing: 24) {
-            Button {
-              try? listPlayer.previous()
-              trackCurrentIndex()
-            } label: {
-              Label("Previous", systemImage: "backward.fill")
-                .labelStyle(.iconOnly)
-                .font(.title2)
-            }
-
-            Button {
-              player.togglePlayPause()
-            } label: {
-              Label(
-                player.isPlaying ? "Pause" : "Play",
-                systemImage: player.isPlaying ? "pause.fill" : "play.fill"
-              )
-              .labelStyle(.iconOnly)
-              .font(.title)
-              .contentTransition(.symbolEffect(.replace))
-            }
-
-            Button {
-              try? listPlayer.next()
-              trackCurrentIndex()
-            } label: {
-              Label("Next", systemImage: "forward.fill")
-                .labelStyle(.iconOnly)
-                .font(.title2)
-            }
-          }
-          .buttonStyle(.plain)
-
-          Picker("Mode", selection: Binding(
-            get: { listPlayer.playbackMode },
-            set: { listPlayer.playbackMode = $0 }
-          )) {
-            Label("Play Once", systemImage: "arrow.right")
-              .tag(PlaybackMode.default)
-            Label("Loop All", systemImage: "repeat")
-              .tag(PlaybackMode.loop)
-            Label("Repeat One", systemImage: "repeat.1")
-              .tag(PlaybackMode.repeat)
-          }
-          .pickerStyle(.segmented)
-          .padding(.horizontal)
-        }
-        .padding()
+        transportControls(player: player, listPlayer: listPlayer)
       }
     }
     .navigationTitle("Playlist")
     #if os(iOS)
       .navigationBarTitleDisplayMode(.inline)
     #endif
-      .task {
-        await setupPlaylist()
-      }
-      .onDisappear {
-        listPlayer?.stop()
-      }
-      .onChange(of: player?.currentMedia?.mrl) { _, newMRL in
-        // Auto-track current index when MediaListPlayer advances
-        guard let newMRL else { return }
-        if let match = items.first(where: { $0.mrl == newMRL }) {
-          currentIndex = match.index
+  }
+  #endif
+
+  // MARK: - tvOS — Horizontal layout
+
+  #if os(tvOS)
+  private var tvOSBody: some View {
+    HStack(spacing: 0) {
+      // Left: video + transport
+      VStack(spacing: 24) {
+        if let player {
+          VideoView(player)
+            .aspectRatio(16 / 9, contentMode: .fit)
+            .clipShape(.rect(cornerRadius: 16))
+            .clipped()
+
+          PlayerStatusBar(player: player)
+            .font(.body)
+        } else if error != nil {
+          ContentUnavailableView(
+            "Playlist Failed",
+            systemImage: "exclamationmark.triangle",
+            description: Text("Could not set up the playlist.")
+          )
+        } else {
+          ProgressView("Loading playlist...")
+            .frame(maxHeight: .infinity)
+        }
+
+        if let player, let listPlayer {
+          transportControls(player: player, listPlayer: listPlayer)
         }
       }
+      .frame(maxWidth: .infinity)
+      .padding(40)
+
+      // Right: track list
+      trackList
+        .frame(width: 500)
+    }
+    .navigationTitle("Playlist")
+  }
+  #endif
+
+  // MARK: - Shared Components
+
+  private var trackList: some View {
+    List(items) { item in
+      Button {
+        playItem(at: item.index)
+      } label: {
+        HStack {
+          if item.index == currentIndex {
+            Image(systemName: "speaker.wave.2.fill")
+              .foregroundStyle(.tint)
+          } else {
+            Image(systemName: "music.note")
+              .foregroundStyle(.secondary)
+          }
+          VStack(alignment: .leading) {
+            Text(item.title)
+              .font(.body)
+              .foregroundStyle(item.index == currentIndex ? .primary : .secondary)
+            if let duration = item.duration {
+              Text(duration.formatted)
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+            }
+          }
+        }
+      }
+      #if !os(tvOS)
+      .buttonStyle(.plain)
+      #endif
+    }
+    #if os(iOS)
+    .listStyle(.insetGrouped)
+    #endif
+  }
+
+  private func transportControls(player: Player, listPlayer: MediaListPlayer) -> some View {
+    VStack(spacing: 8) {
+      HStack(spacing: 24) {
+        Button {
+          try? listPlayer.previous()
+          trackCurrentIndex()
+        } label: {
+          Label("Previous", systemImage: "backward.fill")
+            .labelStyle(.iconOnly)
+            .font(.title2)
+        }
+
+        Button {
+          player.togglePlayPause()
+        } label: {
+          Label(
+            player.isPlaying ? "Pause" : "Play",
+            systemImage: player.isPlaying ? "pause.fill" : "play.fill"
+          )
+          .labelStyle(.iconOnly)
+          .font(.title)
+          .contentTransition(.symbolEffect(.replace))
+        }
+
+        Button {
+          try? listPlayer.next()
+          trackCurrentIndex()
+        } label: {
+          Label("Next", systemImage: "forward.fill")
+            .labelStyle(.iconOnly)
+            .font(.title2)
+        }
+      }
+      .buttonStyle(.plain)
+
+      Picker("Mode", selection: Binding(
+        get: { listPlayer.playbackMode },
+        set: { listPlayer.playbackMode = $0 }
+      )) {
+        Label("Play Once", systemImage: "arrow.right")
+          .tag(PlaybackMode.default)
+        Label("Loop All", systemImage: "repeat")
+          .tag(PlaybackMode.loop)
+        Label("Repeat One", systemImage: "repeat.1")
+          .tag(PlaybackMode.repeat)
+      }
+      .pickerStyle(.segmented)
+      .padding(.horizontal)
+    }
+    .padding()
   }
 
   private func setupPlaylist() async {

--- a/Showcase/SwiftVLCShowcase/Demos/PlaylistDemo.swift
+++ b/Showcase/SwiftVLCShowcase/Demos/PlaylistDemo.swift
@@ -36,6 +36,14 @@ struct PlaylistDemo: View {
 
   #if !os(tvOS)
   private var defaultBody: some View {
+    #if targetEnvironment(macCatalyst)
+    catalystBody
+    #else
+    phoneBody
+    #endif
+  }
+
+  private var phoneBody: some View {
     VStack(spacing: .zero) {
       if let player {
         VideoView(player)
@@ -67,6 +75,42 @@ struct PlaylistDemo: View {
     #if os(iOS)
       .navigationBarTitleDisplayMode(.inline)
     #endif
+  }
+
+  private var catalystBody: some View {
+    HStack(spacing: 0) {
+      // Left: video + transport
+      VStack(spacing: 16) {
+        if let player {
+          VideoView(player)
+            .aspectRatio(16 / 9, contentMode: .fit)
+            .clipShape(.rect(cornerRadius: 12))
+            .clipped()
+
+          PlayerStatusBar(player: player)
+        } else if error != nil {
+          ContentUnavailableView(
+            "Playlist Failed",
+            systemImage: "exclamationmark.triangle",
+            description: Text("Could not set up the playlist.")
+          )
+        } else {
+          ProgressView("Loading playlist...")
+            .frame(maxHeight: .infinity)
+        }
+
+        if let player, let listPlayer {
+          transportControls(player: player, listPlayer: listPlayer)
+        }
+      }
+      .frame(maxWidth: .infinity)
+      .padding()
+
+      // Right: track list
+      trackList
+        .frame(width: 300)
+    }
+    .navigationTitle("Playlist")
   }
   #endif
 

--- a/Showcase/SwiftVLCShowcase/Demos/PolishedPlayer/PolishedPlayer+iOS.swift
+++ b/Showcase/SwiftVLCShowcase/Demos/PolishedPlayer/PolishedPlayer+iOS.swift
@@ -67,6 +67,11 @@ private struct IOSOverlayContent: View {
             onTap()
           }
       }
+      #if targetEnvironment(macCatalyst)
+      .onContinuousHover { phase in
+        if case .active = phase { onInteraction() }
+      }
+      #endif
 
       // Skip indicator
       if let direction = skipIndicator {
@@ -95,6 +100,31 @@ private struct IOSOverlayContent: View {
           .transition(.opacity)
       }
     }
+    #if targetEnvironment(macCatalyst)
+    .focusable()
+    .onKeyPress(.space) {
+      player.togglePlayPause()
+      onInteraction()
+      return .handled
+    }
+    .onKeyPress(.leftArrow) {
+      onSkipBack()
+      return .handled
+    }
+    .onKeyPress(.rightArrow) {
+      onSkipForward()
+      return .handled
+    }
+    .onKeyPress("m") {
+      player.isMuted.toggle()
+      onInteraction()
+      return .handled
+    }
+    .onKeyPress(.escape) {
+      dismiss()
+      return .handled
+    }
+    #endif
   }
 
   private var controlsOverlay: some View {
@@ -162,14 +192,25 @@ private struct IOSOverlayContent: View {
   }
 
   private var volumeControls: some View {
-    Button {
-      player.isMuted.toggle()
-      onInteraction()
-    } label: {
-      Image(systemName: player.isMuted ? "speaker.slash.fill" : "speaker.wave.2.fill")
-        .contentTransition(.symbolEffect(.replace))
+    HStack(spacing: 4) {
+      Button {
+        player.isMuted.toggle()
+        onInteraction()
+      } label: {
+        Image(systemName: player.isMuted ? "speaker.slash.fill" : "speaker.wave.2.fill")
+          .contentTransition(.symbolEffect(.replace))
+      }
+      .buttonStyle(.plain)
+
+      #if targetEnvironment(macCatalyst)
+      Slider(value: Binding(
+        get: { Double(player.volume) },
+        set: { player.volume = Float($0); onInteraction() }
+      ), in: 0...1.25)
+        .frame(width: 100)
+        .tint(.white)
+      #endif
     }
-    .buttonStyle(.plain)
   }
 
   private var rateMenu: some View {

--- a/Showcase/SwiftVLCShowcase/Demos/PolishedPlayer/PolishedPlayer+macOS.swift
+++ b/Showcase/SwiftVLCShowcase/Demos/PolishedPlayer/PolishedPlayer+macOS.swift
@@ -91,13 +91,14 @@ private struct MacOSOverlayContent: View {
       Spacer()
 
       // Bottom bar — seek slider with time, volume, and rate in one row below
-      VStack(spacing: 4) {
+      VStack(spacing: 6) {
         SeekBar(player: player, showTimeLabels: false, onEditingChanged: onSeekEditingChanged)
-        HStack {
+        HStack(spacing: 12) {
           Text(player.currentTime.formatted)
             .monospacedDigit()
             .font(.caption)
             .contentTransition(.numericText())
+            .frame(width: 48, alignment: .leading)
 
           volumeSlider
 
@@ -109,10 +110,11 @@ private struct MacOSOverlayContent: View {
             .monospacedDigit()
             .font(.caption)
             .contentTransition(.numericText())
+            .frame(width: 56, alignment: .trailing)
         }
       }
       .padding(.horizontal)
-      .padding(.bottom)
+      .padding(.bottom, 12)
       .background(alignment: .bottom) { GradientOverlay.bottom }
     }
     .foregroundStyle(.white)
@@ -161,7 +163,7 @@ private struct MacOSOverlayContent: View {
         get: { Double(player.volume) },
         set: { player.volume = Float($0); onInteraction() }
       ), in: 0...1.25)
-        .frame(width: 80)
+        .frame(width: 100)
     }
     .font(.caption)
   }

--- a/Showcase/SwiftVLCShowcase/Demos/PolishedPlayer/PolishedPlayer+tvOS.swift
+++ b/Showcase/SwiftVLCShowcase/Demos/PolishedPlayer/PolishedPlayer+tvOS.swift
@@ -50,23 +50,23 @@ private struct TVOSOverlayContent: View {
       // Top bar
       HStack {
         Text("Big Buck Bunny")
-          .font(.title3)
+          .font(.title2)
         Spacer()
       }
-      .padding(.horizontal)
-      .padding(.top)
+      .padding(.horizontal, 64)
+      .padding(.top, 48)
       .background(alignment: .top) { GradientOverlay.top }
 
       Spacer()
 
       // Center transport
-      HStack(spacing: 60) {
+      HStack(spacing: 80) {
         Button {
           player.seek(by: .seconds(-10))
           onInteraction()
         } label: {
           Image(systemName: "gobackward.10")
-            .font(.title)
+            .font(.system(size: 46))
         }
         .focused($focusedControl, equals: .skipBack)
 
@@ -75,7 +75,7 @@ private struct TVOSOverlayContent: View {
           onInteraction()
         } label: {
           Image(systemName: player.isPlaying ? "pause.fill" : "play.fill")
-            .font(.largeTitle)
+            .font(.system(size: 64))
             .contentTransition(.symbolEffect(.replace))
         }
         .focused($focusedControl, equals: .playPause)
@@ -85,7 +85,7 @@ private struct TVOSOverlayContent: View {
           onInteraction()
         } label: {
           Image(systemName: "goforward.10")
-            .font(.title)
+            .font(.system(size: 46))
         }
         .focused($focusedControl, equals: .skipForward)
       }
@@ -94,9 +94,18 @@ private struct TVOSOverlayContent: View {
       Spacer()
 
       // Bottom bar
-      VStack(spacing: 4) {
-        ProgressView(value: player.position, total: 1.0)
-          .tint(.accentColor)
+      VStack(spacing: 12) {
+        GeometryReader { geo in
+          ZStack(alignment: .leading) {
+            Capsule()
+              .fill(.white.opacity(0.3))
+              .frame(height: 6)
+            Capsule()
+              .fill(Color.accentColor)
+              .frame(width: max(0, geo.size.width * player.position), height: 6)
+          }
+        }
+        .frame(height: 6)
         HStack {
           Text(player.currentTime.formatted)
             .contentTransition(.numericText())
@@ -105,10 +114,10 @@ private struct TVOSOverlayContent: View {
             .contentTransition(.numericText())
         }
         .monospacedDigit()
-        .font(.caption)
+        .font(.body)
       }
-      .padding(.horizontal)
-      .padding(.bottom)
+      .padding(.horizontal, 64)
+      .padding(.bottom, 48)
       .background(alignment: .bottom) { GradientOverlay.bottom }
     }
     .foregroundStyle(.white)

--- a/Showcase/SwiftVLCShowcase/Shared/GradientOverlay.swift
+++ b/Showcase/SwiftVLCShowcase/Shared/GradientOverlay.swift
@@ -2,6 +2,14 @@ import SwiftUI
 
 /// Dark gradient overlays for text legibility over video content.
 enum GradientOverlay {
+  #if os(tvOS)
+  private static let topHeight: CGFloat = 180
+  private static let bottomHeight: CGFloat = 200
+  #else
+  private static let topHeight: CGFloat = 120
+  private static let bottomHeight: CGFloat = 140
+  #endif
+
   /// Top-down gradient for title bars over video.
   static var top: some View {
     LinearGradient(
@@ -9,7 +17,7 @@ enum GradientOverlay {
       startPoint: .top,
       endPoint: .bottom
     )
-    .frame(height: 120)
+    .frame(height: topHeight)
     .allowsHitTesting(false)
   }
 
@@ -20,7 +28,7 @@ enum GradientOverlay {
       startPoint: .top,
       endPoint: .bottom
     )
-    .frame(height: 140)
+    .frame(height: bottomHeight)
     .allowsHitTesting(false)
   }
 }

--- a/Showcase/SwiftVLCShowcase/ShowcaseHub.swift
+++ b/Showcase/SwiftVLCShowcase/ShowcaseHub.swift
@@ -1,84 +1,67 @@
 import SwiftUI
 
 struct ShowcaseHub: View {
-  #if os(macOS)
-  @State private var selection: ShowcaseItem? = .polishedPlayer
-  #endif
+  @State private var showingPlayer = false
 
   var body: some View {
-    #if os(macOS)
-    macOSSplitView
-    #elseif os(tvOS)
-    NavigationStack { tvOSGrid }
-    #else
-    NavigationStack { demoList }
+    NavigationStack {
+      #if os(tvOS)
+      tvOSGrid
+      #else
+      demoList
+      #endif
+    }
+    #if !os(tvOS)
+    .fullScreenCover(isPresented: $showingPlayer) {
+      PolishedPlayerDemo()
+    }
     #endif
   }
 
-  // MARK: - macOS — Sidebar + Detail
+  // MARK: - iOS / macOS — Clean list
 
-  #if os(macOS)
-  private var macOSSplitView: some View {
-    NavigationSplitView {
-      List(ShowcaseItem.available, selection: $selection) { item in
-        Label {
-          VStack(alignment: .leading, spacing: 2) {
-            Text(item.title)
-            Text(item.subtitle)
-              .font(.caption)
-              .foregroundStyle(.secondary)
-          }
-        } icon: {
-          Image(systemName: item.systemImage)
-            .font(.body)
-            .foregroundStyle(.white)
-            .frame(width: 32, height: 32)
-            .background(item.accentColor.gradient, in: .rect(cornerRadius: 8))
-        }
-        .padding(.vertical, 4)
-        .tag(item)
-      }
-      .navigationTitle("SwiftVLC")
-    } detail: {
-      if let selection {
-        destinationView(for: selection)
-      } else {
-        ContentUnavailableView("Select a Demo", systemImage: "play.rectangle.fill")
-      }
-    }
-  }
-  #endif
-
-  // MARK: - iOS — Clean list
-
-  #if os(iOS)
+  #if !os(tvOS)
   private var demoList: some View {
     List {
       ForEach(ShowcaseItem.available) { item in
-        NavigationLink(value: item) {
-          Label {
-            VStack(alignment: .leading, spacing: 2) {
-              Text(item.title)
-              Text(item.subtitle)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-          } icon: {
-            Image(systemName: item.systemImage)
-              .font(.body)
-              .foregroundStyle(.white)
-              .frame(width: 40, height: 40)
-              .background(item.accentColor.gradient, in: .rect(cornerRadius: 10))
+        if item == .polishedPlayer {
+          Button {
+            showingPlayer = true
+          } label: {
+            demoLabel(item)
           }
-          .padding(.vertical, 4)
+        } else {
+          NavigationLink(value: item) {
+            demoLabel(item)
+          }
         }
       }
     }
+    #if os(iOS)
     .listStyle(.insetGrouped)
+    #endif
     .navigationTitle("SwiftVLC Showcase")
     .navigationDestination(for: ShowcaseItem.self) { item in
       destinationView(for: item)
     }
+  }
+
+  private func demoLabel(_ item: ShowcaseItem) -> some View {
+    Label {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(item.title)
+        Text(item.subtitle)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+    } icon: {
+      Image(systemName: item.systemImage)
+        .font(.body)
+        .foregroundStyle(.white)
+        .frame(width: 40, height: 40)
+        .background(item.accentColor.gradient, in: .rect(cornerRadius: 10))
+    }
+    .padding(.vertical, 4)
   }
   #endif
 

--- a/Showcase/SwiftVLCShowcase/ShowcaseHub.swift
+++ b/Showcase/SwiftVLCShowcase/ShowcaseHub.swift
@@ -1,19 +1,57 @@
 import SwiftUI
 
 struct ShowcaseHub: View {
+  #if os(macOS)
+  @State private var selection: ShowcaseItem? = .polishedPlayer
+  #endif
+
   var body: some View {
-    NavigationStack {
-      #if os(tvOS)
-      tvOSGrid
-      #else
-      demoList
-      #endif
-    }
+    #if os(macOS)
+    macOSSplitView
+    #elseif os(tvOS)
+    NavigationStack { tvOSGrid }
+    #else
+    NavigationStack { demoList }
+    #endif
   }
 
-  // MARK: - iOS / macOS — Clean list
+  // MARK: - macOS — Sidebar + Detail
 
-  #if !os(tvOS)
+  #if os(macOS)
+  private var macOSSplitView: some View {
+    NavigationSplitView {
+      List(ShowcaseItem.available, selection: $selection) { item in
+        Label {
+          VStack(alignment: .leading, spacing: 2) {
+            Text(item.title)
+            Text(item.subtitle)
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        } icon: {
+          Image(systemName: item.systemImage)
+            .font(.body)
+            .foregroundStyle(.white)
+            .frame(width: 32, height: 32)
+            .background(item.accentColor.gradient, in: .rect(cornerRadius: 8))
+        }
+        .padding(.vertical, 4)
+        .tag(item)
+      }
+      .navigationTitle("SwiftVLC")
+    } detail: {
+      if let selection {
+        destinationView(for: selection)
+      } else {
+        ContentUnavailableView("Select a Demo", systemImage: "play.rectangle.fill")
+      }
+    }
+  }
+  #endif
+
+  // MARK: - iOS — Clean list
+
+  #if os(iOS)
   private var demoList: some View {
     List {
       ForEach(ShowcaseItem.available) { item in
@@ -36,9 +74,7 @@ struct ShowcaseHub: View {
         }
       }
     }
-    #if os(iOS)
     .listStyle(.insetGrouped)
-    #endif
     .navigationTitle("SwiftVLC Showcase")
     .navigationDestination(for: ShowcaseItem.self) { item in
       destinationView(for: item)
@@ -51,29 +87,28 @@ struct ShowcaseHub: View {
   #if os(tvOS)
   private var tvOSGrid: some View {
     ScrollView {
-      LazyVGrid(columns: [GridItem(.adaptive(minimum: 300))], spacing: 40) {
+      LazyVGrid(columns: [GridItem(.adaptive(minimum: 400))], spacing: 48) {
         ForEach(ShowcaseItem.available) { item in
           NavigationLink(value: item) {
-            VStack(spacing: 12) {
+            VStack(spacing: 16) {
               Image(systemName: item.systemImage)
-                .font(.largeTitle)
+                .font(.system(size: 48))
                 .foregroundStyle(item.accentColor)
               Text(item.title)
-                .font(.headline)
+                .font(.title3)
               Text(item.subtitle)
-                .font(.caption)
+                .font(.body)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
             }
             .frame(maxWidth: .infinity)
-            .padding()
-            .padding()
-            .background(.regularMaterial, in: .rect(cornerRadius: 16))
+            .padding(32)
+            .background(.regularMaterial, in: .rect(cornerRadius: 20))
           }
           .buttonStyle(.card)
         }
       }
-      .padding()
+      .padding(48)
     }
     .navigationTitle("SwiftVLC Showcase")
     .navigationDestination(for: ShowcaseItem.self) { item in

--- a/Showcase/SwiftVLCShowcase/ShowcaseHub.swift
+++ b/Showcase/SwiftVLCShowcase/ShowcaseHub.swift
@@ -11,7 +11,7 @@ struct ShowcaseHub: View {
       demoList
       #endif
     }
-    #if !os(tvOS)
+    #if os(iOS)
     .fullScreenCover(isPresented: $showingPlayer) {
       PolishedPlayerDemo()
     }
@@ -24,6 +24,7 @@ struct ShowcaseHub: View {
   private var demoList: some View {
     List {
       ForEach(ShowcaseItem.available) { item in
+        #if os(iOS)
         if item == .polishedPlayer {
           Button {
             showingPlayer = true
@@ -35,6 +36,11 @@ struct ShowcaseHub: View {
             demoLabel(item)
           }
         }
+        #else
+        NavigationLink(value: item) {
+          demoLabel(item)
+        }
+        #endif
       }
     }
     #if os(iOS)


### PR DESCRIPTION
## Summary
- **macOS**: Switch hub to `NavigationSplitView` sidebar layout; improve polished player bottom bar spacing and volume slider width
- **tvOS**: Scale up hub grid cards, player transport controls, and progress bar for 10-foot UI; add horizontal split layout for playlist demo; increase gradient overlay heights for TV safe areas

## Test plan
- [ ] Build and run Showcase on iOS Simulator — verify no regressions
- [ ] Build and run Showcase on Mac Catalyst — verify sidebar navigation works
- [ ] Build and run Showcase on tvOS Simulator — verify scaled-up UI and playlist horizontal layout
- [ ] CI passes for all three platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)