### PR TITLE
v0.5.0 — Modern Swift concurrency refactor + test hardening + docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,14 @@
 name: Tests
-on: [push, pull_request]
+
+# Run once per change, not twice. `on: [push, pull_request]` would fire
+# both events whenever a PR branch is pushed (push → `refs/heads/<branch>`,
+# pull_request → `refs/pull/<n>/merge`), doubling CI minutes. Restricting
+# `push` to `main` means branch pushes only run under the PR; `main` still
+# gets CI on direct pushes / merges.
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 # Cancel superseded runs on the same branch so stale pushes don't burn billing.
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,14 @@ jobs:
       #   idle       = 180s  (3 min)   — swift test emits a line per
       #                                  test / suite; 3 min of silence
       #                                  means the test process is stuck.
+      #
+      # --no-parallel is load-bearing: `Player` is `@MainActor`, so
+      # integration tests that drive libVLC to `.playing` all compete
+      # for the same actor under Swift Testing's default parallel mode.
+      # On a GHA runner that contention stretches a 200 ms test into a
+      # multi-second timeout. Running serially takes ~45 s for the whole
+      # suite with zero flakes — fractions of a cent in GHA billing and
+      # vastly more predictable than paying for periodic retries.
       - name: Run tests (wall-clock + idle timeouts)
         timeout-minutes: 12
         env:
@@ -121,4 +129,8 @@ jobs:
         # Xcode-provided SDKs/simulators.
         run: |
           ./scripts/ci-run-with-timeouts.py 600 180 \
-            xcrun --toolchain "$TOOLCHAINS" swift test
+            xcrun --toolchain "$TOOLCHAINS" swift test --no-parallel
+
+      - name: Doc coverage
+        timeout-minutes: 3
+        run: ./scripts/doc-coverage.sh

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,8 @@
+# Swift Package Index manifest for DocC generation.
+version: 1
+builder:
+  configs:
+    - documentation_targets: [SwiftVLC]
+      # Hide synthesized protocol conformances; they inherit docs from
+      # the source protocol and only bloat the sidebar.
+      custom_documentation_parameters: [--experimental-skip-synthesized-symbols]

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,13 @@
 # Architecture
 
-Technical decisions and design rationale for SwiftVLC.
+Technical decisions and design rationale for SwiftVLC, written for
+contributors and reviewers.
+
+> Looking for **how to use** SwiftVLC? See the DocC guides (published on
+> Swift Package Index) or run `swift package preview-documentation
+> --target SwiftVLC` locally. This document covers the *why* behind the
+> design: build/release infrastructure, C-interop patterns, isolation
+> choices, deinit ordering, and the testing strategy.
 
 ## Contents
 
@@ -64,8 +71,8 @@ flowchart TB
 
 - **Swift-first**: Direct C → Swift bindings, no Objective-C intermediary (unlike VLCKit)
 - **Observable state**: `@Observable` `@MainActor` Player drives SwiftUI updates automatically
-- **Typed concurrency**: Swift 6 strict concurrency — all public types are `Sendable`, async APIs use `AsyncStream`
-- **One-liner rendering**: `VideoView(player)` — no setup, no delegates, no callbacks
+- **Typed concurrency**: Swift 6 strict concurrency. Every public type is `Sendable`, and async APIs use `AsyncStream`.
+- **One-liner rendering**: `VideoView(player)` covers the setup, delegate wiring, and callbacks in one call.
 - **Typed errors**: `throws(VLCError)` for compile-time error handling
 
 ---
@@ -110,7 +117,7 @@ The central observable type that drives all playback.
 | `Player.swift` | `@Observable @MainActor class` | Wraps `libvlc_media_player_t*`. All playback control, state, and track management. |
 | `EventBridge.swift` | `internal class` | C callbacks → `AsyncStream<PlayerEvent>` multi-consumer broadcaster |
 | `PlayerState.swift` | `enum PlayerState` | `.idle`, `.opening`, `.buffering(Float)`, `.playing`, `.paused`, `.stopped`, `.stopping`, `.error` |
-| `PlayerEvent.swift` | `enum PlayerEvent` | 22 event cases mapped from 31 C event types |
+| `PlayerEvent.swift` | `enum PlayerEvent` | Typed Swift cases mapped from libVLC's player event types |
 | `PlayerRole.swift` | `enum PlayerRole` | Audio behavior hints: `.music`, `.video`, `.communication`, `.game`, etc. |
 | `ABLoop.swift` | `enum ABLoopState` | `.none` → `.pointASet` → `.active` |
 | `NavigationAction.swift` | `enum NavigationAction` | DVD/Blu-ray menu: `.activate`, `.up`, `.down`, `.left`, `.right`, `.popup` |
@@ -164,7 +171,7 @@ Media resource creation, parsing, and metadata.
 | File | Type | Purpose |
 |---|---|---|
 | `Media.swift` | `final class Media: Sendable` | Wraps `libvlc_media_t*`. Create from URL, path, or file descriptor. Async parsing with cancellation. |
-| `Metadata.swift` | `struct Metadata: Sendable` | 17 typed fields: title, artist, album, duration, artworkURL, genre, etc. |
+| `Metadata.swift` | `struct Metadata: Sendable` | libVLC's metadata keys surfaced as typed properties (title, artist, album, duration, artworkURL, genre, …) |
 | `Track.swift` | `struct Track: Sendable` | Audio/video/subtitle track info with type-specific fields (channels, resolution, encoding) |
 | `ThumbnailRequest.swift` | Extension on `Media` | `thumbnail(at:width:height:crop:timeout:) async throws → Data` |
 | `MediaStatistics.swift` | `struct MediaStatistics: Sendable` | Runtime stats: decoded/displayed/lost frames, bitrates, buffer counts |
@@ -196,7 +203,7 @@ Audio output, equalization, and channel configuration.
 | File | Type | Purpose |
 |---|---|---|
 | `AudioOutput.swift` | `struct AudioOutput`, `struct AudioDevice` | Available output modules and devices. Extensions on `VLCInstance` and `Player`. |
-| `Equalizer.swift` | `@MainActor class Equalizer` | 10-band EQ with preamp (-20 to +20 dB). 25 built-in presets. Attach via `player.equalizer`. |
+| `Equalizer.swift` | `@MainActor class Equalizer` | 10-band EQ with preamp (-20 to +20 dB). libVLC's built-in presets. Attach via `player.equalizer`. |
 | `AudioChannelMode.swift` | `enum StereoMode`, `enum MixMode` | Stereo/mono/Dolby, 4.0/5.1/7.1/binaural mixing |
 
 ### Video
@@ -228,8 +235,8 @@ Network service and renderer discovery.
 
 | File | Type | Purpose |
 |---|---|---|
-| `MediaDiscoverer.swift` | `class MediaDiscoverer: @unchecked Sendable` | Discovers media on LAN/SMB/UPnP/SAP. Returns `MediaList` of found items. |
-| `RendererDiscoverer.swift` | `class RendererDiscoverer: @unchecked Sendable` | Discovers Chromecast/AirPlay renderers. `AsyncStream<RendererEvent>` for add/remove. |
+| `MediaDiscoverer.swift` | `final class MediaDiscoverer: Sendable` | Discovers media on LAN/SMB/UPnP/SAP. Returns `MediaList` of found items. |
+| `RendererDiscoverer.swift` | `final class RendererDiscoverer: Sendable` | Discovers Chromecast/AirPlay renderers. `AsyncStream<RendererEvent>` for add/remove. |
 
 ### PiP (iOS/macOS only)
 
@@ -276,7 +283,8 @@ This allows the logging callback to receive a pre-formatted `const char *` inste
 
 ### Linked Frameworks & Libraries
 
-The xcframework links against 21 system frameworks and 7 system libraries:
+The xcframework links against the system frameworks and libraries
+libVLC needs for decoding, rendering, and platform services:
 
 **Frameworks:** AudioToolbox, AudioUnit\*, AVFoundation, AVKit, CoreAudio, CoreFoundation, CoreGraphics, CoreImage, CoreMedia, CoreServices, CoreText, CoreVideo, Foundation, IOKit\*, IOSurface, OpenGL\*, OpenGLES\*, QuartzCore, Security, SystemConfiguration, VideoToolbox
 
@@ -316,19 +324,27 @@ flowchart LR
 3. **C callbacks** fire on libVLC's internal threads. They yield values into `AsyncStream` continuations (which are thread-safe) or dispatch to main via `DispatchQueue.main.async`.
 4. **`nonisolated(unsafe)`** is used for `OpaquePointer` fields that are only valid during the object's lifetime and accessed on the correct actor.
 
-### Pointer-to-Int Pattern
+### Capturing C Pointers in `@Sendable` Closures
 
-For `Sendable` compliance in async closures (e.g., `onCancel` blocks), pointers are converted to `Int`:
+`OpaquePointer` and `UnsafeMutableRawPointer` aren't `Sendable` under Swift's region-based isolation, so getting them into `@Sendable` closures (`withTaskCancellationHandler` `onCancel`, `DispatchQueue.*.async`) needs one of two mechanisms:
 
-```swift
-let pointerAsInt = Int(bitPattern: pointer)
+- **`nonisolated(unsafe) let` local binding**, for captures into a single closure. The local opts out of isolation checking; the pointer is trivially transferable and stays valid for the enclosing scope. Used in `Media.parse`, `Player.deinit`, `MediaListPlayer.deinit`, `PixelBufferRenderer`, and the deinits in `DialogHandler`, `RendererDiscoverer`, and `MediaDiscoverer`.
+  ```swift
+  nonisolated(unsafe) let p = pointer
+  DispatchQueue.global(qos: .utility).async {
+    libvlc_media_player_release(p)
+  }
+  ```
 
-// In Sendable closure:
-let restored = OpaquePointer(bitPattern: pointerAsInt)!
-libvlc_media_parse_stop(restored)
-```
+- **`Mutex<State>` with `State: @unchecked Sendable`**, for persistent storage of pointers that must be read or written from multiple threads. `Mutex`'s `sending` semantics require `State` to be sendable to the callee; marking `State: @unchecked Sendable` honors that while the `Mutex` itself provides the actual mutual exclusion. Used by `LogBroadcaster`, `ThumbnailRequest.RequestBox`, and `PixelBufferRenderer`.
+  ```swift
+  private struct State: @unchecked Sendable {
+    var selfBox: UnsafeMutableRawPointer?
+  }
+  private let state = Mutex(State())
+  ```
 
-This avoids capturing non-`Sendable` `OpaquePointer` values in `@Sendable` closures.
+Never use `Int(bitPattern:)` round-trips to launder pointers through `Sendable`. It loses type information and obscures intent.
 
 ---
 
@@ -339,7 +355,7 @@ Three-layer architecture bridging C callbacks to SwiftUI:
 ```mermaid
 flowchart TB
     subgraph L1["C Callbacks — libVLC thread"]
-        CB["31 event types attached via libvlc_event_attach<br/>playerEventCallback → mapEvent()"]
+        CB["Player event types attached via libvlc_event_attach<br/>playerEventCallback → mapEvent()"]
     end
 
     subgraph L2["AsyncStream Broadcasting — any thread"]
@@ -356,7 +372,7 @@ flowchart TB
 
 ### PlayerEvent Cases
 
-31 C event types are attached to the libVLC event manager and mapped to 22 Swift cases:
+libVLC's player event types are attached to the event manager and mapped to typed Swift cases:
 
 | Category | Swift Cases |
 |---|---|
@@ -373,33 +389,37 @@ flowchart TB
 
 ### Multi-Consumer Broadcasting
 
+Id allocation and dictionary updates live under a single `Mutex<State>`, so registration is one lock acquisition. `broadcast` snapshots the continuations under the lock and yields outside it. Yielding resumes a consumer task and acquires its status-record lock; a concurrent task cancellation holds that same lock and calls `onTermination → remove → acquire Mutex`, so yielding while holding the `Mutex` would produce an AB-BA deadlock.
+
 ```swift
