### PR TITLE
Release 0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="Assets/logo-dark.svg">
-  <source media="(prefers-color-scheme: light)" srcset="Assets/logo-light.svg">
-  <img alt="SwiftVLC" src="Assets/logo-light.svg" width="260">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/harflabs/SwiftVLC/main/Assets/logo-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/harflabs/SwiftVLC/main/Assets/logo-light.svg">
+  <img alt="SwiftVLC" src="https://raw.githubusercontent.com/harflabs/SwiftVLC/main/Assets/logo-light.svg" width="260">
 </picture>
 
 A Swift wrapper around [libVLC](https://www.videolan.org/vlc/libvlc.html) for iOS, macOS, tvOS, and Mac Catalyst.

--- a/Showcase/SwiftVLCShowcase/Demos/AudioPlayerDemo.swift
+++ b/Showcase/SwiftVLCShowcase/Demos/AudioPlayerDemo.swift
@@ -49,14 +49,22 @@ struct AudioPlayerDemo: View {
   }
 
   private func setUp() async {
+    // Tear down the previous run first so retries don't leave an old
+    // player decoding in the background or stale metadata/equalizer
+    // state hanging around in the UI.
+    player?.stop()
+    player = nil
+    metadata = nil
+    equalizer = nil
+    selectedPreset = 0
     error = nil
     do {
       let p = Player()
       player = p
 
       let media = try Media(url: TestMedia.bigBuckBunny)
-      metadata = try await media.parse()
       try p.play(media)
+      metadata = try? await media.parse()
 
       let eq = Equalizer()
       equalizer = eq

--- a/Showcase/SwiftVLCShowcase/Demos/DebugConsoleDemo.swift
+++ b/Showcase/SwiftVLCShowcase/Demos/DebugConsoleDemo.swift
@@ -113,6 +113,12 @@ struct DebugConsoleDemo: View {
   }
 
   private func setUp() async {
+    // Reset the previous session before creating a new player/log stream
+    // so retries don't keep old playback or stale log rows alive.
+    logTask?.cancel()
+    player?.stop()
+    player = nil
+    logEntries.removeAll()
     error = nil
     do {
       let p = Player()

--- a/Showcase/SwiftVLCShowcase/Demos/PiPDemo.swift
+++ b/Showcase/SwiftVLCShowcase/Demos/PiPDemo.swift
@@ -105,6 +105,12 @@ struct PiPDemo: View {
   }
 
   private func setUp() async {
+    // Shut down the previous player/controller pair first so retries
+    // don't leave PiP attached to a stale player instance.
+    pipController?.stop()
+    player?.stop()
+    pipController = nil
+    player = nil
     error = nil
     do {
       let p = Player()

--- a/Showcase/SwiftVLCShowcase/Demos/PlaylistDemo.swift
+++ b/Showcase/SwiftVLCShowcase/Demos/PlaylistDemo.swift
@@ -7,7 +7,6 @@ struct PlaylistDemo: View {
   @State private var player: Player?
   @State private var listPlayer: MediaListPlayer?
   @State private var items: [PlaylistItem] = []
-  @State private var currentIndex = 0
   @State private var error: Error?
 
   var body: some View {
@@ -23,12 +22,7 @@ struct PlaylistDemo: View {
     }
     .onDisappear {
       listPlayer?.stop()
-    }
-    .onChange(of: player?.currentMedia?.mrl) { _, newMRL in
-      guard let newMRL else { return }
-      if let match = items.first(where: { $0.mrl == newMRL }) {
-        currentIndex = match.index
-      }
+      player?.stop()
     }
   }
 
@@ -163,7 +157,7 @@ struct PlaylistDemo: View {
         playItem(at: item.index)
       } label: {
         HStack {
-          if item.index == currentIndex {
+          if item.index == selectedIndex {
             Image(systemName: "speaker.wave.2.fill")
               .foregroundStyle(.tint)
           } else {
@@ -173,7 +167,7 @@ struct PlaylistDemo: View {
           VStack(alignment: .leading) {
             Text(item.title)
               .font(.body)
-              .foregroundStyle(item.index == currentIndex ? .primary : .secondary)
+              .foregroundStyle(item.index == selectedIndex ? .primary : .secondary)
             if let duration = item.duration {
               Text(duration.formatted)
                 .font(.caption)
@@ -196,7 +190,6 @@ struct PlaylistDemo: View {
       HStack(spacing: 24) {
         Button {
           try? listPlayer.previous()
-          trackCurrentIndex()
         } label: {
           Label("Previous", systemImage: "backward.fill")
             .labelStyle(.iconOnly)
@@ -217,7 +210,6 @@ struct PlaylistDemo: View {
 
         Button {
           try? listPlayer.next()
-          trackCurrentIndex()
         } label: {
           Label("Next", systemImage: "forward.fill")
             .labelStyle(.iconOnly)
@@ -244,8 +236,16 @@ struct PlaylistDemo: View {
   }
 
   private func setupPlaylist() async {
+    // Tear down the previous playlist/session before rebuilding it so a
+    // retry doesn't leave old playback or item state wired up.
+    listPlayer?.stop()
+    player?.stop()
+    listPlayer = nil
+    player = nil
+    items = []
     error = nil
     do {
+      let sources = PlaylistSource.defaults
       let p = Player()
       player = p
 
@@ -253,52 +253,52 @@ struct PlaylistDemo: View {
       lp.mediaPlayer = p
       listPlayer = lp
 
-      let urls = [
-        TestMedia.bigBuckBunny,
-        TestMedia.sintel,
-        TestMedia.elephantsDream
-      ]
-
       let list = MediaList()
-      var parsed: [PlaylistItem] = []
-
-      for (index, url) in urls.enumerated() {
-        let media = try Media(url: url)
-        // Parse metadata for title and duration
-        let meta = try? await media.parse()
-        let title = meta?.title ?? url.lastPathComponent
-        parsed.append(PlaylistItem(
+      items = sources.enumerated().map { index, source in
+        PlaylistItem(
           index: index,
-          title: title,
-          duration: meta?.duration,
-          mrl: url.absoluteString
-        ))
+          title: source.title,
+          duration: nil,
+          mrl: source.url.absoluteString
+        )
+      }
+
+      for source in sources {
+        let media = try Media(url: source.url)
         try list.append(media)
       }
 
-      items = parsed
       lp.mediaList = list
       lp.play()
     } catch {
+      listPlayer?.stop()
+      player?.stop()
+      listPlayer = nil
+      player = nil
+      items = []
       self.error = error
     }
   }
 
   private func playItem(at index: Int) {
     try? listPlayer?.play(at: index)
-    currentIndex = index
   }
 
-  private func trackCurrentIndex() {
-    // Short delay to let the list player update its media
-    Task {
-      try? await Task.sleep(for: .milliseconds(100))
-      guard let mrl = player?.currentMedia?.mrl else { return }
-      if let match = items.first(where: { $0.mrl == mrl }) {
-        currentIndex = match.index
-      }
-    }
+  private var selectedIndex: Int? {
+    guard let mrl = player?.currentMedia?.mrl else { return nil }
+    return items.first(where: { $0.mrl == mrl })?.index
   }
+}
+
+private struct PlaylistSource {
+  let title: String
+  let url: URL
+
+  static let defaults: [PlaylistSource] = [
+    PlaylistSource(title: "Big Buck Bunny", url: TestMedia.bigBuckBunny),
+    PlaylistSource(title: "Sintel", url: TestMedia.sintel),
+    PlaylistSource(title: "Elephants Dream", url: TestMedia.elephantsDream)
+  ]
 }
 
 private struct PlaylistItem: Identifiable {

--- a/Showcase/SwiftVLCShowcase/Demos/PolishedPlayer/PolishedPlayerDemo.swift
+++ b/Showcase/SwiftVLCShowcase/Demos/PolishedPlayer/PolishedPlayerDemo.swift
@@ -73,6 +73,9 @@ struct PolishedPlayerDemo: View {
       #endif
     }
     .onChange(of: player?.state) { _, newState in
+      if newState == .playing {
+        scheduleHide()
+      }
       // Show controls when playback ends or errors
       if let newState, newState == .stopped || newState == .error {
         withAnimation(.easeInOut(duration: 0.3)) {

--- a/Showcase/SwiftVLCShowcase/Demos/SnapshotAndLoopDemo.swift
+++ b/Showcase/SwiftVLCShowcase/Demos/SnapshotAndLoopDemo.swift
@@ -61,6 +61,12 @@ struct SnapshotAndLoopDemo: View {
       .frame(maxWidth: 720)
       .frame(maxWidth: .infinity)
     }
+    .onChange(of: player.abLoopState) { _, newState in
+      if newState == .none {
+        aTime = nil
+        bTime = nil
+      }
+    }
   }
 
   // MARK: - Video
@@ -77,7 +83,7 @@ struct SnapshotAndLoopDemo: View {
 
   @ViewBuilder
   private var loopStatePill: some View {
-    if aTime != nil || bTime != nil {
+    if loopPillText.isEmpty == false {
       HStack(spacing: 4) {
         Image(systemName: "repeat")
         Text(loopPillText)
@@ -92,11 +98,21 @@ struct SnapshotAndLoopDemo: View {
   }
 
   private var loopPillText: String {
-    switch (aTime, bTime) {
-    case (let a?, let b?): "\(a.formatted) → \(b.formatted)"
-    case (let a?, nil): "A = \(a.formatted)"
-    case (nil, let b?): "B = \(b.formatted)"
-    default: ""
+    switch player?.abLoopState {
+    case .active?:
+      return switch (aTime, bTime) {
+      case (let a?, let b?): "\(a.formatted) → \(b.formatted)"
+      default: "Loop active"
+      }
+    case .pointASet?:
+      return "Point A set"
+    case .none?:
+      if let aTime, bTime == nil {
+        return "Pending A = \(aTime.formatted)"
+      }
+      return ""
+    case nil:
+      return ""
     }
   }
 
@@ -186,7 +202,7 @@ struct SnapshotAndLoopDemo: View {
             .frame(maxWidth: .infinity)
         }
         .buttonStyle(.bordered)
-        .disabled(aTime == nil && bTime == nil)
+        .disabled(player.abLoopState == .none && aTime == nil && bTime == nil)
       }
 
       loopStatusRow

--- a/Sources/SwiftVLC/Audio/Equalizer.swift
+++ b/Sources/SwiftVLC/Audio/Equalizer.swift
@@ -73,6 +73,9 @@ public final class Equalizer {
   /// Sets the amplification for a specific band (-20.0 to +20.0 dB).
   /// - Throws: `VLCError.operationFailed` if the band index is invalid.
   public func setAmplification(_ amp: Float, forBand band: Int) throws(VLCError) {
+    guard band >= 0 && band < Self.bandCount else {
+      throw .operationFailed("Set equalizer amplification for band \(band)")
+    }
     guard libvlc_audio_equalizer_set_amp_at_index(pointer, amp, UInt32(band)) == 0 else {
       throw .operationFailed("Set equalizer amplification for band \(band)")
     }
@@ -87,7 +90,8 @@ public final class Equalizer {
 
   /// Returns the name of a preset at the given index, or `nil` if the index is invalid.
   public static func presetName(at index: Int) -> String? {
-    libvlc_audio_equalizer_get_preset_name(UInt32(index)).map { String(cString: $0) }
+    guard index >= 0 && index < presetCount else { return nil }
+    return libvlc_audio_equalizer_get_preset_name(UInt32(index)).map { String(cString: $0) }
   }
 
   /// All available preset names.

--- a/Sources/SwiftVLC/Core/DialogHandler.swift
+++ b/Sources/SwiftVLC/Core/DialogHandler.swift
@@ -1,5 +1,7 @@
 import CLibVLC
 import Dispatch
+import Foundation
+import Synchronization
 
 /// Handles VLC dialog prompts (login, question, progress, error) via AsyncStream.
 ///
@@ -20,16 +22,23 @@ import Dispatch
 /// }
 /// ```
 public final class DialogHandler: Sendable {
+  private static let registryQueue = DispatchQueue(label: "swiftvlc.dialog-handler.registry")
+  private nonisolated(unsafe) static var activeHandlers: [UInt: UUID] = [:]
+
   private let instance: VLCInstance
   private let continuation: AsyncStream<DialogEvent>.Continuation
-  private nonisolated(unsafe) let boxOpaque: UnsafeMutableRawPointer
+  private let registrationToken: UUID
+  private let isRegistered: Bool
+  private nonisolated(unsafe) let boxOpaque: UnsafeMutableRawPointer?
 
   /// Stream of dialog events from VLC.
   public let dialogs: AsyncStream<DialogEvent>
 
   /// Registers dialog callbacks with the given VLC instance.
   ///
-  /// Only one dialog handler can be active per instance.
+  /// Only one dialog handler can be active per instance. Additional handlers
+  /// for the same instance finish their stream immediately instead of stealing
+  /// callbacks from the active handler.
   /// - Parameter instance: The VLC instance to handle dialogs for.
   public init(instance: VLCInstance = .shared) {
     self.instance = instance
@@ -37,48 +46,66 @@ public final class DialogHandler: Sendable {
     let (stream, cont) = AsyncStream<DialogEvent>.makeStream(bufferingPolicy: .bufferingNewest(16))
     dialogs = stream
     continuation = cont
+    let token = UUID()
+    registrationToken = token
 
-    // Use a retained box so C callbacks always reference valid memory.
-    // passUnretained(self) would be a use-after-free risk if a callback
-    // fires during deinitialization.
-    let box = Unmanaged.passRetained(DialogContinuationBox(continuation: cont)).toOpaque()
-    boxOpaque = box
+    let registration = Self.registryQueue.sync { () -> (registered: Bool, box: UnsafeMutableRawPointer?) in
+      let key = dialogInstanceKey(instance.pointer)
+      guard Self.activeHandlers[key] == nil else {
+        return (false, nil)
+      }
 
-    // libvlc_dialog_set_callbacks copies the struct (const pointer),
-    // so a local variable is sufficient — no need to store it.
-    var cbs = libvlc_dialog_cbs(
-      pf_display_login: dialogLoginCallback,
-      pf_display_question: dialogQuestionCallback,
-      pf_display_progress: dialogProgressCallback,
-      pf_cancel: dialogCancelCallback,
-      pf_update_progress: dialogUpdateProgressCallback
-    )
+      let box = Unmanaged.passRetained(DialogContinuationBox(continuation: cont)).toOpaque()
+      var cbs = libvlc_dialog_cbs(
+        pf_display_login: dialogLoginCallback,
+        pf_display_question: dialogQuestionCallback,
+        pf_display_progress: dialogProgressCallback,
+        pf_cancel: dialogCancelCallback,
+        pf_update_progress: dialogUpdateProgressCallback
+      )
 
-    libvlc_dialog_set_callbacks(instance.pointer, &cbs, box)
-    libvlc_dialog_set_error_callback(instance.pointer, dialogErrorCallback, box)
+      libvlc_dialog_set_callbacks(instance.pointer, &cbs, box)
+      libvlc_dialog_set_error_callback(instance.pointer, dialogErrorCallback, box)
+      Self.activeHandlers[key] = token
+      return (true, box)
+    }
+
+    isRegistered = registration.registered
+    boxOpaque = registration.box
+
+    if !registration.registered {
+      cont.finish()
+    }
   }
 
   deinit {
-    // libvlc_dialog_set_callbacks(nil, nil) blocks waiting for any in-progress
-    // callback to return — offload off the calling thread (which may be main).
-    //
-    // Strong-capturing `instance` keeps the libvlc_instance_t* alive through
-    // the cleanup. `box` is captured as a raw pointer (trivially transferable)
-    // via a `nonisolated(unsafe)` local to satisfy the Sendable closure.
-    //
-    // Order: clear callbacks (→ libVLC drains in-progress dispatches) → finish
-    // the stream → release the retained box. Reversing the last two would risk
-    // a late callback touching freed memory.
+    guard isRegistered else {
+      continuation.finish()
+      return
+    }
+
     let instance = self.instance
     let continuation = self.continuation
+    let token = self.registrationToken
     nonisolated(unsafe) let box = self.boxOpaque
-    DispatchQueue.global(qos: .utility).async {
-      libvlc_dialog_set_callbacks(instance.pointer, nil, nil)
-      libvlc_dialog_set_error_callback(instance.pointer, nil, nil)
+    Self.registryQueue.async {
+      let key = dialogInstanceKey(instance.pointer)
+      if Self.activeHandlers[key] == token {
+        Self.activeHandlers.removeValue(forKey: key)
+        libvlc_dialog_set_callbacks(instance.pointer, nil, nil)
+        libvlc_dialog_set_error_callback(instance.pointer, nil, nil)
+      }
+
       continuation.finish()
-      Unmanaged<DialogContinuationBox>.fromOpaque(box).release()
+      if let box {
+        Unmanaged<DialogContinuationBox>.fromOpaque(box).release()
+      }
     }
   }
+}
+
+private func dialogInstanceKey(_ pointer: OpaquePointer) -> UInt {
+  UInt(bitPattern: Int(bitPattern: pointer))
 }
 
 // MARK: - Internal Box
@@ -120,7 +147,11 @@ public enum DialogEvent: Sendable {
 /// relevant (e.g. the user navigated away or the underlying operation
 /// was cancelled elsewhere).
 public struct DialogID: Sendable {
-  nonisolated(unsafe) let pointer: OpaquePointer // libvlc_dialog_id*
+  private let storage: DialogIDStorage
+
+  init(pointer: OpaquePointer) {
+    storage = DialogIDStorage.shared(for: pointer)
+  }
 
   /// Dismisses the dialog without responding.
   ///
@@ -130,7 +161,41 @@ public struct DialogID: Sendable {
   /// - Returns: `true` if libVLC accepted the dismissal.
   @discardableResult
   public func dismiss() -> Bool {
-    libvlc_dialog_dismiss(pointer) == 0
+    consume { pointer in
+      libvlc_dialog_dismiss(pointer) == 0
+    }
+  }
+
+  @discardableResult
+  func postLogin(username: String, password: String, store: Bool) -> Bool {
+    consume { pointer in
+      libvlc_dialog_post_login(pointer, username, password, store) == 0
+    }
+  }
+
+  @discardableResult
+  func postAction(_ action: Int) -> Bool {
+    consume { pointer in
+      libvlc_dialog_post_action(pointer, Int32(action)) == 0
+    }
+  }
+
+  var pointer: OpaquePointer? {
+    storage.currentPointer()
+  }
+
+  var _isValidForTesting: Bool {
+    pointer != nil
+  }
+
+  @discardableResult
+  func _consumeForTesting() -> OpaquePointer? {
+    storage.consumePointer()
+  }
+
+  private func consume(_ operation: (OpaquePointer) -> Bool) -> Bool {
+    guard let pointer = storage.consumePointer() else { return false }
+    return operation(pointer)
   }
 }
 
@@ -153,7 +218,7 @@ public struct LoginRequest: Sendable {
   /// - Returns: `true` if the credentials were accepted by VLC.
   @discardableResult
   public func post(username: String, password: String, store: Bool = false) -> Bool {
-    libvlc_dialog_post_login(dialogId.pointer, username, password, store) == 0
+    dialogId.postLogin(username: username, password: password, store: store)
   }
 
   /// Dismisses the login dialog without responding.
@@ -201,7 +266,7 @@ public struct QuestionRequest: Sendable {
   /// - Returns: `true` if the response was accepted by libVLC.
   @discardableResult
   public func post(action: Int) -> Bool {
-    libvlc_dialog_post_action(dialogId.pointer, Int32(action)) == 0
+    dialogId.postAction(action)
   }
 
   /// Dismisses the question dialog.
@@ -325,7 +390,9 @@ private func dialogCancelCallback(
 ) {
   guard let data, let dialogId else { return }
   let box = Unmanaged<DialogContinuationBox>.fromOpaque(data).takeUnretainedValue()
-  box.continuation.yield(.cancel(DialogID(pointer: dialogId)))
+  let dialog = DialogID(pointer: dialogId)
+  box.continuation.yield(.cancel(dialog))
+  _ = dialog.dismiss()
 }
 
 private func dialogUpdateProgressCallback(
@@ -354,4 +421,73 @@ private func dialogErrorCallback(
     title: String(cString: title),
     message: String(cString: text)
   ))
+}
+
+private final class WeakDialogIDStorage: @unchecked Sendable {
+  weak var value: DialogIDStorage?
+
+  init(_ value: DialogIDStorage) {
+    self.value = value
+  }
+}
+
+private final class DialogIDStorage: @unchecked Sendable {
+  private struct State: @unchecked Sendable {
+    var pointer: OpaquePointer?
+  }
+
+  private static let registryQueue = DispatchQueue(label: "swiftvlc.dialog-id.registry")
+  private nonisolated(unsafe) static var registry: [UInt: WeakDialogIDStorage] = [:]
+
+  static func shared(for pointer: OpaquePointer) -> DialogIDStorage {
+    let key = UInt(bitPattern: Int(bitPattern: pointer))
+    return registryQueue.sync {
+      if let storage = registry[key]?.value {
+        return storage
+      }
+
+      let storage = DialogIDStorage(pointer: pointer, key: key)
+      registry[key] = WeakDialogIDStorage(storage)
+      return storage
+    }
+  }
+
+  private let key: UInt
+  private let state: Mutex<State>
+
+  private init(pointer: OpaquePointer, key: UInt) {
+    self.key = key
+    state = Mutex(State(pointer: pointer))
+  }
+
+  func currentPointer() -> OpaquePointer? {
+    state.withLock { $0.pointer }
+  }
+
+  func consumePointer() -> OpaquePointer? {
+    let pointer = state.withLock { state -> OpaquePointer? in
+      let pointer = state.pointer
+      state.pointer = nil
+      return pointer
+    }
+
+    if pointer != nil {
+      Self.registryQueue.async { [key] in
+        if Self.registry[key]?.value === self {
+          Self.registry.removeValue(forKey: key)
+        }
+      }
+    }
+
+    return pointer
+  }
+
+  deinit {
+    let key = self.key
+    Self.registryQueue.async {
+      if Self.registry[key]?.value == nil {
+        Self.registry.removeValue(forKey: key)
+      }
+    }
+  }
 }

--- a/Sources/SwiftVLC/Core/Logging.swift
+++ b/Sources/SwiftVLC/Core/Logging.swift
@@ -1,4 +1,5 @@
 import CLibVLC
+import Dispatch
 import Synchronization
 
 /// A single log message from libVLC.
@@ -100,53 +101,53 @@ final class LogBroadcaster: Sendable {
     /// The shim bridge context returned by `swiftvlc_log_set`, or `nil`
     /// when the callback isn't installed.
     var bridgeContext: UnsafeMutableRawPointer?
+    /// Prevents concurrent first-subscriber installs from racing each other.
+    var isInstalling = false
   }
 
   private let state = Mutex(State())
+  private let maintenanceQueue = DispatchQueue(label: "swiftvlc.logging.maintenance")
   nonisolated(unsafe) let instancePointer: OpaquePointer
+  private let installBridge: @Sendable (OpaquePointer, UnsafeMutableRawPointer) -> UnsafeMutableRawPointer?
+  private let uninstallBridge: @Sendable (OpaquePointer, UnsafeMutableRawPointer?) -> Void
 
-  init(instancePointer: OpaquePointer) {
+  init(
+    instancePointer: OpaquePointer,
+    installBridge: @escaping @Sendable (OpaquePointer, UnsafeMutableRawPointer) -> UnsafeMutableRawPointer? = { instance, data in
+      swiftvlc_log_set(instance, logCallback, data)
+    },
+    uninstallBridge: @escaping @Sendable (OpaquePointer, UnsafeMutableRawPointer?) -> Void = { instance, bridge in
+      swiftvlc_log_unset(instance, bridge)
+    }
+  ) {
     self.instancePointer = instancePointer
+    self.installBridge = installBridge
+    self.uninstallBridge = uninstallBridge
   }
 
   func add(
     continuation: AsyncStream<LogEntry>.Continuation,
     minimumLevel: LogLevel
   ) -> Int {
-    let (id, shouldInstall) = state.withLock { state -> (Int, Bool) in
+    let id = state.withLock { state -> Int in
       let id = state.nextID
       state.nextID += 1
       state.subscribers[id] = Subscriber(
         continuation: continuation,
         minimumLevel: minimumLevel
       )
-      // Try to install whenever the callback isn't currently registered —
-      // not just for the first subscriber. If a previous install() failed
-      // (e.g. shim malloc returned NULL under memory pressure), every
-      // subsequent subscriber retries so we self-heal rather than stay
-      // silent forever.
-      return (id, state.selfBox == nil)
+      return id
     }
 
-    if shouldInstall {
-      install()
-    }
+    scheduleReconcile()
     return id
   }
 
   func remove(id: Int) {
-    let uninstall = state.withLock { state -> (bridge: UnsafeMutableRawPointer?, box: UnsafeMutableRawPointer)? in
+    _ = state.withLock { state in
       state.subscribers.removeValue(forKey: id)
-      guard state.subscribers.isEmpty, let box = state.selfBox else { return nil }
-      let bridge = state.bridgeContext
-      state.bridgeContext = nil
-      state.selfBox = nil
-      return (bridge, box)
     }
-
-    guard let uninstall else { return }
-    swiftvlc_log_unset(instancePointer, uninstall.bridge)
-    Unmanaged<LogBroadcaster>.fromOpaque(uninstall.box).release()
+    scheduleReconcile()
   }
 
   /// Terminates all active subscribers and uninstalls the libVLC log
@@ -154,24 +155,18 @@ final class LogBroadcaster: Sendable {
   /// the libVLC instance pointer is about to be released, so no further
   /// callbacks can fire.
   func invalidate() {
-    let (subscribers, uninstall) = state.withLock { state
-      -> ([Subscriber], (bridge: UnsafeMutableRawPointer?, box: UnsafeMutableRawPointer)?) in
+    let subscribers = state.withLock { state -> [Subscriber] in
       let subs = Array(state.subscribers.values)
       state.subscribers.removeAll()
-      let capture: (bridge: UnsafeMutableRawPointer?, box: UnsafeMutableRawPointer)? =
-        state.selfBox.map { (state.bridgeContext, $0) }
-      state.bridgeContext = nil
-      state.selfBox = nil
-      return (subs, capture)
+      return subs
     }
 
     for sub in subscribers {
       sub.continuation.finish()
     }
 
-    if let uninstall {
-      swiftvlc_log_unset(instancePointer, uninstall.bridge)
-      Unmanaged<LogBroadcaster>.fromOpaque(uninstall.box).release()
+    maintenanceQueue.sync {
+      reconcile()
     }
   }
 
@@ -187,19 +182,65 @@ final class LogBroadcaster: Sendable {
     }
   }
 
-  private func install() {
-    let selfBox = Unmanaged.passRetained(self).toOpaque()
-    guard let bridgeContext = swiftvlc_log_set(instancePointer, logCallback, selfBox) else {
-      // Shim malloc failed. Release the retained self and bail;
-      // subscribers receive no events until a later install() succeeds.
-      Unmanaged<LogBroadcaster>.fromOpaque(selfBox).release()
-      return
+  private enum Action {
+    case install
+    case uninstall(box: UnsafeMutableRawPointer, bridge: UnsafeMutableRawPointer?)
+    case none
+  }
+
+  private func scheduleReconcile() {
+    maintenanceQueue.async { [self] in
+      reconcile()
+    }
+  }
+
+  private func reconcile() {
+    let action = state.withLock { state -> Action in
+      if state.subscribers.isEmpty {
+        guard let box = state.selfBox else { return .none }
+        let bridge = state.bridgeContext
+        state.selfBox = nil
+        state.bridgeContext = nil
+        return .uninstall(box: box, bridge: bridge)
+      }
+
+      guard state.selfBox == nil, !state.isInstalling else { return .none }
+      state.isInstalling = true
+      return .install
     }
 
-    state.withLock {
-      $0.selfBox = selfBox
-      $0.bridgeContext = bridgeContext
+    switch action {
+    case .install:
+      install()
+    case .uninstall(let box, let bridge):
+      uninstallBridge(instancePointer, bridge)
+      Unmanaged<LogBroadcaster>.fromOpaque(box).release()
+    case .none:
+      return
     }
+  }
+
+  private func install() {
+    let selfBox = Unmanaged.passRetained(self).toOpaque()
+    let bridgeContext = installBridge(instancePointer, selfBox)
+
+    let keepInstall = state.withLock { state -> Bool in
+      state.isInstalling = false
+      guard let bridgeContext, !state.subscribers.isEmpty, state.selfBox == nil else {
+        return false
+      }
+
+      state.selfBox = selfBox
+      state.bridgeContext = bridgeContext
+      return true
+    }
+
+    guard !keepInstall else { return }
+
+    if bridgeContext != nil {
+      uninstallBridge(instancePointer, bridgeContext)
+    }
+    Unmanaged<LogBroadcaster>.fromOpaque(selfBox).release()
   }
 }
 

--- a/Sources/SwiftVLC/Media/Media.swift
+++ b/Sources/SwiftVLC/Media/Media.swift
@@ -63,6 +63,7 @@ public struct MediaSlave: Sendable, Hashable {
 /// via `player.load(media)`.
 public final class Media: Sendable {
   nonisolated(unsafe) let pointer: OpaquePointer // libvlc_media_t*
+  let thumbnailCoordinator = ThumbnailCoordinator()
 
   /// Creates media from a URL.
   ///

--- a/Sources/SwiftVLC/Media/ThumbnailRequest.swift
+++ b/Sources/SwiftVLC/Media/ThumbnailRequest.swift
@@ -31,32 +31,57 @@ extension Media {
     instance: VLCInstance = .shared
   )
     async throws(VLCError) -> Data {
+    try await thumbnailCoordinator.acquire()
+    defer {
+      Task {
+        await thumbnailCoordinator.release()
+      }
+    }
+
+    if Task.isCancelled {
+      throw .operationFailed("Generate thumbnail: cancelled")
+    }
+
     let media = pointer
     let em = libvlc_media_event_manager(media)!
     let instancePtr = instance.pointer
-
-    // `requestBox` stores only the libVLC request pointer and exposes an
-    // idempotent destroy. It has no lifecycle dependency on the
-    // ThumbnailContinuation box: both the callback and onCancel can call
-    // `requestBox.destroy()` safely without risking a use-after-free, no
-    // matter which one races first.
-    let requestBox = RequestBox()
+    let operationRef = ThumbnailOperationRef()
 
     let result: Result<Data, VLCError> = await withTaskCancellationHandler {
       await withCheckedContinuation { cont in
-        let ctx = ThumbnailContinuation(
+        let operation = ThumbnailOperation(
           continuation: cont,
-          eventManager: em,
-          requestBox: requestBox
+          eventManager: em
         )
-        let box = Unmanaged.passRetained(ctx).toOpaque()
+        operationRef.store(operation)
+        let box = Unmanaged.passRetained(operation).toOpaque()
 
-        libvlc_event_attach(
-          em,
-          Int32(libvlc_MediaThumbnailGenerated.rawValue),
-          thumbnailCallback,
-          box
-        )
+        guard
+          libvlc_event_attach(
+            em,
+            Int32(libvlc_MediaThumbnailGenerated.rawValue),
+            thumbnailCallback,
+            box
+          ) == 0 else {
+          Unmanaged<ThumbnailOperation>.fromOpaque(box).release()
+          operation.finish(with: .failure(.operationFailed("Generate thumbnail: attach callback")))
+          return
+        }
+
+        guard operation.installCallbackBox(box) else {
+          libvlc_event_detach(
+            em,
+            Int32(libvlc_MediaThumbnailGenerated.rawValue),
+            thumbnailCallback,
+            box
+          )
+          return
+        }
+
+        if Task.isCancelled {
+          operation.cancel()
+          return
+        }
 
         guard
           let request = libvlc_media_thumbnail_request_by_time(
@@ -70,26 +95,21 @@ extension Media {
             libvlc_picture_Png,
             timeout.milliseconds
           ) else {
-          libvlc_event_detach(
-            em,
-            Int32(libvlc_MediaThumbnailGenerated.rawValue),
-            thumbnailCallback,
-            box
-          )
-          Unmanaged<ThumbnailContinuation>.fromOpaque(box).release()
-          cont.resume(returning: .failure(.operationFailed("Generate thumbnail")))
+          operation.finish(with: .failure(.operationFailed("Generate thumbnail")))
           return
         }
 
-        requestBox.store(request)
+        guard operation.storeRequest(request) else {
+          libvlc_media_thumbnail_request_destroy(request)
+          return
+        }
+
+        if Task.isCancelled {
+          operation.cancel()
+        }
       }
     } onCancel: {
-      // Destroy the in-flight request via the standalone request box. The
-      // callback will still fire (with p_thumbnail == nil) and handle its
-      // own cleanup / continuation resume. We never touch the Unmanaged
-      // ThumbnailContinuation here, so the callback's box.release() and
-      // onCancel can never race.
-      requestBox.destroy()
+      operationRef.value()?.cancel()
     }
     return try result.get()
   }
@@ -97,50 +117,203 @@ extension Media {
 
 // MARK: - Internals
 
-/// Holds the libVLC `libvlc_media_thumbnail_request_t*` pointer. Its
-/// `destroy()` is idempotent and atomic so the callback and the cancel
-/// handler can both call it without stepping on each other.
-///
-/// `@unchecked` on `Storage` because `OpaquePointer` isn't Sendable under
-/// Swift's region analysis; safety is provided by the enclosing `Mutex`
-/// — every read/write happens under `storage.withLock`.
-private final class RequestBox: Sendable {
+actor ThumbnailCoordinator {
+  private var isBusy = false
+  private var waiters: [ThumbnailGate] = []
+
+  func acquire() async throws(VLCError) {
+    guard !Task.isCancelled else {
+      throw .operationFailed("Generate thumbnail: cancelled")
+    }
+
+    guard isBusy else {
+      isBusy = true
+      return
+    }
+
+    let gate = ThumbnailGate()
+    waiters.append(gate)
+    guard await gate.wait() else {
+      throw .operationFailed("Generate thumbnail: cancelled")
+    }
+  }
+
+  func release() {
+    while !waiters.isEmpty {
+      let gate = waiters.removeFirst()
+      if gate.open() {
+        return
+      }
+    }
+
+    isBusy = false
+  }
+}
+
+/// Async gate used by `ThumbnailCoordinator` to serialize media-wide
+/// thumbnail generation.
+private final class ThumbnailGate: @unchecked Sendable {
+  private enum Status: @unchecked Sendable {
+    case waiting
+    case open
+    case cancelled
+  }
+
   private struct Storage: @unchecked Sendable {
-    var pointer: OpaquePointer?
+    var continuation: CheckedContinuation<Bool, Never>?
+    var status: Status = .waiting
   }
 
   private let storage = Mutex(Storage())
 
-  func store(_ request: OpaquePointer) {
-    storage.withLock { $0.pointer = request }
+  func wait() async -> Bool {
+    await withTaskCancellationHandler {
+      await withCheckedContinuation { continuation in
+        let immediateResult = storage.withLock { storage -> Bool? in
+          switch storage.status {
+          case .open:
+            return true
+          case .cancelled:
+            return false
+          case .waiting:
+            storage.continuation = continuation
+            return nil
+          }
+        }
+
+        if let immediateResult {
+          continuation.resume(returning: immediateResult)
+        }
+      }
+    } onCancel: {
+      cancel()
+    }
   }
 
-  /// Atomically clears the stored pointer and destroys it if present.
-  /// Subsequent calls are no-ops.
-  func destroy() {
-    let captured = storage.withLock { storage -> OpaquePointer? in
-      let p = storage.pointer
-      storage.pointer = nil
-      return p
+  @discardableResult
+  func open() -> Bool {
+    let (opened, continuation) = storage.withLock { storage
+      -> (Bool, CheckedContinuation<Bool, Never>?) in
+      guard storage.status == .waiting else { return (false, nil) }
+      storage.status = .open
+      let continuation = storage.continuation
+      storage.continuation = nil
+      return (true, continuation)
     }
-    guard let captured else { return }
-    libvlc_media_thumbnail_request_destroy(captured)
+    continuation?.resume(returning: true)
+    return opened
+  }
+
+  private func cancel() {
+    let continuation = storage.withLock { storage -> CheckedContinuation<Bool, Never>? in
+      guard storage.status == .waiting else { return nil }
+      storage.status = .cancelled
+      let continuation = storage.continuation
+      storage.continuation = nil
+      return continuation
+    }
+    continuation?.resume(returning: false)
   }
 }
 
-private final class ThumbnailContinuation: Sendable {
-  let continuation: CheckedContinuation<Result<Data, VLCError>, Never>
+private final class ThumbnailOperationRef: Sendable {
+  private let storage = Mutex<ThumbnailOperation?>(nil)
+
+  func store(_ operation: ThumbnailOperation) {
+    storage.withLock { $0 = operation }
+  }
+
+  func value() -> ThumbnailOperation? {
+    storage.withLock { $0 }
+  }
+}
+
+private final class ThumbnailOperation: Sendable {
+  private struct State: @unchecked Sendable {
+    var continuation: CheckedContinuation<Result<Data, VLCError>, Never>?
+    var request: OpaquePointer?
+    var callbackBox: UnsafeMutableRawPointer?
+    var eventAttached = false
+    var isFinished = false
+  }
+
+  private struct Cleanup {
+    let continuation: CheckedContinuation<Result<Data, VLCError>, Never>?
+    let request: OpaquePointer?
+    let callbackBox: UnsafeMutableRawPointer?
+    let shouldDetachEvent: Bool
+  }
+
   nonisolated(unsafe) let eventManager: OpaquePointer
-  let requestBox: RequestBox
+  private let state: Mutex<State>
 
   init(
     continuation: CheckedContinuation<Result<Data, VLCError>, Never>,
-    eventManager: OpaquePointer,
-    requestBox: RequestBox
+    eventManager: OpaquePointer
   ) {
-    self.continuation = continuation
     self.eventManager = eventManager
-    self.requestBox = requestBox
+    state = Mutex(State(continuation: continuation))
+  }
+
+  func installCallbackBox(_ box: UnsafeMutableRawPointer) -> Bool {
+    state.withLock { state -> Bool in
+      guard !state.isFinished else { return false }
+      state.callbackBox = box
+      state.eventAttached = true
+      return true
+    }
+  }
+
+  func storeRequest(_ request: OpaquePointer) -> Bool {
+    state.withLock { state -> Bool in
+      guard !state.isFinished else { return false }
+      state.request = request
+      return true
+    }
+  }
+
+  func cancel() {
+    finish(with: .failure(.operationFailed("Generate thumbnail: cancelled")))
+  }
+
+  func finish(with result: Result<Data, VLCError>) {
+    let cleanup = state.withLock { state -> Cleanup? in
+      guard !state.isFinished else { return nil }
+      state.isFinished = true
+
+      let cleanup = Cleanup(
+        continuation: state.continuation,
+        request: state.request,
+        callbackBox: state.callbackBox,
+        shouldDetachEvent: state.eventAttached
+      )
+
+      state.continuation = nil
+      state.request = nil
+      state.callbackBox = nil
+      state.eventAttached = false
+      return cleanup
+    }
+    guard let cleanup else { return }
+
+    if cleanup.shouldDetachEvent, let box = cleanup.callbackBox {
+      libvlc_event_detach(
+        eventManager,
+        Int32(libvlc_MediaThumbnailGenerated.rawValue),
+        thumbnailCallback,
+        box
+      )
+    }
+
+    if let request = cleanup.request {
+      libvlc_media_thumbnail_request_destroy(request)
+    }
+
+    cleanup.continuation?.resume(returning: result)
+
+    if let box = cleanup.callbackBox {
+      Unmanaged<ThumbnailOperation>.fromOpaque(box).release()
+    }
   }
 }
 
@@ -150,17 +323,7 @@ private func thumbnailCallback(
 ) {
   guard let event, let opaque else { return }
 
-  let box = Unmanaged<ThumbnailContinuation>.fromOpaque(opaque)
-  let ctx = box.takeUnretainedValue()
-
-  // Always detach and free the request before resuming.
-  libvlc_event_detach(
-    ctx.eventManager,
-    Int32(libvlc_MediaThumbnailGenerated.rawValue),
-    thumbnailCallback,
-    opaque
-  )
-  ctx.requestBox.destroy()
+  let operation = Unmanaged<ThumbnailOperation>.fromOpaque(opaque).takeUnretainedValue()
 
   let resumeValue: Result<Data, VLCError>
   if let picture = event.pointee.u.media_thumbnail_generated.p_thumbnail {
@@ -174,6 +337,5 @@ private func thumbnailCallback(
     resumeValue = .failure(.operationFailed("Generate thumbnail: no image produced"))
   }
 
-  ctx.continuation.resume(returning: resumeValue)
-  box.release()
+  operation.finish(with: resumeValue)
 }

--- a/Sources/SwiftVLC/Media/ThumbnailRequest.swift
+++ b/Sources/SwiftVLC/Media/ThumbnailRequest.swift
@@ -69,12 +69,19 @@ extension Media {
         }
 
         guard operation.installCallbackBox(box) else {
+          // The operation was already finished (typically by `onCancel`
+          // racing between `passRetained` above and this check), so
+          // `finish()` didn't see a `callbackBox` to release. We own
+          // the retain here and must release it ourselves, or the
+          // `ThumbnailOperation` (with its `CheckedContinuation` /
+          // `Mutex` state) leaks.
           libvlc_event_detach(
             em,
             Int32(libvlc_MediaThumbnailGenerated.rawValue),
             thumbnailCallback,
             box
           )
+          Unmanaged<ThumbnailOperation>.fromOpaque(box).release()
           return
         }
 

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -2,6 +2,7 @@
 import AVFoundation
 import AVKit
 import CLibVLC
+import Dispatch
 import Observation
 
 /// Controls Picture-in-Picture playback for a ``Player``.
@@ -22,15 +23,45 @@ import Observation
 /// yourContainerView.layer.addSublayer(controller.layer)
 /// controller.start()
 /// ```
+@Observable
 @MainActor
 public final class PiPController: NSObject {
+  struct PlaybackDriver {
+    let pause: @MainActor () -> Void
+    let resume: @MainActor () -> Void
+    let seek: @MainActor (Duration) -> Void
+
+    static func live(player: Player) -> Self {
+      Self(
+        pause: { player.pause() },
+        resume: { player.resume() },
+        seek: { player.seek(to: $0) }
+      )
+    }
+  }
+
+  @ObservationIgnored
   private let player: Player
+  @ObservationIgnored
+  private let playbackDriver: PlaybackDriver
+  @ObservationIgnored
+  private let pauseDebounce: Duration
+  @ObservationIgnored
   private let renderer: PixelBufferRenderer
+  @ObservationIgnored
   private let displayLayer: AVSampleBufferDisplayLayer
+  @ObservationIgnored
   private var pipController: AVPictureInPictureController?
+  @ObservationIgnored
   private var rendererOpaque: Unmanaged<PixelBufferRenderer>?
+  @ObservationIgnored
   private var controlTimebase: CMTimebase?
+  @ObservationIgnored
   private var stateObserverTask: Task<Void, Never>?
+  @ObservationIgnored
+  private var possibleObservation: NSKeyValueObservation?
+  @ObservationIgnored
+  private var activeObservation: NSKeyValueObservation?
 
   /// Tracks the playback state as PiP sees it. Updated synchronously
   /// in `setPlaying` (PiP-initiated) and by the observer (VLC-initiated,
@@ -38,18 +69,28 @@ public final class PiPController: NSObject {
   /// consistent value immediately, without waiting for VLC's async
   /// state transitions — which is critical because PiP queries state
   /// right after calling `setPlaying` and gets confused by stale values.
+  @ObservationIgnored
   private var pipPlaybackActive: Bool = false
 
-  /// Deferred pause task. PiP calls `setPlaying(false)` before every skip,
-  /// then `setPlaying(true)` after. Pausing VLC synchronously causes a
-  /// visible blink. By deferring the actual `player.pause()` to the next
-  /// run-loop iteration, `skipByInterval` can cancel it — avoiding a
-  /// pointless pause→seek→resume cycle.
+  /// Debounced pause task. AVKit can transiently report "paused" during
+  /// skip and PiP transitions; issuing a real libVLC pause for those
+  /// short-lived state flips can trip libVLC's pause/resume assertions on
+  /// streaming media. We therefore wait briefly before sending the native
+  /// pause command, and cancel it if AVKit settles back to playing.
+  @ObservationIgnored
   private var deferredPauseTask: Task<Void, Never>?
+  /// Monotonic generation used to invalidate older pause requests.
+  @ObservationIgnored
+  private var deferredPauseGeneration: UInt64 = 0
+  /// Tracks whether PiP actually paused libVLC, so `setPlaying(true)` can
+  /// avoid issuing redundant resumes for transient AVKit state changes.
+  @ObservationIgnored
+  private var didIssueDeferredPause: Bool = false
 
   /// Timestamp of the last PiP skip. The observer uses this to avoid
   /// overwriting the skip handler's timebase position with stale
   /// `currentTime` data that hasn't caught up to the seek yet.
+  @ObservationIgnored
   private var lastSkipTimestamp: CFAbsoluteTime = 0
 
   /// Whether PiP can be started right now.
@@ -58,14 +99,10 @@ public final class PiPController: NSObject {
   /// and briefly after initialization until the system has validated
   /// the layer. Observe this before enabling a "Picture-in-Picture"
   /// button in your UI.
-  public var isPossible: Bool {
-    pipController?.isPictureInPicturePossible ?? false
-  }
+  public private(set) var isPossible: Bool = false
 
   /// Whether a PiP window is currently visible.
-  public var isActive: Bool {
-    pipController?.isPictureInPictureActive ?? false
-  }
+  public private(set) var isActive: Bool = false
 
   /// The layer that renders video frames for both the inline and PiP
   /// presentations.
@@ -83,6 +120,31 @@ public final class PiPController: NSObject {
   /// - Parameter player: The player to control.
   public init(player: Player) {
     self.player = player
+    playbackDriver = .live(player: player)
+    pauseDebounce = .milliseconds(250)
+    displayLayer = AVSampleBufferDisplayLayer()
+    renderer = PixelBufferRenderer(displayLayer: displayLayer)
+
+    super.init()
+
+    displayLayer.videoGravity = .resizeAspect
+    displayLayer.backgroundColor = CGColor(red: 0, green: 0, blue: 0, alpha: 1)
+
+    configureAudioSession()
+    setupControlTimebase()
+    attachCallbacks()
+    setupPiPController()
+    startStateObserver()
+  }
+
+  init(
+    player: Player,
+    playbackDriver: PlaybackDriver,
+    pauseDebounce: Duration
+  ) {
+    self.player = player
+    self.playbackDriver = playbackDriver
+    self.pauseDebounce = pauseDebounce
     displayLayer = AVSampleBufferDisplayLayer()
     renderer = PixelBufferRenderer(displayLayer: displayLayer)
 
@@ -99,8 +161,10 @@ public final class PiPController: NSObject {
   }
 
   isolated deinit {
-    deferredPauseTask?.cancel()
+    cancelDeferredPause()
     stateObserverTask?.cancel()
+    possibleObservation = nil
+    activeObservation = nil
     libvlc_video_set_callbacks(player.pointer, nil, nil, nil, nil)
     libvlc_video_set_format_callbacks(player.pointer, nil, nil)
     rendererOpaque?.release()
@@ -192,6 +256,100 @@ public final class PiPController: NSObject {
     controller.canStartPictureInPictureAutomaticallyFromInline = true
     #endif
     pipController = controller
+    updatePiPPossible(controller.isPictureInPicturePossible)
+    updatePiPActive(controller.isPictureInPictureActive)
+    observePiPState(of: controller)
+  }
+
+  private func observePiPState(of controller: AVPictureInPictureController) {
+    possibleObservation = controller.observe(\.isPictureInPicturePossible, options: [.initial, .new]) {
+      [weak self] controller, _
+      in
+      let isPossible = controller.isPictureInPicturePossible
+      Task { @MainActor [weak self] in
+        self?.updatePiPPossible(isPossible)
+      }
+    }
+
+    activeObservation = controller.observe(\.isPictureInPictureActive, options: [.initial, .new]) {
+      [weak self] controller, _
+      in
+      let isActive = controller.isPictureInPictureActive
+      Task { @MainActor [weak self] in
+        self?.updatePiPActive(isActive)
+      }
+    }
+  }
+
+  private func updatePiPPossible(_ isPossible: Bool) {
+    guard self.isPossible != isPossible else { return }
+    self.isPossible = isPossible
+  }
+
+  private func updatePiPActive(_ isActive: Bool) {
+    guard self.isActive != isActive else { return }
+    self.isActive = isActive
+  }
+
+  private func cancelDeferredPause() {
+    deferredPauseGeneration &+= 1
+    deferredPauseTask?.cancel()
+    deferredPauseTask = nil
+  }
+
+  private func scheduleDeferredPause() {
+    cancelDeferredPause()
+
+    let generation = deferredPauseGeneration
+    deferredPauseTask = Task { @MainActor [weak self] in
+      guard let self else { return }
+
+      while !Task.isCancelled {
+        do {
+          try await Task.sleep(for: pauseDebounce)
+        } catch {
+          return
+        }
+
+        guard !Task.isCancelled, deferredPauseGeneration == generation, !pipPlaybackActive else { return }
+
+        switch player.state {
+        case .playing:
+          didIssueDeferredPause = true
+          deferredPauseTask = nil
+          playbackDriver.pause()
+          return
+        case .opening, .buffering:
+          // Avoid pausing libVLC while it is still stabilizing input state.
+          // Keep waiting unless AVKit changes its mind first.
+          continue
+        default:
+          deferredPauseTask = nil
+          return
+        }
+      }
+    }
+  }
+
+  private func resumeIfNeeded() {
+    let shouldResume = didIssueDeferredPause || player.state == .paused
+    didIssueDeferredPause = false
+    guard shouldResume else { return }
+    playbackDriver.resume()
+  }
+
+  /// AVKit can invoke PiP delegate callbacks from non-main threads.
+  /// Bridge them synchronously so delegate responses stay immediate
+  /// without relying on `MainActor.assumeIsolated` off the main thread.
+  private nonisolated func withMainActorSync<T: Sendable>(
+    _ body: @MainActor @Sendable () -> T
+  ) -> T {
+    if Thread.isMainThread {
+      return MainActor.assumeIsolated(body)
+    }
+    return DispatchQueue.main.sync {
+      MainActor.assumeIsolated(body)
+    }
   }
 
   // MARK: - State Observation
@@ -212,6 +370,10 @@ public final class PiPController: NSObject {
         if active != wasActive {
           wasActive = active
           syncTimebase(playing: active)
+
+          if active {
+            didIssueDeferredPause = false
+          }
 
           // Only update pipPlaybackActive and notify PiP for
           // VLC-initiated changes (end-of-media, error). For
@@ -258,6 +420,53 @@ public final class PiPController: NSObject {
     }
   }
 
+  private func handleSetPlaying(_ playing: Bool) {
+    cancelDeferredPause()
+
+    // Set immediately so isPlaybackPaused returns the correct value
+    // when PiP queries it right after this call (before VLC catches up).
+    pipPlaybackActive = playing
+
+    if playing {
+      resumeIfNeeded()
+    } else {
+      scheduleDeferredPause()
+    }
+
+    syncTimebase(playing: playing)
+    pipController?.invalidatePlaybackState()
+  }
+
+  private func handleSkip(
+    by skipInterval: CMTime,
+    completion completionHandler: @escaping @Sendable () -> Void
+  ) {
+    // Cancel any pending transient pause. Skip actions should not drive
+    // libVLC through a pause → seek → resume cycle.
+    cancelDeferredPause()
+
+    let currentMs = player.currentTime.milliseconds
+    let durationMs = player.duration?.milliseconds ?? Int64.max
+    let offsetMs = Int64(skipInterval.seconds * 1000)
+    let targetMs = max(0, min(currentMs + offsetMs, durationMs))
+
+    playbackDriver.seek(.milliseconds(targetMs))
+
+    lastSkipTimestamp = CFAbsoluteTimeGetCurrent()
+
+    // Apple docs: "the control timebase should reflect the current
+    // playback time and rate when the closure is invoked"
+    if let tb = controlTimebase {
+      CMTimebaseSetTime(tb, time: CMTime(
+        seconds: Double(targetMs) / 1000.0,
+        preferredTimescale: 1000
+      ))
+      CMTimebaseSetRate(tb, rate: pipPlaybackActive ? 1.0 : 0.0)
+    }
+
+    completionHandler()
+  }
+
   /// Sets the controlTimebase time to the player's current position.
   private func syncTimebaseTime() {
     guard let tb = controlTimebase else { return }
@@ -272,40 +481,74 @@ public final class PiPController: NSObject {
     syncTimebaseTime()
     CMTimebaseSetRate(tb, rate: playing ? 1.0 : 0.0)
   }
+
+  func _setStateForTesting(
+    isPossible: Bool? = nil,
+    isActive: Bool? = nil
+  ) {
+    if let isPossible {
+      updatePiPPossible(isPossible)
+    }
+    if let isActive {
+      updatePiPActive(isActive)
+    }
+  }
+
+  nonisolated func _isPlaybackPausedForTesting(_ controller: AVPictureInPictureController) -> Bool {
+    pictureInPictureControllerIsPlaybackPaused(controller)
+  }
+
+  func _setPlayingForTesting(_ playing: Bool) {
+    handleSetPlaying(playing)
+  }
+
+  func _skipByIntervalForTesting(_ skipInterval: CMTime) {
+    handleSkip(by: skipInterval) {}
+  }
 }
 
 // MARK: - AVPictureInPictureControllerDelegate
 
 extension PiPController: AVPictureInPictureControllerDelegate {
-  /// `AVPictureInPictureControllerDelegate` hook — no additional work is
-  /// needed; the state observer drives our internal sync.
+  /// Mirrors AVKit's active flag into Observation so SwiftUI can keep
+  /// button labels and status UI in sync with system-driven PiP changes.
   public nonisolated func pictureInPictureControllerDidStartPictureInPicture(
     _: AVPictureInPictureController
-  ) {}
+  ) {
+    withMainActorSync {
+      updatePiPActive(true)
+    }
+  }
 
-  /// `AVPictureInPictureControllerDelegate` hook — no-op; cleanup happens
-  /// in ``stop()`` and on `deinit`.
+  /// Mirrors AVKit's active flag into Observation when PiP exits from
+  /// either our own controls or the system's close affordance.
   public nonisolated func pictureInPictureControllerDidStopPictureInPicture(
     _: AVPictureInPictureController
-  ) {}
+  ) {
+    withMainActorSync {
+      updatePiPActive(false)
+    }
+  }
 
   /// `AVPictureInPictureControllerDelegate` hook. SwiftVLC does not
-  /// propagate PiP start failures; inspect the Console log if PiP
-  /// refuses to start.
+  /// propagate PiP start failures; we still resync the observed flags so
+  /// the UI doesn't stay stuck in a stale "starting" state.
   public nonisolated func pictureInPictureController(
     _: AVPictureInPictureController,
     failedToStartPictureInPictureWithError _: Error
-  ) {}
+  ) {
+    withMainActorSync {
+      updatePiPActive(false)
+    }
+  }
 }
 
 // MARK: - AVPictureInPictureSampleBufferPlaybackDelegate
 
 extension PiPController: AVPictureInPictureSampleBufferPlaybackDelegate {
-  // NOTE: All delegate methods are called by the PiP system on the main thread.
-  // They MUST execute synchronously (MainActor.assumeIsolated) — not via
-  // Task { @MainActor in }, which defers to the next run-loop iteration.
-  // The PiP system queries state immediately after calling these; if the
-  // action hasn't executed yet the UI reverts to stale state.
+  // NOTE: PiP may invoke these callbacks off the main thread.
+  // They still need synchronous answers, so SwiftVLC bridges them
+  // onto the main actor without deferring through an async task.
 
   /// `AVPictureInPictureSampleBufferPlaybackDelegate` hook. Translates
   /// PiP play/pause presses into ``Player`` state changes, with the
@@ -316,31 +559,8 @@ extension PiPController: AVPictureInPictureSampleBufferPlaybackDelegate {
     _: AVPictureInPictureController,
     setPlaying playing: Bool
   ) {
-    MainActor.assumeIsolated {
-      deferredPauseTask?.cancel()
-      deferredPauseTask = nil
-
-      // Set immediately so isPlaybackPaused returns the correct value
-      // when PiP queries it right after this call (before VLC catches up).
-      pipPlaybackActive = playing
-
-      if playing {
-        // Use resume (unpause) rather than play (restart) — the player
-        // was paused, not stopped, so unpause is the correct operation.
-        player.resume()
-      } else {
-        // Defer the actual VLC pause to the next run-loop iteration.
-        // PiP calls setPlaying(false) before every skip, then
-        // setPlaying(true) after. If skipByInterval arrives before
-        // this executes, it cancels the task — so VLC never pauses
-        // and there's no visible blink.
-        deferredPauseTask = Task { @MainActor [weak self] in
-          guard let self, !Task.isCancelled else { return }
-          player.pause()
-        }
-      }
-      syncTimebase(playing: playing)
-      pipController?.invalidatePlaybackState()
+    withMainActorSync {
+      handleSetPlaying(playing)
     }
   }
 
@@ -352,7 +572,7 @@ extension PiPController: AVPictureInPictureSampleBufferPlaybackDelegate {
   public nonisolated func pictureInPictureControllerTimeRangeForPlayback(
     _: AVPictureInPictureController
   ) -> CMTimeRange {
-    let duration: Duration? = MainActor.assumeIsolated { player.duration }
+    let duration: Duration? = withMainActorSync { player.duration }
 
     let durationSeconds = duration.map {
       Double($0.components.seconds) + Double($0.components.attoseconds) / 1e18
@@ -377,44 +597,20 @@ extension PiPController: AVPictureInPictureSampleBufferPlaybackDelegate {
   public nonisolated func pictureInPictureControllerIsPlaybackPaused(
     _: AVPictureInPictureController
   ) -> Bool {
-    MainActor.assumeIsolated { !pipPlaybackActive }
+    withMainActorSync { !pipPlaybackActive }
   }
 
   /// `AVPictureInPictureSampleBufferPlaybackDelegate` hook. Routes PiP
-  /// skip buttons into a relative ``Player/seek(by:)`` and updates the
-  /// control timebase so the PiP UI reflects the new position before
-  /// libVLC's own time change arrives.
+  /// skip buttons into a clamped absolute seek and updates the control
+  /// timebase so the PiP UI reflects the new position before libVLC's
+  /// own time change arrives.
   public nonisolated func pictureInPictureController(
     _: AVPictureInPictureController,
     skipByInterval skipInterval: CMTime,
     completion completionHandler: @escaping @Sendable () -> Void
   ) {
-    MainActor.assumeIsolated {
-      // Cancel the deferred pause — VLC should keep playing through the skip
-      deferredPauseTask?.cancel()
-      deferredPauseTask = nil
-
-      let currentMs = player.currentTime.milliseconds
-      let durationMs = player.duration?.milliseconds ?? Int64.max
-      let offsetMs = Int64(skipInterval.seconds * 1000)
-      let targetMs = max(0, min(currentMs + offsetMs, durationMs))
-
-      // Relative seek — same API the demo app skip buttons use
-      player.seek(by: .milliseconds(offsetMs))
-
-      lastSkipTimestamp = CFAbsoluteTimeGetCurrent()
-
-      // Apple docs: "the control timebase should reflect the current
-      // playback time and rate when the closure is invoked"
-      if let tb = controlTimebase {
-        CMTimebaseSetTime(tb, time: CMTime(
-          seconds: Double(targetMs) / 1000.0,
-          preferredTimescale: 1000
-        ))
-        CMTimebaseSetRate(tb, rate: 1.0)
-      }
-
-      completionHandler()
+    withMainActorSync {
+      handleSkip(by: skipInterval, completion: completionHandler)
     }
   }
 

--- a/Sources/SwiftVLC/PiP/PiPVideoView.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView.swift
@@ -39,18 +39,29 @@ public struct PiPVideoView: UIViewRepresentable {
 
     context.coordinator.pipController = controller
     context.coordinator.displayLayer = displayLayer
+    context.coordinator.player = player
 
     // Defer binding update — SwiftUI doesn't allow state changes during view construction
-    let binding = controllerBinding
-    Task { @MainActor in
-      binding?.wrappedValue = controller
-    }
+    pushControllerBinding(controller)
 
     return container
   }
 
-  public func updateUIView(_: UIView, context _: Context) {
-    // Layout is handled by SampleBufferVideoView.layoutSubviews
+  public func updateUIView(_ uiView: UIView, context: Context) {
+    guard let container = uiView as? SampleBufferVideoView else { return }
+    if context.coordinator.player !== player {
+      context.coordinator.pipController?.stop()
+
+      let controller = PiPController(player: player)
+      let displayLayer = controller.layer
+      container.setDisplayLayer(displayLayer)
+
+      context.coordinator.player = player
+      context.coordinator.pipController = controller
+      context.coordinator.displayLayer = displayLayer
+    }
+
+    pushControllerBinding(context.coordinator.pipController)
   }
 
   public static func dismantleUIView(_: UIView, coordinator: Coordinator) {
@@ -70,20 +81,28 @@ public struct PiPVideoView: UIViewRepresentable {
   /// view updates and are cleaned up on dismantle.
   @MainActor
   public final class Coordinator {
+    weak var player: Player?
     var pipController: PiPController?
     var displayLayer: AVSampleBufferDisplayLayer?
+  }
+
+  @MainActor
+  private func pushControllerBinding(_ controller: PiPController?) {
+    let binding = controllerBinding
+    Task { @MainActor in
+      binding?.wrappedValue = controller
+    }
   }
 }
 
 /// UIView subclass that keeps the AVSampleBufferDisplayLayer
 /// sized to fill its bounds on every layout pass.
 private final class SampleBufferVideoView: UIView {
-  private let displayLayer: AVSampleBufferDisplayLayer
+  private var displayLayer: AVSampleBufferDisplayLayer?
 
   init(displayLayer: AVSampleBufferDisplayLayer) {
-    self.displayLayer = displayLayer
     super.init(frame: .zero)
-    layer.addSublayer(displayLayer)
+    setDisplayLayer(displayLayer)
   }
 
   @available(*, unavailable)
@@ -91,12 +110,20 @@ private final class SampleBufferVideoView: UIView {
     fatalError()
   }
 
+  func setDisplayLayer(_ displayLayer: AVSampleBufferDisplayLayer) {
+    self.displayLayer?.removeFromSuperlayer()
+    self.displayLayer = displayLayer
+    layer.addSublayer(displayLayer)
+    setNeedsLayout()
+    layoutIfNeeded()
+  }
+
   override func layoutSubviews() {
     super.layoutSubviews()
     // Disable implicit animations so the layer doesn't animate to the new size
     CATransaction.begin()
     CATransaction.setDisableActions(true)
-    displayLayer.frame = bounds
+    displayLayer?.frame = bounds
     CATransaction.commit()
   }
 }
@@ -129,16 +156,29 @@ public struct PiPVideoView: NSViewRepresentable {
 
     context.coordinator.pipController = controller
     context.coordinator.displayLayer = displayLayer
+    context.coordinator.player = player
 
-    let binding = controllerBinding
-    Task { @MainActor in
-      binding?.wrappedValue = controller
-    }
+    pushControllerBinding(controller)
 
     return container
   }
 
-  public func updateNSView(_: NSView, context _: Context) {}
+  public func updateNSView(_ nsView: NSView, context: Context) {
+    guard let container = nsView as? SampleBufferVideoView else { return }
+    if context.coordinator.player !== player {
+      context.coordinator.pipController?.stop()
+
+      let controller = PiPController(player: player)
+      let displayLayer = controller.layer
+      container.setDisplayLayer(displayLayer)
+
+      context.coordinator.player = player
+      context.coordinator.pipController = controller
+      context.coordinator.displayLayer = displayLayer
+    }
+
+    pushControllerBinding(context.coordinator.pipController)
+  }
 
   public static func dismantleNSView(_: NSView, coordinator: Coordinator) {
     coordinator.pipController?.stop()
@@ -157,20 +197,28 @@ public struct PiPVideoView: NSViewRepresentable {
   /// view updates and are cleaned up on dismantle.
   @MainActor
   public final class Coordinator {
+    weak var player: Player?
     var pipController: PiPController?
     var displayLayer: AVSampleBufferDisplayLayer?
+  }
+
+  @MainActor
+  private func pushControllerBinding(_ controller: PiPController?) {
+    let binding = controllerBinding
+    Task { @MainActor in
+      binding?.wrappedValue = controller
+    }
   }
 }
 
 private final class SampleBufferVideoView: NSView {
-  private let displayLayer: AVSampleBufferDisplayLayer
+  private var displayLayer: AVSampleBufferDisplayLayer?
 
   init(displayLayer: AVSampleBufferDisplayLayer) {
-    self.displayLayer = displayLayer
     super.init(frame: .zero)
     wantsLayer = true
     layer?.backgroundColor = NSColor.black.cgColor
-    layer?.addSublayer(displayLayer)
+    setDisplayLayer(displayLayer)
   }
 
   @available(*, unavailable)
@@ -178,11 +226,19 @@ private final class SampleBufferVideoView: NSView {
     fatalError()
   }
 
+  func setDisplayLayer(_ displayLayer: AVSampleBufferDisplayLayer) {
+    self.displayLayer?.removeFromSuperlayer()
+    self.displayLayer = displayLayer
+    layer?.addSublayer(displayLayer)
+    needsLayout = true
+    layoutSubtreeIfNeeded()
+  }
+
   override func layout() {
     super.layout()
     CATransaction.begin()
     CATransaction.setDisableActions(true)
-    displayLayer.frame = bounds
+    displayLayer?.frame = bounds
     CATransaction.commit()
   }
 }

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -241,8 +241,6 @@ public final class Player {
   private var eventTask: Task<Void, Never>?
   private var _position: Double = 0
   private var _equalizer: Equalizer?
-  private var hasStartedPlayback = false
-
   let instance: VLCInstance
 
   // MARK: - Lifecycle
@@ -321,7 +319,6 @@ public final class Player {
       let reason = libvlc_errmsg().map { String(cString: $0) } ?? "unknown"
       throw .playbackFailed(reason: reason)
     }
-    hasStartedPlayback = true
   }
 
   /// Pauses playback.
@@ -768,13 +765,20 @@ public final class Player {
 
   /// Sets a renderer for output (e.g. Chromecast).
   ///
-  /// Pass `nil` to revert to local playback.
+  /// Pass `nil` to revert to local playback. libVLC rejects renderer
+  /// changes while media is active, so this is only valid when the
+  /// player is `.idle`, `.stopped`, or `.error` — call `stop()` first
+  /// if you need to reconfigure casting mid-session.
+  ///
   /// - Parameter renderer: A ``RendererItem`` discovered by ``RendererDiscoverer``, or `nil`.
-  /// - Throws: `VLCError.operationFailed` if the renderer cannot be set, or
-  ///   when playback has already started on this player.
+  /// - Throws: `VLCError.operationFailed` if the renderer cannot be set,
+  ///   or if the player isn't in an idle-like state.
   public func setRenderer(_ renderer: RendererItem?) throws(VLCError) {
-    guard !hasStartedPlayback else {
-      throw .operationFailed("Set renderer before playback starts")
+    switch state {
+    case .idle, .stopped, .error:
+      break
+    default:
+      throw .operationFailed("Set renderer while player is \(state)")
     }
     let result = libvlc_media_player_set_renderer(pointer, renderer?.pointer)
     guard result == 0 else { throw .operationFailed("Set renderer") }

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -206,12 +206,14 @@ public final class Player {
 
   /// Whether the player is currently playing.
   public var isPlaying: Bool {
-    state == .playing
+    access(keyPath: \.isPlaying)
+    return state == .playing
   }
 
   /// Whether playback is active (playing or buffering during playback).
   public var isActive: Bool {
-    switch state {
+    access(keyPath: \.isActive)
+    return switch state {
     case .playing, .opening, .buffering:
       true
     default:
@@ -239,6 +241,7 @@ public final class Player {
   private var eventTask: Task<Void, Never>?
   private var _position: Double = 0
   private var _equalizer: Equalizer?
+  private var hasStartedPlayback = false
 
   let instance: VLCInstance
 
@@ -290,6 +293,8 @@ public final class Player {
   /// reference after the call.
   public func load(_ media: sending Media) {
     currentMedia = media
+    resetMediaDerivedState()
+    withMutation(keyPath: \.abLoopState) {}
     libvlc_media_player_set_media(pointer, media.pointer)
     refreshTracks()
   }
@@ -316,6 +321,7 @@ public final class Player {
       let reason = libvlc_errmsg().map { String(cString: $0) } ?? "unknown"
       throw .playbackFailed(reason: reason)
     }
+    hasStartedPlayback = true
   }
 
   /// Pauses playback.
@@ -521,6 +527,7 @@ public final class Player {
     guard libvlc_media_player_set_abloop_time(pointer, a.milliseconds, b.milliseconds) == 0 else {
       throw .operationFailed("Set A-B loop by time")
     }
+    withMutation(keyPath: \.abLoopState) {}
   }
 
   /// Sets an A-B loop using fractional positions (0.0...1.0).
@@ -529,6 +536,7 @@ public final class Player {
     guard libvlc_media_player_set_abloop_position(pointer, aPosition, bPosition) == 0 else {
       throw .operationFailed("Set A-B loop by position")
     }
+    withMutation(keyPath: \.abLoopState) {}
   }
 
   /// Resets (disables) the A-B loop.
@@ -537,10 +545,12 @@ public final class Player {
     guard libvlc_media_player_reset_abloop(pointer) == 0 else {
       throw .operationFailed("Reset A-B loop")
     }
+    withMutation(keyPath: \.abLoopState) {}
   }
 
   /// Current A-B loop state.
   public var abLoopState: ABLoopState {
+    access(keyPath: \.abLoopState)
     var aTime: Int64 = 0
     var aPos: Double = 0
     var bTime: Int64 = 0
@@ -687,6 +697,7 @@ public final class Player {
 
   /// Current audio output device identifier.
   public var currentAudioDevice: String? {
+    access(keyPath: \.currentAudioDevice)
     guard let cstr = libvlc_audio_output_device_get(pointer) else { return nil }
     defer { free(cstr) }
     return String(cString: cstr)
@@ -724,6 +735,7 @@ public final class Player {
 
   /// Lists all available programs in the current media.
   public var programs: [Program] {
+    access(keyPath: \.programs)
     guard let list = libvlc_media_player_get_programlist(pointer) else { return [] }
     defer { libvlc_player_programlist_delete(list) }
 
@@ -735,6 +747,7 @@ public final class Player {
 
   /// The currently selected program.
   public var selectedProgram: Program? {
+    access(keyPath: \.selectedProgram)
     guard let prog = libvlc_media_player_get_selected_program(pointer) else { return nil }
     defer { libvlc_player_program_delete(prog) }
     return Program(from: prog.pointee)
@@ -747,7 +760,8 @@ public final class Player {
 
   /// Whether the current program is scrambled (encrypted).
   public var isProgramScrambled: Bool {
-    libvlc_media_player_program_scrambled(pointer)
+    access(keyPath: \.isProgramScrambled)
+    return libvlc_media_player_program_scrambled(pointer)
   }
 
   // MARK: - Renderer (Chromecast / AirPlay)
@@ -756,8 +770,12 @@ public final class Player {
   ///
   /// Pass `nil` to revert to local playback.
   /// - Parameter renderer: A ``RendererItem`` discovered by ``RendererDiscoverer``, or `nil`.
-  /// - Throws: `VLCError.operationFailed` if the renderer cannot be set.
+  /// - Throws: `VLCError.operationFailed` if the renderer cannot be set, or
+  ///   when playback has already started on this player.
   public func setRenderer(_ renderer: RendererItem?) throws(VLCError) {
+    guard !hasStartedPlayback else {
+      throw .operationFailed("Set renderer before playback starts")
+    }
     let result = libvlc_media_player_set_renderer(pointer, renderer?.pointer)
     guard result == 0 else { throw .operationFailed("Set renderer") }
   }
@@ -821,6 +839,8 @@ public final class Player {
     audioTracks = fetchTracks(type: .audio)
     videoTracks = fetchTracks(type: .video)
     subtitleTracks = fetchTracks(type: .subtitle)
+    withMutation(keyPath: \.selectedAudioTrack) {}
+    withMutation(keyPath: \.selectedSubtitleTrack) {}
   }
 
   private func fetchTracks(type: TrackType) -> [Track] {
@@ -858,11 +878,14 @@ public final class Player {
     switch event {
     case .stateChanged(let newState):
       state = newState
+      withMutation(keyPath: \.isPlaying) {}
+      withMutation(keyPath: \.isActive) {}
       if case .stopped = newState {
         currentTime = .zero
         withMutation(keyPath: \.position) {
           _position = 0
         }
+        withMutation(keyPath: \.abLoopState) {}
       }
 
     case .timeChanged(let time):
@@ -886,10 +909,18 @@ public final class Player {
       refreshTracks()
 
     case .mediaChanged:
+      syncCurrentMediaFromNative()
+      resetMediaDerivedState()
+      withMutation(keyPath: \.abLoopState) {}
+      withMutation(keyPath: \.programs) {}
+      withMutation(keyPath: \.selectedProgram) {}
+      withMutation(keyPath: \.isProgramScrambled) {}
       refreshTracks()
 
     case .encounteredError:
       state = .error
+      withMutation(keyPath: \.isPlaying) {}
+      withMutation(keyPath: \.isActive) {}
 
     case .bufferingProgress(let pct):
       // VLC sends buffer-level events continuously during playback.
@@ -897,6 +928,7 @@ public final class Player {
       switch state {
       case .idle, .opening, .buffering:
         state = .buffering(pct)
+        withMutation(keyPath: \.isActive) {}
       default:
         break
       }
@@ -920,11 +952,69 @@ public final class Player {
 
     // Events without a matching observable property are exposed only
     // via the raw `events` stream — consumers that care subscribe there.
-    case .corked, .uncorked, .audioDeviceChanged, .voutChanged,
+    case .audioDeviceChanged:
+      withMutation(keyPath: \.currentAudioDevice) {}
+
+    case .programAdded, .programDeleted, .programSelected, .programUpdated:
+      withMutation(keyPath: \.programs) {}
+      withMutation(keyPath: \.selectedProgram) {}
+      withMutation(keyPath: \.isProgramScrambled) {}
+
+    case .corked, .uncorked, .voutChanged,
          .recordingChanged, .titleListChanged, .snapshotTaken,
-         .mediaStopping, .programAdded, .programDeleted,
-         .programSelected, .programUpdated:
+         .mediaStopping:
       break
+    }
+  }
+
+  private func resetMediaDerivedState() {
+    currentTime = .zero
+    duration = nil
+    isSeekable = false
+    isPausable = false
+    withMutation(keyPath: \.position) {
+      _position = 0
+    }
+  }
+
+  private func syncCurrentMediaFromNative() {
+    guard let media = libvlc_media_player_get_media(pointer) else {
+      currentMedia = nil
+      return
+    }
+    libvlc_media_retain(media)
+    currentMedia = Media(retaining: media)
+  }
+
+  func _handleEventForTesting(_ event: PlayerEvent) {
+    handleEvent(event)
+  }
+
+  func _setStateForTesting(
+    state: PlayerState? = nil,
+    currentTime: Duration? = nil,
+    duration: Duration? = nil,
+    position: Double? = nil,
+    isSeekable: Bool? = nil,
+    isPausable: Bool? = nil
+  ) {
+    if let state {
+      self.state = state
+    }
+    if let currentTime {
+      self.currentTime = currentTime
+    }
+    if let duration {
+      self.duration = duration
+    }
+    if let position {
+      _position = position
+    }
+    if let isSeekable {
+      self.isSeekable = isSeekable
+    }
+    if let isPausable {
+      self.isPausable = isPausable
     }
   }
 }

--- a/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
+++ b/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
@@ -18,14 +18,16 @@ import Dispatch
 /// ```
 @MainActor
 public final class MediaListPlayer {
-  let pointer: OpaquePointer // libvlc_media_list_player_t*
+  var pointer: OpaquePointer // libvlc_media_list_player_t*
   private var _mediaPlayer: Player?
   private var _mediaList: MediaList?
   private var _playbackMode: PlaybackMode = .default
+  private let instance: VLCInstance
 
   /// Creates a new media list player.
   /// - Parameter instance: The VLC instance to use.
   public init(instance: VLCInstance = .shared) {
+    self.instance = instance
     guard let p = libvlc_media_list_player_new(instance.pointer) else {
       preconditionFailure("Failed to create libvlc media list player. Is the libvlc.xcframework linked correctly?")
     }
@@ -49,6 +51,8 @@ public final class MediaListPlayer {
       _mediaPlayer = newValue
       if let newValue {
         libvlc_media_list_player_set_media_player(pointer, newValue.pointer)
+      } else {
+        rebuildNativePlayer()
       }
     }
   }
@@ -60,6 +64,8 @@ public final class MediaListPlayer {
       _mediaList = newValue
       if let newValue {
         libvlc_media_list_player_set_media_list(pointer, newValue.pointer)
+      } else {
+        rebuildNativePlayer()
       }
     }
   }
@@ -137,6 +143,28 @@ public final class MediaListPlayer {
   public func previous() throws(VLCError) {
     guard libvlc_media_list_player_previous(pointer) == 0 else {
       throw .operationFailed("Go to previous item")
+    }
+  }
+
+  private func rebuildNativePlayer() {
+    guard let replacement = libvlc_media_list_player_new(instance.pointer) else {
+      preconditionFailure("Failed to rebuild libvlc media list player. Is the libvlc.xcframework linked correctly?")
+    }
+
+    libvlc_media_list_player_set_playback_mode(replacement, _playbackMode.cValue)
+    if let mediaPlayer = _mediaPlayer {
+      libvlc_media_list_player_set_media_player(replacement, mediaPlayer.pointer)
+    }
+    if let mediaList = _mediaList {
+      libvlc_media_list_player_set_media_list(replacement, mediaList.pointer)
+    }
+
+    let previous = pointer
+    pointer = replacement
+    nonisolated(unsafe) let oldPointer = previous
+    DispatchQueue.global(qos: .utility).async {
+      libvlc_media_list_player_stop_async(oldPointer)
+      libvlc_media_list_player_release(oldPointer)
     }
   }
 }

--- a/Sources/SwiftVLC/Video/VideoView.swift
+++ b/Sources/SwiftVLC/Video/VideoView.swift
@@ -51,6 +51,9 @@ final class VideoSurface: UIView {
 
   func attach(to player: Player) {
     guard attachedPlayer !== player else { return }
+    if let attachedPlayer {
+      libvlc_media_player_set_nsobject(attachedPlayer.pointer, nil)
+    }
     attachedPlayer = player
     let viewPtr = Unmanaged.passUnretained(self).toOpaque()
     libvlc_media_player_set_nsobject(player.pointer, viewPtr)
@@ -125,6 +128,9 @@ final class VideoSurface: NSView {
 
   func attach(to player: Player) {
     guard attachedPlayer !== player else { return }
+    if let attachedPlayer {
+      libvlc_media_player_set_nsobject(attachedPlayer.pointer, nil)
+    }
     attachedPlayer = player
     let viewPtr = Unmanaged.passUnretained(self).toOpaque()
     libvlc_media_player_set_nsobject(player.pointer, viewPtr)

--- a/Tests/SwiftVLCTests/Audio/EqualizerTests.swift
+++ b/Tests/SwiftVLCTests/Audio/EqualizerTests.swift
@@ -65,6 +65,14 @@ struct EqualizerTests {
   }
 
   @Test
+  func `Negative band index throws instead of trapping`() {
+    let eq = Equalizer()
+    #expect(throws: VLCError.self) {
+      try eq.setAmplification(5.0, forBand: -1)
+    }
+  }
+
+  @Test
   func `Preset count is positive`() {
     #expect(Equalizer.presetCount > 0)
   }
@@ -86,6 +94,11 @@ struct EqualizerTests {
   func `Preset name at invalid index`() {
     let name = Equalizer.presetName(at: 9999)
     #expect(name == nil)
+  }
+
+  @Test
+  func `Preset name at negative index returns nil`() {
+    #expect(Equalizer.presetName(at: -1) == nil)
   }
 
   @Test

--- a/Tests/SwiftVLCTests/Core/DialogHandlerExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Core/DialogHandlerExtendedTests.swift
@@ -31,7 +31,15 @@ struct DialogHandlerExtendedTests {
 
     let id1 = DialogID(pointer: ptr)
     let id2 = id1 // copy
+    let id3 = DialogID(pointer: ptr)
     #expect(id1.pointer == id2.pointer)
+    #expect(id1.pointer == id3.pointer)
+
+    let consumed = id1._consumeForTesting()
+    #expect(consumed == ptr)
+    #expect(id1.pointer == nil)
+    #expect(id2.pointer == nil)
+    #expect(id3.pointer == nil)
 
     // Sendable conformance
     let _: any Sendable = id1

--- a/Tests/SwiftVLCTests/Core/DialogHandlerTests.swift
+++ b/Tests/SwiftVLCTests/Core/DialogHandlerTests.swift
@@ -63,14 +63,20 @@ struct DialogHandlerTests {
     let _: any Sendable.Type = ProgressUpdate.self
   }
 
-  @Test
-  func `Multiple handlers replace each other`() throws {
+  @Test(.tags(.async))
+  func `Second handler on the same instance finishes immediately`() async throws {
     let instance = try VLCInstance()
     let handler1 = DialogHandler(instance: instance)
     let handler2 = DialogHandler(instance: instance)
-    // Second handler replaces first — no crash
-    _ = handler1.dialogs
-    _ = handler2.dialogs
+    _ = handler1
+    let eventCount = await Task {
+      var count = 0
+      for await _ in handler2.dialogs {
+        count += 1
+      }
+      return count
+    }.value
+    #expect(eventCount == 0)
   }
 
   @Test

--- a/Tests/SwiftVLCTests/Core/LoggingExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Core/LoggingExtendedTests.swift
@@ -101,6 +101,67 @@ struct LoggingExtendedTests {
     // No crash = success
   }
 
+  @Test(.tags(.async))
+  func `Concurrent subscription churn leaves logging reusable`() async {
+    await withTaskGroup(of: Void.self) { group in
+      for _ in 0..<16 {
+        group.addTask {
+          for _ in 0..<8 {
+            let stream = VLCInstance.shared.logStream(minimumLevel: .debug)
+            let task = Task {
+              for await _ in stream {
+                break
+              }
+            }
+            task.cancel()
+            await task.value
+          }
+        }
+      }
+    }
+
+    let stream = VLCInstance.shared.logStream(minimumLevel: .debug)
+    let task = Task {
+      for await _ in stream {
+        break
+      }
+    }
+    task.cancel()
+    await task.value
+  }
+
+  @Test(.tags(.async))
+  func `Failed log install retries only on later reconciles`() async {
+    let attempts = Mutex(0)
+    let broadcaster = LogBroadcaster(
+      instancePointer: VLCInstance.shared.pointer,
+      installBridge: { _, _ in
+        attempts.withLock { $0 += 1 }
+        return nil
+      },
+      uninstallBridge: { _, _ in }
+    )
+    defer { broadcaster.invalidate() }
+
+    let (stream1, continuation1) = AsyncStream<LogEntry>.makeStream()
+    _ = stream1
+    let firstID = broadcaster.add(continuation: continuation1, minimumLevel: .debug)
+    try? await Task.sleep(for: .milliseconds(100))
+    #expect(attempts.withLock { $0 } == 1)
+
+    broadcaster.remove(id: firstID)
+    continuation1.finish()
+    try? await Task.sleep(for: .milliseconds(100))
+    #expect(attempts.withLock { $0 } == 1)
+
+    let (stream2, continuation2) = AsyncStream<LogEntry>.makeStream()
+    _ = stream2
+    _ = broadcaster.add(continuation: continuation2, minimumLevel: .debug)
+    try? await Task.sleep(for: .milliseconds(100))
+    #expect(attempts.withLock { $0 } == 2)
+    continuation2.finish()
+  }
+
   @Test
   func `LogLevel comparison operators work correctly for all pairs`() {
     let levels: [LogLevel] = [.debug, .notice, .warning, .error]

--- a/Tests/SwiftVLCTests/Discovery/MediaDiscovererFinalTests.swift
+++ b/Tests/SwiftVLCTests/Discovery/MediaDiscovererFinalTests.swift
@@ -13,7 +13,10 @@ struct MediaDiscovererFinalTests {
       let d = try MediaDiscoverer(name: "___completely_invalid_discoverer_name___")
       _ = d // If it succeeds, that's fine too
     } catch {
-      #expect(error is VLCError)
+      guard case .instanceCreationFailed = error else {
+        Issue.record("Expected .instanceCreationFailed, got \(error)")
+        return
+      }
     }
   }
 

--- a/Tests/SwiftVLCTests/Media/ThumbnailRequestTests.swift
+++ b/Tests/SwiftVLCTests/Media/ThumbnailRequestTests.swift
@@ -35,18 +35,77 @@ struct ThumbnailRequestTests {
   }
 
   @Test
-  func `Cancellation safety`() async throws {
+  func `Cancellation completes promptly`() async throws {
     let media = try Media(url: TestMedia.testMP4URL)
-    let task = Task {
-      try await media.thumbnail(at: .zero, width: 64)
+    let completed = await withTaskGroup(of: Bool.self) { group in
+      group.addTask {
+        let task = Task {
+          try await media.thumbnail(at: .zero, width: 64)
+        }
+        task.cancel()
+        do {
+          _ = try await task.value
+        } catch {
+          // Expected — cancellation or operation failure
+        }
+        return true
+      }
+      group.addTask {
+        try? await Task.sleep(for: .seconds(3))
+        return false
+      }
+      let first = await group.next() ?? false
+      group.cancelAll()
+      return first
     }
-    task.cancel()
-    // Should not crash regardless of outcome
-    do {
-      _ = try await task.value
-    } catch {
-      // Expected — cancellation or operation failure
+
+    #expect(completed, "Cancelled thumbnail request should not hang indefinitely")
+  }
+
+  @Test
+  func `Concurrent thumbnails on the same media stay isolated`() async throws {
+    let media = try Media(url: TestMedia.testMP4URL)
+    async let first = media.thumbnail(at: .zero, width: 64, height: 0)
+    async let second = media.thumbnail(at: .milliseconds(250), width: 64, height: 0)
+    let thumbnails = try await [first, second]
+    #expect(thumbnails.count == 2)
+    #expect(thumbnails.allSatisfy { !$0.isEmpty })
+  }
+
+  @Test(.tags(.async))
+  func `Queued thumbnail coordinator cancellation completes promptly`() async throws {
+    let coordinator = ThumbnailCoordinator()
+    try await coordinator.acquire()
+    defer {
+      Task {
+        await coordinator.release()
+      }
     }
+
+    let completed = await withTaskGroup(of: Bool.self) { group in
+      group.addTask {
+        let task = Task {
+          do {
+            try await coordinator.acquire()
+            await coordinator.release()
+          } catch {
+            // Expected cancellation path
+          }
+        }
+        task.cancel()
+        await task.value
+        return true
+      }
+      group.addTask {
+        try? await Task.sleep(for: .seconds(1))
+        return false
+      }
+      let first = await group.next() ?? false
+      group.cancelAll()
+      return first
+    }
+
+    #expect(completed, "Queued acquire should stop waiting as soon as it is cancelled")
   }
 
   @Test

--- a/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
@@ -1,11 +1,30 @@
 #if os(iOS) || os(macOS)
 @testable import SwiftVLC
 import AVFoundation
+import AVKit
+import Dispatch
+import Observation
+import Synchronization
 import Testing
 
 @Suite(.tags(.integration, .mainActor), .timeLimit(.minutes(1)))
 @MainActor
 struct PiPControllerTests {
+  @MainActor
+  final class PlaybackRecorder {
+    var pauseCount = 0
+    var resumeCount = 0
+    var seekTargets: [Int64] = []
+
+    var driver: PiPController.PlaybackDriver {
+      .init(
+        pause: { self.pauseCount += 1 },
+        resume: { self.resumeCount += 1 },
+        seek: { self.seekTargets.append($0.milliseconds) }
+      )
+    }
+  }
+
   @Test
   func `Init with player does not crash`() {
     let player = Player()
@@ -35,7 +54,6 @@ struct PiPControllerTests {
     let player = Player()
     let controller = PiPController(player: player)
     let layer = controller.layer
-    #expect(layer is AVSampleBufferDisplayLayer)
     #expect(layer.videoGravity == .resizeAspect)
   }
 
@@ -98,6 +116,129 @@ struct PiPControllerTests {
     // Both players should remain functional
     #expect(player1.state == .idle)
     #expect(player2.state == .idle)
+  }
+
+  @Test
+  func `isActive invalidates observation`() {
+    let player = Player()
+    let controller = PiPController(player: player)
+    let fired = Mutex(false)
+
+    withObservationTracking {
+      _ = controller.isActive
+    } onChange: {
+      fired.withLock { $0 = true }
+    }
+
+    controller._setStateForTesting(isActive: true)
+
+    #expect(fired.withLock { $0 })
+    #expect(controller.isActive == true)
+  }
+
+  @Test
+  func `isPossible invalidates observation`() {
+    let player = Player()
+    let controller = PiPController(player: player)
+    let fired = Mutex(false)
+    let nextValue = !controller.isPossible
+
+    withObservationTracking {
+      _ = controller.isPossible
+    } onChange: {
+      fired.withLock { $0 = true }
+    }
+
+    controller._setStateForTesting(isPossible: nextValue)
+
+    #expect(fired.withLock { $0 })
+    #expect(controller.isPossible == nextValue)
+  }
+
+  @Test
+  func `delegate state queries are safe off the main thread`() async throws {
+    guard AVPictureInPictureController.isPictureInPictureSupported() else { return }
+
+    let player = Player()
+    let controller = PiPController(player: player)
+    let contentSource = AVPictureInPictureController.ContentSource(
+      sampleBufferDisplayLayer: controller.layer,
+      playbackDelegate: controller
+    )
+    let pip = AVPictureInPictureController(contentSource: contentSource)
+
+    let controllerOpaque = UInt(bitPattern: Unmanaged.passRetained(controller).toOpaque())
+    let pipOpaque = UInt(bitPattern: Unmanaged.passRetained(pip).toOpaque())
+    defer {
+      let controllerPtr = try #require(UnsafeMutableRawPointer(bitPattern: controllerOpaque))
+      Unmanaged<PiPController>.fromOpaque(controllerPtr).release()
+      let pipPtr = try #require(UnsafeMutableRawPointer(bitPattern: pipOpaque))
+      Unmanaged<AVPictureInPictureController>.fromOpaque(pipPtr).release()
+    }
+
+    let paused = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+      DispatchQueue.global().async {
+        let controllerPtr = UnsafeMutableRawPointer(bitPattern: controllerOpaque)!
+        let controller = Unmanaged<PiPController>.fromOpaque(controllerPtr).takeUnretainedValue()
+        let pipPtr = UnsafeMutableRawPointer(bitPattern: pipOpaque)!
+        let pip = Unmanaged<AVPictureInPictureController>.fromOpaque(pipPtr).takeUnretainedValue()
+        continuation.resume(returning: controller._isPlaybackPausedForTesting(pip))
+      }
+    }
+
+    #expect(paused == true)
+  }
+
+  @Test
+  func `transient PiP pause then play does not send native pause or resume`() async throws {
+    let player = Player()
+    try player.play(url: TestMedia.twosecURL)
+    guard try await poll(until: { player.state == .playing }) else {
+      player.stop()
+      return
+    }
+    defer { player.stop() }
+
+    let recorder = PlaybackRecorder()
+    let controller = PiPController(
+      player: player,
+      playbackDriver: recorder.driver,
+      pauseDebounce: .milliseconds(20)
+    )
+
+    controller._setPlayingForTesting(false)
+    controller._setPlayingForTesting(true)
+    try? await Task.sleep(for: .milliseconds(80))
+
+    #expect(recorder.pauseCount == 0)
+    #expect(recorder.resumeCount == 0)
+  }
+
+  @Test
+  func `PiP skip cancels pending pause and suppresses redundant resume`() async throws {
+    let player = Player()
+    try player.play(url: TestMedia.twosecURL)
+    guard try await poll(until: { player.state == .playing }) else {
+      player.stop()
+      return
+    }
+    defer { player.stop() }
+
+    let recorder = PlaybackRecorder()
+    let controller = PiPController(
+      player: player,
+      playbackDriver: recorder.driver,
+      pauseDebounce: .milliseconds(20)
+    )
+
+    controller._setPlayingForTesting(false)
+    controller._skipByIntervalForTesting(CMTime(seconds: 1, preferredTimescale: 1000))
+    controller._setPlayingForTesting(true)
+    try? await Task.sleep(for: .milliseconds(80))
+
+    #expect(recorder.pauseCount == 0)
+    #expect(recorder.resumeCount == 0)
+    #expect(recorder.seekTargets.count == 1)
   }
 }
 #endif

--- a/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
@@ -169,10 +169,14 @@ struct PiPControllerTests {
 
     let controllerOpaque = UInt(bitPattern: Unmanaged.passRetained(controller).toOpaque())
     let pipOpaque = UInt(bitPattern: Unmanaged.passRetained(pip).toOpaque())
+    // `defer` bodies can't throw, so force-unwrap — both pointers were
+    // just produced by `passRetained` a line ago and are guaranteed
+    // non-nil. If they somehow were nil we'd have bigger problems than
+    // a leaked retain.
     defer {
-      let controllerPtr = try #require(UnsafeMutableRawPointer(bitPattern: controllerOpaque))
+      let controllerPtr = UnsafeMutableRawPointer(bitPattern: controllerOpaque)!
       Unmanaged<PiPController>.fromOpaque(controllerPtr).release()
-      let pipPtr = try #require(UnsafeMutableRawPointer(bitPattern: pipOpaque))
+      let pipPtr = UnsafeMutableRawPointer(bitPattern: pipOpaque)!
       Unmanaged<AVPictureInPictureController>.fromOpaque(pipPtr).release()
     }
 

--- a/Tests/SwiftVLCTests/Player/ObservationTests.swift
+++ b/Tests/SwiftVLCTests/Player/ObservationTests.swift
@@ -105,15 +105,108 @@ struct ObservationTests {
     #expect(fired.withLock { $0 })
   }
 
+  @Test
+  func `state events invalidate isPlaying and isActive`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    let isPlayingFired = Mutex(false)
+    let isActiveFired = Mutex(false)
+
+    withObservationTracking {
+      _ = player.isPlaying
+    } onChange: {
+      isPlayingFired.withLock { $0 = true }
+    }
+
+    withObservationTracking {
+      _ = player.isActive
+    } onChange: {
+      isActiveFired.withLock { $0 = true }
+    }
+
+    player._handleEventForTesting(.stateChanged(.playing))
+    #expect(isPlayingFired.withLock { $0 })
+    #expect(isActiveFired.withLock { $0 })
+  }
+
+  @Test
+  func `tracksChanged invalidates selected track observations`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    let audioFired = Mutex(false)
+    let subtitleFired = Mutex(false)
+
+    withObservationTracking {
+      _ = player.selectedAudioTrack
+    } onChange: {
+      audioFired.withLock { $0 = true }
+    }
+
+    withObservationTracking {
+      _ = player.selectedSubtitleTrack
+    } onChange: {
+      subtitleFired.withLock { $0 = true }
+    }
+
+    player._handleEventForTesting(.tracksChanged)
+    #expect(audioFired.withLock { $0 })
+    #expect(subtitleFired.withLock { $0 })
+  }
+
+  @Test
+  func `audioDeviceChanged invalidates currentAudioDevice observation`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    let fired = Mutex(false)
+    withObservationTracking {
+      _ = player.currentAudioDevice
+    } onChange: {
+      fired.withLock { $0 = true }
+    }
+
+    player._handleEventForTesting(.audioDeviceChanged(nil))
+    #expect(fired.withLock { $0 })
+  }
+
+  @Test
+  func `program events invalidate program-derived observations`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    let programsFired = Mutex(false)
+    let selectedFired = Mutex(false)
+    let scrambledFired = Mutex(false)
+
+    withObservationTracking {
+      _ = player.programs
+    } onChange: {
+      programsFired.withLock { $0 = true }
+    }
+
+    withObservationTracking {
+      _ = player.selectedProgram
+    } onChange: {
+      selectedFired.withLock { $0 = true }
+    }
+
+    withObservationTracking {
+      _ = player.isProgramScrambled
+    } onChange: {
+      scrambledFired.withLock { $0 = true }
+    }
+
+    player._handleEventForTesting(.programUpdated(1))
+    #expect(programsFired.withLock { $0 })
+    #expect(selectedFired.withLock { $0 })
+    #expect(scrambledFired.withLock { $0 })
+  }
+
   // MARK: - Stored properties (regression guards for macro wiring)
 
   /// `.state` is stored, so the macro wires observation up automatically
   /// via the generated setter. Use a real playback event (the first
-  /// `.stateChanged` VLC emits) to cause the mutation, and wait on the
-  /// event stream directly rather than polling for the `onChange` flag.
+  /// `.stateChanged` VLC emits) to cause the mutation, then wait for the
+  /// observation callback itself because the raw VLC event stream can
+  /// advance slightly ahead of the main-actor observer.
   @Test
   func `state mutation fires observation`() async throws {
     let player = Player(instance: TestInstance.makeAudioOnly())
+    defer { player.stop() }
     let fired = Mutex(false)
     withObservationTracking {
       _ = player.state
@@ -125,11 +218,7 @@ struct ObservationTests {
     let playing = subscribeAndAwait(.playing, on: player)
     try player.play(Media(url: TestMedia.twosecURL))
     try #require(await playing.value)
-    // `onChange` fires from the event consumer's `withMutation`, which
-    // runs on MainActor just like this test. By the time `playing.value`
-    // resolves, the consumer has processed the event.
-    #expect(fired.withLock { $0 })
-    player.stop()
+    #expect(try await poll(until: { fired.withLock { $0 } }))
   }
 
   // MARK: - Keypath isolation (guards against over-eager withMutation)

--- a/Tests/SwiftVLCTests/Player/PlayerControlTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerControlTests.swift
@@ -60,9 +60,15 @@ struct PlayerControlTests {
   }
 
   @Test
-  func `Setting renderer after playback starts throws`() throws {
+  func `Setting renderer while playing throws`() async throws {
     let player = Player(instance: TestInstance.makeAudioOnly())
+    // Subscribe before `play()` so we don't miss `.playing`. `setRenderer`
+    // is only rejected when the player is past `.idle`/`.stopped`, so we
+    // must wait for a non-idle state before asserting.
+    let playing = subscribeAndAwait(.playing, on: player)
     try player.play(Media(url: TestMedia.twosecURL))
+    try #require(await playing.value)
+
     #expect(throws: VLCError.self) {
       try player.setRenderer(nil)
     }

--- a/Tests/SwiftVLCTests/Player/PlayerControlTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerControlTests.swift
@@ -60,6 +60,16 @@ struct PlayerControlTests {
   }
 
   @Test
+  func `Setting renderer after playback starts throws`() throws {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    try player.play(Media(url: TestMedia.twosecURL))
+    #expect(throws: VLCError.self) {
+      try player.setRenderer(nil)
+    }
+    player.stop()
+  }
+
+  @Test
   func `setDeinterlace accepts auto disable enable`() throws {
     let player = Player(instance: TestInstance.makeAudioOnly())
     try player.setDeinterlace(state: -1)

--- a/Tests/SwiftVLCTests/Player/PlayerTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerTests.swift
@@ -1,4 +1,5 @@
 @testable import SwiftVLC
+import CLibVLC
 import Foundation
 import Testing
 
@@ -61,6 +62,54 @@ struct PlayerTests {
     let media = try Media(url: TestMedia.testMP4URL)
     player.load(media)
     #expect(player.currentMedia != nil)
+  }
+
+  @Test
+  func `mediaChanged resyncs currentMedia and clears timeline state`() throws {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    let initial = try Media(url: TestMedia.testMP4URL)
+    let replacement = try Media(url: TestMedia.twosecURL)
+
+    player.load(initial)
+    player._setStateForTesting(
+      currentTime: .seconds(5),
+      duration: .seconds(30),
+      position: 0.5,
+      isSeekable: true,
+      isPausable: true
+    )
+
+    libvlc_media_player_set_media(player.pointer, replacement.pointer)
+    player._handleEventForTesting(.mediaChanged)
+
+    #expect(player.currentMedia?.mrl == replacement.mrl)
+    #expect(player.currentTime == .zero)
+    #expect(player.duration == nil)
+    #expect(player.position == 0)
+    #expect(player.isSeekable == false)
+    #expect(player.isPausable == false)
+  }
+
+  @Test
+  func `mediaChanged retains synced media after native player switches again`() throws {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    let initial = try Media(url: TestMedia.testMP4URL)
+    player.load(initial)
+
+    let syncedMedia: Media
+    let syncedMRL: String
+    do {
+      let replacement = try Media(url: TestMedia.twosecURL)
+      libvlc_media_player_set_media(player.pointer, replacement.pointer)
+      player._handleEventForTesting(.mediaChanged)
+      syncedMedia = try #require(player.currentMedia)
+      syncedMRL = try #require(replacement.mrl)
+    }
+
+    libvlc_media_player_set_media(player.pointer, initial.pointer)
+    player._handleEventForTesting(.mediaChanged)
+
+    #expect(syncedMedia.mrl == syncedMRL)
   }
 
   @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))

--- a/Tests/SwiftVLCTests/Playlist/MediaListPlayerTests.swift
+++ b/Tests/SwiftVLCTests/Playlist/MediaListPlayerTests.swift
@@ -1,4 +1,5 @@
 @testable import SwiftVLC
+import CLibVLC
 import Testing
 
 @Suite(.tags(.integration, .mainActor))
@@ -203,6 +204,14 @@ struct MediaListPlayerTests {
     #expect(listPlayer.mediaPlayer != nil)
     listPlayer.mediaPlayer = nil
     #expect(listPlayer.mediaPlayer == nil)
+    let nativePlayer = libvlc_media_list_player_get_media_player(listPlayer.pointer)
+    defer {
+      if let nativePlayer {
+        libvlc_media_player_release(nativePlayer)
+      }
+    }
+    #expect(nativePlayer != nil)
+    #expect(nativePlayer != player.pointer)
   }
 
   @Test
@@ -213,5 +222,21 @@ struct MediaListPlayerTests {
     #expect(listPlayer.mediaList != nil)
     listPlayer.mediaList = nil
     #expect(listPlayer.mediaList == nil)
+  }
+
+  @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
+  func `Clearing media list removes stale native playback state`() async throws {
+    let listPlayer = MediaListPlayer()
+    let player = Player()
+    listPlayer.mediaPlayer = player
+
+    let list = MediaList()
+    try list.append(Media(url: TestMedia.twosecURL))
+    listPlayer.mediaList = list
+    listPlayer.mediaList = nil
+
+    listPlayer.play()
+    try await Task.sleep(for: .milliseconds(300))
+    #expect(!listPlayer.isPlaying)
   }
 }

--- a/Tests/SwiftVLCTests/Video/VideoViewFinalTests.swift
+++ b/Tests/SwiftVLCTests/Video/VideoViewFinalTests.swift
@@ -1,4 +1,5 @@
 @testable import SwiftVLC
+import CLibVLC
 import Testing
 
 #if canImport(AppKit)
@@ -10,6 +11,10 @@ import UIKit
 @Suite(.tags(.integration, .mainActor), .timeLimit(.minutes(1)))
 @MainActor
 struct VideoViewFinalTests {
+  private func drawable(of player: Player) -> UnsafeMutableRawPointer? {
+    libvlc_media_player_get_nsobject(player.pointer)
+  }
+
   @Test
   func `NSView VideoSurface creation`() {
     let surface = VideoSurface()
@@ -25,9 +30,9 @@ struct VideoViewFinalTests {
   func `attach sets nsobject on player`() {
     let player = Player()
     let surface = VideoSurface()
+    let surfacePtr = Unmanaged.passUnretained(surface).toOpaque()
     surface.attach(to: player)
-    // Attaching should store the player reference (no crash = success)
-    // Detach to confirm the reference was stored
+    #expect(drawable(of: player) == surfacePtr)
     surface.detach()
   }
 
@@ -37,6 +42,7 @@ struct VideoViewFinalTests {
     let surface = VideoSurface()
     surface.attach(to: player)
     surface.detach()
+    #expect(drawable(of: player) == nil)
     // A second detach should be a no-op (guard clause: attachedPlayer is nil)
     surface.detach()
   }
@@ -98,10 +104,13 @@ struct VideoViewFinalTests {
     let player1 = Player()
     let player2 = Player()
     let surface = VideoSurface()
+    let surfacePtr = Unmanaged.passUnretained(surface).toOpaque()
 
     surface.attach(to: player1)
-    // Attaching a different player should pass the guard (player1 !== player2)
+    #expect(drawable(of: player1) == surfacePtr)
     surface.attach(to: player2)
+    #expect(drawable(of: player1) == nil)
+    #expect(drawable(of: player2) == surfacePtr)
     surface.detach()
   }
 

--- a/scripts/build-libvlc.sh
+++ b/scripts/build-libvlc.sh
@@ -40,6 +40,12 @@ BUILD_TVOS=no
 BUILD_MACOS=no
 BUILD_CATALYST=no
 
+# Keep these deployment targets in sync with Package.swift.
+SWIFTVLC_MIN_IOS="18.0"
+SWIFTVLC_MIN_TVOS="18.0"
+SWIFTVLC_MIN_MACOS="15.0"
+SWIFTVLC_MIN_CATALYST="18.0"
+
 BUILD_START_TIME=$(date +%s)
 
 if [ -z "$MAKEFLAGS" ]; then
@@ -304,7 +310,7 @@ build_conf_path = sys.argv[2]
 # --- Patch build.conf: add Catalyst deployment target ---
 with open(build_conf_path, 'a') as f:
     f.write('\n# Mac Catalyst deployment target\n')
-    f.write('export VLC_DEPLOYMENT_TARGET_CATALYST="16.0"\n')
+    f.write('export VLC_DEPLOYMENT_TARGET_CATALYST="18.0"\n')
 
 # --- Patch build.sh ---
 with open(build_sh_path, 'r') as f:
@@ -683,6 +689,54 @@ PYEOF
 }
 
 patch_vlc_ldflags
+
+patch_vlc_deployment_targets() {
+    local BUILD_CONF="${VLC_SRC}/extras/package/apple/build.conf"
+
+    info "Patching VLC deployment targets to match SwiftVLC's supported minimums..."
+
+    python3 - "$BUILD_CONF" \
+        "$SWIFTVLC_MIN_MACOS" \
+        "$SWIFTVLC_MIN_IOS" \
+        "$SWIFTVLC_MIN_TVOS" \
+        "$SWIFTVLC_MIN_CATALYST" << 'PYEOF'
+import re
+import sys
+
+build_conf_path, macos, ios, tvos, catalyst = sys.argv[1:]
+
+with open(build_conf_path, 'r') as f:
+    content = f.read()
+
+replacements = {
+    r'^export VLC_DEPLOYMENT_TARGET_MACOSX=.*$': f'export VLC_DEPLOYMENT_TARGET_MACOSX="{macos}"',
+    r'^export VLC_DEPLOYMENT_TARGET_IOS=.*$': f'export VLC_DEPLOYMENT_TARGET_IOS="{ios}"',
+    r'^export VLC_DEPLOYMENT_TARGET_IOS_SIMULATOR=.*$': f'export VLC_DEPLOYMENT_TARGET_IOS_SIMULATOR="{ios}"',
+    r'^export VLC_DEPLOYMENT_TARGET_TVOS=.*$': f'export VLC_DEPLOYMENT_TARGET_TVOS="{tvos}"',
+    r'^export VLC_DEPLOYMENT_TARGET_TVOS_SIMULATOR=.*$': f'export VLC_DEPLOYMENT_TARGET_TVOS_SIMULATOR="{tvos}"',
+}
+
+for pattern, replacement in replacements.items():
+    content = re.sub(pattern, replacement, content, flags=re.MULTILINE)
+
+if re.search(r'^export VLC_DEPLOYMENT_TARGET_CATALYST=.*$', content, flags=re.MULTILINE):
+    content = re.sub(
+        r'^export VLC_DEPLOYMENT_TARGET_CATALYST=.*$',
+        f'export VLC_DEPLOYMENT_TARGET_CATALYST="{catalyst}"',
+        content,
+        flags=re.MULTILINE
+    )
+
+with open(build_conf_path, 'w') as f:
+    f.write(content)
+
+print('Deployment targets patched successfully')
+PYEOF
+
+    info "VLC deployment targets patched"
+}
+
+patch_vlc_deployment_targets
 
 # --- Step 1e: Force libtool --tag=CC for Objective-C convenience library ---
 # VLC's src/Makefile.am builds libvlccore_objc.la from .m files, but doesn't


### PR DESCRIPTION
## Summary
- fix multiple SwiftVLC wrapper races and state-sync issues across logging, dialogs, thumbnails, player/media, video binding, PiP, and playlists
- tighten showcase demos so PiP and playlist state behave correctly and the playlist demo starts playback without noisy background metadata requests
- add and extend regression coverage for the fixed edge cases across player, PiP, dialogs, logging, thumbnails, equalizer, video view, and playlist behaviors

## Verification
- swift test --filter PiPControllerTests
- swift test --parallel
- xcodebuild -project Showcase/SwiftVLCShowcase.xcodeproj -scheme SwiftVLCShowcase -destination 'platform=macOS' -derivedDataPath /tmp/swiftvlc-showcase-playlist CODE_SIGNING_ALLOWED=NO build