-// Internal: EventBridge
-func makeStream() -> AsyncStream<PlayerEvent> {
-  let id = UUID()
-  return AsyncStream { continuation in
-    store.withLock { $0[id] = continuation }
-    continuation.onTermination = { _ in
-      store.withLock { $0.removeValue(forKey: id) }
+private final class ContinuationStore: Sendable {
+  private struct State {
+    var nextID: Int = 0
+    var continuations: [Int: AsyncStream<PlayerEvent>.Continuation] = [:]
+  }
+  private let state = Mutex(State())
+
+  func add(continuation: AsyncStream<PlayerEvent>.Continuation) -> Int {
+    state.withLock { state in
+      let id = state.nextID
+      state.nextID += 1
+      state.continuations[id] = continuation
+      return id
     }
   }
-}
 
-// From C callback:
-func broadcast(_ event: PlayerEvent) {
-  store.withLock { continuations in
-    for (_, continuation) in continuations {
-      continuation.yield(event)
-    }
+  func broadcast(_ event: PlayerEvent) {
+    let snapshot = state.withLock { Array($0.continuations.values) }
+    for cont in snapshot { cont.yield(event) }  // yield outside the lock
   }
 }
 ```
 
 ### Lifecycle
 
-1. **`Player.init()`** — creates `EventBridge`, attaches all event types to the libVLC event manager
-2. **`startEventConsumer()`** — spawns a `Task` that consumes the bridge stream and updates `@Observable` properties
-3. **`Player.deinit`** — cancels consumer task, calls `EventBridge.invalidate()` (detaches C callbacks, finishes continuations, releases store)
+1. **`Player.init()`** creates the `EventBridge` and attaches every event type to the libVLC event manager.
+2. **`startEventConsumer()`** spawns a `Task` that reads the bridge stream and updates the player's `@Observable` properties.
+3. **`Player.deinit`** cancels the consumer task, then calls `EventBridge.invalidate()` to detach the C callbacks, finish the continuations, and release the store.
 
 ---
 
@@ -432,7 +452,7 @@ For C callback contexts that need to bridge to Swift objects:
 
 ### Deinit Ordering
 
-Critical ordering in `Player.deinit` — detaching listeners **before** releasing the player prevents use-after-free if a callback fires during teardown:
+Ordering in `Player.deinit` is load-bearing: detaching the listeners **before** releasing the player prevents use-after-free when a callback fires during teardown.
 
 1. Cancel event consumer task
 2. `EventBridge.invalidate()`
@@ -466,7 +486,7 @@ sequenceDiagram
     VideoSurface->>libVLC: set_nsobject(nil)
 ```
 
-Zero configuration — no `CALayer` setup, no `MTKView`, no `AVPlayerLayer`. libVLC handles all rendering internally.
+There is no `CALayer` setup, no `MTKView`, and no `AVPlayerLayer` to configure. libVLC handles all rendering internally.
 
 ---
 
@@ -504,15 +524,15 @@ flowchart TB
 
 ### PiPController Responsibilities
 
-1. **Timebase sync** — creates `CMTimebase` and keeps it in sync with player state (playing/paused/rate)
-2. **Duration reporting** — invalidates PiP controller when duration becomes known (required for controls)
-3. **Playback delegation** — implements `AVPictureInPictureSampleBufferPlaybackDelegate` for play/pause/seek from PiP controls
-4. **State observation** — observer task detects VLC-initiated vs PiP-initiated state changes
-5. **Deferred pause** — handles skip-without-blink by deferring pause via task cancellation
+1. **Timebase sync.** Creates a `CMTimebase` and keeps it aligned with the player's state (playing, paused, or rate-shifted).
+2. **Duration reporting.** Invalidates the PiP controller once the duration becomes known, which is required before the controls can render.
+3. **Playback delegation.** Implements `AVPictureInPictureSampleBufferPlaybackDelegate` so the play, pause, and seek buttons on the PiP window route into the ``Player``.
+4. **State observation.** An observer task distinguishes VLC-initiated state changes from PiP-initiated ones.
+5. **Deferred pause.** Skip-without-blink by deferring the pause via task cancellation.
 
 ### Mutually Exclusive
 
-`VideoView` and `PiPVideoView` are mutually exclusive for a given player — `set_nsobject` and vmem callbacks cannot coexist.
+`VideoView` and `PiPVideoView` are mutually exclusive for a given player: `set_nsobject` and vmem callbacks cannot coexist on the same `libvlc_media_player_t`.
 
 ---
 
@@ -556,7 +576,9 @@ All errors conform to `LocalizedError` and `CustomStringConvertible` for logging
 
 ### Overview
 
-**758 tests** across 61 suites using the **Swift Testing** framework (not XCTest).
+A comprehensive **Swift Testing** suite (not XCTest) covers every
+public API. Every test is an integration test that exercises the real
+libVLC binary.
 
 ```
 Tests/SwiftVLCTests/
@@ -568,7 +590,7 @@ Tests/SwiftVLCTests/
 │   ├── twosec.mp4           # 2s, for seeking tests
 │   ├── silence.wav          # Audio-only
 │   └── test.srt             # Subtitle file
-└── [32 test suites]         # One per domain area
+└── …                        # One test suite per domain area
 ```
 
 ### Test Tags
@@ -583,7 +605,7 @@ Tests/SwiftVLCTests/
 
 ### Testing Patterns
 
-**Integration tests with real libVLC** — no mocking. Tests create actual `Player` and `Media` instances:
+**Integration tests with real libVLC.** No mocking; every test creates actual `Player` and `Media` instances:
 
 ```swift
 @Test(.tags(.integration, .media, .async))
@@ -594,7 +616,7 @@ func playAndWaitForState() async throws {
 }
 ```
 
-**CI execution** — GitHub Actions on `macos-latest` with Xcode pinned to `latest-stable` (currently 26.x) plus the Swift 6.3 open-source toolchain from swift.org invoked via `xcrun --toolchain`. The test step is wrapped by `scripts/ci-run-with-timeouts.py` which enforces a 10-minute wall clock and a 3-minute idle watchdog — either fires a SIGKILL to the process group. Three layered caches keep cold-start cost down: the libvlc xcframework (keyed on its SHA-256), compiled build products (`hashFiles` on sources + manifest), and SPM dependency checkouts.
+**CI execution.** GitHub Actions runs on `macos-latest` with Xcode pinned to `latest-stable` (currently 26.x) plus the Swift 6.3 open-source toolchain from swift.org, invoked via `xcrun --toolchain`. The test step is wrapped by `scripts/ci-run-with-timeouts.py`, which enforces a 10-minute wall clock and a 3-minute idle watchdog and sends SIGKILL to the process group when either fires. Three layered caches keep cold-start cost down: the libvlc xcframework (keyed on its SHA-256), compiled build products (keyed on `hashFiles` of sources and the manifest), and SPM dependency checkouts.
 
 ---
 
@@ -613,7 +635,7 @@ func playAndWaitForState() async throws {
 
 ### Package.swift resolution strategy
 
-Every branch — including `main` — carries the local-path form of the libvlc `binaryTarget`:
+Every branch, including `main`, carries the local-path form of the libvlc `binaryTarget`:
 
 ```swift
 .binaryTarget(name: "libvlc", path: "Vendor/libvlc.xcframework")
@@ -634,11 +656,11 @@ Tag-only: the commit that pins `Package.swift` to the remote url+checksum is rea
 
 ```mermaid
 flowchart LR
-    BUILD["build-libvlc.sh --all"] --> XCF["Vendor/libvlc.xcframework<br/>(6 GB unstripped)"]
+    BUILD["build-libvlc.sh --all"] --> XCF["Vendor/libvlc.xcframework<br/>(unstripped)"]
     XCF --> RELEASE["release.sh vX.Y.Z"]
-    RELEASE --> VERIFY["Verify 6 slices present"]
-    VERIFY --> STRIP["strip -S → 887 MB"]
-    STRIP --> ZIP["ditto -c -k → ~300 MB"]
+    RELEASE --> VERIFY["Verify all required slices present"]
+    VERIFY --> STRIP["strip -S"]
+    STRIP --> ZIP["ditto -c -k"]
     ZIP --> SUM["swift package compute-checksum"]
     SUM --> DETACH["Detached commit:<br/>Package.swift → url+checksum"]
     DETACH --> TAG["git tag vX.Y.Z"]
@@ -648,7 +670,7 @@ flowchart LR
     GH --> SPM["Consumers pin vX.Y.Z"]
 ```
 
-Preflight refuses releases from non-`main` branches (`--allow-dirty-branch` overrides), pre-existing local tags, and unauthenticated `gh`. If any step fails after the detached commit is made, the EXIT trap resets the branch to its pre-release HEAD so nothing dangles. A post-write regex guard verifies the rewritten `Package.swift` still contains the `CLibVLC` target — catches a malformed replacement before the tag is cut.
+Preflight refuses releases from non-`main` branches (`--allow-dirty-branch` overrides), pre-existing local tags, and unauthenticated `gh`. If any step fails after the detached commit is made, the `EXIT` trap resets the branch to its pre-release HEAD so nothing is left dangling. A post-write regex guard verifies that the rewritten `Package.swift` still contains the `CLibVLC` target, catching a malformed replacement before the tag is cut.
 
 ### CI/CD
 
@@ -665,10 +687,10 @@ Preflight refuses releases from non-`main` branches (`--allow-dirty-branch` over
 SwiftVLC/
 ├── Sources/
 │   ├── CLibVLC/                    # C bridging layer
-│   │   ├── include/vlc/            # libVLC 4.0 C headers (14 files)
+│   │   ├── include/vlc/            # libVLC 4.0 C headers
 │   │   └── shim.c                  # va_list formatting shim
 │   │
-│   └── SwiftVLC/                   # Main library (~5.2K lines)
+│   └── SwiftVLC/                   # Main library
 │       ├── Core/                   # VLCInstance, VLCError, Logging, Duration
 │       ├── Player/                 # Player, EventBridge, PlayerState, Events, ABLoop, etc.
 │       ├── Media/                  # Media, Metadata, Track, Thumbnails, Statistics
@@ -678,7 +700,7 @@ SwiftVLC/
 │       ├── Discovery/             # MediaDiscoverer, RendererDiscoverer
 │       └── PiP/                   # PiPController, PiPVideoView, PixelBufferRenderer
 │
-├── Tests/SwiftVLCTests/            # 757 tests across 61 suites, ~10.2K lines
+├── Tests/SwiftVLCTests/            # Swift Testing suite, one file per domain
 │   ├── Support/                    # TestMedia fixtures, Tag definitions
 │   └── Fixtures/                   # Bundled media files (~50 KB)
 │
@@ -686,7 +708,7 @@ SwiftVLC/
 │   ├── Shared/                     # Reusable: SeekBar, TransportControls, StatusBar
 │   └── Demos/                      # PolishedPlayer, AudioPlayer, Playlist, PiP, DebugConsole
 │
-├── Vendor/                         # libvlc.xcframework (~6 GB unstripped; release zip ~300 MB)
+├── Vendor/                         # libvlc.xcframework (multi-GB unstripped; release zip a few hundred MB)
 │
 ├── scripts/
 │   ├── build-libvlc.sh                   # Compile libvlc from source
@@ -706,11 +728,3 @@ SwiftVLC/
 └── README.md                     # User guide
 ```
 
-### Size Metrics
-
-| Component | Lines of Code | Size |
-|---|---|---|
-| SwiftVLC source | ~5,200 | — |
-| Tests | ~10,200 | — |
-| Showcase app | ~2,300 | — |
-| Test-to-source ratio | ~196% | — |

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,10 @@ let package = Package(
   products: [
     .library(name: "SwiftVLC", targets: ["SwiftVLC"])
   ],
+  dependencies: [
+    // Build-time plugin only; not linked into consumers.
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.6")
+  ],
   targets: [
     .binaryTarget(name: "libvlc", path: "Vendor/libvlc.xcframework"),
     .target(
@@ -66,7 +70,7 @@ let package = Package(
     ),
     .testTarget(
       name: "SwiftVLCTests",
-      dependencies: ["SwiftVLC"],
+      dependencies: ["SwiftVLC", "CLibVLC"],
       resources: [.copy("Fixtures")],
       swiftSettings: [
         .swiftLanguageMode(.v6),

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
   <img alt="SwiftVLC" src="Assets/logo-light.svg" width="260">
 </picture>
 
-A modern Swift wrapper around [libVLC](https://www.videolan.org/vlc/libvlc.html) for iOS, macOS, tvOS, and Mac Catalyst.
+A Swift wrapper around [libVLC](https://www.videolan.org/vlc/libvlc.html) for iOS, macOS, tvOS, and Mac Catalyst.
 
 ## Why?
 
-Apple's AVFoundation is great until it isn't. It can't play MKV, FLAC, or most subtitle formats. It doesn't support network streams like RTSP, SMB, or UPnP. Codec support is limited to what Apple ships. If your app needs to play anything beyond MP4/HLS, you hit a wall.
+Apple's AVFoundation covers a narrow slice of the media landscape. It cannot play MKV, FLAC, or most subtitle formats, and it does not support network protocols like RTSP, SMB, or UPnP. Codec support is limited to what Apple ships. Any app that needs to reach beyond MP4 and HLS eventually runs out of runway.
 
-[VLC](https://www.videolan.org/) solves this — it plays virtually everything. And its engine, **libVLC**, is available as a C library that can be embedded in any app.
+[VLC](https://www.videolan.org/) plays virtually everything, and its engine, **libVLC**, is available as a C library you can embed in any app.
 
-The existing iOS wrapper, [VLCKit](https://code.videolan.org/videolan/VLCKit), is Objective-C. It uses delegates, KVO, `NSNotificationCenter`, and manual thread management. It was designed before Swift existed and it shows.
+The existing iOS wrapper, [VLCKit](https://code.videolan.org/videolan/VLCKit), is written in Objective-C. It uses delegates, KVO, `NSNotificationCenter`, and manual thread management, which is a faithful reflection of the era it was designed in.
 
-**SwiftVLC** wraps libVLC 4.0 directly in Swift — no Objective-C layer in between. It's built for `@Observable`, `async/await`, and `VideoView(player)`.
+**SwiftVLC** wraps libVLC 4.0 directly in Swift, with no Objective-C layer in between. It is built for `@Observable`, `async/await`, and `VideoView(player)`.
 
 ## SwiftVLC vs VLCKit
 
@@ -22,28 +22,28 @@ The existing iOS wrapper, [VLCKit](https://code.videolan.org/videolan/VLCKit), i
 |---|---|---|
 | **Language** | Swift 6 | Objective-C |
 | **Bindings** | Direct C → Swift | C → Objective-C → Swift bridging |
-| **State management** | `@Observable` — automatic SwiftUI updates | KVO / `NSNotificationCenter` / delegates |
+| **State management** | `@Observable`, drives SwiftUI directly | KVO, `NSNotificationCenter`, and delegates |
 | **Concurrency** | `@MainActor`, `Sendable`, `async/await` | Manual thread dispatch, no isolation |
-| **Video rendering** | `VideoView(player)` — one line | Manual `UIView` setup + drawable configuration |
-| **Errors** | `throws(VLCError)` — typed, exhaustive | `NSError` codes |
-| **Events** | `AsyncStream<PlayerEvent>` — multi-consumer | `NSNotificationCenter` |
+| **Video rendering** | `VideoView(player)` | Manual `UIView` setup plus drawable configuration |
+| **Errors** | `throws(VLCError)`, typed and exhaustive | `NSError` codes |
+| **Events** | `AsyncStream<PlayerEvent>` with multiple consumers | `NSNotificationCenter` |
 | **libVLC version** | 4.0 | 3.x |
-| **PiP** | Built-in via vmem pipeline | Not included |
-| **Swift 6 safe** | Yes — strict concurrency, all types `Sendable` | No |
+| **PiP** | Built in via the vmem pipeline | Not included |
+| **Swift 6 safe** | Yes, with strict concurrency | No |
 
 ## Features
 
-- **`@Observable` Player** — state, time, duration, tracks, volume all drive SwiftUI automatically
-- **One-line video** — `VideoView(player)` handles the entire rendering lifecycle
-- **Typed errors** — `throws(VLCError)` instead of error codes
-- **Async media parsing** — `try await media.parse()` with cancellation support
-- **10-band equalizer** with 25 built-in presets
-- **A-B looping**, playback rate control, subtitle/audio delay
-- **Picture-in-Picture** with full playback controls
-- **Network discovery** — LAN, SMB, UPnP media and Chromecast/AirPlay renderers
-- **360° video** — viewpoint control (yaw, pitch, roll, FOV)
-- **Thumbnails** — async generation at any timestamp
-- **Playlist** — `MediaListPlayer` with loop/repeat modes
+- `@Observable` player: state, current time, duration, tracks, and volume drive SwiftUI directly.
+- `VideoView(player)` handles the rendering lifecycle in a single SwiftUI view.
+- Typed errors via `throws(VLCError)` instead of error codes.
+- Asynchronous media parsing: `try await media.parse()` with cancellation support.
+- 10-band equalizer with libVLC's built-in presets.
+- A-B looping, playback rate control, and subtitle and audio delay.
+- Picture-in-Picture with full playback controls.
+- Network discovery for LAN, SMB, UPnP media sources, and Chromecast and AirPlay renderers.
+- 360° video with full viewpoint control over yaw, pitch, roll, and field of view.
+- Asynchronous thumbnail generation at arbitrary timestamps.
+- `MediaListPlayer` for playlist playback with loop and repeat modes.
 
 ## Requirements
 
@@ -52,15 +52,22 @@ The existing iOS wrapper, [VLCKit](https://code.videolan.org/videolan/VLCKit), i
 
 ## Installation
 
-Add SwiftVLC as a Swift Package dependency:
+In Xcode, choose **File → Add Package Dependencies**, paste the repo
+URL, and Xcode will pick up the latest release automatically:
 
-```swift
-.package(url: "https://github.com/harflabs/SwiftVLC.git", from: "0.1.0")
+```
+https://github.com/harflabs/SwiftVLC.git
 ```
 
-Or in Xcode: **File > Add Package Dependencies** and enter the URL above.
+From a `Package.swift` manifest, add a dependency and pin to the
+current release. The version string lives on the
+[releases page](https://github.com/harflabs/SwiftVLC/releases).
 
-The pre-built libVLC xcframework (~1.2 GB) downloads automatically via SPM.
+```swift
+.package(url: "https://github.com/harflabs/SwiftVLC.git", from: "x.y.z")
+```
+
+The pre-built libVLC xcframework downloads automatically via SPM. It's a large binary (multi-GB unstripped; the release zip is a few hundred MB).
 
 ## Quick Start
 
@@ -113,22 +120,27 @@ for await event in player.events {
 
 ## Showcase App
 
-The `Showcase/` directory contains a full-featured demo app for all supported platforms:
+The `Showcase/` directory contains a full-featured demo app for each supported platform:
 
-- **iOS** — Tap-to-show controls, swipe gestures, equalizer, PiP
-- **macOS** — Hover controls, keyboard shortcuts, floating settings panel
-- **tvOS** — 10-foot UI with Siri Remote, swipe-to-scrub
-- **Mac Catalyst** — iOS player running natively on Mac
+- **iOS.** Tap-to-show controls, swipe gestures, equalizer, and PiP.
+- **macOS.** Hover controls, keyboard shortcuts, and a floating settings panel.
+- **tvOS.** A 10-foot UI with Siri Remote navigation and swipe-to-scrub.
+- **Mac Catalyst.** The iOS player running natively on Mac.
 
 ## Testing
 
-757 tests across 61 suites using [Swift Testing](https://developer.apple.com/xcode/swift-testing/) — real libVLC integration, no mocking.
+A comprehensive [Swift Testing](https://developer.apple.com/xcode/swift-testing/)
+suite covers every public API. There is no XCTest and no mocks: every
+test runs against the real libVLC binary, so regressions in the C
+bridge surface immediately rather than hiding behind a fake. CI runs
+the full suite on every push and every pull request.
 
 ```bash
 swift test
 ```
 
-See [ARCHITECTURE.md](ARCHITECTURE.md#testing-strategy) for test tags, fixtures, and structure.
+See [ARCHITECTURE.md](ARCHITECTURE.md#testing-strategy) for test tags,
+fixtures, and structure.
 
 ## Development Setup
 
@@ -139,18 +151,18 @@ cd SwiftVLC
 swift test
 ```
 
-`setup-dev.sh` downloads `libvlc.xcframework.zip` (~250 MB) from the latest release into `Vendor/`. `Package.swift` on every branch points at that local path, so no manifest edits are needed before building.
+`setup-dev.sh` downloads `libvlc.xcframework.zip` from the latest release into `Vendor/`. `Package.swift` on every branch points at that local path, so no manifest edits are needed before building.
 
 | `setup-dev.sh` flag | Effect |
 |---|---|
 | *(none)* | Download the latest release if `Vendor/` is empty; otherwise keep existing. |
-| `v0.3.0` *(positional)* | Pin to a specific release tag. |
+| `vX.Y.Z` *(positional)* | Pin to a specific release tag. |
 | `--force` | Re-download even if `Vendor/` already exists. |
-| `--skip-download` | Only flip `Package.swift` to local path. Expects `Vendor/` to already exist — useful after `build-libvlc.sh`. |
+| `--skip-download` | Only flip `Package.swift` to local path. Expects `Vendor/` to already exist, which is useful after running `build-libvlc.sh`. |
 
 ## Building libVLC from Source
 
-Needed only when bumping `VLC_HASH`, modifying build patches, or preparing a release — not for day-to-day Swift work.
+Needed only when bumping `VLC_HASH`, modifying build patches, or preparing a release. Day-to-day Swift development doesn't require it.
 
 ```bash
 brew install autoconf automake libtool cmake pkg-config gettext
@@ -176,11 +188,11 @@ Expect ~15–20 minutes on a clean run and ~2–7 minutes warm on Apple Silicon.
 
 VLC master doesn't build cleanly against current Xcode and Homebrew libtool. The script applies these patches in-tree on every invocation, idempotently:
 
-1. **Mac Catalyst** — teaches VLC's build system the macabi target triple and guards OpenGLES-only code paths.
-2. **Xcode 26 LDFLAGS** — adds `-isysroot` to linker invocations so libSystem resolves.
-3. **libtool 2.5 OBJC tag** — adds `_LIBTOOLFLAGS = --tag=CC` to the 15 `Makefile.am` files with `.m` sources. Older libtool versions inferred the tag; 2.5 refuses.
-4. **Rust contribs disabled** — `cargo-c 0.9.29` no longer compiles on recent Rust. The only Rust contrib on Apple is `rav1e` (AV1 *encoder*); `dav1d` handles decoding.
-5. **`dup3` / `pipe2`** — forced unavailable via autoconf cache vars. iOS Simulator SDK 26 exports these Linux-only syscalls from libSystem, fooling configure into using them.
+1. **Mac Catalyst.** Teaches VLC's build system the `macabi` target triple and guards OpenGLES-only code paths.
+2. **Xcode 26 LDFLAGS.** Adds `-isysroot` to linker invocations so libSystem resolves.
+3. **libtool 2.5 OBJC tag.** Adds `_LIBTOOLFLAGS = --tag=CC` to the `Makefile.am` files that contain `.m` sources. Older libtool versions inferred the tag; 2.5 refuses.
+4. **Rust contribs disabled.** `cargo-c 0.9.29` no longer compiles on recent Rust. The only Rust contrib on Apple is `rav1e` (AV1 *encoder*); `dav1d` handles decoding.
+5. **`dup3` / `pipe2`.** Forced unavailable via autoconf cache vars. iOS Simulator SDK 26 exports these Linux-only syscalls from libSystem, fooling configure into using them.
 
 `git reset --hard` only runs when HEAD is not at `VLC_HASH`, so the patches and per-platform build dirs survive repeated runs.
 
@@ -190,8 +202,8 @@ Releases use a **tag-only** model: the commit that pins `Package.swift` to the r
 
 ```bash
 ./scripts/build-libvlc.sh --all          # produces Vendor/libvlc.xcframework
-./scripts/release.sh 0.4.0 --dry-run     # strip + zip + checksum, no push
-./scripts/release.sh 0.4.0               # cut the release
+./scripts/release.sh X.Y.Z --dry-run     # strip + zip + checksum, no push
+./scripts/release.sh X.Y.Z               # cut the release
 ```
 
 What `release.sh` does:
@@ -201,7 +213,7 @@ What `release.sh` does:
 3. Computes SHA-256 via `swift package compute-checksum`.
 4. Creates a detached commit with `Package.swift` rewritten to the remote URL and checksum.
 5. Tags that commit as `vX.Y.Z`.
-6. Resets the branch back to its previous HEAD — the commit survives only as the tag.
+6. Resets the branch back to its previous HEAD; the commit survives only as the tag.
 7. Pushes the tag (never the branch).
 8. Uploads the zip to a new GitHub Release.
 
@@ -209,16 +221,16 @@ Preflight refuses non-`main` branches (`--allow-dirty-branch` to override), pre-
 
 ## Architecture
 
-For internals — module design, C interop, concurrency model, event system, memory management, and the PiP rendering pipeline — see **[ARCHITECTURE.md](ARCHITECTURE.md)**.
+For internals, including module design, C interop, the concurrency model, the event system, memory management, and the PiP rendering pipeline, see **[ARCHITECTURE.md](ARCHITECTURE.md)**.
 
 ## License
 
-MIT License — see [LICENSE](LICENSE).
+MIT. See [LICENSE](LICENSE).
 
 libVLC is licensed under [LGPLv2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html). Static linking may have licensing implications. See the [VLC licensing FAQ](https://www.videolan.org/legal.html).
 
 ## Acknowledgments
 
-SwiftVLC is built on the incredible work of the [VideoLAN](https://www.videolan.org/) community. The VLC media player and libVLC are among the most important open-source projects in media — decades of work by hundreds of contributors making it possible to play virtually anything, anywhere.
+SwiftVLC stands on the work of the [VideoLAN](https://www.videolan.org/) community. The VLC media player and libVLC are among the most important open-source projects in media, representing decades of work by hundreds of contributors that made it possible to play virtually anything, anywhere.
 
-Special thanks to [VLCKit](https://code.videolan.org/videolan/VLCKit) for paving the way for libVLC on Apple platforms. VLCKit proved that embedding VLC in iOS and macOS apps was not only possible but practical, and it has powered countless apps over the years. SwiftVLC wouldn't exist without the foundation VLCKit laid.
+Thanks also to [VLCKit](https://code.videolan.org/videolan/VLCKit) for paving the way for libVLC on Apple platforms. VLCKit proved that embedding VLC in iOS and macOS apps was not only possible but practical, and it has powered countless apps over the years. SwiftVLC would not exist without the foundation VLCKit laid.

--- a/Sources/SwiftVLC/Audio/AudioOutput.swift
+++ b/Sources/SwiftVLC/Audio/AudioOutput.swift
@@ -8,6 +8,7 @@ public struct AudioOutput: Sendable, Identifiable, Hashable {
   /// Human-readable description.
   public let outputDescription: String
 
+  /// Stable identifier, backed by ``name``.
   public var id: String {
     name
   }
@@ -21,6 +22,7 @@ public struct AudioDevice: Sendable, Identifiable, Hashable {
   /// Human-readable description.
   public let deviceDescription: String
 
+  /// Stable identifier, backed by ``deviceId``.
   public var id: String {
     deviceId
   }

--- a/Sources/SwiftVLC/Audio/Equalizer.swift
+++ b/Sources/SwiftVLC/Audio/Equalizer.swift
@@ -38,7 +38,10 @@ public final class Equalizer {
 
   // MARK: - Preamp
 
-  /// Preamp gain in dB (-20.0 to +20.0).
+  /// Preamp gain applied ahead of the per-band amplification, in dB.
+  ///
+  /// Valid range is `-20.0` to `+20.0`; libVLC clamps values outside
+  /// that window.
   public var preamp: Float {
     get { libvlc_audio_equalizer_get_preamp(pointer) }
     set { libvlc_audio_equalizer_set_preamp(pointer, newValue) }

--- a/Sources/SwiftVLC/Core/DialogHandler.swift
+++ b/Sources/SwiftVLC/Core/DialogHandler.swift
@@ -1,4 +1,5 @@
 import CLibVLC
+import Dispatch
 
 /// Handles VLC dialog prompts (login, question, progress, error) via AsyncStream.
 ///
@@ -58,13 +59,25 @@ public final class DialogHandler: Sendable {
   }
 
   deinit {
-    // Clear callbacks first (waits for in-progress callbacks to finish),
-    // then release the box. This ordering guarantees no callback can
-    // access the box after it's freed.
-    libvlc_dialog_set_callbacks(instance.pointer, nil, nil)
-    libvlc_dialog_set_error_callback(instance.pointer, nil, nil)
-    continuation.finish()
-    Unmanaged<DialogContinuationBox>.fromOpaque(boxOpaque).release()
+    // libvlc_dialog_set_callbacks(nil, nil) blocks waiting for any in-progress
+    // callback to return — offload off the calling thread (which may be main).
+    //
+    // Strong-capturing `instance` keeps the libvlc_instance_t* alive through
+    // the cleanup. `box` is captured as a raw pointer (trivially transferable)
+    // via a `nonisolated(unsafe)` local to satisfy the Sendable closure.
+    //
+    // Order: clear callbacks (→ libVLC drains in-progress dispatches) → finish
+    // the stream → release the retained box. Reversing the last two would risk
+    // a late callback touching freed memory.
+    let instance = self.instance
+    let continuation = self.continuation
+    nonisolated(unsafe) let box = self.boxOpaque
+    DispatchQueue.global(qos: .utility).async {
+      libvlc_dialog_set_callbacks(instance.pointer, nil, nil)
+      libvlc_dialog_set_error_callback(instance.pointer, nil, nil)
+      continuation.finish()
+      Unmanaged<DialogContinuationBox>.fromOpaque(box).release()
+    }
   }
 }
 
@@ -99,12 +112,22 @@ public enum DialogEvent: Sendable {
 
 // MARK: - Dialog ID
 
-/// An opaque identifier for an active dialog.
+/// A handle to an in-flight dialog issued by libVLC.
+///
+/// Each ``DialogEvent`` that represents a user-facing prompt carries its
+/// own `DialogID`. Call ``dismiss()`` to close the dialog without
+/// responding — useful when the UI showing the prompt is no longer
+/// relevant (e.g. the user navigated away or the underlying operation
+/// was cancelled elsewhere).
 public struct DialogID: Sendable {
   nonisolated(unsafe) let pointer: OpaquePointer // libvlc_dialog_id*
 
-  /// Dismisses the dialog.
-  /// - Returns: `true` if the dialog was dismissed successfully.
+  /// Dismisses the dialog without responding.
+  ///
+  /// Safe to call on an already-closed dialog; the return value
+  /// reports whether libVLC acknowledged the dismissal.
+  ///
+  /// - Returns: `true` if libVLC accepted the dismissal.
   @discardableResult
   public func dismiss() -> Bool {
     libvlc_dialog_dismiss(pointer) == 0
@@ -170,9 +193,12 @@ public struct QuestionRequest: Sendable {
   /// Label for the second action button, if available.
   public let action2Text: String?
 
-  /// Posts a response.
-  /// - Parameter action: `1` for ``action1Text``, `2` for ``action2Text``.
-  /// - Returns: `true` if the response was accepted by VLC.
+  /// Posts the user's chosen action to libVLC.
+  ///
+  /// - Parameter action: `1` to pick the button labeled ``action1Text``,
+  ///   or `2` to pick ``action2Text``. By convention `1` is the primary
+  ///   (accept/allow) action and `2` is the secondary (reject/deny).
+  /// - Returns: `true` if the response was accepted by libVLC.
   @discardableResult
   public func post(action: Int) -> Bool {
     libvlc_dialog_post_action(dialogId.pointer, Int32(action)) == 0

--- a/Sources/SwiftVLC/Core/Logging.swift
+++ b/Sources/SwiftVLC/Core/Logging.swift
@@ -87,13 +87,19 @@ final class LogBroadcaster: Sendable {
     let minimumLevel: LogLevel
   }
 
-  private struct State {
+  /// `@unchecked` because `UnsafeMutableRawPointer` isn't Sendable under
+  /// Swift's region analysis. Safety is provided by the enclosing `Mutex`
+  /// — every read/write happens under `state.withLock`, so the non-Sendable
+  /// pointer fields never straddle isolation domains.
+  private struct State: @unchecked Sendable {
     var nextID: Int = 0
     var subscribers: [Int: Subscriber] = [:]
-    /// The opaque broadcaster pointer passed to libVLC, or 0 if not installed.
-    var selfBoxBits: Int = 0
-    /// The shim bridge context returned by `swiftvlc_log_set`, or 0 if not installed.
-    var bridgeContextBits: Int = 0
+    /// The retained `LogBroadcaster` box passed to libVLC, or `nil` when
+    /// the callback isn't installed. Owned by the C side while set.
+    var selfBox: UnsafeMutableRawPointer?
+    /// The shim bridge context returned by `swiftvlc_log_set`, or `nil`
+    /// when the callback isn't installed.
+    var bridgeContext: UnsafeMutableRawPointer?
   }
 
   private let state = Mutex(State())
@@ -119,7 +125,7 @@ final class LogBroadcaster: Sendable {
       // (e.g. shim malloc returned NULL under memory pressure), every
       // subsequent subscriber retries so we self-heal rather than stay
       // silent forever.
-      return (id, state.selfBoxBits == 0)
+      return (id, state.selfBox == nil)
     }
 
     if shouldInstall {
@@ -129,21 +135,18 @@ final class LogBroadcaster: Sendable {
   }
 
   func remove(id: Int) {
-    let uninstall = state.withLock { state -> (Int, Int)? in
+    let uninstall = state.withLock { state -> (bridge: UnsafeMutableRawPointer?, box: UnsafeMutableRawPointer)? in
       state.subscribers.removeValue(forKey: id)
-      guard state.subscribers.isEmpty, state.selfBoxBits != 0 else { return nil }
-      let capture = (state.bridgeContextBits, state.selfBoxBits)
-      state.bridgeContextBits = 0
-      state.selfBoxBits = 0
-      return capture
+      guard state.subscribers.isEmpty, let box = state.selfBox else { return nil }
+      let bridge = state.bridgeContext
+      state.bridgeContext = nil
+      state.selfBox = nil
+      return (bridge, box)
     }
 
-    guard let (bridgeBits, boxBits) = uninstall else { return }
-    let bridge = UnsafeMutableRawPointer(bitPattern: bridgeBits)
-    swiftvlc_log_unset(instancePointer, bridge)
-    if let rawBox = UnsafeMutableRawPointer(bitPattern: boxBits) {
-      Unmanaged<LogBroadcaster>.fromOpaque(rawBox).release()
-    }
+    guard let uninstall else { return }
+    swiftvlc_log_unset(instancePointer, uninstall.bridge)
+    Unmanaged<LogBroadcaster>.fromOpaque(uninstall.box).release()
   }
 
   /// Terminates all active subscribers and uninstalls the libVLC log
@@ -152,14 +155,13 @@ final class LogBroadcaster: Sendable {
   /// callbacks can fire.
   func invalidate() {
     let (subscribers, uninstall) = state.withLock { state
-      -> ([Subscriber], (Int, Int)?) in
+      -> ([Subscriber], (bridge: UnsafeMutableRawPointer?, box: UnsafeMutableRawPointer)?) in
       let subs = Array(state.subscribers.values)
       state.subscribers.removeAll()
-      let capture: (Int, Int)? = state.selfBoxBits != 0
-        ? (state.bridgeContextBits, state.selfBoxBits)
-        : nil
-      state.bridgeContextBits = 0
-      state.selfBoxBits = 0
+      let capture: (bridge: UnsafeMutableRawPointer?, box: UnsafeMutableRawPointer)? =
+        state.selfBox.map { (state.bridgeContext, $0) }
+      state.bridgeContext = nil
+      state.selfBox = nil
       return (subs, capture)
     }
 
@@ -167,12 +169,9 @@ final class LogBroadcaster: Sendable {
       sub.continuation.finish()
     }
 
-    if let (bridgeBits, boxBits) = uninstall {
-      let bridge = UnsafeMutableRawPointer(bitPattern: bridgeBits)
-      swiftvlc_log_unset(instancePointer, bridge)
-      if let rawBox = UnsafeMutableRawPointer(bitPattern: boxBits) {
-        Unmanaged<LogBroadcaster>.fromOpaque(rawBox).release()
-      }
+    if let uninstall {
+      swiftvlc_log_unset(instancePointer, uninstall.bridge)
+      Unmanaged<LogBroadcaster>.fromOpaque(uninstall.box).release()
     }
   }
 
@@ -191,15 +190,15 @@ final class LogBroadcaster: Sendable {
   private func install() {
     let selfBox = Unmanaged.passRetained(self).toOpaque()
     guard let bridgeContext = swiftvlc_log_set(instancePointer, logCallback, selfBox) else {
-      // Shim malloc failed — release the retained self and bail. Subscribers
-      // will simply see no events until the next (hopefully successful) install.
+      // Shim malloc failed. Release the retained self and bail;
+      // subscribers receive no events until a later install() succeeds.
       Unmanaged<LogBroadcaster>.fromOpaque(selfBox).release()
       return
     }
 
     state.withLock {
-      $0.selfBoxBits = Int(bitPattern: selfBox)
-      $0.bridgeContextBits = Int(bitPattern: bridgeContext)
+      $0.selfBox = selfBox
+      $0.bridgeContext = bridgeContext
     }
   }
 }

--- a/Sources/SwiftVLC/Core/VLCError.swift
+++ b/Sources/SwiftVLC/Core/VLCError.swift
@@ -1,24 +1,41 @@
 import Foundation
 
-/// Typed error for all SwiftVLC operations.
+/// The single error type thrown by every failable SwiftVLC API.
 ///
-/// Used with Swift's typed throws: `throws(VLCError)`.
+/// All throwing functions in SwiftVLC use Swift's typed throws form
+/// `throws(VLCError)`, so the cases below are exhaustive — there is no
+/// need for a general `catch` when the compiler can statically see that
+/// this is the only possible error.
+///
+/// Every case carries enough context (URL, operation name, reason string)
+/// to log meaningfully without consulting libVLC's own diagnostics.
 public enum VLCError: Error, Sendable, LocalizedError, CustomStringConvertible {
-  /// The libVLC instance or player could not be allocated.
+  /// libVLC could not allocate an instance, player, or discoverer.
+  ///
+  /// Typically indicates that the `libvlc.xcframework` is not linked
+  /// correctly, required plugins are missing, or the process is out of
+  /// memory.
   case instanceCreationFailed
-  /// A ``Media`` object could not be created from the given source.
+  /// A ``Media`` object could not be created from the given URL, path,
+  /// or file descriptor.
   case mediaCreationFailed(source: String)
-  /// Playback could not start.
+  /// Playback could not start. The `reason` is libVLC's most recent
+  /// error message at the time the call failed.
   case playbackFailed(reason: String)
-  /// Media metadata parsing failed before completion.
+  /// Parsing ended with a non-success status before the timeout expired
+  /// (e.g. the resource was unreachable or malformed).
   case parseFailed(reason: String)
-  /// Media metadata parsing exceeded the timeout.
+  /// Parsing did not complete within the requested timeout.
   case parseTimeout
-  /// No track matching the given identifier was found.
+  /// The requested track identifier does not match any track on the
+  /// current media.
   case trackNotFound(id: String)
-  /// The operation is not valid in the current playback state.
+  /// The operation is valid in principle but not in the player's
+  /// current state (e.g. setting an A-B loop before any media is
+  /// loaded). The associated string names the constraint that failed.
   case invalidState(String)
-  /// A libVLC operation returned an error code.
+  /// A libVLC call returned a non-zero error code. The associated
+  /// string names the operation that was attempted.
   case operationFailed(_ operation: String)
 
   public var description: String {

--- a/Sources/SwiftVLC/Discovery/MediaDiscoverer.swift
+++ b/Sources/SwiftVLC/Discovery/MediaDiscoverer.swift
@@ -1,14 +1,26 @@
 import CLibVLC
+import Dispatch
 
 /// Discovers media sources on the local network, devices, or local directories.
 ///
+/// Use ``availableServices(category:instance:)`` to enumerate the
+/// discoverers available on the host, construct one by `name`, then
+/// ``start()`` it. Discovered items populate ``mediaList`` as they are
+/// found — inspect the list while the discoverer runs.
+///
 /// ```swift
 /// let services = MediaDiscoverer.availableServices(category: .lan)
-/// for service in services {
-///     let discoverer = try MediaDiscoverer(name: service.name)
-///     try discoverer.start()
-///     let mediaList = discoverer.mediaList
-///     // Monitor mediaList for discovered items
+/// guard let service = services.first else { return }
+///
+/// let discoverer = try MediaDiscoverer(name: service.name)
+/// try discoverer.start()
+///
+/// // Let discovery run briefly, then inspect the list.
+/// try? await Task.sleep(for: .seconds(2))
+/// if let list = discoverer.mediaList {
+///     for i in 0..<list.count {
+///         print(list[i]?.mrl ?? "?")
+///     }
 /// }
 /// ```
 public final class MediaDiscoverer: Sendable {
@@ -29,7 +41,13 @@ public final class MediaDiscoverer: Sendable {
   }
 
   deinit {
-    libvlc_media_discoverer_release(pointer)
+    // libvlc_media_discoverer_release waits for the discovery thread to stop —
+    // offload off the calling thread so the last reference drop doesn't stall
+    // main when the discoverer is owned by a SwiftUI view.
+    nonisolated(unsafe) let discoverer = pointer
+    DispatchQueue.global(qos: .utility).async {
+      libvlc_media_discoverer_release(discoverer)
+    }
   }
 
   /// Starts discovery.

--- a/Sources/SwiftVLC/Discovery/RendererDiscoverer.swift
+++ b/Sources/SwiftVLC/Discovery/RendererDiscoverer.swift
@@ -1,6 +1,11 @@
 import CLibVLC
+import Dispatch
 
 /// Discovers available renderers (Chromecast, AirPlay, etc.) on the local network.
+///
+/// Start the discoverer, then observe ``events`` to be notified as renderers
+/// come and go. Cast to a discovered renderer by passing its
+/// ``RendererItem`` to ``Player/setRenderer(_:)``.
 ///
 /// ```swift
 /// let services = RendererDiscoverer.availableServices()
@@ -12,7 +17,7 @@ import CLibVLC
 /// for await event in discoverer.events {
 ///     switch event {
 ///     case let .itemAdded(renderer):
-///         player.setRenderer(renderer)
+///         try? player.setRenderer(renderer)
 ///     case let .itemDeleted(renderer):
 ///         print("Lost: \(renderer.name)")
 ///     }
@@ -52,12 +57,22 @@ public final class RendererDiscoverer: Sendable {
   }
 
   deinit {
-    let em = libvlc_renderer_discoverer_event_manager(pointer)!
-    libvlc_event_detach(em, Int32(libvlc_RendererDiscovererItemAdded.rawValue), rendererCallback, opaque)
-    libvlc_event_detach(em, Int32(libvlc_RendererDiscovererItemDeleted.rawValue), rendererCallback, opaque)
-    continuation.finish()
-    Unmanaged<RendererContinuationBox>.fromOpaque(opaque).release()
-    libvlc_renderer_discoverer_release(pointer)
+    // libvlc_event_detach blocks on in-progress callbacks and
+    // libvlc_renderer_discoverer_release waits for the discovery thread to
+    // stop — offload off the calling thread. Pointers are trivially
+    // transferable via `nonisolated(unsafe)` locals, and the continuation
+    // is Sendable so it can be captured directly.
+    nonisolated(unsafe) let discoverer = pointer
+    nonisolated(unsafe) let box = opaque
+    let continuation = self.continuation
+    DispatchQueue.global(qos: .utility).async {
+      let em = libvlc_renderer_discoverer_event_manager(discoverer)!
+      libvlc_event_detach(em, Int32(libvlc_RendererDiscovererItemAdded.rawValue), rendererCallback, box)
+      libvlc_event_detach(em, Int32(libvlc_RendererDiscovererItemDeleted.rawValue), rendererCallback, box)
+      continuation.finish()
+      Unmanaged<RendererContinuationBox>.fromOpaque(box).release()
+      libvlc_renderer_discoverer_release(discoverer)
+    }
   }
 
   /// Starts renderer discovery.

--- a/Sources/SwiftVLC/Media/Media.swift
+++ b/Sources/SwiftVLC/Media/Media.swift
@@ -91,14 +91,18 @@ public final class Media: Sendable {
     pointer = media
   }
 
-  /// Parses media metadata asynchronously.
+  /// Parses the media's metadata and track list, awaiting the result.
   ///
-  /// Supports cooperative cancellation — cancelling the parent `Task` aborts the parse.
+  /// Reads both local and network sources. Cancelling the enclosing
+  /// `Task` aborts the parse promptly, leaving the media untouched.
+  ///
   /// - Parameters:
-  ///   - timeout: Maximum time to wait for parsing.
-  ///   - instance: VLC instance (needed for parse API in VLC 4.0).
-  /// - Returns: Parsed ``Metadata``.
-  /// - Throws: `VLCError.parseFailed` or `VLCError.parseTimeout`.
+  ///   - timeout: Maximum time to wait before giving up.
+  ///   - instance: The libVLC instance that performs the parse.
+  /// - Returns: The parsed ``Metadata``. Call ``tracks()`` afterwards
+  ///   to obtain the discovered tracks.
+  /// - Throws: ``VLCError/parseTimeout`` if `timeout` expires, or
+  ///   ``VLCError/parseFailed(reason:)`` for any other failure.
   public func parse(
     timeout: Duration = .seconds(10),
     instance: VLCInstance = .shared
@@ -108,9 +112,14 @@ public final class Media: Sendable {
     let em = libvlc_media_event_manager(media)!
     let instancePtr = instance.pointer
 
-    // Convert pointers to Int for Sendable compliance in onCancel closure.
-    let mediaBits = Int(bitPattern: media)
-    let instanceBits = Int(bitPattern: instancePtr)
+    // `onCancel` is a `@Sendable` closure and `OpaquePointer` isn't Sendable,
+    // so bind the pointers to `nonisolated(unsafe)` locals — the same pattern
+    // used elsewhere for libVLC pointer captures (Player.deinit,
+    // PixelBufferRenderer). The pointers are valid for the duration of this
+    // call because `self` (Media) and `instance` (VLCInstance) are retained
+    // by the surrounding `async` frame.
+    nonisolated(unsafe) let cancelMedia = media
+    nonisolated(unsafe) let cancelInstance = instancePtr
 
     let result: Result<Metadata, VLCError> = await withTaskCancellationHandler {
       await withCheckedContinuation { cont in
@@ -132,9 +141,7 @@ public final class Media: Sendable {
     } onCancel: {
       // Stop the in-progress parse. VLC will fire MediaParsedChanged
       // with a failed status, which resumes the continuation.
-      let m = OpaquePointer(bitPattern: mediaBits)!
-      let inst = OpaquePointer(bitPattern: instanceBits)!
-      libvlc_media_parse_stop(inst, m)
+      libvlc_media_parse_stop(cancelInstance, cancelMedia)
     }
     return try result.get()
   }
@@ -245,7 +252,7 @@ public final class Media: Sendable {
   /// Creates media from an open file descriptor.
   ///
   /// The file descriptor must be open for reading. libVLC will **not** close it.
-  /// - Parameter fileDescriptor: An open file descriptor.
+  /// - Parameter fd: An open file descriptor.
   /// - Throws: `VLCError.mediaCreationFailed` if creation fails.
   public init(fileDescriptor fd: Int) throws(VLCError) {
     guard let media = libvlc_media_new_fd(Int32(fd)) else {
@@ -254,7 +261,14 @@ public final class Media: Sendable {
     pointer = media
   }
 
-  /// Adds a VLC option string to this media (e.g. ":network-caching=1000").
+  /// Applies a libVLC option to this media before playback starts.
+  ///
+  /// Options use libVLC's command-line syntax, with a leading `:` for
+  /// input options — for example, `:network-caching=1000` to set a
+  /// one-second network buffer, or `:start-time=30` to skip the first
+  /// 30 seconds. Multiple options can be added by calling this method
+  /// repeatedly. Options have no effect once the media has begun
+  /// playing.
   public func addOption(_ option: String) {
     libvlc_media_add_option(pointer, option)
   }

--- a/Sources/SwiftVLC/Media/MediaStatistics.swift
+++ b/Sources/SwiftVLC/Media/MediaStatistics.swift
@@ -1,9 +1,12 @@
 import CLibVLC
 
-/// Playback statistics for a media item.
+/// Point-in-time playback statistics for a media item.
 ///
-/// Provides real-time metrics about input, demux, decoding, and output.
-/// Access via ``Player/statistics`` during playback.
+/// Read via ``Player/statistics`` once a media has been loaded. The
+/// values are cumulative counters and instantaneous bitrates sampled at
+/// the moment of the call — capture multiple snapshots if you want to
+/// display rates over time. Counters read as `0` before their stage of
+/// the pipeline has processed any data.
 public struct MediaStatistics: Sendable, Equatable {
   // MARK: - Input
 

--- a/Sources/SwiftVLC/Media/Metadata.swift
+++ b/Sources/SwiftVLC/Media/Metadata.swift
@@ -87,38 +87,58 @@ public struct Metadata: Sendable, Equatable {
 }
 
 /// Keys for accessing individual metadata fields on a ``Media`` item.
+///
+/// Raw values match libVLC's `libvlc_meta_t` enumeration.
 public enum MetadataKey: Int, Sendable, CaseIterable, Hashable {
+  /// Track or media title.
   case title = 0
+  /// Performing artist.
   case artist = 1
+  /// Genre (e.g. "Rock", "Classical").
   case genre = 2
+  /// Copyright notice.
   case copyright = 3
+  /// Album name.
   case album = 4
+  /// Track number within the album, as a string.
   case trackNumber = 5
+  /// Free-form description or comment embedded in the file.
   case description = 6
   /// User or critic rating.
   case rating = 7
+  /// Release date (typically "YYYY" or "YYYY-MM-DD").
   case date = 8
   /// Application-specific setting string.
   case setting = 9
   /// URL associated with the media (e.g. podcast link).
   case url = 10
+  /// Content language (ISO 639 code or free-form).
   case language = 11
   /// Currently playing content (often used by radio streams).
   case nowPlaying = 12
+  /// Publisher or record label.
   case publisher = 13
   /// Software or person that encoded the file.
   case encodedBy = 14
+  /// URL to album art or thumbnail image.
   case artworkURL = 15
   /// Unique track identifier within a collection.
   case trackID = 16
   /// Total number of tracks in the album or collection.
   case trackTotal = 17
+  /// Director (for film and episodic content).
   case director = 18
+  /// Season number (for episodic content).
   case season = 19
+  /// Episode number (for episodic content).
   case episode = 20
+  /// TV show name (for episodic content).
   case showName = 21
+  /// Cast members, typically as a delimited list.
   case actors = 22
+  /// Album-level artist (may differ from track artist on compilations).
   case albumArtist = 23
+  /// Disc number in a multi-disc set.
   case discNumber = 24
   /// Total number of discs in a multi-disc set.
   case discTotal = 25

--- a/Sources/SwiftVLC/Media/ThumbnailRequest.swift
+++ b/Sources/SwiftVLC/Media/ThumbnailRequest.swift
@@ -100,23 +100,31 @@ extension Media {
 /// Holds the libVLC `libvlc_media_thumbnail_request_t*` pointer. Its
 /// `destroy()` is idempotent and atomic so the callback and the cancel
 /// handler can both call it without stepping on each other.
+///
+/// `@unchecked` on `Storage` because `OpaquePointer` isn't Sendable under
+/// Swift's region analysis; safety is provided by the enclosing `Mutex`
+/// — every read/write happens under `storage.withLock`.
 private final class RequestBox: Sendable {
-  private let bits = Mutex<Int>(0)
+  private struct Storage: @unchecked Sendable {
+    var pointer: OpaquePointer?
+  }
+
+  private let storage = Mutex(Storage())
 
   func store(_ request: OpaquePointer) {
-    bits.withLock { $0 = Int(bitPattern: UnsafeRawPointer(request)) }
+    storage.withLock { $0.pointer = request }
   }
 
   /// Atomically clears the stored pointer and destroys it if present.
   /// Subsequent calls are no-ops.
   func destroy() {
-    let captured = bits.withLock { value -> Int in
-      let c = value
-      value = 0
-      return c
+    let captured = storage.withLock { storage -> OpaquePointer? in
+      let p = storage.pointer
+      storage.pointer = nil
+      return p
     }
-    guard captured != 0, let ptr = OpaquePointer(bitPattern: captured) else { return }
-    libvlc_media_thumbnail_request_destroy(ptr)
+    guard let captured else { return }
+    libvlc_media_thumbnail_request_destroy(captured)
   }
 }
 

--- a/Sources/SwiftVLC/Media/Track.swift
+++ b/Sources/SwiftVLC/Media/Track.swift
@@ -23,7 +23,8 @@ public struct Track: Sendable, Identifiable, Hashable {
   /// Codec identifier as a FourCC integer (e.g. `0x34363248` for "H264").
   public let codec: Int
 
-  /// ISO 639 language code.
+  /// ISO 639 language code (e.g. `"eng"`, `"fra"`, `"ja"`) as declared
+  /// in the container, or `nil` if the track is unlabeled.
   public let language: String?
 
   /// Track description from the container.

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -6,12 +6,20 @@ import Observation
 
 /// Controls Picture-in-Picture playback for a ``Player``.
 ///
-/// When PiP is used, all rendering goes through vmem callbacks →
-/// `AVSampleBufferDisplayLayer` (both inline and PiP windows).
-/// This is mutually exclusive with `libvlc_media_player_set_nsobject()`.
+/// `PiPController` routes video through libVLC's vmem callbacks and an
+/// `AVSampleBufferDisplayLayer`, which is the only rendering path
+/// AVKit's PiP can attach to. Using a `PiPController` therefore
+/// replaces the default `VideoView` pipeline — do not use both on the
+/// same player.
+///
+/// Most apps should prefer ``PiPVideoView``, which creates and owns a
+/// `PiPController` behind a single SwiftUI view. Instantiate
+/// `PiPController` directly only when you need fine-grained control
+/// over the layer's placement or lifecycle.
 ///
 /// ```swift
 /// let controller = PiPController(player: player)
+/// yourContainerView.layer.addSublayer(controller.layer)
 /// controller.start()
 /// ```
 @MainActor
@@ -44,17 +52,27 @@ public final class PiPController: NSObject {
   /// `currentTime` data that hasn't caught up to the seek yet.
   private var lastSkipTimestamp: CFAbsoluteTime = 0
 
-  /// Whether PiP can be activated.
+  /// Whether PiP can be started right now.
+  ///
+  /// Returns `false` on devices or simulators that don't support PiP,
+  /// and briefly after initialization until the system has validated
+  /// the layer. Observe this before enabling a "Picture-in-Picture"
+  /// button in your UI.
   public var isPossible: Bool {
     pipController?.isPictureInPicturePossible ?? false
   }
 
-  /// Whether PiP is currently active.
+  /// Whether a PiP window is currently visible.
   public var isActive: Bool {
     pipController?.isPictureInPictureActive ?? false
   }
 
-  /// The display layer used for rendering. Add this to your view hierarchy.
+  /// The layer that renders video frames for both the inline and PiP
+  /// presentations.
+  ///
+  /// Add it to your own view's layer hierarchy if you're not using
+  /// ``PiPVideoView``. Size the layer to fit its container — its
+  /// `videoGravity` is `.resizeAspect`.
   public var layer: AVSampleBufferDisplayLayer {
     displayLayer
   }
@@ -259,14 +277,21 @@ public final class PiPController: NSObject {
 // MARK: - AVPictureInPictureControllerDelegate
 
 extension PiPController: AVPictureInPictureControllerDelegate {
+  /// `AVPictureInPictureControllerDelegate` hook — no additional work is
+  /// needed; the state observer drives our internal sync.
   public nonisolated func pictureInPictureControllerDidStartPictureInPicture(
     _: AVPictureInPictureController
   ) {}
 
+  /// `AVPictureInPictureControllerDelegate` hook — no-op; cleanup happens
+  /// in ``stop()`` and on `deinit`.
   public nonisolated func pictureInPictureControllerDidStopPictureInPicture(
     _: AVPictureInPictureController
   ) {}
 
+  /// `AVPictureInPictureControllerDelegate` hook. SwiftVLC does not
+  /// propagate PiP start failures; inspect the Console log if PiP
+  /// refuses to start.
   public nonisolated func pictureInPictureController(
     _: AVPictureInPictureController,
     failedToStartPictureInPictureWithError _: Error
@@ -282,6 +307,11 @@ extension PiPController: AVPictureInPictureSampleBufferPlaybackDelegate {
   // The PiP system queries state immediately after calling these; if the
   // action hasn't executed yet the UI reverts to stale state.
 
+  /// `AVPictureInPictureSampleBufferPlaybackDelegate` hook. Translates
+  /// PiP play/pause presses into ``Player`` state changes, with the
+  /// internal `pipPlaybackActive` flag kept in sync so subsequent
+  /// delegate queries return the right value before libVLC's async
+  /// state transition completes.
   public nonisolated func pictureInPictureController(
     _: AVPictureInPictureController,
     setPlaying playing: Bool
@@ -314,6 +344,11 @@ extension PiPController: AVPictureInPictureSampleBufferPlaybackDelegate {
     }
   }
 
+  /// `AVPictureInPictureSampleBufferPlaybackDelegate` hook. Returns the
+  /// media's time range so the PiP scrubber can render. When the
+  /// duration isn't known yet, reports a 24-hour sentinel so the
+  /// scrubber doesn't collapse to 100%; the observer invalidates the
+  /// state once the real duration arrives.
   public nonisolated func pictureInPictureControllerTimeRangeForPlayback(
     _: AVPictureInPictureController
   ) -> CMTimeRange {
@@ -335,12 +370,20 @@ extension PiPController: AVPictureInPictureSampleBufferPlaybackDelegate {
     return CMTimeRange(start: .zero, duration: cmDuration)
   }
 
+  /// `AVPictureInPictureSampleBufferPlaybackDelegate` hook. Returns the
+  /// paused state as PiP sees it — backed by the internal flag so the
+  /// answer is consistent right after a play/pause command, before
+  /// libVLC's asynchronous state transition settles.
   public nonisolated func pictureInPictureControllerIsPlaybackPaused(
     _: AVPictureInPictureController
   ) -> Bool {
     MainActor.assumeIsolated { !pipPlaybackActive }
   }
 
+  /// `AVPictureInPictureSampleBufferPlaybackDelegate` hook. Routes PiP
+  /// skip buttons into a relative ``Player/seek(by:)`` and updates the
+  /// control timebase so the PiP UI reflects the new position before
+  /// libVLC's own time change arrives.
   public nonisolated func pictureInPictureController(
     _: AVPictureInPictureController,
     skipByInterval skipInterval: CMTime,
@@ -375,6 +418,9 @@ extension PiPController: AVPictureInPictureSampleBufferPlaybackDelegate {
     }
   }
 
+  /// `AVPictureInPictureSampleBufferPlaybackDelegate` hook. The PiP
+  /// window resizes automatically from the sample-buffer layer; we
+  /// don't need to react.
   public nonisolated func pictureInPictureController(
     _: AVPictureInPictureController,
     didTransitionToRenderSize _: CMVideoDimensions

--- a/Sources/SwiftVLC/PiP/PiPVideoView.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView.swift
@@ -64,6 +64,10 @@ public struct PiPVideoView: UIViewRepresentable {
     Coordinator()
   }
 
+  /// Internal state for the SwiftUI view's lifecycle.
+  ///
+  /// Retains the ``PiPController`` and its display layer so they survive
+  /// view updates and are cleaned up on dismantle.
   @MainActor
   public final class Coordinator {
     var pipController: PiPController?
@@ -147,6 +151,10 @@ public struct PiPVideoView: NSViewRepresentable {
     Coordinator()
   }
 
+  /// Internal state for the SwiftUI view's lifecycle.
+  ///
+  /// Retains the ``PiPController`` and its display layer so they survive
+  /// view updates and are cleaned up on dismantle.
   @MainActor
   public final class Coordinator {
     var pipController: PiPController?

--- a/Sources/SwiftVLC/Player/ChapterTitle.swift
+++ b/Sources/SwiftVLC/Player/ChapterTitle.swift
@@ -11,13 +11,15 @@ public struct Title: Sendable, Identifiable, Hashable {
   /// Title duration.
   public let duration: Duration
 
-  /// Human-readable title name.
+  /// Human-readable title name, if the container provides one.
   public let name: String?
 
-  /// Whether this title is a menu.
+  /// `true` when the title contains menu content (DVD menus, BD-J menus).
   public let isMenu: Bool
 
-  /// Whether this title is interactive.
+  /// `true` when the title responds to user input beyond playback
+  /// controls (BD-J interactive titles). Seeking may be disabled
+  /// inside interactive titles.
   public let isInteractive: Bool
 }
 

--- a/Sources/SwiftVLC/Player/EventBridge.swift
+++ b/Sources/SwiftVLC/Player/EventBridge.swift
@@ -104,22 +104,28 @@ final class EventBridge: Sendable {
 // MARK: - Continuation Store
 
 /// Thread-safe storage for multiple `AsyncStream` continuations.
-/// Passed to C callbacks via `Unmanaged`.
+/// Passed to C callbacks via `Unmanaged`. Id allocation and dictionary
+/// update live under a single `Mutex<State>`, so registration is one
+/// lock acquisition.
 private final class ContinuationStore: Sendable {
-  private let nextID = Mutex<Int>(0)
-  private let continuations: Mutex<[Int: AsyncStream<PlayerEvent>.Continuation]> = Mutex([:])
+  private struct State {
+    var nextID: Int = 0
+    var continuations: [Int: AsyncStream<PlayerEvent>.Continuation] = [:]
+  }
+
+  private let state = Mutex(State())
 
   func add(continuation: AsyncStream<PlayerEvent>.Continuation) -> Int {
-    let id = nextID.withLock { id -> Int in
-      defer { id += 1 }
+    state.withLock { state in
+      let id = state.nextID
+      state.nextID += 1
+      state.continuations[id] = continuation
       return id
     }
-    continuations.withLock { $0[id] = continuation }
-    return id
   }
 
   func remove(id: Int) {
-    continuations.withLock { _ = $0.removeValue(forKey: id) }
+    state.withLock { _ = $0.continuations.removeValue(forKey: id) }
   }
 
   func broadcast(_ event: PlayerEvent) {
@@ -128,16 +134,16 @@ private final class ContinuationStore: Sendable {
     // lock. If we held the Mutex during yield, a concurrent task
     // cancellation (which holds the status lock and calls onTermination
     // → remove → acquire Mutex) would deadlock (AB-BA).
-    let snapshot = continuations.withLock { Array($0.values) }
+    let snapshot = state.withLock { Array($0.continuations.values) }
     for cont in snapshot {
       cont.yield(event)
     }
   }
 
   func finishAll() {
-    let snapshot = continuations.withLock { dict -> [AsyncStream<PlayerEvent>.Continuation] in
-      let values = Array(dict.values)
-      dict.removeAll()
+    let snapshot = state.withLock { state -> [AsyncStream<PlayerEvent>.Continuation] in
+      let values = Array(state.continuations.values)
+      state.continuations.removeAll()
       return values
     }
     for cont in snapshot {

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -98,7 +98,9 @@ public final class Player {
     }
   }
 
-  /// Playback rate (0.25...4.0, where 1.0 = normal speed).
+  /// Playback rate, where `1.0` is normal speed, `0.5` is half, and `2.0`
+  /// is double. Any positive rate is accepted, but extreme values may
+  /// degrade audio/video sync; `0.25` to `4.0` is the practical range.
   public var rate: Float {
     get {
       access(keyPath: \.rate)
@@ -111,7 +113,10 @@ public final class Player {
     }
   }
 
-  /// Selected audio track. Set `nil` to use default.
+  /// The currently selected audio track, or `nil` if none is selected.
+  ///
+  /// Setting to `nil` deselects any active audio track (effectively silent
+  /// output until another track is chosen).
   public var selectedAudioTrack: Track? {
     get {
       access(keyPath: \.selectedAudioTrack)
@@ -124,7 +129,9 @@ public final class Player {
     }
   }
 
-  /// Selected subtitle track. Set `nil` to disable subtitles.
+  /// The currently selected subtitle track, or `nil` if subtitles are off.
+  ///
+  /// Setting to `nil` deselects the active subtitle track.
   public var selectedSubtitleTrack: Track? {
     get {
       access(keyPath: \.selectedSubtitleTrack)
@@ -274,10 +281,13 @@ public final class Player {
 
   // MARK: - Media Loading
 
-  /// Loads media for playback.
+  /// Loads media into the player, replacing whatever was previously loaded.
   ///
-  /// The `sending` modifier transfers ownership of the media to the player,
-  /// preventing data races across isolation boundaries.
+  /// `media` is declared `sending`, which lets callers construct a
+  /// ``Media`` on any actor or task and hand it off to this main-actor
+  /// method without copies or bridging. The ownership transfer is
+  /// enforced by the compiler — the caller cannot retain the original
+  /// reference after the call.
   public func load(_ media: sending Media) {
     currentMedia = media
     libvlc_media_player_set_media(pointer, media.pointer)
@@ -328,18 +338,28 @@ public final class Player {
     libvlc_media_player_stop_async(pointer)
   }
 
-  /// Seeks to an absolute time.
+  /// Seeks to an absolute time in the current media.
+  ///
+  /// Has no effect if the media is not seekable — observe ``isSeekable``
+  /// before exposing scrub controls. The seek is asynchronous; watch
+  /// ``currentTime`` (or the ``PlayerEvent/timeChanged(_:)`` event) for
+  /// completion.
   public func seek(to time: Duration) {
     libvlc_media_player_set_time(pointer, time.milliseconds, /* fast */ false)
   }
 
-  /// Seeks by a relative offset from current position.
-  /// Uses VLC 4.0's `jump_time` for efficiency.
+  /// Seeks by a relative offset from the current position.
+  ///
+  /// Negative offsets rewind, positive offsets fast-forward. Has no effect
+  /// if the media is not seekable.
   public func seek(by offset: Duration) {
     libvlc_media_player_jump_time(pointer, offset.milliseconds)
   }
 
-  /// Advances to the next video frame (pauses playback if playing).
+  /// Pauses playback and advances one video frame.
+  ///
+  /// Requires the current media to be pausable (see ``isPausable``).
+  /// Calling repeatedly yields frame-by-frame stepping.
   public func nextFrame() {
     libvlc_media_player_next_frame(pointer)
   }
@@ -362,13 +382,21 @@ public final class Player {
 
   // MARK: - Snapshot
 
-  /// Takes a snapshot of the current video frame.
+  /// Takes a snapshot of the current video frame and writes it to disk as PNG.
+  ///
+  /// Pass `0` for `width` or `height` to derive that dimension from the
+  /// other while preserving the source aspect ratio. Passing `0` for both
+  /// writes the frame at its native resolution.
   ///
   /// - Parameters:
-  ///   - path: File path to save the snapshot.
-  ///   - width: Desired width (0 to preserve aspect ratio or use original).
-  ///   - height: Desired height (0 to preserve aspect ratio or use original).
-  /// - Throws: `VLCError.operationFailed` if the snapshot cannot be taken.
+  ///   - path: Destination file path. The file is always PNG regardless of
+  ///     the extension you provide.
+  ///   - width: Desired width in pixels, or `0` to derive from `height`
+  ///     and the aspect ratio.
+  ///   - height: Desired height in pixels, or `0` to derive from `width`
+  ///     and the aspect ratio.
+  /// - Throws: ``VLCError/operationFailed(_:)`` if no frame is available
+  ///   (e.g. audio-only media) or the file cannot be written.
   public func takeSnapshot(to path: String, width: Int = 0, height: Int = 0) throws(VLCError) {
     guard libvlc_video_take_snapshot(pointer, 0, path, UInt32(width), UInt32(height)) == 0 else {
       throw .operationFailed("Take snapshot")
@@ -528,10 +556,10 @@ public final class Player {
     VideoAdjustments(player: self)
   }
 
-  /// Scoped access to video adjustments for batch operations.
+  /// Scoped access to video adjustments for batched mutations.
   ///
-  /// More efficient than repeated `player.adjustments.x = ...` calls
-  /// when setting multiple values:
+  /// Prefer this over repeated `player.adjustments.x = ...` assignments
+  /// when setting several values in sequence:
   /// ```swift
   /// player.withAdjustments { adj in
   ///     adj.isEnabled = true
@@ -809,11 +837,11 @@ public final class Player {
 
   // MARK: - Event Consumer
 
-  /// Internal Task that consumes the event stream and updates @Observable properties.
-  /// This is what makes Player work with SwiftUI — no external bridging needed.
+  /// Consumes the event stream and mirrors each event onto the
+  /// `@Observable` properties that SwiftUI binds to.
   private func startEventConsumer() {
-    // Capture eventBridge strongly (lightweight object) but self weakly
-    // to avoid a retain cycle (Player → eventTask → Player).
+    // Capture eventBridge strongly and self weakly to avoid the retain
+    // cycle Player → eventTask → Player.
     let bridge = eventBridge
     eventTask = Task { [weak self] in
       for await event in bridge.makeStream() {
@@ -873,11 +901,30 @@ public final class Player {
         break
       }
 
-    case .volumeChanged, .muted, .unmuted, .corked, .uncorked, .audioDeviceChanged,
-         .voutChanged, .chapterChanged, .recordingChanged, .titleListChanged,
-         .titleSelectionChanged, .snapshotTaken, .mediaStopping,
-         .programAdded, .programDeleted, .programSelected, .programUpdated:
-      break // Observable properties handle these via getters or are consumed via event stream
+    // Computed properties read fresh state from libVLC in their getter.
+    // An empty `withMutation` is what re-triggers SwiftUI when the
+    // underlying C state changes externally (hardware keys, AirPlay,
+    // CarPlay, renderer-initiated chapter/title moves). Without this
+    // the observers stay pinned to their last read.
+    case .volumeChanged:
+      withMutation(keyPath: \.volume) {}
+
+    case .muted, .unmuted:
+      withMutation(keyPath: \.isMuted) {}
+
+    case .chapterChanged:
+      withMutation(keyPath: \.currentChapter) {}
+
+    case .titleSelectionChanged:
+      withMutation(keyPath: \.currentTitle) {}
+
+    // Events without a matching observable property are exposed only
+    // via the raw `events` stream — consumers that care subscribe there.
+    case .corked, .uncorked, .audioDeviceChanged, .voutChanged,
+         .recordingChanged, .titleListChanged, .snapshotTaken,
+         .mediaStopping, .programAdded, .programDeleted,
+         .programSelected, .programUpdated:
+      break
     }
   }
 }

--- a/Sources/SwiftVLC/Player/PlayerEvent.swift
+++ b/Sources/SwiftVLC/Player/PlayerEvent.swift
@@ -37,8 +37,8 @@ public enum PlayerEvent: Sendable {
   /// identifier, or `nil` if unknown.
   case audioDeviceChanged(String?)
   /// The current media is stopping. A good time to release input resources
-  /// (network connections, custom I/O callbacks). The player transitions
-  /// through this before emitting ``stateChanged(.stopped)``.
+  /// (network connections, custom I/O callbacks). The player emits this
+  /// before transitioning to ``PlayerState/stopped``.
   case mediaStopping
   /// Number of active video outputs changed.
   case voutChanged(Int)

--- a/Sources/SwiftVLC/Playlist/MediaList.swift
+++ b/Sources/SwiftVLC/Playlist/MediaList.swift
@@ -2,14 +2,17 @@ import CLibVLC
 
 /// A thread-safe playlist of media items.
 ///
-/// The underlying `libvlc_media_list_t` uses internal locking.
-/// All mutating operations acquire/release the lock automatically.
+/// Mutating operations acquire the underlying libVLC lock automatically.
+/// For batch reads that should see a consistent snapshot, use
+/// ``withLocked(_:)`` to hold the lock across multiple calls.
 ///
 /// ```swift
 /// let list = MediaList()
 /// let media = try Media(url: videoURL)
-/// list.append(media)
+/// try list.append(media)
 /// ```
+///
+/// Pair with a ``MediaListPlayer`` to play the items in sequence.
 public final class MediaList: Sendable {
   nonisolated(unsafe) let pointer: OpaquePointer // libvlc_media_list_t*
 

--- a/Sources/SwiftVLC/SwiftVLC.docc/AudioFeatures.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/AudioFeatures.md
@@ -1,0 +1,113 @@
+# Audio features
+
+Tune volume, output routing, channel mixing, and equalization.
+
+## Volume, mute, delay
+
+```swift
+player.volume = 0.8            // 0.0 silent, 1.0 is 100%, up to 1.25
+player.isMuted = false
+player.audioDelay = .milliseconds(30)    // positive = audio plays later
+```
+
+Volume is normalized, so `0.0 ... 1.0` covers the useful range; values
+above `1.0` amplify beyond normal (capped around 1.25 / 125%).
+
+## Output modules and devices
+
+List available output modules (CoreAudio, auhal, etc.) for the running
+instance:
+
+```swift
+for module in VLCInstance.shared.audioOutputs() {
+    print(module.name, module.outputDescription)
+}
+try player.setAudioOutput("auhal")   // macOS example
+```
+
+Then pick a device within that module:
+
+```swift
+for device in player.audioDevices() {
+    print(device.deviceId, device.deviceDescription)
+}
+try player.setAudioDevice("external-speakers-uid")
+```
+
+Observe ``PlayerEvent/audioDeviceChanged(_:)`` if you need to react to
+system-initiated device changes (e.g. headphones connecting).
+
+## Equalizer
+
+``Equalizer`` is a 10-band parametric EQ with a preamp and preset
+support. Build one, tune it, and attach it to a player:
+
+```swift
+let eq = Equalizer()
+eq.preamp = 4.0                              // dB; clamped to -20...+20
+try eq.setAmplification(5.0, forBand: 0)     // bass lift
+player.equalizer = eq
+```
+
+Use a built-in preset by index:
+
+```swift
+let rock = Equalizer(preset: Equalizer.presetNames.firstIndex(of: "Rock") ?? 0)
+player.equalizer = rock
+```
+
+Pass `nil` to disable: `player.equalizer = nil`.
+
+## Channel layout
+
+Two independent properties shape the output signal:
+
+- ``Player/stereoMode`` picks a stereo transformation (standard,
+  reversed, mono, or Dolby Surround).
+- ``Player/mixMode`` selects the channel count of the final mix,
+  including stereo, 4.0, 5.1, 7.1, and binaural rendering for
+  headphones.
+
+```swift
+player.stereoMode = .mono        // collapse to mono
+player.mixMode = .binaural       // spatialize for headphones
+```
+
+## Role hints
+
+Tell the system what kind of audio you're playing so it can route and
+duck appropriately:
+
+```swift
+player.role = .music         // long-form listening
+player.role = .communication // voice chat; enables VoIP-style processing
+```
+
+See ``PlayerRole`` for the full set.
+
+## Topics
+
+### Volume
+- ``Player/volume``
+- ``Player/isMuted``
+- ``Player/audioDelay``
+
+### Output routing
+- ``Player/setAudioOutput(_:)``
+- ``Player/audioDevices()``
+- ``Player/setAudioDevice(_:)``
+- ``Player/currentAudioDevice``
+- ``AudioOutput``
+- ``AudioDevice``
+
+### Equalization
+- ``Equalizer``
+- ``Player/equalizer``
+
+### Channel layout and role
+- ``Player/stereoMode``
+- ``Player/mixMode``
+- ``Player/role``
+- ``StereoMode``
+- ``MixMode``
+- ``PlayerRole``

--- a/Sources/SwiftVLC/SwiftVLC.docc/ComparisonWithVLCKit.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/ComparisonWithVLCKit.md
@@ -1,0 +1,170 @@
+# SwiftVLC vs VLCKit
+
+Both libraries embed VLC's playback engine into Apple apps, but the
+integration they hand back to the developer looks very different.
+This page walks through where they diverge and which trade-offs apply
+to each.
+
+## What they are
+
+**VLCKit** is VideoLAN's own wrapper around libVLC. It is written
+primarily in Objective-C and distributed for macOS, iOS, and tvOS,
+with the 4.0 line adding visionOS and watchOS. It has been the
+canonical answer for embedding VLC on Apple platforms for over a
+decade, and ships as three CocoaPods (`VLCKit`, `MobileVLCKit`,
+`TVVLCKit`) or as pre-built frameworks via Carthage.
+
+**SwiftVLC** is a Swift 6 binding to libVLC's C API, with no
+Objective-C layer in between. It targets only modern Apple platforms
+(iOS 18+, macOS 15+, tvOS 18+, macCatalyst 18+) and ships exclusively
+through Swift Package Manager.
+
+## libVLC generation
+
+| | VLCKit | SwiftVLC |
+|---|---|---|
+| Stable line | libVLC 3.x | libVLC 4.0 |
+| libVLC 4.0 port | Still in alpha | Shipping as the stable line |
+
+VLCKit's stable 3.x branch tracks libVLC 3.0 and is actively
+maintained. Its 4.0 line has been in alpha since early 2025 and
+continues to iterate. SwiftVLC is already built against libVLC 4.0 on
+its stable line, which makes the newer libVLC features available on a
+non-prerelease today. Those features include subsecond seek precision,
+the new track-selection API, two simultaneous subtitle tracks, and a
+richer metadata surface.
+
+## Language and integration surface
+
+VLCKit is Objective-C (roughly 85% by SLOC). Calling it from Swift
+routes through the C → Objective-C → Swift bridge: types are
+`NSObject` subclasses, events arrive via delegate protocols and
+`NSNotificationCenter`, and errors are `NSError` instances.
+
+SwiftVLC compiles Swift 6.3 against libVLC's C headers directly. There
+are no `NS` types, no bridging header, and no Objective-C runtime in
+the call path.
+
+```swift
+// VLCKit: delegate callbacks plus NSNotification
+class ViewController: UIViewController, VLCMediaPlayerDelegate {
+    let player = VLCMediaPlayer()
+    override func viewDidLoad() {
+        player.delegate = self
+        player.drawable = videoView
+        player.media = VLCMedia(url: url)
+        player.play()
+    }
+    func mediaPlayerStateChanged(_ notification: Notification!) { /* … */ }
+    func mediaPlayerTimeChanged(_ notification: Notification!) { /* … */ }
+}
+
+// SwiftVLC: @Observable plus SwiftUI
+struct PlayerView: View {
+    @State var player = Player()
+    var body: some View {
+        VideoView(player)
+            .task { try? player.play(url: url) }
+    }
+}
+```
+
+## Concurrency model
+
+VLCKit predates Swift concurrency. Its types are not `Sendable`, there
+is no `@MainActor` isolation, and callers are expected to hop to the
+main thread manually for UI-adjacent work.
+
+SwiftVLC is strict-concurrency native:
+
+- ``Player`` is `@MainActor` and `@Observable`.
+- ``Media``, ``MediaList``, ``VLCInstance``, ``MediaDiscoverer``, and
+  ``RendererDiscoverer`` are `Sendable`, so they can be created on any
+  task and handed to the player.
+- ``Player/load(_:)`` takes `sending Media`, so the compiler enforces
+  ownership transfer across isolation.
+- ``Marquee``, ``Logo``, and ``VideoAdjustments`` are `~Copyable` and
+  `~Escapable`, binding their lifetime to the player at compile time.
+
+See <doc:ConcurrencyModel> for the full isolation map.
+
+## Events and errors
+
+| | VLCKit | SwiftVLC |
+|---|---|---|
+| Playback events | Delegate + `NSNotificationCenter` | `AsyncStream<PlayerEvent>` |
+| State changes | KVO / delegate callbacks | `@Observable` properties |
+| Errors | `NSError` codes and out-params | `throws(VLCError)`, typed and exhaustive |
+| Logging | Delegate protocol | `AsyncStream<LogEntry>` with level filtering |
+| Dialog prompts | Delegate protocol | `AsyncStream<DialogEvent>` |
+
+Multiple consumers can subscribe to any SwiftVLC stream concurrently;
+each receives every event broadcast after creation.
+
+## SwiftUI
+
+VLCKit exposes a `UIView`/`NSView` drawable. Wiring it into SwiftUI
+means writing your own `UIViewRepresentable`, coordinating lifetime,
+and re-publishing state yourself.
+
+SwiftVLC ships ``VideoView``, ``PiPVideoView``, and a ``PiPController``
+that handle the view bridge, the drawable attachment, and the
+sample-buffer pipeline for Picture-in-Picture. See
+<doc:DisplayingVideo> and <doc:PictureInPicture>.
+
+## Distribution
+
+| | VLCKit | SwiftVLC |
+|---|---|---|
+| Swift Package Manager | Not officially supported (open since 2022) | Yes, and the only supported method |
+| CocoaPods | `VLCKit` / `MobileVLCKit` / `TVVLCKit` | No |
+| Carthage binaries | Yes | No |
+| Pre-built framework | Yes | xcframework distributed via the SPM `.binaryTarget` |
+
+## Platforms and deployment targets
+
+| | VLCKit 3.x | VLCKit 4.0 (alpha) | SwiftVLC |
+|---|---|---|---|
+| iOS | 8.4+ | iOS (target not finalized) | 18+ |
+| macOS | 10.9+ | — | 15+ |
+| tvOS | 10.2+ | — | 18+ |
+| visionOS | — | Added | — |
+| watchOS | — | Added | — |
+| macCatalyst | — | — | 18+ |
+
+## License
+
+- **libVLC** itself is LGPLv2.1 or later. Both libraries link against
+  this same binary dependency.
+- **VLCKit** is LGPLv2.1 or later.
+- **SwiftVLC** is MIT for the Swift wrapper code. The bundled libVLC
+  xcframework remains under LGPLv2.1, and its terms propagate to
+  anything that embeds it.
+
+Either choice requires your shipped app to meet libVLC's LGPL
+requirements.
+
+## When to pick which
+
+**Pick VLCKit if:**
+
+- You need to support older OS versions (iOS 8.4+, macOS 10.9+).
+- You need watchOS today (via VLCKit 4.0 alpha).
+- You have an existing Objective-C codebase where the delegate /
+  notification idioms fit naturally.
+- You prefer a long-established library with many years of production
+  use, even if the 4.0 port is still in alpha.
+
+**Pick SwiftVLC if:**
+
+- Your project targets iOS 18+ / macOS 15+ / tvOS 18+.
+- You want `@Observable`, `AsyncStream`, typed throws, and strict
+  concurrency without writing bridging code.
+- You're building on SwiftUI and want `VideoView(player)` to be the
+  whole video setup.
+- You want libVLC 4.0 features today on a stable release line.
+- You're integrating via Swift Package Manager only.
+
+Both libraries are actively maintained, and they coexist. SwiftVLC is
+not a fork of VLCKit or a replacement for it; it's a different set of
+trade-offs aimed at a different generation of Swift.

--- a/Sources/SwiftVLC/SwiftVLC.docc/ConcurrencyModel.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/ConcurrencyModel.md
@@ -1,0 +1,88 @@
+# Concurrency model
+
+Which types are isolated, which are `Sendable`, and how `sending`
+transfers flow between them.
+
+## Isolation at a glance
+
+| Type | Isolation |
+|---|---|
+| ``Player``, ``MediaListPlayer``, ``Equalizer``, ``PiPController`` | `@MainActor` |
+| ``Marquee``, ``Logo``, ``VideoAdjustments`` | `@MainActor`, also `~Copyable`/`~Escapable` |
+| ``Media``, ``MediaList``, ``VLCInstance``, ``MediaDiscoverer``, ``RendererDiscoverer`` | `Sendable` (any actor) |
+| ``Track``, ``Metadata``, ``PlayerState``, ``PlayerEvent``, ``VLCError``, … | `Sendable` value types |
+
+The main-actor types own stateful C resources: players, equalizers,
+the PiP pipeline. The `Sendable` ones are safe to create and pass
+around freely. A typical pattern is to build a ``Media`` on a
+background task, transfer it to the main actor, and play it from
+there.
+
+## The sending transfer
+
+``Player/load(_:)`` and ``Player/play(_:)`` take `sending Media`:
+
+```swift
+public func load(_ media: sending Media)
+```
+
+`sending` asks the compiler to transfer ownership of `media` across
+the isolation boundary. Because the caller cannot retain a reference
+after the call, there can never be a race between a background task
+still holding `media` and the main-actor player using it.
+
+```swift
+Task.detached {
+    let media = try Media(url: url)       // built off-actor
+    await MainActor.run {
+        try? player.play(media)           // ownership transfers in
+    }
+}
+```
+
+## Event streams
+
+Events, logs, dialogs, and discoverers all surface through
+`AsyncStream`. The streams are multiplexed: calling ``Player/events``
+twice returns two independent streams, both of which receive every
+event broadcast after their creation.
+
+```swift
+Task { for await e in player.events { handleA(e) } }
+Task { for await e in player.events { handleB(e) } }
+```
+
+Backpressure is `bufferingNewest`; slow consumers drop oldest events
+rather than block the callback thread.
+
+## Cancellation
+
+Every async API that waits on libVLC honors task cancellation:
+
+- ``Media/parse(timeout:instance:)``: canceling the enclosing task
+  stops the parse.
+- ``Media/thumbnail(at:width:height:crop:timeout:instance:)``:
+  canceling destroys the in-flight thumbnail request.
+- Streams finish when their owning type (`Player`, `VLCInstance`, or
+  a discoverer) is released.
+
+## Deinit off the main actor
+
+Several main-actor types release their C resources on a background
+queue during `deinit`. The underlying `libvlc_*_release` calls can
+block for several milliseconds, and for seconds under load, so doing
+the work inline would stall SwiftUI transitions. Teardown runs
+asynchronously by design: the event manager is detached first, then
+stop and release execute on a utility queue.
+
+No waiting is required on the caller's side. From the outside, `deinit`
+simply returns.
+
+## Topics
+
+- ``Player``
+- ``Media``
+- ``VLCInstance``
+- ``PlayerEvent``
+- ``DialogHandler``
+- ``LogEntry``

--- a/Sources/SwiftVLC/SwiftVLC.docc/DiscoveryAndCasting.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/DiscoveryAndCasting.md
@@ -1,0 +1,87 @@
+# Discovery and casting
+
+Find media on the local network, and cast to Chromecast or AirPlay
+receivers.
+
+## Discovering media sources
+
+``MediaDiscoverer`` wraps a named libVLC service, such as UPnP, SMB,
+local directories, or podcasts. List the available services, then
+start one:
+
+```swift
+let services = MediaDiscoverer.availableServices(category: .lan)
+guard let upnp = services.first(where: { $0.name == "upnp" }) else { return }
+
+let discoverer = try MediaDiscoverer(name: upnp.name)
+try discoverer.start()
+
+try? await Task.sleep(for: .seconds(2))
+if let list = discoverer.mediaList {
+    for i in 0..<list.count {
+        print(list[i]?.mrl ?? "?")
+    }
+}
+```
+
+Categories:
+
+| ``DiscoveryCategory`` | What it finds |
+|---|---|
+| `.devices` | Physical devices (portable music players, disc drives) |
+| `.lan` | UPnP, SMB, SAP, Bonjour |
+| `.podcasts` | Podcast directories |
+| `.localDirectories` | System Music/Video/Pictures folders |
+
+## Casting to a renderer
+
+``RendererDiscoverer`` discovers Chromecast, AirPlay, and UPnP/DLNA
+renderers. It emits events through an `AsyncStream`, so apps can react
+as soon as a renderer appears or disappears:
+
+```swift
+let services = RendererDiscoverer.availableServices()
+guard let service = services.first else { return }
+
+let discoverer = try RendererDiscoverer(name: service.name)
+try discoverer.start()
+
+for await event in discoverer.events {
+    switch event {
+    case .itemAdded(let renderer):
+        print("Found", renderer.name, renderer.type)
+        try? player.setRenderer(renderer)
+    case .itemDeleted(let renderer):
+        print("Lost", renderer.name)
+    }
+}
+```
+
+Pass `nil` to ``Player/setRenderer(_:)`` to revert to local playback.
+
+## Inspecting a renderer
+
+``RendererItem`` exposes the device's display name, type, and
+capabilities:
+
+```swift
+if renderer.canVideo && renderer.type == "chromecast" {
+    // OK to cast video
+}
+```
+
+## Topics
+
+### Media discovery
+- ``MediaDiscoverer``
+- ``DiscoveryService``
+- ``DiscoveryCategory``
+
+### Renderer discovery
+- ``RendererDiscoverer``
+- ``RendererItem``
+- ``RendererEvent``
+- ``RendererService``
+
+### Controlling output
+- ``Player/setRenderer(_:)``

--- a/Sources/SwiftVLC/SwiftVLC.docc/DisplayingVideo.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/DisplayingVideo.md
@@ -1,0 +1,96 @@
+# Displaying video
+
+Render frames to a SwiftUI view, control aspect ratio, and understand
+when to choose ``VideoView`` vs ``PiPVideoView``.
+
+## The default: VideoView
+
+``VideoView`` is a `UIViewRepresentable` / `NSViewRepresentable` that
+hands libVLC a drawable surface. For most apps it's all you need:
+
+```swift
+VideoView(player)
+    .frame(maxWidth: .infinity)
+    .aspectRatio(16/9, contentMode: .fit)
+```
+
+A single player can back multiple views, but only one renders at a
+time. libVLC moves its native rendering subview onto whichever
+`VideoView` was most recently attached.
+
+## Aspect ratio
+
+Set ``Player/aspectRatio`` to shape the output:
+
+```swift
+player.aspectRatio = .default           // letterbox/pillarbox to fit
+player.aspectRatio = .ratio(16, 9)      // force 16:9
+player.aspectRatio = .fill              // cover the display; may crop
+```
+
+| Case | Behavior |
+|---|---|
+| ``AspectRatio/default`` | Preserve the source AR, fit into the smaller dimension |
+| ``AspectRatio/ratio(_:_:)`` | Force a specific AR |
+| ``AspectRatio/fill`` | Fit to the larger dimension (crop as needed) |
+
+## When to use PiPVideoView instead
+
+For Picture-in-Picture on iOS or macOS, use ``PiPVideoView`` in place
+of ``VideoView``. The two cannot share a player: PiP routes frames
+through vmem callbacks into an `AVSampleBufferDisplayLayer`, which is
+incompatible with the `set_nsobject` drawable that ``VideoView`` uses.
+
+See <doc:PictureInPicture> for the complete setup.
+
+## Taking a snapshot
+
+Write the current video frame to disk as PNG:
+
+```swift
+try player.takeSnapshot(
+    to: "/tmp/frame.png",
+    width: 1920,        // pass 0 to derive from aspect ratio
+    height: 0
+)
+```
+
+The file is always PNG regardless of the path extension.
+
+## Overlays
+
+Add text, an image, or color adjustments through scoped accessors on
+the player. They're `~Copyable` and `~Escapable`, so the compiler
+prevents you from storing a reference that outlives the player.
+
+```swift
+player.withMarquee { m in
+    m.isEnabled = true
+    m.setText("LIVE")
+    m.fontSize = 32
+}
+```
+
+See <doc:VideoOverlays> for marquee, logo, video adjustments, and
+360/VR viewpoint.
+
+## Topics
+
+### Views
+- ``VideoView``
+- ``PiPVideoView``
+
+### Aspect
+- ``AspectRatio``
+- ``Player/aspectRatio``
+
+### Snapshot
+- ``Player/takeSnapshot(to:width:height:)``
+
+### Overlays
+- ``Player/withMarquee(_:)``
+- ``Player/withLogo(_:)``
+- ``Player/withAdjustments(_:)``
+- ``Marquee``
+- ``Logo``
+- ``VideoAdjustments``

--- a/Sources/SwiftVLC/SwiftVLC.docc/GettingStarted.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/GettingStarted.md
@@ -1,0 +1,91 @@
+# Getting started
+
+This guide walks through adding SwiftVLC to a project, loading a
+media, and rendering it on screen.
+
+## Add the package
+
+The quickest path is through Xcode. Choose **File → Add Package
+Dependencies** and paste the repository URL; Xcode resolves the latest
+release automatically.
+
+```
+https://github.com/harflabs/SwiftVLC.git
+```
+
+To add it from a `Package.swift` manifest, pin to the current release.
+The version string lives on the
+[releases page](https://github.com/harflabs/SwiftVLC/releases).
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/harflabs/SwiftVLC.git", from: "x.y.z")
+],
+targets: [
+    .target(name: "MyApp", dependencies: ["SwiftVLC"])
+]
+```
+
+SwiftVLC requires Swift 6.3 and supports iOS 18, macOS 15, tvOS 18,
+and macCatalyst 18.
+
+## Play a URL
+
+```swift
+import SwiftUI
+import SwiftVLC
+
+struct PlayerView: View {
+    @State private var player = Player()
+
+    var body: some View {
+        VideoView(player)
+            .task {
+                try? player.play(url: URL(string: "https://example.com/stream.m3u8")!)
+            }
+    }
+}
+```
+
+``VideoView`` hosts the player's output, and ``Player`` publishes its
+state through `@Observable`, which is enough for SwiftUI to redraw as
+playback progresses.
+
+## Drive the UI from state
+
+Most controls read a handful of observable properties directly:
+
+```swift
+Text(player.state.description)
+ProgressView(value: player.position)
+Button(player.isPlaying ? "Pause" : "Play") {
+    player.isPlaying ? player.pause() : try? player.play()
+}
+```
+
+<doc:PlaybackEssentials> documents the full observable surface;
+<doc:DisplayingVideo> covers sizing and aspect ratios.
+
+## Handle errors as typed throws
+
+Every failable API throws ``VLCError`` specifically, so `catch`
+clauses can match individual cases:
+
+```swift
+do {
+    try player.play(url: url)
+} catch .mediaCreationFailed(let source) {
+    print("Bad URL: \(source)")
+} catch {
+    print("Playback error: \(error)")
+}
+```
+
+See <doc:HandlingErrors> for the full case list.
+
+## Next steps
+
+- <doc:PlaybackEssentials>: the shape of ``Player``.
+- <doc:WorkingWithMedia>: parsing metadata, tracks, and slaves.
+- <doc:DisplayingVideo>: aspect ratios and layer lifecycle.
+- <doc:PictureInPicture>: background playback and floating windows.

--- a/Sources/SwiftVLC/SwiftVLC.docc/HandlingErrors.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/HandlingErrors.md
@@ -1,0 +1,57 @@
+# Handling errors
+
+How ``VLCError`` shapes the error surface, and how typed throws let
+you match on its cases exhaustively.
+
+## One error type for the whole library
+
+Every failable SwiftVLC API uses Swift's typed throws form, with
+``VLCError`` as the only error it can produce:
+
+```swift
+public func play(url: URL) throws(VLCError)
+```
+
+The compiler therefore knows the complete set of cases a call site
+might see. Pattern matching can be exhaustive, with no residual
+`catch` branch needed:
+
+```swift
+do {
+    try player.play(url: url)
+} catch .mediaCreationFailed(let source) {
+    print("Couldn't build media for: \(source)")
+} catch .playbackFailed(let reason) {
+    print("Playback refused: \(reason)")
+} catch .invalidState(let message) {
+    print("Player wasn't ready: \(message)")
+} catch .operationFailed(let op) {
+    print("libVLC call failed: \(op)")
+}
+```
+
+## The cases at a glance
+
+| Case | Typically triggered by |
+|---|---|
+| ``VLCError/instanceCreationFailed`` | `libvlc.xcframework` not linked, missing plugins, OOM |
+| ``VLCError/mediaCreationFailed(source:)`` | Invalid URL, unreadable path, or bad file descriptor |
+| ``VLCError/playbackFailed(reason:)`` | libVLC refused to start playback; `reason` is its last error string |
+| ``VLCError/parseFailed(reason:)`` | ``Media/parse(timeout:instance:)`` ended with a non-success status |
+| ``VLCError/parseTimeout`` | ``Media/parse(timeout:instance:)`` hit the requested timeout |
+| ``VLCError/trackNotFound(id:)`` | No track matches the requested identifier |
+| ``VLCError/invalidState(_:)`` | Operation is valid but the player isn't in the right state |
+| ``VLCError/operationFailed(_:)`` | A libVLC call returned non-zero; the string names the attempted op |
+
+## When the failure mode doesn't matter
+
+When the control flow doesn't need to distinguish between failure
+causes, `try?` reduces the result to an optional:
+
+```swift
+try? player.play(url: url)
+```
+
+## Topics
+
+- ``VLCError``

--- a/Sources/SwiftVLC/SwiftVLC.docc/Logging.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/Logging.md
@@ -1,0 +1,63 @@
+# Logging
+
+Pipe libVLC's internal logs into your app through an `AsyncStream`,
+filtered by severity.
+
+## Subscribe to a stream
+
+Any ``VLCInstance`` exposes a ``VLCInstance/logStream(minimumLevel:)``.
+Start a task and iterate:
+
+```swift
+Task {
+    for await entry in VLCInstance.shared.logStream(minimumLevel: .warning) {
+        print("[\(entry.level)] \(entry.module ?? "vlc"): \(entry.message)")
+    }
+}
+```
+
+Each ``LogEntry`` carries a severity ``LogLevel``, the message text,
+and the libVLC module name (e.g. `avcodec`, `http`, `rtsp`) when the
+emitter provided one.
+
+## Multiple consumers
+
+Multiple tasks can subscribe at the same time, and each stream filters
+independently:
+
+```swift
+Task { for await e in instance.logStream(minimumLevel: .error) {
+    diagnostics.record(e)
+}}
+
+Task { for await e in instance.logStream(minimumLevel: .debug) {
+    devConsole.append(e)
+}}
+```
+
+The underlying libVLC callback is installed lazily on the first
+subscription and removed when the last consumer's stream terminates.
+
+## Severity levels
+
+``LogLevel`` conforms to `Comparable`, so filtering is a natural
+comparison:
+
+| Level | Typical use |
+|---|---|
+| ``LogLevel/debug`` | Verbose diagnostics for investigation |
+| ``LogLevel/notice`` | Normal informational messages |
+| ``LogLevel/warning`` | Potential problems that don't stop playback |
+| ``LogLevel/error`` | Failures that may affect playback |
+
+## Ending a stream
+
+An `AsyncStream` finishes automatically when the ``VLCInstance`` that
+owns it is released, or when the consuming task is cancelled. No
+explicit close is required.
+
+## Topics
+
+- ``VLCInstance/logStream(minimumLevel:)``
+- ``LogEntry``
+- ``LogLevel``

--- a/Sources/SwiftVLC/SwiftVLC.docc/MediaPlaylists.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/MediaPlaylists.md
@@ -1,0 +1,81 @@
+# Media playlists
+
+Chain multiple ``Media`` items with ``MediaList``, and advance through
+them automatically using ``MediaListPlayer``.
+
+## Building a list
+
+```swift
+let list = MediaList()
+try list.append(Media(url: url1))
+try list.append(Media(url: url2))
+try list.insert(Media(url: url3), at: 1)
+```
+
+``MediaList`` is `Sendable` and thread-safe. Every mutation acquires
+the underlying libVLC lock automatically.
+
+For batch reads that must see a consistent snapshot, hold the lock
+across the whole scope with ``MediaList/withLocked(_:)``:
+
+```swift
+let mrls = list.withLocked { view in
+    (0..<view.count).compactMap { view.media(at: $0)?.mrl }
+}
+```
+
+The view passed to the closure is `~Copyable` and `~Escapable`, so the
+compiler rejects any attempt to store or return it.
+
+## Playing the list
+
+Attach a ``MediaListPlayer`` to an existing ``Player``:
+
+```swift
+let listPlayer = MediaListPlayer()
+listPlayer.mediaPlayer = player
+listPlayer.mediaList = list
+listPlayer.playbackMode = .loop
+listPlayer.play()
+```
+
+Control is per-item:
+
+```swift
+try listPlayer.next()
+try listPlayer.previous()
+try listPlayer.play(at: 3)
+listPlayer.togglePause()
+listPlayer.stop()
+```
+
+## Playback modes
+
+| Mode | Behavior |
+|---|---|
+| ``PlaybackMode/default`` | Play through once, then stop |
+| ``PlaybackMode/loop`` | Repeat the whole list |
+| ``PlaybackMode/repeat`` | Repeat the current item |
+
+## Topics
+
+### Types
+- ``MediaList``
+- ``MediaListPlayer``
+- ``PlaybackMode``
+
+### Mutating the list
+- ``MediaList/append(_:)``
+- ``MediaList/insert(_:at:)``
+- ``MediaList/remove(at:)``
+
+### Scoped reads
+- ``MediaList/withLocked(_:)``
+- ``MediaList/LockedView``
+
+### Control
+- ``MediaListPlayer/play()``
+- ``MediaListPlayer/play(at:)``
+- ``MediaListPlayer/next()``
+- ``MediaListPlayer/previous()``
+- ``MediaListPlayer/stop()``

--- a/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
@@ -1,0 +1,97 @@
+# Picture-in-Picture
+
+Float a miniature player above other apps on iOS, or into the system
+PiP on macOS.
+
+## Using PiPVideoView
+
+``PiPVideoView`` replaces ``VideoView`` and configures AVKit's PiP
+controller on your behalf.
+
+```swift
+struct PlayerScreen: View {
+    @State private var player = Player()
+    @State private var pip: PiPController?
+
+    var body: some View {
+        VStack {
+            PiPVideoView(player, controller: $pip)
+                .aspectRatio(16/9, contentMode: .fit)
+
+            Button("Picture in Picture") { pip?.toggle() }
+                .disabled(pip?.isPossible != true)
+        }
+    }
+}
+```
+
+The `controller` binding is populated during view construction and
+stays in sync with the view's lifetime. It's `nil` on platforms that
+don't support sample-buffer PiP (e.g. tvOS).
+
+## Audio session (iOS only)
+
+PiP requires a playback-category audio session. ``PiPController``
+configures one automatically on `init`:
+
+```swift
+try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .moviePlayback)
+try? AVAudioSession.sharedInstance().setActive(true)
+```
+
+Your app must also declare background modes in its Info.plist:
+
+```xml
+<key>UIBackgroundModes</key>
+<array>
+    <string>audio</string>
+</array>
+```
+
+## Using PiPController directly
+
+Instantiate ``PiPController`` yourself when placing the video into a
+non-SwiftUI view hierarchy, or when your layout needs more control
+than ``PiPVideoView`` offers:
+
+```swift
+let controller = PiPController(player: player)
+container.layer.addSublayer(controller.layer)
+controller.start()
+```
+
+``PiPController/layer`` uses `videoGravity = .resizeAspect`. Size the
+parent view to the aspect ratio you want.
+
+## Common pitfalls
+
+- **Never mix rendering paths.** A player attached to ``PiPController``
+  cannot also back a ``VideoView``. Frames flow through vmem callbacks
+  into an `AVSampleBufferDisplayLayer`; libVLC's `set_nsobject`
+  drawable is disabled on the same player.
+- **Add the layer to a view before calling `player.play()`.** PiP
+  recognizes the sample-buffer layer as a valid content source only
+  once it's on screen.
+
+## Platform availability
+
+Picture-in-Picture is available on iOS and macOS. tvOS has no PiP API
+(its system player UI handles background playback instead), so
+``PiPController`` and ``PiPVideoView`` are not compiled on that
+platform.
+
+## Topics
+
+### Views and controllers
+- ``PiPVideoView``
+- ``PiPController``
+
+### State
+- ``PiPController/isPossible``
+- ``PiPController/isActive``
+- ``PiPController/layer``
+
+### Control
+- ``PiPController/start()``
+- ``PiPController/stop()``
+- ``PiPController/toggle()``

--- a/Sources/SwiftVLC/SwiftVLC.docc/PlaybackEssentials.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/PlaybackEssentials.md
@@ -1,0 +1,140 @@
+# Playback essentials
+
+The shape of ``Player``, the events it publishes, and the properties
+that SwiftUI binds to.
+
+## The central type
+
+``Player`` is `@Observable` and `@MainActor`. Each instance owns one
+`libvlc_media_player_t` and one stream of ``PlayerEvent`` values. The
+rest of the library's types exist to feed media to a player or to
+decorate its output.
+
+```swift
+@State private var player = Player()
+```
+
+Construction allocates the underlying libVLC resources. Release
+happens off the main actor in `deinit`, so tearing down a view never
+stalls the UI thread.
+
+## Observable state
+
+Read-only properties refresh whenever libVLC reports new state. SwiftUI
+binds to them directly, without a publisher or Combine adapter.
+
+| Property | Type | Meaning |
+|---|---|---|
+| ``Player/state`` | ``PlayerState`` | `.idle`, `.opening`, `.buffering(pct)`, `.playing`, `.paused`, `.stopped`, `.stopping`, `.error` |
+| ``Player/currentTime`` | `Duration` | Wall-clock position, millisecond resolution |
+| ``Player/duration`` | `Duration?` | `nil` until the container reports length |
+| ``Player/isSeekable`` | `Bool` | Whether seek operations take effect |
+| ``Player/isPausable`` | `Bool` | Whether pause/frame-step is available |
+| ``Player/currentMedia`` | ``Media``? | Last item loaded |
+| ``Player/audioTracks`` / ``Player/videoTracks`` / ``Player/subtitleTracks`` | `[Track]` | Track list, refreshed automatically |
+
+### Convenience
+
+- ``Player/isPlaying`` is `true` when `state == .playing`.
+- ``Player/isActive`` is `true` while the player is opening, buffering,
+  or playing.
+
+## Bindable state
+
+The following properties are read-write and mirror their values back
+to libVLC on set. Because they're observed, SwiftUI can bind controls
+to them directly:
+
+```swift
+Slider(value: $player.position)   // 0.0 ... 1.0
+Slider(value: $player.volume)     // 0.0 ... 1.25 (values above 1.0 amplify)
+```
+
+| Property | Range | Notes |
+|---|---|---|
+| ``Player/position`` | `0.0 ... 1.0` | Fractional playback position |
+| ``Player/volume`` | `0.0 ... 1.25` | `1.0` is 100%; above 1.0 amplifies |
+| ``Player/isMuted`` | — | Independent of volume |
+| ``Player/rate`` | any positive | `1.0` is normal; practical range `0.25 ... 4.0` |
+| ``Player/aspectRatio`` | ``AspectRatio`` | See <doc:DisplayingVideo> |
+| ``Player/audioDelay`` / ``Player/subtitleDelay`` | `Duration` | Positive values delay the channel |
+| ``Player/subtitleTextScale`` | `0.1 ... 5.0` | Clamped by libVLC |
+
+## Control
+
+```swift
+try player.play()              // start / resume from stopped
+player.pause()                 // pause current playback
+player.resume()                // unpause
+player.togglePlayPause()       // flip between pause/resume
+player.stop()                  // async stop
+player.seek(to: .seconds(30))  // absolute seek
+player.seek(by: .seconds(-10)) // relative seek
+player.nextFrame()             // pause + step one frame
+```
+
+Seeks are asynchronous. Observe ``Player/currentTime`` (or the
+``PlayerEvent/timeChanged(_:)`` event) to detect completion.
+
+## The raw event stream
+
+The observable properties are enough for typical playback UI. For
+logic that needs event-level granularity — recording transitions,
+snapshot completion, program changes, or custom bridging — iterate
+``Player/events`` directly:
+
+```swift
+for await event in player.events {
+    switch event {
+    case .recordingChanged(let isRecording, let path): ...
+    case .snapshotTaken(let path): ...
+    default: break
+    }
+}
+```
+
+Multiple consumers can subscribe at the same time. Each call to
+``Player/events`` returns an independent ``PlayerEvent`` stream.
+
+## Main actor and `sending`
+
+``Player`` is `@MainActor`; every method call must originate on the
+main actor. ``Media`` is `Sendable`, so constructing it on a
+background task and transferring ownership to the player is legal
+and race-free:
+
+```swift
+let media = try Media(url: url)       // any actor
+await MainActor.run {
+    try? player.play(media)           // main actor; ownership transfers
+}
+```
+
+See <doc:ConcurrencyModel> for the full isolation story.
+
+## Topics
+
+### Reading state
+- ``Player/state``
+- ``Player/currentTime``
+- ``Player/duration``
+- ``Player/isPlaying``
+- ``Player/isActive``
+- ``PlayerState``
+- ``PlayerEvent``
+
+### Controlling playback
+- ``Player/play(_:)``
+- ``Player/play(url:)``
+- ``Player/pause()``
+- ``Player/resume()``
+- ``Player/stop()``
+- ``Player/seek(to:)``
+- ``Player/seek(by:)``
+- ``Player/nextFrame()``
+
+### Bindable properties
+- ``Player/position``
+- ``Player/volume``
+- ``Player/isMuted``
+- ``Player/rate``

--- a/Sources/SwiftVLC/SwiftVLC.docc/SwiftVLC.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/SwiftVLC.md
@@ -1,0 +1,165 @@
+# ``SwiftVLC``
+
+A Swift 6 wrapper around libVLC 4.0 for SwiftUI apps.
+
+## Overview
+
+SwiftVLC binds directly to libVLC's C API, with no Objective-C
+intermediary. The resulting surface uses `@Observable` for player
+state, `AsyncStream` for events, and typed throws for errors, so
+playback integrates with SwiftUI the same way any other `@Observable`
+model does.
+
+- **Observable state.** ``Player`` is `@Observable` and `@MainActor`.
+  SwiftUI views track `state`, `currentTime`, `duration`, and the
+  track lists without manual bridging.
+- **Typed errors.** Every failable API uses `throws(VLCError)`, so
+  the compiler sees the full error surface and a general `catch` is
+  never needed.
+- **Structured events.** Playback, discovery, logging, and dialog
+  prompts all surface through `AsyncStream`. Multiple consumers can
+  subscribe concurrently.
+- **Ownership-aware overlays.** ``Marquee``, ``Logo``, and
+  ``VideoAdjustments`` are `~Copyable` `~Escapable` views scoped to
+  the player's lifetime, so the compiler rejects any code that would
+  store a dangling pointer.
+- **Tested against real libVLC.** A comprehensive Swift Testing suite
+  exercises the full C bridge with no mocks or fakes, and CI runs it
+  on every push.
+
+### First play
+
+```swift
+import SwiftUI
+import SwiftVLC
+
+struct ContentView: View {
+    @State private var player = Player()
+
+    var body: some View {
+        VideoView(player)
+            .task { try? player.play(url: videoURL) }
+    }
+}
+```
+
+### Where next
+
+If you're new to the library, read <doc:GettingStarted>. From there,
+<doc:PlaybackEssentials> covers the shape of ``Player`` and
+<doc:DisplayingVideo> covers the rendering side. The feature guides
+below walk through Picture-in-Picture, playlists, casting, and the
+audio and video overlay APIs.
+
+## Topics
+
+### Essentials
+
+- <doc:GettingStarted>
+- <doc:PlaybackEssentials>
+- <doc:WorkingWithMedia>
+- <doc:DisplayingVideo>
+
+### Feature guides
+
+- <doc:PictureInPicture>
+- <doc:MediaPlaylists>
+- <doc:AudioFeatures>
+- <doc:VideoOverlays>
+- <doc:DiscoveryAndCasting>
+
+### Reference guides
+
+- <doc:HandlingErrors>
+- <doc:ConcurrencyModel>
+- <doc:Logging>
+- <doc:ComparisonWithVLCKit>
+
+### Playback
+
+- ``Player``
+- ``PlayerState``
+- ``PlayerEvent``
+- ``PlayerRole``
+- ``VLCInstance``
+
+### Media
+
+- ``Media``
+- ``MediaType``
+- ``MediaSlave``
+- ``MediaSlaveType``
+- ``Metadata``
+- ``MetadataKey``
+- ``Track``
+- ``TrackType``
+- ``MediaStatistics``
+
+### Playlists
+
+- ``MediaList``
+- ``MediaListPlayer``
+- ``PlaybackMode``
+
+### Video display
+
+- ``VideoView``
+- ``AspectRatio``
+
+### Overlays and adjustments
+
+- ``Marquee``
+- ``Logo``
+- ``VideoAdjustments``
+- ``Viewpoint``
+
+### Audio
+
+- ``Equalizer``
+- ``AudioOutput``
+- ``AudioDevice``
+- ``StereoMode``
+- ``MixMode``
+
+### Picture-in-Picture
+
+- ``PiPVideoView``
+- ``PiPController``
+
+### Chapters, titles, and programs
+
+- ``Title``
+- ``Chapter``
+- ``NavigationAction``
+- ``ABLoopState``
+- ``Program``
+
+### Discovery and casting
+
+- ``MediaDiscoverer``
+- ``DiscoveryService``
+- ``DiscoveryCategory``
+- ``RendererDiscoverer``
+- ``RendererItem``
+- ``RendererEvent``
+- ``RendererService``
+
+### Dialog prompts
+
+- ``DialogHandler``
+- ``DialogEvent``
+- ``DialogID``
+- ``LoginRequest``
+- ``QuestionRequest``
+- ``QuestionType``
+- ``ProgressInfo``
+- ``ProgressUpdate``
+
+### Diagnostics
+
+- ``LogEntry``
+- ``LogLevel``
+
+### Errors
+
+- ``VLCError``

--- a/Sources/SwiftVLC/SwiftVLC.docc/VideoOverlays.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/VideoOverlays.md
@@ -1,0 +1,105 @@
+# Video overlays
+
+Text marquees, image logos, color adjustments, and 360/VR viewpoints.
+
+## Ownership-aware overlays
+
+``Marquee``, ``Logo``, and ``VideoAdjustments`` are `~Copyable` and
+`~Escapable`. They hold a pointer into the player and are scoped to the
+player's lifetime, which means the compiler rejects any attempt to
+store them in a property, return them from a function, or capture them
+in a `Task`.
+
+Use them either one-off through a property, or inside a `with*` scope
+for batched mutations:
+
+```swift
+player.marquee.isEnabled = true
+player.marquee.setText("LIVE")
+
+player.withLogo { logo in
+    logo.isEnabled = true
+    logo.setFile("/tmp/watermark.png")
+    logo.opacity = 200
+}
+```
+
+## Marquee (text overlay)
+
+``Marquee`` displays a text string on top of the video. It supports
+strftime-style placeholders refreshed at the interval configured by
+``Marquee/refresh``:
+
+```swift
+player.withMarquee { m in
+    m.isEnabled = true
+    m.setText("%H:%M:%S")
+    m.refresh = 1000          // refresh every second
+    m.fontSize = 24
+    m.color = 0xFFFFFF
+    m.position = 8 | 1        // bottom-left (8 = bottom, 1 = left)
+}
+```
+
+Position is a bitmask: combine `1` (left), `2` (right), `4` (top),
+`8` (bottom) with bitwise OR. `0` centers.
+
+## Logo (image overlay)
+
+``Logo`` layers a PNG (or a sequence of PNGs for animation) on top of
+the video:
+
+```swift
+player.withLogo { logo in
+    logo.isEnabled = true
+    logo.setFile("/tmp/logo.png")
+    logo.opacity = 200        // 0–255
+    logo.position = 4 | 2     // top-right
+}
+```
+
+For an animated sequence, pass `"file,delay,transparency;…"` to
+``Logo/setFile(_:)``.
+
+## Video adjustments
+
+Tweak contrast, brightness, hue, saturation, and gamma in real time:
+
+```swift
+player.withAdjustments { adj in
+    adj.isEnabled = true
+    adj.contrast = 1.1
+    adj.brightness = 1.05
+    adj.saturation = 1.2
+}
+```
+
+## 360 / VR viewpoint
+
+For equirectangular or cubemap content, animate the viewpoint with
+``Player/updateViewpoint(_:absolute:)``:
+
+```swift
+try player.updateViewpoint(
+    Viewpoint(yaw: 90, pitch: 0, fieldOfView: 80)
+)
+```
+
+Pass `absolute: false` to nudge the viewpoint relative to the current
+orientation, which is useful for gyroscope-driven look-around.
+
+## Topics
+
+### Overlays
+- ``Marquee``
+- ``Logo``
+- ``VideoAdjustments``
+
+### Scoped access
+- ``Player/withMarquee(_:)``
+- ``Player/withLogo(_:)``
+- ``Player/withAdjustments(_:)``
+
+### 360/VR
+- ``Viewpoint``
+- ``Player/updateViewpoint(_:absolute:)``

--- a/Sources/SwiftVLC/SwiftVLC.docc/WorkingWithMedia.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/WorkingWithMedia.md
@@ -1,0 +1,138 @@
+# Working with media
+
+Creating ``Media``, parsing metadata, enumerating tracks, and
+attaching external subtitle or audio files.
+
+## Creating media
+
+```swift
+// A URL works for both local files and network streams.
+let media = try Media(url: URL(string: "https://example.com/movie.mp4")!)
+
+// A filesystem path, for convenience.
+let media = try Media(path: "/Users/me/video.mkv")
+
+// An already-open file descriptor (libVLC does not close it).
+let media = try Media(fileDescriptor: fd)
+```
+
+``Media`` is `Sendable`, so it's safe to build on any task and hand to
+the player from the main actor.
+
+## Parsing metadata
+
+Parsing reads the container to discover duration, tracks, and
+``Metadata``. It runs asynchronously and honors cooperative
+cancellation: canceling the enclosing `Task` aborts the parse
+promptly.
+
+```swift
+let media = try Media(url: url)
+let metadata = try await media.parse(timeout: .seconds(10))
+
+print(metadata.title ?? "Unknown")
+print(metadata.duration ?? "—")
+print(metadata.artworkURL?.absoluteString ?? "no artwork")
+```
+
+Every libVLC metadata key is typed on ``Metadata``. Access less-common
+keys through the subscript:
+
+```swift
+let now = metadata[.nowPlaying]
+let encoded = metadata[.encodedBy]
+```
+
+## Tracks
+
+A media reports its tracks once parsing has completed, or once the
+player has loaded it:
+
+```swift
+let audio = media.tracks().filter { $0.type == .audio }
+audio.forEach { print($0.name, $0.language ?? "—", $0.channels ?? 0) }
+```
+
+The ``Player`` exposes the same lists as ``Player/audioTracks``,
+``Player/videoTracks``, and ``Player/subtitleTracks``, kept up to date
+as tracks appear mid-stream.
+
+## External subtitles and audio
+
+A "slave" is an extra track attached to a media, typically a sidecar
+`.srt` subtitle file or an alternate audio dub. Attach one before
+playback begins:
+
+```swift
+try media.addSlave(
+    from: URL(fileURLWithPath: "/path/to/sub.srt"),
+    type: .subtitle
+)
+```
+
+Or attach during playback through the player (and select it
+immediately):
+
+```swift
+try player.addExternalTrack(
+    from: URL(fileURLWithPath: "/path/to/alt-audio.m4a"),
+    type: .audio,
+    select: true
+)
+```
+
+## Options
+
+libVLC's playback is configured through colon-prefixed option strings:
+
+```swift
+media.addOption(":network-caching=1500")
+media.addOption(":start-time=30")
+```
+
+Options only affect media that has not yet started playing.
+
+## Statistics
+
+Real-time counters for input, demux, decoders, and output are available
+while a media is loaded:
+
+```swift
+if let stats = player.statistics {
+    print("Input bitrate: \(stats.inputBitrate) kbps")
+    print("Dropped frames: \(stats.lostPictures)")
+}
+```
+
+Values are snapshots at the moment of the call. Capture them on a
+timer to display rates over time.
+
+## Topics
+
+### Creating media
+- ``Media/init(url:)``
+- ``Media/init(path:)``
+- ``Media/init(fileDescriptor:)``
+
+### Parsing
+- ``Media/parse(timeout:instance:)``
+- ``Metadata``
+- ``MetadataKey``
+
+### Tracks
+- ``Media/tracks()``
+- ``Track``
+- ``TrackType``
+
+### Slaves
+- ``Media/addSlave(from:type:priority:)``
+- ``Media/slaves``
+- ``Media/clearSlaves()``
+- ``Player/addExternalTrack(from:type:select:)``
+- ``MediaSlave``
+- ``MediaSlaveType``
+
+### Options and statistics
+- ``Media/addOption(_:)``
+- ``MediaStatistics``
+- ``Player/statistics``

--- a/Sources/SwiftVLC/Video/AspectRatio.swift
+++ b/Sources/SwiftVLC/Video/AspectRatio.swift
@@ -4,13 +4,14 @@
 /// player.aspectRatio = .ratio(16, 9)
 /// ```
 public enum AspectRatio: Sendable, Hashable, CustomStringConvertible {
-  /// Original aspect ratio (default).
+  /// Preserve the source aspect ratio by fitting into the smaller dimension
+  /// of the display (may add letterbox/pillarbox bars).
   case `default`
 
-  /// Specific aspect ratio (e.g. `.ratio(16, 9)`).
+  /// Force a specific aspect ratio (e.g. `.ratio(16, 9)`).
   case ratio(Int, Int)
 
-  /// Fill the display area (may crop).
+  /// Fill the display by fitting to the larger dimension (may crop content).
   case fill
 
   public var description: String {

--- a/Sources/SwiftVLC/Video/Logo.swift
+++ b/Sources/SwiftVLC/Video/Logo.swift
@@ -68,7 +68,9 @@ public struct Logo: ~Copyable, ~Escapable {
     nonmutating set { libvlc_video_set_logo_int(pointer, UInt32(libvlc_logo_repeat.rawValue), Int32(newValue)) }
   }
 
-  /// Screen position preset (0 = center, 1 = left, 2 = right, 4 = top, 8 = bottom; combine with addition).
+  /// Screen position as a bitmask: `0` = center, `1` = left, `2` = right,
+  /// `4` = top, `8` = bottom. Combine horizontal and vertical flags with
+  /// bitwise OR — e.g. `4 | 1` for top-left.
   public var position: Int {
     get { Int(libvlc_video_get_logo_int(pointer, UInt32(libvlc_logo_position.rawValue))) }
     nonmutating set { libvlc_video_set_logo_int(pointer, UInt32(libvlc_logo_position.rawValue), Int32(newValue)) }

--- a/Sources/SwiftVLC/Video/Marquee.swift
+++ b/Sources/SwiftVLC/Video/Marquee.swift
@@ -80,7 +80,9 @@ public struct Marquee: ~Copyable, ~Escapable {
     nonmutating set { libvlc_video_set_marquee_int(pointer, UInt32(libvlc_marquee_Refresh.rawValue), Int32(newValue)) }
   }
 
-  /// Screen position preset (0 = center, 1 = left, 2 = right, 4 = top, 8 = bottom; combine with addition).
+  /// Screen position as a bitmask: `0` = center, `1` = left, `2` = right,
+  /// `4` = top, `8` = bottom. Combine horizontal and vertical flags with
+  /// bitwise OR — e.g. `4 | 1` for top-left.
   public var position: Int {
     get { Int(libvlc_video_get_marquee_int(pointer, UInt32(libvlc_marquee_Position.rawValue))) }
     nonmutating set { libvlc_video_set_marquee_int(pointer, UInt32(libvlc_marquee_Position.rawValue), Int32(newValue)) }

--- a/Sources/SwiftVLC/Video/Viewpoint.swift
+++ b/Sources/SwiftVLC/Video/Viewpoint.swift
@@ -1,20 +1,30 @@
 import CLibVLC
 
-/// 360/VR video viewpoint.
+/// Orientation and field of view for 360°/VR video.
+///
+/// Pass to ``Player/updateViewpoint(_:absolute:)`` to look around
+/// equirectangular or cubemap content. All angles are in degrees.
+///
+/// ```swift
+/// try player.updateViewpoint(Viewpoint(yaw: 90, pitch: 0))
+/// ```
 public struct Viewpoint: Sendable, Hashable {
-  /// Yaw in degrees (-180 to 180).
+  /// Horizontal look direction in degrees, where `0` faces forward.
+  /// Range: `-180` to `180`.
   public var yaw: Float
 
-  /// Pitch in degrees (-90 to 90).
+  /// Vertical look direction in degrees, where `0` is level.
+  /// Range: `-90` (straight down) to `90` (straight up).
   public var pitch: Float
 
-  /// Roll in degrees (-180 to 180).
+  /// Camera-roll rotation in degrees. Range: `-180` to `180`.
   public var roll: Float
 
-  /// Field of view in degrees (0 to 180, default 80).
+  /// Field of view in degrees. Range: `0` to `180`; default is `80`.
+  /// Smaller values zoom in, larger values zoom out.
   public var fieldOfView: Float
 
-  /// Creates a viewpoint with the given orientation.
+  /// Creates a viewpoint with the given orientation and field of view.
   public init(yaw: Float = 0, pitch: Float = 0, roll: Float = 0, fieldOfView: Float = 80) {
     self.yaw = yaw
     self.pitch = pitch

--- a/Tests/SwiftVLCTests/Audio/AudioChannelModeTests.swift
+++ b/Tests/SwiftVLCTests/Audio/AudioChannelModeTests.swift
@@ -2,7 +2,7 @@
 import CLibVLC
 import Testing
 
-@Suite(.tags(.logic))
+@Suite(.tags(.logic), .timeLimit(.minutes(1)))
 struct AudioChannelModeTests {
   @Test(
     arguments: [

--- a/Tests/SwiftVLCTests/Audio/AudioOutputTests.swift
+++ b/Tests/SwiftVLCTests/Audio/AudioOutputTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct AudioOutputTests {
   @Test
   func `AudioOutput id is name`() {

--- a/Tests/SwiftVLCTests/Audio/EqualizerExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Audio/EqualizerExtendedTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.integration, .mainActor))
+@Suite(.tags(.integration, .mainActor), .timeLimit(.minutes(1)))
 @MainActor
 struct EqualizerExtendedTests {
   // MARK: - Preset Initialization

--- a/Tests/SwiftVLCTests/Audio/EqualizerTests.swift
+++ b/Tests/SwiftVLCTests/Audio/EqualizerTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.integration, .mainActor))
+@Suite(.tags(.integration, .mainActor), .timeLimit(.minutes(1)))
 @MainActor
 struct EqualizerTests {
   @Test

--- a/Tests/SwiftVLCTests/Core/DialogHandlerExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Core/DialogHandlerExtendedTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct DialogHandlerExtendedTests {
   // MARK: - Helper
 

--- a/Tests/SwiftVLCTests/Core/DialogHandlerTests.swift
+++ b/Tests/SwiftVLCTests/Core/DialogHandlerTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct DialogHandlerTests {
   @Test
   func `Init creates dialogs stream`() throws {

--- a/Tests/SwiftVLCTests/Core/DurationExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Core/DurationExtendedTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.logic))
+@Suite(.tags(.logic), .timeLimit(.minutes(1)))
 struct DurationExtendedTests {
   @Test
   func `Negative duration formatting prefixed with minus`() {

--- a/Tests/SwiftVLCTests/Core/DurationExtensionsTests.swift
+++ b/Tests/SwiftVLCTests/Core/DurationExtensionsTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.logic))
+@Suite(.tags(.logic), .timeLimit(.minutes(1)))
 struct DurationExtensionsTests {
   @Test(
     arguments: [

--- a/Tests/SwiftVLCTests/Core/LoggingTests.swift
+++ b/Tests/SwiftVLCTests/Core/LoggingTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct LoggingTests {
   @Test(
     arguments: [

--- a/Tests/SwiftVLCTests/Core/VLCErrorTests.swift
+++ b/Tests/SwiftVLCTests/Core/VLCErrorTests.swift
@@ -2,7 +2,7 @@
 import Foundation
 import Testing
 
-@Suite(.tags(.logic))
+@Suite(.tags(.logic), .timeLimit(.minutes(1)))
 struct VLCErrorTests {
   @Test(
     arguments: [

--- a/Tests/SwiftVLCTests/Core/VLCInstanceTests.swift
+++ b/Tests/SwiftVLCTests/Core/VLCInstanceTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct VLCInstanceTests {
   @Test
   func `Shared instance returns the same object`() {

--- a/Tests/SwiftVLCTests/Discovery/DiscoveryExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Discovery/DiscoveryExtendedTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct DiscoveryExtendedTests {
   @Test
   func `MediaDiscoverer is Sendable`() {

--- a/Tests/SwiftVLCTests/Discovery/MediaDiscovererFinalTests.swift
+++ b/Tests/SwiftVLCTests/Discovery/MediaDiscovererFinalTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct MediaDiscovererFinalTests {
   // MARK: - Init with invalid name throws
 

--- a/Tests/SwiftVLCTests/Discovery/MediaDiscovererTests.swift
+++ b/Tests/SwiftVLCTests/Discovery/MediaDiscovererTests.swift
@@ -2,7 +2,7 @@
 import CLibVLC
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct MediaDiscovererTests {
   @Test(
     arguments: [

--- a/Tests/SwiftVLCTests/Discovery/RendererDiscovererExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Discovery/RendererDiscovererExtendedTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct RendererDiscovererExtendedTests {
   // MARK: - Events stream
 

--- a/Tests/SwiftVLCTests/Discovery/RendererDiscovererFinalTests.swift
+++ b/Tests/SwiftVLCTests/Discovery/RendererDiscovererFinalTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct RendererDiscovererFinalTests {
   @Test
   func `Init from availableServices creates discoverer`() throws {

--- a/Tests/SwiftVLCTests/Discovery/RendererDiscovererTests.swift
+++ b/Tests/SwiftVLCTests/Discovery/RendererDiscovererTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct RendererDiscovererTests {
   @Test
   func `Available services`() {

--- a/Tests/SwiftVLCTests/LifecycleStressTests.swift
+++ b/Tests/SwiftVLCTests/LifecycleStressTests.swift
@@ -1,0 +1,189 @@
+@testable import SwiftVLC
+import Synchronization
+import Testing
+
+/// Hammers the create/destroy lifecycle of every SwiftVLC type that
+/// offloads blocking libVLC teardown to `DispatchQueue.global`. Catches
+/// regressions in the async-deinit plumbing: use-after-free on the
+/// retained callback box, double-release, leaked `VLCInstance`
+/// references, or a deadlock if cleanup ordering drifts.
+///
+/// Serial (`--no-parallel` in CI). Each test asserts *on its own
+/// thread* that construction and destruction complete without
+/// crashing — the offloaded cleanup runs on the utility queue
+/// independently, so the test body deliberately doesn't wait for it.
+/// If the offload ever had a bug that the current thread could observe
+/// (e.g. use-after-free via a retained pointer), the loop body — not a
+/// post-loop sleep — is where it would surface.
+@Suite(
+  .tags(.integration, .mainActor, .async),
+  .timeLimit(.minutes(1)),
+  .serialized
+)
+@MainActor
+struct LifecycleStressTests {
+  // MARK: - Player
+
+  @Test
+  func `Rapid Player create destroy does not crash`() {
+    for _ in 0..<50 {
+      let player = Player(instance: TestInstance.shared)
+      _ = player.state
+    }
+  }
+
+  @Test
+  func `Player create with active stream then drop`() {
+    // Exercises the path where the event consumer Task is still live
+    // when deinit fires — Player.deinit cancels `eventTask`, then
+    // offloads bridge invalidation + C-object release.
+    for _ in 0..<30 {
+      let player = Player(instance: TestInstance.shared)
+      let stream = player.events
+      let task = Task.detached { @Sendable in
+        for await _ in stream {}
+      }
+      task.cancel()
+    }
+  }
+
+  @Test
+  func `Player deinit during active playback does not crash`() throws {
+    // Start and immediately drop — the deinit races against libVLC's
+    // demuxer + decoder spinning up. The offload means the blocking
+    // `libvlc_media_player_stop_async` / release runs on a background
+    // queue; nothing on the test thread should fault.
+    //
+    // Kept small (3 players) because each blocking teardown pins a
+    // utility-queue worker for up to a second.
+    for _ in 0..<3 {
+      let player = Player(instance: TestInstance.shared)
+      try player.play(Media(url: TestMedia.twosecURL))
+    }
+  }
+
+  // MARK: - DialogHandler
+
+  @Test
+  func `Rapid DialogHandler create destroy`() {
+    // DialogHandler.deinit offloads `libvlc_dialog_set_callbacks(nil,
+    // nil)` off the calling thread while strong-capturing the
+    // `VLCInstance`. 100 iterations stress the cleanup ordering:
+    // clear callbacks → finish stream → release retained box.
+    for _ in 0..<100 {
+      let handler = DialogHandler(instance: TestInstance.shared)
+      _ = handler.dialogs
+    }
+  }
+
+  /// Captures the stream, drops the handler, then asserts the stream
+  /// finishes deterministically via `continuation.finish()` in the
+  /// offloaded deinit. The enclosing `withTaskGroup` races the drain
+  /// against a 2-second ceiling; on success the drain wins and we
+  /// return immediately, on regression the ceiling wins and the
+  /// `#expect` fails with a clear message.
+  @Test
+  func `DialogHandler stream finishes after handler deinit`() async {
+    let stream: AsyncStream<DialogEvent>
+    do {
+      let handler = DialogHandler(instance: TestInstance.shared)
+      stream = handler.dialogs
+    } // handler dropped — offloaded deinit must eventually finish the stream
+
+    let drained = Mutex(false)
+    await withTaskGroup(of: Void.self) { group in
+      group.addTask { @Sendable in
+        for await _ in stream {}
+        drained.withLock { $0 = true }
+      }
+      group.addTask { @Sendable in
+        try? await Task.sleep(for: .seconds(2))
+      }
+      await group.next()
+      group.cancelAll()
+    }
+    #expect(drained.withLock { $0 }, "stream did not finish within 2s after DialogHandler deinit")
+  }
+
+  // MARK: - RendererDiscoverer
+
+  @Test
+  func `Rapid RendererDiscoverer create destroy`() throws {
+    // Each discoverer attaches two event callbacks and spins a
+    // discovery thread. The offloaded deinit must detach both, finish
+    // the continuation, release the box, and release the discoverer —
+    // in that order.
+    guard let service = RendererDiscoverer.availableServices(instance: TestInstance.shared).first else {
+      return // No services on this platform — the test is a no-op.
+    }
+    for _ in 0..<30 {
+      let d = try RendererDiscoverer(name: service.name, instance: TestInstance.shared)
+      _ = d.events
+    }
+  }
+
+  @Test
+  func `RendererDiscoverer started then dropped`() throws {
+    guard let service = RendererDiscoverer.availableServices(instance: TestInstance.shared).first else {
+      return
+    }
+    // Start discovery before dropping so deinit has to stop an actively
+    // running thread.
+    for _ in 0..<10 {
+      let d = try RendererDiscoverer(name: service.name, instance: TestInstance.shared)
+      try d.start()
+    }
+  }
+
+  // MARK: - MediaDiscoverer
+
+  @Test
+  func `Rapid MediaDiscoverer create destroy`() throws {
+    guard let service = MediaDiscoverer.availableServices(category: .lan, instance: TestInstance.shared).first else {
+      return
+    }
+    for _ in 0..<30 {
+      _ = try MediaDiscoverer(name: service.name, instance: TestInstance.shared)
+    }
+  }
+
+  // MARK: - Mixed
+
+  @Test
+  func `Mixed lifecycle across types`() {
+    // All offload paths churning together — exercises the shared
+    // utility queue with concurrent cleanup work.
+    for _ in 0..<30 {
+      let p = Player(instance: TestInstance.shared)
+      _ = p.events
+      let h = DialogHandler(instance: TestInstance.shared)
+      _ = h.dialogs
+    }
+  }
+
+  // MARK: - Media / MediaList
+
+  @Test
+  func `Rapid Media create and drop`() throws {
+    // Media's deinit is a synchronous `libvlc_media_release` — no
+    // offload needed. Test still guards against a regression if we
+    // ever change that.
+    for _ in 0..<200 {
+      _ = try Media(url: TestMedia.testMP4URL)
+    }
+  }
+
+  @Test
+  func `Rapid MediaList mutate`() throws {
+    let list = MediaList()
+    for _ in 0..<100 {
+      let media = try Media(url: TestMedia.testMP4URL)
+      try list.append(media)
+    }
+    #expect(list.count == 100)
+    for _ in 0..<50 {
+      try list.remove(at: 0)
+    }
+    #expect(list.count == 50)
+  }
+}

--- a/Tests/SwiftVLCTests/Media/MediaTests.swift
+++ b/Tests/SwiftVLCTests/Media/MediaTests.swift
@@ -2,7 +2,7 @@
 import Foundation
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct MediaTests {
   @Test
   func `Init from URL`() throws {

--- a/Tests/SwiftVLCTests/Media/MetadataExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Media/MetadataExtendedTests.swift
@@ -2,7 +2,7 @@
 import CLibVLC
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct MetadataExtendedTests {
   // MARK: - All 26 MetadataKey cases are iterable via CaseIterable
 

--- a/Tests/SwiftVLCTests/Media/MetadataFinalTests.swift
+++ b/Tests/SwiftVLCTests/Media/MetadataFinalTests.swift
@@ -3,7 +3,7 @@
 import Foundation
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct MetadataFinalTests {
   // MARK: - trackNumber is Int for test.mp4
 

--- a/Tests/SwiftVLCTests/Media/MetadataTests.swift
+++ b/Tests/SwiftVLCTests/Media/MetadataTests.swift
@@ -3,7 +3,7 @@
 import Foundation
 import Testing
 
-@Suite(.tags(.integration, .media))
+@Suite(.tags(.integration, .media), .timeLimit(.minutes(1)))
 struct MetadataTests {
   @Test(.tags(.async))
   func `Parsed title from test MP4`() async throws {

--- a/Tests/SwiftVLCTests/Media/ThumbnailRequestTests.swift
+++ b/Tests/SwiftVLCTests/Media/ThumbnailRequestTests.swift
@@ -4,7 +4,8 @@ import Testing
 
 @Suite(
   .tags(.integration, .media, .async),
-  .enabled(if: TestCondition.canPlayMedia, "Requires video output (skipped on CI)")
+  .enabled(if: TestCondition.canPlayMedia, "Requires video output (skipped on CI)"),
+  .timeLimit(.minutes(1))
 )
 struct ThumbnailRequestTests {
   @Test

--- a/Tests/SwiftVLCTests/Media/TrackExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Media/TrackExtendedTests.swift
@@ -2,7 +2,7 @@
 import CLibVLC
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct TrackExtendedTests {
   // MARK: - TrackType cValue round-trip
 

--- a/Tests/SwiftVLCTests/Media/TrackFinalTests.swift
+++ b/Tests/SwiftVLCTests/Media/TrackFinalTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct TrackFinalTests {
   // MARK: - Audio track codec from parsed media
 

--- a/Tests/SwiftVLCTests/Media/TrackTests.swift
+++ b/Tests/SwiftVLCTests/Media/TrackTests.swift
@@ -2,7 +2,7 @@
 import CLibVLC
 import Testing
 
-@Suite(.tags(.logic))
+@Suite(.tags(.logic), .timeLimit(.minutes(1)))
 struct TrackTests {
   @Test(
     arguments: [

--- a/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
@@ -3,7 +3,7 @@
 import AVFoundation
 import Testing
 
-@Suite(.tags(.integration, .mainActor))
+@Suite(.tags(.integration, .mainActor), .timeLimit(.minutes(1)))
 @MainActor
 struct PiPControllerTests {
   @Test

--- a/Tests/SwiftVLCTests/PiP/PixelBufferRendererCallbackTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferRendererCallbackTests.swift
@@ -1,0 +1,204 @@
+#if os(iOS) || os(macOS)
+@testable import SwiftVLC
+import AVFoundation
+import CoreMedia
+import CoreVideo
+import Synchronization
+import Testing
+
+/// Exercises the vmem C callbacks directly with mocked inputs. Without a
+/// live decoder we can't trigger them via the normal play path, but the
+/// callbacks are plain free functions so we can invoke them with
+/// hand-built parameters and verify the state transitions.
+///
+/// Covers format → lock → unlock → display → cleanup — the core pipeline
+/// that moves decoded frames from libVLC into an
+/// `AVSampleBufferDisplayLayer`.
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
+struct PixelBufferRendererCallbackTests {
+  /// Build the 4-tuple of buffers libVLC hands to the format callback.
+  private struct FormatBuffers {
+    var chroma: [CChar] = Array(repeating: 0, count: 4)
+    var width: UInt32 = 320
+    var height: UInt32 = 240
+    var pitches: UInt32 = 0
+    var lines: UInt32 = 0
+  }
+
+  // MARK: - Format callback
+
+  @Test
+  func `Format callback creates pool and updates state`() {
+    let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+    let retained = Unmanaged.passRetained(renderer)
+    defer { retained.release() }
+
+    var opaqueSlot: UnsafeMutableRawPointer? = retained.toOpaque()
+    var buffers = FormatBuffers()
+
+    let result = withUnsafeMutablePointer(to: &opaqueSlot) { opaquePtr in
+      buffers.chroma.withUnsafeMutableBufferPointer { chromaBuf in
+        withUnsafeMutablePointer(to: &buffers.width) { widthPtr in
+          withUnsafeMutablePointer(to: &buffers.height) { heightPtr in
+            withUnsafeMutablePointer(to: &buffers.pitches) { pitchPtr in
+              withUnsafeMutablePointer(to: &buffers.lines) { linesPtr in
+                pixelBufferFormatCallback(
+                  opaque: opaquePtr,
+                  chroma: chromaBuf.baseAddress,
+                  width: widthPtr,
+                  height: heightPtr,
+                  pitches: pitchPtr,
+                  lines: linesPtr
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+
+    #expect(result == 1) // single BGRA plane
+
+    // Chroma should be forced to BGRA.
+    let chromaString = String(
+      bytes: buffers.chroma.map { UInt8(bitPattern: $0) },
+      encoding: .ascii
+    )
+    #expect(chromaString == "BGRA")
+
+    // Pool + dimensions should now be set in state.
+    let state = renderer.state.withLock { $0 }
+    #expect(state.pool != nil)
+    #expect(state.width == 320)
+    #expect(state.height == 240)
+
+    // Pitch must match actual CVPixelBufferGetBytesPerRow, not the
+    // nominal width * 4 — libVLC relies on this exact alignment.
+    #expect(buffers.pitches >= 320 * 4)
+    #expect(buffers.lines == 240)
+
+    // Cleanup callback should release the pool.
+    pixelBufferCleanupCallback(opaque: retained.toOpaque())
+    let cleared = renderer.state.withLock { $0.pool }
+    #expect(cleared == nil)
+  }
+
+  @Test
+  func `Format callback with nil opaque returns 0`() {
+    var chroma: [CChar] = Array(repeating: 0, count: 4)
+    var width: UInt32 = 0
+    var height: UInt32 = 0
+    var pitches: UInt32 = 0
+    var lines: UInt32 = 0
+
+    let result = chroma.withUnsafeMutableBufferPointer { chromaBuf in
+      withUnsafeMutablePointer(to: &width) { w in
+        withUnsafeMutablePointer(to: &height) { h in
+          withUnsafeMutablePointer(to: &pitches) { p in
+            withUnsafeMutablePointer(to: &lines) { l in
+              pixelBufferFormatCallback(
+                opaque: nil, // ← guard hit
+                chroma: chromaBuf.baseAddress,
+                width: w,
+                height: h,
+                pitches: p,
+                lines: l
+              )
+            }
+          }
+        }
+      }
+    }
+    #expect(result == 0)
+  }
+
+  // MARK: - Lock / unlock callback
+
+  @Test
+  func `Lock callback returns nil before pool is initialized`() {
+    let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+    let retained = Unmanaged.passRetained(renderer)
+    defer { retained.release() }
+
+    var plane: UnsafeMutableRawPointer?
+    let result = withUnsafeMutablePointer(to: &plane) { planePtr in
+      pixelBufferLockCallback(opaque: retained.toOpaque(), planes: planePtr)
+    }
+    // No pool yet → lock returns nil.
+    #expect(result == nil)
+  }
+
+  @Test
+  func `Lock callback with nil opaque returns nil`() {
+    var plane: UnsafeMutableRawPointer?
+    let result = withUnsafeMutablePointer(to: &plane) {
+      pixelBufferLockCallback(opaque: nil, planes: $0)
+    }
+    #expect(result == nil)
+  }
+
+  @Test
+  func `Lock then unlock round trip after format`() {
+    let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+    let retained = Unmanaged.passRetained(renderer)
+    defer { retained.release() }
+
+    // Prime the pool via format callback.
+    var opaqueSlot: UnsafeMutableRawPointer? = retained.toOpaque()
+    var buffers = FormatBuffers()
+    _ = withUnsafeMutablePointer(to: &opaqueSlot) { opaquePtr in
+      buffers.chroma.withUnsafeMutableBufferPointer { chromaBuf in
+        withUnsafeMutablePointer(to: &buffers.width) { w in
+          withUnsafeMutablePointer(to: &buffers.height) { h in
+            withUnsafeMutablePointer(to: &buffers.pitches) { p in
+              withUnsafeMutablePointer(to: &buffers.lines) { l in
+                pixelBufferFormatCallback(
+                  opaque: opaquePtr,
+                  chroma: chromaBuf.baseAddress,
+                  width: w,
+                  height: h,
+                  pitches: p,
+                  lines: l
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Lock → get a pixel buffer handle, base address written into plane.
+    var plane: UnsafeMutableRawPointer?
+    let handle = withUnsafeMutablePointer(to: &plane) { planePtr in
+      pixelBufferLockCallback(opaque: retained.toOpaque(), planes: planePtr)
+    }
+    let pictureHandle = try? #require(handle)
+    #expect(plane != nil)
+
+    // Unlock must succeed regardless of opaque (it doesn't dereference it).
+    pixelBufferUnlockCallback(opaque: retained.toOpaque(), picture: pictureHandle, planes: nil)
+
+    // Balance the retain `pixelBufferLockCallback` performed internally.
+    if let h = pictureHandle {
+      Unmanaged<AnyObject>.fromOpaque(h).release()
+    }
+
+    // Clean up the pool.
+    pixelBufferCleanupCallback(opaque: retained.toOpaque())
+  }
+
+  @Test
+  func `Unlock callback with nil picture is a no-op`() {
+    // Purely a liveness test — the function must defensively accept
+    // nil (which happens after a failed lock).
+    pixelBufferUnlockCallback(opaque: nil, picture: nil, planes: nil)
+  }
+
+  // MARK: - Cleanup callback
+
+  @Test
+  func `Cleanup callback with nil opaque is a no-op`() {
+    pixelBufferCleanupCallback(opaque: nil)
+  }
+}
+#endif

--- a/Tests/SwiftVLCTests/PiP/PixelBufferRendererTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferRendererTests.swift
@@ -5,7 +5,7 @@ import CoreMedia
 import Synchronization
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct PixelBufferRendererTests {
   @Test
   func `Can be created with an AVSampleBufferDisplayLayer`() {
@@ -51,7 +51,7 @@ struct PixelBufferRendererTests {
 
 // MARK: - Extended Tests
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct PixelBufferRendererExtendedTests {
   @Test
   func `State pool is initially nil`() {

--- a/Tests/SwiftVLCTests/Player/ABLoopTests.swift
+++ b/Tests/SwiftVLCTests/Player/ABLoopTests.swift
@@ -2,7 +2,7 @@
 import CLibVLC
 import Testing
 
-@Suite(.tags(.logic))
+@Suite(.tags(.logic), .timeLimit(.minutes(1)))
 struct ABLoopTests {
   @Test(
     arguments: [

--- a/Tests/SwiftVLCTests/Player/ChapterTitleTests.swift
+++ b/Tests/SwiftVLCTests/Player/ChapterTitleTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.logic))
+@Suite(.tags(.logic), .timeLimit(.minutes(1)))
 struct ChapterTitleTests {
   @Test
   func `Title id returns index`() {

--- a/Tests/SwiftVLCTests/Player/EventBridgeConcurrencyTests.swift
+++ b/Tests/SwiftVLCTests/Player/EventBridgeConcurrencyTests.swift
@@ -1,0 +1,230 @@
+@testable import SwiftVLC
+import Synchronization
+import Testing
+
+/// Concurrency hardening for the event-bridge broadcaster. Regression
+/// guards for the single-`Mutex<State>` `ContinuationStore`: heavy
+/// concurrent `add`/`remove`, guaranteed delivery under churn, and the
+/// AB-BA deadlock that would appear if `broadcast` yielded while
+/// holding the lock.
+///
+/// Each test creates its own VLC instance via
+/// `TestInstance.makeAudioOnly()` so libVLC's per-instance state can't
+/// bleed between tests. Serial (`--no-parallel` in CI) keeps MainActor
+/// contention out of the picture.
+@Suite(
+  .tags(.integration, .mainActor, .async),
+  .timeLimit(.minutes(1)),
+  .serialized
+)
+@MainActor
+struct EventBridgeConcurrencyTests {
+  // MARK: - Heavy fan-out
+
+  /// Registers many concurrent consumers, drives playback, and verifies
+  /// every consumer receives at least one event. Indirectly exercises
+  /// the broadcaster's snapshot-under-lock pattern — if the Mutex were
+  /// held during yield and a consumer cancelled mid-broadcast, we'd
+  /// deadlock.
+  @Test
+  func `Hundred concurrent consumers all receive events`() async throws {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    let consumerCount = 100
+    let counts = Mutex<[Int]>(Array(repeating: 0, count: consumerCount))
+
+    // Subscribe all consumers BEFORE starting playback so no consumer
+    // misses the early events.
+    var tasks: [Task<Void, Never>] = []
+    for i in 0..<consumerCount {
+      let stream = player.events
+      tasks.append(Task.detached { @Sendable in
+        for await _ in stream {
+          counts.withLock { $0[i] += 1 }
+          return
+        }
+      })
+    }
+
+    try player.play(Media(url: TestMedia.twosecURL))
+
+    // Race a short-interval poll on the count array against a 5-second
+    // ceiling. First to finish ends the wait. No event subscription is
+    // needed — the child consumer tasks are the true event observers;
+    // here we just wait for all of them to tick their slot.
+    let converged = await withTaskGroup(of: Bool.self) { group in
+      group.addTask { @Sendable in
+        while !Task.isCancelled {
+          if counts.withLock({ $0.allSatisfy { $0 >= 1 } }) { return true }
+          try? await Task.sleep(for: .milliseconds(5))
+        }
+        return false
+      }
+      group.addTask { @Sendable in
+        try? await Task.sleep(for: .seconds(5))
+        return false
+      }
+      let first = await group.next() ?? false
+      group.cancelAll()
+      return first
+    }
+
+    player.stop()
+    for task in tasks {
+      task.cancel()
+    }
+
+    let received = counts.withLock { $0.count(where: { $0 >= 1 }) }
+    #expect(
+      converged && received == consumerCount,
+      "only \(received)/\(consumerCount) consumers received events"
+    )
+  }
+
+  // MARK: - Churn during active broadcast
+
+  /// Creates and cancels streams continuously while playback generates
+  /// real events. Regression guard for use-after-free in `onTermination →
+  /// remove` and for Mutex deadlocks between `broadcast` and `remove`.
+  @Test
+  func `Subscribe unsubscribe churn during playback`() async throws {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+
+    // Subscribe a pre-playback watcher so we don't race the `.playing`
+    // event with the subsequent churn.
+    let playing = subscribeAndAwait(.playing, on: player)
+    try player.play(Media(url: TestMedia.twosecURL))
+    try #require(await playing.value)
+
+    // 200 rounds of subscribe + immediate cancel. A use-after-free
+    // in `onTermination → remove` or a lock inversion between
+    // `broadcast` and `remove` would surface here as a crash or
+    // hang (caught by the suite's `.timeLimit`).
+    for _ in 0..<200 {
+      let stream = player.events
+      let t = Task.detached { @Sendable in
+        for await _ in stream {
+          break
+        }
+      }
+      t.cancel()
+    }
+
+    // Reaching here means 200 subscribe/unsubscribe cycles completed
+    // without crashing or hanging. That's the actual regression guard.
+    player.stop()
+  }
+
+  // MARK: - Cancellation mid-broadcast (AB-BA regression)
+
+  /// Starts consumers, then cancels them in bulk. If the AB-BA guard
+  /// in `ContinuationStore.broadcast` ever regresses (i.e. someone
+  /// moves `yield()` back inside `withLock`), one of the onTermination
+  /// callbacks would deadlock against a live broadcast and this test
+  /// would never complete — the suite `.timeLimit(.minutes(1))` would
+  /// fire, not a polling-based fallback.
+  @Test
+  func `Cancelling during broadcast does not deadlock`() async throws {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+
+    // Subscribe the `.playing` watcher BEFORE we create the 32 busy
+    // consumers and BEFORE `play()` — otherwise the watcher's
+    // subscription can race past the state-change event we're waiting
+    // for and we'd sit on the 5s ceiling for no reason.
+    let playing = subscribeAndAwait(.playing, on: player)
+
+    var tasks: [Task<Void, Never>] = []
+    for _ in 0..<32 {
+      let stream = player.events
+      tasks.append(Task.detached { @Sendable in
+        for await _ in stream {
+          // Heavy body widens the race window between yield and cancel.
+          for _ in 0..<50 {
+            _ = (0..<10).reduce(0, +)
+          }
+        }
+      })
+    }
+
+    try player.play(Media(url: TestMedia.twosecURL))
+    try #require(await playing.value, "player did not reach .playing within 5s")
+
+    // All 32 consumers are inside `for await`. Cancel them together —
+    // each cancellation calls back into the ContinuationStore to remove
+    // itself while broadcasts may be in flight.
+    for t in tasks {
+      t.cancel()
+    }
+    player.stop()
+  }
+
+  // MARK: - Lifetime — stream outlives player
+
+  /// The stream's retained `ContinuationStore` box must keep the bridge
+  /// alive until consumers drain. After the player is gone, a paused
+  /// consumer must still receive the terminal `finish()` and exit
+  /// cleanly — if it doesn't, this test's `.timeLimit` fires.
+  @Test
+  func `Stream finishes cleanly when player deinits`() async {
+    let stream: AsyncStream<PlayerEvent>
+    do {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      stream = player.events
+    } // player goes out of scope
+
+    // Drain the stream — this must return, not hang. `Player.deinit`
+    // offloads bridge invalidation to a background queue, which calls
+    // `continuation.finish()` so the for-await loop exits.
+    await withTaskGroup(of: Void.self) { group in
+      group.addTask {
+        for await _ in stream {}
+      }
+      group.addTask {
+        try? await Task.sleep(for: .seconds(2))
+      }
+      // First task to finish ends the wait (usually the stream drain).
+      await group.next()
+      group.cancelAll()
+    }
+  }
+
+  // MARK: - Multi-player isolation
+
+  /// Each `Player` owns its own `EventBridge`. Events on player A must
+  /// never reach player B's consumers.
+  @Test
+  func `Events from one player do not reach another`() async throws {
+    let a = Player(instance: TestInstance.makeAudioOnly())
+    let b = Player(instance: TestInstance.makeAudioOnly())
+
+    let bReceivedActivity = Mutex(false)
+    let bStream = b.events
+    let consumer = Task.detached { @Sendable in
+      for await event in bStream {
+        if
+          case .stateChanged(let s) = event,
+          s != .idle, s != .stopped, s != .stopping {
+          bReceivedActivity.withLock { $0 = true }
+          return
+        }
+      }
+    }
+
+    // Subscribe for A's `.playing` BEFORE starting — otherwise the
+    // subscription can race past the event.
+    let aPlaying = subscribeAndAwait(.playing, on: a)
+    try a.play(Media(url: TestMedia.twosecURL))
+    try #require(await aPlaying.value)
+
+    // Give player B's consumer a bounded window to incorrectly observe
+    // activity. If cross-contamination exists, the dedicated consumer
+    // above sets `bReceivedActivity`.
+    try await Task.sleep(for: .milliseconds(200))
+
+    #expect(
+      !bReceivedActivity.withLock { $0 },
+      "player B received activity while only player A was driven"
+    )
+    a.stop()
+    consumer.cancel()
+  }
+}

--- a/Tests/SwiftVLCTests/Player/NavigationActionTests.swift
+++ b/Tests/SwiftVLCTests/Player/NavigationActionTests.swift
@@ -2,7 +2,7 @@
 import CLibVLC
 import Testing
 
-@Suite(.tags(.logic))
+@Suite(.tags(.logic), .timeLimit(.minutes(1)))
 struct NavigationActionTests {
   @Test(
     arguments: [

--- a/Tests/SwiftVLCTests/Player/ObservationTests.swift
+++ b/Tests/SwiftVLCTests/Player/ObservationTests.swift
@@ -1,0 +1,182 @@
+@testable import SwiftVLC
+import Observation
+import Synchronization
+import Testing
+
+/// Verifies the library drives SwiftUI through the Observation framework
+/// correctly for both stored and computed `@Observable` properties.
+///
+/// Computed properties like `volume`, `isMuted`, `currentChapter`, and
+/// `currentTitle` read fresh values from libVLC in their getters. Their
+/// `access(keyPath:)` call alone does not cause SwiftUI to re-render
+/// when the underlying C state changes; the setter (and the event
+/// consumer, for VLC-initiated changes) must call
+/// `withMutation(keyPath:)`.
+///
+/// Observation's `willSet` / `didSet` run synchronously, so we don't
+/// need to poll or sleep — the `onChange` closure has either fired or
+/// conclusively not by the time the setter returns.
+@Suite(
+  .tags(.integration, .mainActor, .async),
+  .timeLimit(.minutes(1)),
+  .serialized
+)
+@MainActor
+struct ObservationTests {
+  // MARK: - Setter path
+
+  // Setter → withMutation → didSet → onChange, all synchronous.
+
+  @Test
+  func `Volume setter invalidates volume observation`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    let fired = Mutex(false)
+    withObservationTracking {
+      _ = player.volume
+    } onChange: {
+      fired.withLock { $0 = true }
+    }
+    player.volume = 0.5
+    #expect(fired.withLock { $0 })
+  }
+
+  @Test
+  func `isMuted setter invalidates isMuted observation`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    let fired = Mutex(false)
+    withObservationTracking {
+      _ = player.isMuted
+    } onChange: {
+      fired.withLock { $0 = true }
+    }
+    player.isMuted = true
+    #expect(fired.withLock { $0 })
+  }
+
+  @Test
+  func `rate setter invalidates rate observation`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    let fired = Mutex(false)
+    withObservationTracking {
+      _ = player.rate
+    } onChange: {
+      fired.withLock { $0 = true }
+    }
+    player.rate = 1.25
+    #expect(fired.withLock { $0 })
+  }
+
+  @Test
+  func `audioDelay setter invalidates observation`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    let fired = Mutex(false)
+    withObservationTracking {
+      _ = player.audioDelay
+    } onChange: {
+      fired.withLock { $0 = true }
+    }
+    player.audioDelay = .milliseconds(100)
+    #expect(fired.withLock { $0 })
+  }
+
+  @Test
+  func `subtitleTextScale setter invalidates observation`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    let fired = Mutex(false)
+    withObservationTracking {
+      _ = player.subtitleTextScale
+    } onChange: {
+      fired.withLock { $0 = true }
+    }
+    player.subtitleTextScale = 1.5
+    #expect(fired.withLock { $0 })
+  }
+
+  @Test
+  func `role setter invalidates observation`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    let fired = Mutex(false)
+    withObservationTracking {
+      _ = player.role
+    } onChange: {
+      fired.withLock { $0 = true }
+    }
+    player.role = .music
+    #expect(fired.withLock { $0 })
+  }
+
+  // MARK: - Stored properties (regression guards for macro wiring)
+
+  /// `.state` is stored, so the macro wires observation up automatically
+  /// via the generated setter. Use a real playback event (the first
+  /// `.stateChanged` VLC emits) to cause the mutation, and wait on the
+  /// event stream directly rather than polling for the `onChange` flag.
+  @Test
+  func `state mutation fires observation`() async throws {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    let fired = Mutex(false)
+    withObservationTracking {
+      _ = player.state
+    } onChange: {
+      fired.withLock { $0 = true }
+    }
+    // Subscribe the `.playing` watcher BEFORE `play()` so the stream
+    // can't miss the state-change event.
+    let playing = subscribeAndAwait(.playing, on: player)
+    try player.play(Media(url: TestMedia.twosecURL))
+    try #require(await playing.value)
+    // `onChange` fires from the event consumer's `withMutation`, which
+    // runs on MainActor just like this test. By the time `playing.value`
+    // resolves, the consumer has processed the event.
+    #expect(fired.withLock { $0 })
+    player.stop()
+  }
+
+  // MARK: - Keypath isolation (guards against over-eager withMutation)
+
+  /// Setting `volume` must NOT invalidate `isMuted` observers. Regression
+  /// guard: if anyone ever changes `handleEvent` to fire
+  /// `withMutation(keyPath: \.isMuted)` on `.volumeChanged`, SwiftUI
+  /// would pointlessly re-render mute-dependent views on every volume
+  /// change.
+  @Test
+  func `Volume change does not invalidate isMuted`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    let muteFired = Mutex(false)
+    withObservationTracking {
+      _ = player.isMuted
+    } onChange: {
+      muteFired.withLock { $0 = true }
+    }
+    player.volume = 0.3
+    #expect(!muteFired.withLock { $0 }, "isMuted observer fired for a volume-only mutation")
+  }
+
+  /// Setting `isMuted` must NOT invalidate `volume` observers.
+  @Test
+  func `Mute change does not invalidate volume`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    let volumeFired = Mutex(false)
+    withObservationTracking {
+      _ = player.volume
+    } onChange: {
+      volumeFired.withLock { $0 = true }
+    }
+    player.isMuted = true
+    #expect(!volumeFired.withLock { $0 }, "volume observer fired for a mute-only mutation")
+  }
+
+  /// A fresh `Player`'s `currentChapter` observation must not fire
+  /// spuriously before any mutation is applied.
+  @Test
+  func `currentChapter observer does not fire spuriously on idle`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    let chapterFired = Mutex(false)
+    withObservationTracking {
+      _ = player.currentChapter
+    } onChange: {
+      chapterFired.withLock { $0 = true }
+    }
+    #expect(!chapterFired.withLock { $0 })
+  }
+}

--- a/Tests/SwiftVLCTests/Player/PlayerControlTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerControlTests.swift
@@ -1,0 +1,151 @@
+@testable import SwiftVLC
+import Foundation
+import Testing
+
+/// Exercises `Player` control APIs on a `--no-video --no-audio` VLC
+/// instance (created per test via `TestInstance.makeAudioOnly`) so
+/// `swift test` can drive the state machine headlessly.
+///
+/// Serialized because the integration tests all mutate the same
+/// `@MainActor` `Player` fields; parallel execution would add
+/// scheduling noise without changing coverage. CI also runs `swift
+/// test --no-parallel` for the same reason.
+///
+/// State-transition waits use `subscribeAndAwait` /
+/// `subscribeAndAwaitTerminalStop` — the subscription is set up
+/// *before* the triggering action so no event can race past it. Each
+/// wait is bounded by a 5-second hard timeout that fails the test
+/// loudly if a signal never arrives.
+@Suite(
+  .tags(.integration, .mainActor, .async),
+  .timeLimit(.minutes(1)),
+  .serialized
+)
+@MainActor
+struct PlayerControlTests {
+  // MARK: - Idle-safe API coverage
+
+  // These don't need real playback; they assert that the C wrapper calls
+  // execute cleanly and the state machine observes the setters.
+
+  @Test
+  func `pause resume togglePlayPause on idle do not crash`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    player.pause()
+    player.resume()
+    player.togglePlayPause()
+    player.togglePlayPause()
+    #expect(player.state == .idle)
+  }
+
+  @Test
+  func `seek on idle player is a no-op`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    player.seek(to: .milliseconds(500))
+    player.seek(by: .milliseconds(200))
+    #expect(player.state == .idle)
+  }
+
+  @Test
+  func `nextFrame on idle player does not crash`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    player.nextFrame()
+    #expect(player.state == .idle)
+  }
+
+  @Test
+  func `Setting nil renderer reverts to local`() throws {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    try player.setRenderer(nil)
+  }
+
+  @Test
+  func `setDeinterlace accepts auto disable enable`() throws {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    try player.setDeinterlace(state: -1)
+    try player.setDeinterlace(state: 0)
+    try player.setDeinterlace(state: 1, mode: "blend")
+  }
+
+  // A-B loop APIs (`setABLoop`, `resetABLoop`) require libVLC to have
+  // an active timeline and the debug libVLC rejects them before play
+  // has produced a real media clock. They're exercised by the Showcase
+  // apps' transport-control flow, not from this headless suite.
+
+  @Test
+  func `Equalizer attach and detach on idle player`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    let eq = Equalizer()
+    eq.preamp = 3.0
+    player.equalizer = eq
+    #expect(player.equalizer != nil)
+    player.equalizer = nil
+    #expect(player.equalizer == nil)
+  }
+
+  @Test
+  func `rate setter updates libVLC state`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    player.rate = 1.5
+    // Rate is read back via libvlc_media_player_get_rate — no playback
+    // needed for the C call itself to work.
+    #expect(player.rate == 1.5)
+  }
+
+  @Test
+  func `startRecording stopRecording on idle do not crash`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    player.startRecording(to: NSTemporaryDirectory())
+    player.stopRecording()
+  }
+
+  @Test
+  func `Selecting nil audio track on idle player`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    // No tracks loaded yet; setter must handle the nil case without
+    // crashing. Hits the `unselect_track_type` branch in `selectTrack`.
+    player.selectedAudioTrack = nil
+  }
+
+  @Test
+  func `Selecting nil subtitle track on idle player`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    player.selectedSubtitleTrack = nil
+  }
+
+  // MARK: - Live playback
+
+  //
+  // Under `--no-video --no-audio` libVLC sprints through the demuxer
+  // with no real render path to pace the stream, so `.playing` can
+  // flip to `.stopped` in the same instant. We therefore don't assert
+  // on synchronous `player.state` reads after `.playing` — the
+  // regression we DO guard is "did the lifecycle emit the expected
+  // events in order?", which is observable deterministically via the
+  // event stream.
+  //
+  // Behavioral assertions around `pause`/`resume` during live playback
+  // need the audio subsystem (libVLC synchronizes pause state through
+  // the aout stream) and aren't viable headlessly — the shipped debug
+  // libVLC trips `vlc_aout_stream_Play: pause_date == VLC_TICK_INVALID`.
+  // Those paths are exercised by the Showcase apps and by anyone
+  // running the suite inside Xcode with real audio/video devices.
+
+  @Test
+  func `Playback lifecycle emits playing then stopped`() async throws {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+
+    // Subscribe for both terminal signals BEFORE play() so nothing can
+    // race past the subscription.
+    let playing = subscribeAndAwait(.playing, on: player)
+    let terminated = subscribeAndAwaitTerminalStop(on: player)
+
+    try player.play(Media(url: TestMedia.twosecURL))
+    try #require(await playing.value, "player did not emit .playing within 5s")
+
+    // `stop()` is idempotent with any natural end-of-media libVLC may
+    // emit first; either path resolves `terminated.value`.
+    player.stop()
+    try #require(await terminated.value, "player did not emit stopped/stopping within 5s")
+  }
+}

--- a/Tests/SwiftVLCTests/Player/PlayerEventTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerEventTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.logic))
+@Suite(.tags(.logic), .timeLimit(.minutes(1)))
 struct PlayerEventTests {
   @Test
   func `Exhaustive switch over all cases`() {

--- a/Tests/SwiftVLCTests/Player/PlayerRoleTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerRoleTests.swift
@@ -2,7 +2,7 @@
 import CLibVLC
 import Testing
 
-@Suite(.tags(.logic))
+@Suite(.tags(.logic), .timeLimit(.minutes(1)))
 struct PlayerRoleTests {
   @Test(
     arguments: [

--- a/Tests/SwiftVLCTests/Player/PlayerStateTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerStateTests.swift
@@ -2,7 +2,7 @@
 import CLibVLC
 import Testing
 
-@Suite(.tags(.logic))
+@Suite(.tags(.logic), .timeLimit(.minutes(1)))
 struct PlayerStateTests {
   @Test(
     arguments: [

--- a/Tests/SwiftVLCTests/Player/ProgramTests.swift
+++ b/Tests/SwiftVLCTests/Player/ProgramTests.swift
@@ -3,7 +3,7 @@ import CLibVLC
 import Foundation
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct ProgramTests {
   @Test(.tags(.mainActor))
   @MainActor

--- a/Tests/SwiftVLCTests/Playlist/MediaListDeepTests.swift
+++ b/Tests/SwiftVLCTests/Playlist/MediaListDeepTests.swift
@@ -2,7 +2,7 @@
 import Synchronization
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct MediaListDeepTests {
   // MARK: - withLocked returning nil for out-of-bounds via LockedView.media(at:)
 

--- a/Tests/SwiftVLCTests/Playlist/MediaListExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Playlist/MediaListExtendedTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Synchronization
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct MediaListExtendedTests {
   // MARK: - subscript access on MediaList
 

--- a/Tests/SwiftVLCTests/Playlist/MediaListFinalTests.swift
+++ b/Tests/SwiftVLCTests/Playlist/MediaListFinalTests.swift
@@ -2,7 +2,7 @@
 import Synchronization
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct MediaListFinalTests {
   // MARK: - init(retaining:) via subscript round-trip
 

--- a/Tests/SwiftVLCTests/Playlist/MediaListTests.swift
+++ b/Tests/SwiftVLCTests/Playlist/MediaListTests.swift
@@ -2,7 +2,7 @@
 import Foundation
 import Testing
 
-@Suite(.tags(.integration))
+@Suite(.tags(.integration), .timeLimit(.minutes(1)))
 struct MediaListTests {
   @Test
   func `Init empty has count zero`() {

--- a/Tests/SwiftVLCTests/Playlist/PlaybackModeTests.swift
+++ b/Tests/SwiftVLCTests/Playlist/PlaybackModeTests.swift
@@ -2,7 +2,7 @@
 import CLibVLC
 import Testing
 
-@Suite(.tags(.logic))
+@Suite(.tags(.logic), .timeLimit(.minutes(1)))
 struct PlaybackModeTests {
   @Test(
     arguments: [

--- a/Tests/SwiftVLCTests/Support/AwaitEvent.swift
+++ b/Tests/SwiftVLCTests/Support/AwaitEvent.swift
@@ -1,0 +1,75 @@
+@testable import SwiftVLC
+
+/// Subscribes to `player.events` *before* returning, so a caller can
+/// kick off an action (e.g. `player.play(...)`) without racing the
+/// subscription against the first event. The returned future resolves
+/// when a matching `.stateChanged` event is seen or `timeout` elapses.
+///
+/// Subscribing from a detached task means event delivery bypasses
+/// MainActor entirely — events arrive straight from the libVLC thread
+/// via `AsyncStream.Continuation.yield` without having to wait for the
+/// main actor to become available.
+///
+/// Usage:
+/// ```swift
+/// let playing = subscribeAndAwait(.playing, on: player)
+/// try player.play(...)
+/// try #require(await playing.value)
+/// ```
+///
+/// - Returns: A `Task` whose `.value` is `true` when a matching event
+///   arrives before the timeout, `false` if the stream ended or the
+///   timeout elapsed first.
+func subscribeAndAwait(
+  _ state: PlayerState,
+  on player: Player,
+  timeout: Duration = .seconds(5)
+) -> Task<Bool, Never> {
+  let stream = player.events
+  return Task.detached { @Sendable in
+    await withTaskGroup(of: Bool.self) { group in
+      group.addTask {
+        for await event in stream {
+          if case .stateChanged(let s) = event, s == state { return true }
+        }
+        return false
+      }
+      group.addTask {
+        try? await Task.sleep(for: timeout)
+        return false
+      }
+      let first = await group.next() ?? false
+      group.cancelAll()
+      return first
+    }
+  }
+}
+
+/// VLC emits either `.stopping` or `.stopped` as the terminal state
+/// depending on build / media type, so any `.stop()`-triggered
+/// assertion needs to accept either.
+func subscribeAndAwaitTerminalStop(
+  on player: Player,
+  timeout: Duration = .seconds(5)
+) -> Task<Bool, Never> {
+  let stream = player.events
+  return Task.detached { @Sendable in
+    await withTaskGroup(of: Bool.self) { group in
+      group.addTask {
+        for await event in stream {
+          if case .stateChanged(let s) = event, s == .stopped || s == .stopping {
+            return true
+          }
+        }
+        return false
+      }
+      group.addTask {
+        try? await Task.sleep(for: timeout)
+        return false
+      }
+      let first = await group.next() ?? false
+      group.cancelAll()
+      return first
+    }
+  }
+}

--- a/Tests/SwiftVLCTests/Support/TestInstance.swift
+++ b/Tests/SwiftVLCTests/Support/TestInstance.swift
@@ -1,0 +1,54 @@
+@testable import SwiftVLC
+
+/// VLC instances tuned for deterministic integration tests.
+///
+/// Two problems rule out using `VLCInstance.shared` directly from tests:
+///
+/// 1. **No `NSApplication` in `swift test`.** libVLC fails to create a
+///    video-output window and the decoder deadlocks before the player
+///    ever reaches `.playing`. Passing `--no-video` skips video output
+///    entirely and avoids the deadlock.
+/// 2. **Cross-test libVLC state.** The debug libVLC carries per-instance
+///    decoder / aout state that occasionally survives a `Player`
+///    teardown and trips `assert(stream->timing.pause_date ==
+///    VLC_TICK_INVALID)` when the next test rapidly creates another
+///    player on the same instance. Giving each playback-driving test
+///    its own instance isolates that state.
+///
+/// The cost of a fresh instance (~50 ms) is negligible. Tests that only
+/// create and destroy objects without reaching `.playing` can still use
+/// ``shared`` to avoid paying that cost repeatedly.
+enum TestInstance {
+  private static let audioOnlyArguments = VLCInstance.defaultArguments + [
+    // `--no-video` avoids the `NSApplication` requirement for the
+    // video-output window.
+    //
+    // `--no-audio` skips libVLC's audio-output subsystem entirely. The
+    // debug build ships with `assert(stream->timing.pause_date ==
+    // VLC_TICK_INVALID)` inside the decoder's stream-play path, which
+    // trips intermittently when tests pause/resume a player quickly
+    // after reaching `.playing`. Disabling audio output means the
+    // stream-play path is never entered; the wrapper's state-machine
+    // events, lifecycle, and C API calls are still fully exercised.
+    "--no-video",
+    "--no-audio",
+    "--quiet"
+  ]
+
+  /// Creates an independent VLC instance with audio and video outputs
+  /// disabled. Call this in the body of any test that drives playback
+  /// to `.playing` — isolation keeps libVLC's decoder / aout state from
+  /// bleeding into the next test.
+  ///
+  /// `try!` is appropriate: if libVLC can't initialize at all, the whole
+  /// test target is unrunnable, so failing fast is the right behavior.
+  static func makeAudioOnly() -> VLCInstance {
+    try! VLCInstance(arguments: audioOnlyArguments)
+  }
+
+  /// A single shared instance for tests that only exercise lightweight
+  /// lifecycle behavior (create + destroy without reaching `.playing`).
+  /// Skips the ~50 ms instance-creation cost for tests that don't need
+  /// per-test isolation.
+  static let shared: VLCInstance = makeAudioOnly()
+}

--- a/Tests/SwiftVLCTests/Video/AspectRatioTests.swift
+++ b/Tests/SwiftVLCTests/Video/AspectRatioTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.logic))
+@Suite(.tags(.logic), .timeLimit(.minutes(1)))
 struct AspectRatioTests {
   @Test(
     arguments: [

--- a/Tests/SwiftVLCTests/Video/LogoTests.swift
+++ b/Tests/SwiftVLCTests/Video/LogoTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.integration, .mainActor))
+@Suite(.tags(.integration, .mainActor), .timeLimit(.minutes(1)))
 @MainActor
 struct LogoTests {
   @Test

--- a/Tests/SwiftVLCTests/Video/MarqueeTests.swift
+++ b/Tests/SwiftVLCTests/Video/MarqueeTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.integration, .mainActor))
+@Suite(.tags(.integration, .mainActor), .timeLimit(.minutes(1)))
 @MainActor
 struct MarqueeTests {
   @Test

--- a/Tests/SwiftVLCTests/Video/VideoAdjustmentsTests.swift
+++ b/Tests/SwiftVLCTests/Video/VideoAdjustmentsTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.integration, .mainActor))
+@Suite(.tags(.integration, .mainActor), .timeLimit(.minutes(1)))
 @MainActor
 struct VideoAdjustmentsTests {
   @Test

--- a/Tests/SwiftVLCTests/Video/VideoOverlayBatchTests.swift
+++ b/Tests/SwiftVLCTests/Video/VideoOverlayBatchTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.integration, .mainActor))
+@Suite(.tags(.integration, .mainActor), .timeLimit(.minutes(1)))
 @MainActor
 struct VideoOverlayBatchTests {
   // MARK: - withAdjustments batch

--- a/Tests/SwiftVLCTests/Video/VideoViewFinalTests.swift
+++ b/Tests/SwiftVLCTests/Video/VideoViewFinalTests.swift
@@ -7,7 +7,7 @@ import AppKit
 import UIKit
 #endif
 
-@Suite(.tags(.integration, .mainActor))
+@Suite(.tags(.integration, .mainActor), .timeLimit(.minutes(1)))
 @MainActor
 struct VideoViewFinalTests {
   @Test

--- a/Tests/SwiftVLCTests/Video/VideoViewTests.swift
+++ b/Tests/SwiftVLCTests/Video/VideoViewTests.swift
@@ -7,7 +7,7 @@ import AppKit
 import UIKit
 #endif
 
-@Suite(.tags(.integration, .mainActor))
+@Suite(.tags(.integration, .mainActor), .timeLimit(.minutes(1)))
 @MainActor
 struct VideoViewTests {
   @Test

--- a/Tests/SwiftVLCTests/Video/ViewpointTests.swift
+++ b/Tests/SwiftVLCTests/Video/ViewpointTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftVLC
 import Testing
 
-@Suite(.tags(.logic))
+@Suite(.tags(.logic), .timeLimit(.minutes(1)))
 struct ViewpointTests {
   @Test
   func `Default init values`() {

--- a/scripts/doc-coverage.sh
+++ b/scripts/doc-coverage.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Reports documentation coverage for SwiftVLC's public API.
+#
+# Emits the module's symbol graph via swift-symbolgraph-extract (bundled
+# with every Swift toolchain), then walks every public symbol and
+# reports the ones whose doc comment is missing. Compiler-synthesized
+# symbols (e.g. Hashable's `hash(into:)` via raw-value synthesis) have
+# no source location and are skipped — they're not ours to document.
+#
+# Exit codes:
+#   0 — all public, non-synthesized symbols are documented
+#   1 — one or more symbols are missing docs
+#
+# Usage:
+#   ./scripts/doc-coverage.sh            # report + summary
+#   ./scripts/doc-coverage.sh --json     # emit JSON (for CI consumption)
+
+set -euo pipefail
+
+MODULE="SwiftVLC"
+TARGET="arm64-apple-macosx15.0"
+OUT_DIR="$(mktemp -d)"
+trap 'rm -rf "$OUT_DIR"' EXIT
+
+# xcrun respects $TOOLCHAINS when CI pins a specific Swift toolchain.
+xcrun swift build --target "$MODULE" >/dev/null
+
+SDK="$(xcrun --sdk macosx --show-sdk-path)"
+MODULES_DIR=".build/arm64-apple-macosx/debug/Modules"
+FRAMEWORKS_DIR=".build/arm64-apple-macosx/debug/PackageFrameworks"
+
+xcrun swift-symbolgraph-extract \
+  -module-name "$MODULE" \
+  -target "$TARGET" \
+  -sdk "$SDK" \
+  -I "$MODULES_DIR" \
+  -I Sources/CLibVLC/include \
+  -F "$FRAMEWORKS_DIR" \
+  -minimum-access-level public \
+  -output-dir "$OUT_DIR" >/dev/null
+
+/usr/bin/python3 - "$OUT_DIR/$MODULE.symbols.json" "${1:-}" <<'PY'
+import json, pathlib, collections, sys
+
+path = pathlib.Path(sys.argv[1])
+mode = sys.argv[2] if len(sys.argv) > 2 else ""
+data = json.loads(path.read_text())
+
+# Symbol kinds that should carry a doc comment.
+DOC_REQUIRED_KINDS = {
+    "swift.class", "swift.struct", "swift.enum", "swift.protocol",
+    "swift.func", "swift.method", "swift.init",
+    "swift.var", "swift.property", "swift.type.property", "swift.type.method",
+    "swift.subscript", "swift.enum.case", "swift.typealias",
+}
+
+documented = 0
+undocumented = []
+synthesized_skipped = 0
+by_file = collections.defaultdict(list)
+
+for sym in data["symbols"]:
+    kind = sym["kind"]["identifier"]
+    if kind not in DOC_REQUIRED_KINDS:
+        continue
+    loc = sym.get("location", {})
+    uri = loc.get("uri")
+    # Symbols without a source location are compiler-synthesized
+    # (protocol conformance fills like Hashable's hash(into:)). They
+    # inherit the protocol's documentation, so don't flag them.
+    if not uri:
+        synthesized_skipped += 1
+        continue
+    qname = ".".join(sym["pathComponents"])
+    line = loc.get("position", {}).get("line", 0) + 1
+    if sym.get("docComment") and sym["docComment"].get("lines"):
+        documented += 1
+    else:
+        undocumented.append((uri, line, kind, qname))
+        by_file[uri].append((line, kind, qname))
+
+total = documented + len(undocumented)
+pct = (documented / total * 100) if total else 100.0
+
+if mode == "--json":
+    print(json.dumps({
+        "total": total,
+        "documented": documented,
+        "undocumented": len(undocumented),
+        "coverage_percent": round(pct, 2),
+        "synthesized_skipped": synthesized_skipped,
+        "gaps": [
+            {"file": u, "line": l, "kind": k, "symbol": q}
+            for (u, l, k, q) in undocumented
+        ],
+    }, indent=2))
+else:
+    print(f"Public symbols: {total}")
+    print(f"Documented:     {documented}")
+    print(f"Undocumented:   {len(undocumented)}")
+    print(f"Coverage:       {pct:.1f}%")
+    print(f"Synthesized skipped: {synthesized_skipped}")
+    if undocumented:
+        print()
+        print("Undocumented symbols:")
+        for uri, items in sorted(by_file.items()):
+            short = uri.split("swiftvlc/")[-1] if "swiftvlc/" in uri else uri
+            print(f"  {short}")
+            for line, kind, qname in sorted(items):
+                print(f"    L{line:<4} {kind:<22} {qname}")
+
+sys.exit(0 if not undocumented else 1)
+PY

--- a/scripts/doc-coverage.sh
+++ b/scripts/doc-coverage.sh
@@ -19,16 +19,21 @@
 set -euo pipefail
 
 MODULE="SwiftVLC"
-TARGET="arm64-apple-macosx15.0"
 OUT_DIR="$(mktemp -d)"
 trap 'rm -rf "$OUT_DIR"' EXIT
 
 # xcrun respects $TOOLCHAINS when CI pins a specific Swift toolchain.
 xcrun swift build --target "$MODULE" >/dev/null
 
+# Derive target triple and build layout from the active toolchain / SwiftPM
+# rather than hard-coding `arm64-apple-macosx15.0` + `.build/arm64-apple-macosx/…`.
+# Hard-coded paths break on Intel runners and future SwiftPM layouts.
+TARGET="$(xcrun swiftc -print-target-info \
+  | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["target"]["triple"])')"
+BIN_DIR="$(xcrun swift build --target "$MODULE" --show-bin-path)"
 SDK="$(xcrun --sdk macosx --show-sdk-path)"
-MODULES_DIR=".build/arm64-apple-macosx/debug/Modules"
-FRAMEWORKS_DIR=".build/arm64-apple-macosx/debug/PackageFrameworks"
+MODULES_DIR="$BIN_DIR/Modules"
+FRAMEWORKS_DIR="$BIN_DIR/PackageFrameworks"
 
 xcrun swift-symbolgraph-extract \
   -module-name "$MODULE" \


### PR DESCRIPTION
## Summary

**Modern Swift concurrency refactor**, **test suite hardening**, and **documentation** for the 0.5.0 release. No public API breaks.

### Concurrency modernization (internal)
- Replace `Int(bitPattern:)` pointer laundering with direct pointer storage in `Mutex<State>` (+ documented `@unchecked Sendable` gated by the lock) or `nonisolated(unsafe) let` locals. Affected: `LogBroadcaster`, `ThumbnailRequest.RequestBox`, `Media.parse` onCancel.
- Consolidate `EventBridge.ContinuationStore` to a single `Mutex<State>` — one lock acquisition per `add`, AB-BA-safe `broadcast` preserved.
- Offload blocking libVLC teardown in `DialogHandler`, `RendererDiscoverer`, `MediaDiscoverer` deinits to `DispatchQueue.global(qos: .utility)` with strong-captured `instance`, matching the `Player` pattern.
- Fix `Player.handleEvent`: `.volumeChanged`, `.muted/.unmuted`, `.chapterChanged`, `.titleSelectionChanged` now fire empty `withMutation(keyPath:)` so SwiftUI observers of computed properties update for VLC-initiated changes (hardware keys, AirPlay, CarPlay).

### Test hardening (billing-aware)
- **757 → 801 tests**, **line coverage 77.8% → 82.1%**. Biggest gains: `PixelBufferRenderer` **7.9 → 64.6%**, `Player` **84.2 → 90.7%**, `EventBridge` **91.9 → 94.1%**.
- New suites: `ObservationTests`, `PlayerControlTests`, `EventBridgeConcurrencyTests`, `LifecycleStressTests`, `PixelBufferRendererCallbackTests`.
- Event-driven waits (`subscribeAndAwait` / `subscribeAndAwaitTerminalStop`) replace every poll-based `.playing` wait. Subscriptions are set up BEFORE the triggering action; each wait races the signal against a 5-second hard ceiling inside `withTaskGroup` — no polling, no silent guard-returns.
- `TestInstance.makeAudioOnly()` builds `--no-video --no-audio` instances so `swift test` can drive playback headlessly without NSApplication and without tripping debug libVLC's `vlc_aout_stream_Play` assertion.
- Every suite has an explicit `.timeLimit(.minutes(1))` so a hung test can never stall the runner.
- All arbitrary `Task.sleep` wallclock padding removed.
- CI pins `swift test --no-parallel` — Swift Testing's default parallel mode fights for MainActor on `@Observable @MainActor Player` and stretches sub-second tests into multi-second timeouts. Serial runs the full suite in **~37s with zero flakes across 5 consecutive runs**.

### Documentation
- 14 new DocC guides (Getting Started, Playback Essentials, Working With Media, Displaying Video, Video Overlays, Audio Features, Media Playlists, Picture-in-Picture, Discovery and Casting, Logging, Handling Errors, Concurrency Model, Comparison With VLCKit, landing SwiftVLC article).
- `ARCHITECTURE.md`: remove outdated "Pointer-to-Int Pattern" section; add guidance on `nonisolated(unsafe) let` vs `Mutex<State>`; correct stale `@unchecked Sendable` references.
- `scripts/doc-coverage.sh` enforces 100% public-API doc coverage via `swift-symbolgraph-extract`, wired into CI.

## Test plan
- [x] `swift build` — clean, debug + release
- [x] `swift test --no-parallel` — 801/801 pass, ~37s wall time
- [x] 5 consecutive full-suite runs — zero flakes
- [x] `xcodebuild` Showcase app (Mac Catalyst) — BUILD SUCCEEDED
- [ ] CI run on this PR (GitHub Actions — first run with `--no-parallel`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)