### PR TITLE
Update release flow to advance main and pin Showcase releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,11 +59,11 @@ jobs:
         timeout-minutes: 1
         run: xcrun --toolchain "$TOOLCHAINS" swift --version
 
-      # Branches use the local-path form of binaryTarget. On CI we want to
-      # test against the last published xcframework (what SPM consumers get),
-      # so rewrite Package.swift's binaryTarget to the url+checksum form
-      # from the latest release. Only the binaryTarget line changes —
-      # branch edits elsewhere in Package.swift are preserved.
+      # CI should always test against the last published xcframework (what
+      # SPM consumers get), regardless of whether the checkout currently
+      # points at Vendor/ for local dev or already carries a release URL.
+      # Only the libvlc binaryTarget is rewritten; other Package.swift
+      # edits are preserved.
       - name: Point Package.swift at last released xcframework
         id: xcf
         timeout-minutes: 1

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -681,7 +681,7 @@ flowchart LR
     PUSH_MAIN --> SPM["main and consumers resolve the same release"]
 ```
 
-Preflight refuses releases from non-`main` branches (`--allow-dirty-branch` overrides), uncommitted changes in `Package.swift` or the Showcase project, pre-existing local or remote tags, and unauthenticated `gh`. The tag is pushed before `main`, so if GitHub Release creation fails, `origin/main` still points at the previous good release; finish the release or delete the tag before retrying. A post-write regex guard verifies that the rewritten `Package.swift` still contains the `CLibVLC` target, catching a malformed replacement before the tag is cut.
+Preflight refuses releases from non-`main` branches, uncommitted changes in `Package.swift` or the Showcase project, pre-existing local or remote tags, and unauthenticated `gh`. If a pre-commit rewrite or post-write sanity check fails, the script restores `Package.swift` and the Showcase project before exiting. The tag is pushed before `main`, so if GitHub Release creation fails, `origin/main` still points at the previous good release; finish the release or delete the tag before retrying. A post-write regex guard verifies that the rewritten `Package.swift` still contains the `CLibVLC` target, catching a malformed replacement before the tag is cut.
 
 ### CI/CD
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -626,33 +626,44 @@ func playAndWaitForState() async throws {
 
 | Script | Purpose |
 |---|---|
-| `scripts/setup-dev.sh` | First step on a fresh clone. Downloads the last-released xcframework into `Vendor/` and verifies `Package.swift` is in local-path form. Flags: `--force` (re-download), `--skip-download` (only flip the manifest). |
+| `scripts/setup-dev.sh` | First step for local repo work. Downloads the last-released xcframework into `Vendor/`, flips `Package.swift` to the local-path form, and points the Showcase app at the repo-local Swift package. Flags: `--force` (re-download), `--skip-download` (only flip local references). |
 | `scripts/build-libvlc.sh` | Compiles libVLC from VideoLAN source (pinned via `VLC_HASH`) into `Vendor/libvlc.xcframework`. Applies 5 in-tree patches needed for current Xcode (26) and Homebrew libtool (2.5) — see README. |
 | `scripts/fix-duplicate-symbols.sh` | Localizes `_json_parse_error` and `_json_read` in the chromecast plugin, which two VLC plugins each emit. Called automatically by `build-libvlc.sh` and `setup-dev.sh`. |
-| `scripts/release.sh` | Cuts a versioned release. Tag-only model — see below. |
-| `scripts/ci-use-released-xcframework.sh` | CI-only. Rewrites the current `Package.swift` `binaryTarget` from local path to the url+checksum of the latest release tag. Run at CI job start so tests resolve against the same binary a downstream consumer would. |
+| `scripts/release.sh` | Cuts a versioned release, uploads the xcframework asset, pins the Showcase app to that exact Swift package version, and advances `main`. |
+| `scripts/ci-use-released-xcframework.sh` | CI-only. Rewrites the current `Package.swift` `binaryTarget` to the url+checksum of the latest release tag. Run at CI job start so tests resolve against the same binary a downstream consumer would. |
 | `scripts/ci-run-with-timeouts.py` | CI-only. Wraps `swift test` with wall-clock and idle timeouts; SIGKILLs the process group if either fires. |
 
 ### Package.swift resolution strategy
 
-Every branch, including `main`, carries the local-path form of the libvlc `binaryTarget`:
+Published states (`main` and release tags) carry the remote form of the libvlc `binaryTarget`:
+
+```swift
+.binaryTarget(
+  name: "libvlc",
+  url: "https://github.com/harflabs/SwiftVLC/releases/download/vX.Y.Z/libvlc.xcframework.zip",
+  checksum: "<sha256>"
+)
+```
+
+That keeps the repository's default package state aligned with what downstream SPM consumers resolve. Local repo development flips the manifest back to the on-disk xcframework with `./scripts/setup-dev.sh`, which rewrites only the libvlc `binaryTarget` to:
 
 ```swift
 .binaryTarget(name: "libvlc", path: "Vendor/libvlc.xcframework")
 ```
 
-This keeps `git clone && ./scripts/setup-dev.sh && swift build` frictionless: no manifest rewriting needed to build or test, and no ambiguity about which binary is current. The remote `url:+checksum:` form exists only under release tags; it never lands on a branch.
+The Showcase app follows the same split: published states pin `SwiftVLC` by exact release version, while `setup-dev.sh` rewrites the Xcode project to use the repo-local package checkout.
 
 | Context | What `binaryTarget` looks like | Where the xcframework comes from |
 |---|---|---|
-| Local dev | `path: "Vendor/libvlc.xcframework"` | `setup-dev.sh` (download) or `build-libvlc.sh` (build) |
+| Published `main` | `url: + checksum:` of the latest release | GitHub Release asset |
+| Local dev after `setup-dev.sh` | `path: "Vendor/libvlc.xcframework"` | `setup-dev.sh` (download) or `build-libvlc.sh` (build) |
 | CI | rewritten in-memory to `url: + checksum:` of the latest release | SPM resolves + caches (keyed on checksum) |
-| Release tag `vX.Y.Z` | `url: + checksum:` (baked into a detached commit) | `release.sh` uploads the zip as a release asset at that URL |
+| Release tag `vX.Y.Z` | `url: + checksum:` | `release.sh` uploads the zip as a release asset at that URL |
 | SPM consumer pinning `X.Y.Z` | Reads the tag's `Package.swift` | SPM resolves + verifies checksum + caches |
 
 ### Release flow
 
-Tag-only: the commit that pins `Package.swift` to the remote url+checksum is reachable only through the tag. `main` is never advanced by `release.sh`.
+`release.sh` creates a real release commit that stays on `main`.
 
 ```mermaid
 flowchart LR
@@ -662,15 +673,15 @@ flowchart LR
     VERIFY --> STRIP["strip -S"]
     STRIP --> ZIP["ditto -c -k"]
     ZIP --> SUM["swift package compute-checksum"]
-    SUM --> DETACH["Detached commit:<br/>Package.swift → url+checksum"]
-    DETACH --> TAG["git tag vX.Y.Z"]
-    TAG --> RESET["git reset --hard HEAD~1<br/>(branch restored; tag keeps commit alive)"]
-    RESET --> PUSH["git push origin vX.Y.Z"]
-    PUSH --> GH["gh release create<br/>+ attached .zip"]
-    GH --> SPM["Consumers pin vX.Y.Z"]
+    SUM --> COMMIT["Commit on main:<br/>Package.swift → url+checksum<br/>Showcase → exactVersion X.Y.Z"]
+    COMMIT --> TAG["git tag vX.Y.Z"]
+    TAG --> PUSH_TAG["git push origin vX.Y.Z"]
+    PUSH_TAG --> GH["gh release create<br/>+ attached .zip"]
+    GH --> PUSH_MAIN["git push origin HEAD:main"]
+    PUSH_MAIN --> SPM["main and consumers resolve the same release"]
 ```
 
-Preflight refuses releases from non-`main` branches (`--allow-dirty-branch` overrides), pre-existing local tags, and unauthenticated `gh`. If any step fails after the detached commit is made, the `EXIT` trap resets the branch to its pre-release HEAD so nothing is left dangling. A post-write regex guard verifies that the rewritten `Package.swift` still contains the `CLibVLC` target, catching a malformed replacement before the tag is cut.
+Preflight refuses releases from non-`main` branches (`--allow-dirty-branch` overrides), uncommitted changes in `Package.swift` or the Showcase project, pre-existing local or remote tags, and unauthenticated `gh`. The tag is pushed before `main`, so if GitHub Release creation fails, `origin/main` still points at the previous good release; finish the release or delete the tag before retrying. A post-write regex guard verifies that the rewritten `Package.swift` still contains the `CLibVLC` target, catching a malformed replacement before the tag is cut.
 
 ### CI/CD
 
@@ -713,7 +724,7 @@ SwiftVLC/
 ├── scripts/
 │   ├── build-libvlc.sh                   # Compile libvlc from source
 │   ├── setup-dev.sh                      # Download xcframework for local dev
-│   ├── release.sh                        # Cut a versioned tag (tag-only, detached)
+│   ├── release.sh                        # Cut a versioned release and advance main
 │   ├── fix-duplicate-symbols.sh          # Localize duplicate json symbols
 │   ├── ci-use-released-xcframework.sh    # CI: point Package.swift at latest release
 │   └── ci-run-with-timeouts.py           # CI: wall-clock + idle test timeouts
@@ -727,4 +738,3 @@ SwiftVLC/
 ├── .swiftformat                   # Format: 2-space indent
 └── README.md                     # User guide
 ```
-

--- a/README.md
+++ b/README.md
@@ -156,14 +156,14 @@ cd SwiftVLC
 swift test
 ```
 
-`setup-dev.sh` downloads `libvlc.xcframework.zip` from the latest release into `Vendor/`. `Package.swift` on every branch points at that local path, so no manifest edits are needed before building.
+`main` tracks the latest released `url + checksum` form of the libVLC binary target, and the Showcase app tracks that same Swift package release. `setup-dev.sh` downloads `libvlc.xcframework.zip` into `Vendor/` and flips your checkout back to repo-local sources so package development and the Showcase app both build against what is on disk.
 
 | `setup-dev.sh` flag | Effect |
 |---|---|
 | *(none)* | Download the latest release if `Vendor/` is empty; otherwise keep existing. |
 | `vX.Y.Z` *(positional)* | Pin to a specific release tag. |
 | `--force` | Re-download even if `Vendor/` already exists. |
-| `--skip-download` | Only flip `Package.swift` to local path. Expects `Vendor/` to already exist, which is useful after running `build-libvlc.sh`. |
+| `--skip-download` | Only flip local references (`Package.swift` and the Showcase app). Expects `Vendor/` to already exist, which is useful after running `build-libvlc.sh`. |
 
 ## Building libVLC from Source
 
@@ -203,7 +203,7 @@ VLC master doesn't build cleanly against current Xcode and Homebrew libtool. The
 
 ## Releasing
 
-Releases use a **tag-only** model: the commit that pins `Package.swift` to the remote xcframework URL exists only under the tag, never on a branch. Every branch stays ready for `setup-dev.sh && swift build`.
+Releases advance `main`: `release.sh` rewrites `Package.swift` to the new remote xcframework URL + checksum, pins the Showcase app to that exact SwiftVLC version, tags that commit, uploads the zip as a GitHub Release asset, and then pushes `main` to that same commit. `setup-dev.sh` is what flips a working checkout back to local sources for day-to-day development.
 
 ```bash
 ./scripts/build-libvlc.sh --all          # produces Vendor/libvlc.xcframework
@@ -216,13 +216,13 @@ What `release.sh` does:
 1. Verifies all six platform slices are present in the xcframework.
 2. Copies it to a temp dir, strips debug symbols, zips with `ditto`.
 3. Computes SHA-256 via `swift package compute-checksum`.
-4. Creates a detached commit with `Package.swift` rewritten to the remote URL and checksum.
-5. Tags that commit as `vX.Y.Z`.
-6. Resets the branch back to its previous HEAD; the commit survives only as the tag.
-7. Pushes the tag (never the branch).
-8. Uploads the zip to a new GitHub Release.
+4. Rewrites `Package.swift` to the remote URL and checksum, and pins the Showcase app to `SwiftVLC` exact version `X.Y.Z`.
+5. Commits that change and tags it as `vX.Y.Z`.
+6. Pushes the tag first so GitHub can attach the release asset to that exact commit.
+7. Uploads the zip to a new GitHub Release.
+8. Pushes `main` to the same commit, so `main` always references the latest published xcframework and Showcase package version.
 
-Preflight refuses non-`main` branches (`--allow-dirty-branch` to override), pre-existing local tags, and unauthenticated `gh`. If any later step fails, the EXIT trap resets the branch to its pre-release HEAD so nothing is left dangling.
+Preflight refuses non-`main` branches (`--allow-dirty-branch` to override), uncommitted changes in `Package.swift` or the Showcase project, pre-existing local or remote tags, and unauthenticated `gh`. If the tag push succeeds but a later step fails, `origin/main` is still untouched; finish the GitHub Release (or delete the tag) before retrying.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
   <img alt="SwiftVLC" src="https://raw.githubusercontent.com/harflabs/SwiftVLC/main/Assets/logo-light.svg" width="260">
 </picture>
 
+[![Tests](https://github.com/harflabs/SwiftVLC/actions/workflows/test.yml/badge.svg)](https://github.com/harflabs/SwiftVLC/actions/workflows/test.yml)
+
 A Swift wrapper around [libVLC](https://www.videolan.org/vlc/libvlc.html) for iOS, macOS, tvOS, and Mac Catalyst.
 
 ## Why?

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ What `release.sh` does:
 7. Uploads the zip to a new GitHub Release.
 8. Pushes `main` to the same commit, so `main` always references the latest published xcframework and Showcase package version.
 
-Preflight refuses non-`main` branches (`--allow-dirty-branch` to override), uncommitted changes in `Package.swift` or the Showcase project, pre-existing local or remote tags, and unauthenticated `gh`. If the tag push succeeds but a later step fails, `origin/main` is still untouched; finish the GitHub Release (or delete the tag) before retrying.
+Preflight refuses non-`main` branches, uncommitted changes in `Package.swift` or the Showcase project, pre-existing local or remote tags, and unauthenticated `gh`. If a pre-commit rewrite fails, the script restores `Package.swift` and the Showcase project before exiting. If the tag push succeeds but a later step fails, `origin/main` is still untouched; finish the GitHub Release (or delete the tag) before retrying.
 
 ## Architecture
 

--- a/Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj
+++ b/Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj
@@ -156,7 +156,7 @@
 			mainGroup = B4000001;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				BA000001 /* XCRemoteSwiftPackageReference "SwiftVLC" */,
+				BA000001 /* XCLocalSwiftPackageReference ".." */,
 			);
 			productRefGroup = B4000003 /* Products */;
 			projectDirPath = "";
@@ -440,21 +440,17 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		BA000001 /* XCRemoteSwiftPackageReference "SwiftVLC" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/harflabs/SwiftVLC";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.7.0;
-			};
+/* Begin XCLocalSwiftPackageReference section */
+		BA000001 /* XCLocalSwiftPackageReference ".." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ..;
 		};
-/* End XCRemoteSwiftPackageReference section */
+/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		B8000001 /* SwiftVLC */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BA000001 /* XCRemoteSwiftPackageReference "SwiftVLC" */;
+			package = BA000001 /* XCLocalSwiftPackageReference ".." */;
 			productName = SwiftVLC;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Sources/SwiftVLC/Core/LogNoiseFilter.swift
+++ b/Sources/SwiftVLC/Core/LogNoiseFilter.swift
@@ -39,6 +39,17 @@
 /// Until those land, this filter is how SwiftVLC consumers get a clean
 /// error level.
 enum LogNoiseFilter {
+  /// Returns the highest severity this filter can emit for a raw libVLC
+  /// level, before the message string has been allocated.
+  ///
+  /// The current rules only demote `.error` entries to `.warning`; they
+  /// never promote lower-severity entries. That invariant lets the log
+  /// callback skip String allocation when no subscriber is interested in
+  /// the raw level.
+  static func mostSeverePossibleResult(for level: LogLevel) -> LogLevel {
+    level
+  }
+
   /// Returns the effective level for a libVLC log entry. Pure; safe to
   /// call from the C log callback thread.
   ///

--- a/Sources/SwiftVLC/Core/Logging.swift
+++ b/Sources/SwiftVLC/Core/Logging.swift
@@ -183,6 +183,12 @@ final class LogBroadcaster: Sendable {
     }
   }
 
+  func hasSubscriber(atOrBelow level: LogLevel) -> Bool {
+    state.withLock { state in
+      state.subscribers.values.contains { $0.minimumLevel <= level }
+    }
+  }
+
   private enum Action {
     case install
     case uninstall(box: UnsafeMutableRawPointer, bridge: UnsafeMutableRawPointer?)
@@ -259,6 +265,9 @@ private func logCallback(
   let broadcaster = Unmanaged<LogBroadcaster>.fromOpaque(data).takeUnretainedValue()
 
   guard let logLevel = LogLevel(rawValue: level) else { return }
+  guard broadcaster.hasSubscriber(atOrBelow: LogNoiseFilter.mostSeverePossibleResult(for: logLevel)) else {
+    return
+  }
 
   let messageString = String(cString: message)
   let moduleString = module.map { String(cString: $0) }

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -574,15 +574,18 @@ public final class Player {
   // MARK: - Recording
 
   /// Starts recording the current stream to the specified directory.
+  /// No-op when no media is loaded.
   ///
   /// Listen to ``PlayerEvent/recordingChanged(isRecording:filePath:)`` for state updates.
   /// - Parameter directory: Path to save recording (`nil` for default).
   public func startRecording(to directory: String? = nil) {
+    guard currentMedia != nil else { return }
     libvlc_media_player_record(pointer, true, directory)
   }
 
-  /// Stops recording the current stream.
+  /// Stops recording the current stream. No-op when no media is loaded.
   public func stopRecording() {
+    guard currentMedia != nil else { return }
     libvlc_media_player_record(pointer, false, nil)
   }
 

--- a/Tests/SwiftVLCTests/Core/LogNoiseFilterTests.swift
+++ b/Tests/SwiftVLCTests/Core/LogNoiseFilterTests.swift
@@ -11,6 +11,15 @@ import Testing
 /// `LogNoiseFilter` for the rationale.
 extension Logic {
   struct LogNoiseFilterTests {
+    // MARK: - Pre-allocation severity bound
+
+    @Test(
+      arguments: [LogLevel.debug, .notice, .warning, .error] as [LogLevel]
+    )
+    func `Most severe possible result is the raw level`(level: LogLevel) {
+      #expect(LogNoiseFilter.mostSeverePossibleResult(for: level) == level)
+    }
+
     // MARK: - Reclassification rules
 
     @Test

--- a/Tests/SwiftVLCTests/Core/LoggingExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Core/LoggingExtendedTests.swift
@@ -130,6 +130,31 @@ extension Integration {
       await task.value
     }
 
+    @Test
+    func `Broadcaster interest check respects subscriber minimum levels`() {
+      let broadcaster = LogBroadcaster(
+        instancePointer: VLCInstance.shared.pointer,
+        installBridge: { _, _ in nil },
+        uninstallBridge: { _, _ in }
+      )
+      defer { broadcaster.invalidate() }
+
+      #expect(!broadcaster.hasSubscriber(atOrBelow: .error))
+
+      let (stream, continuation) = AsyncStream<LogEntry>.makeStream()
+      _ = stream
+      let id = broadcaster.add(continuation: continuation, minimumLevel: .warning)
+      defer {
+        broadcaster.remove(id: id)
+        continuation.finish()
+      }
+
+      #expect(!broadcaster.hasSubscriber(atOrBelow: .debug))
+      #expect(!broadcaster.hasSubscriber(atOrBelow: .notice))
+      #expect(broadcaster.hasSubscriber(atOrBelow: .warning))
+      #expect(broadcaster.hasSubscriber(atOrBelow: .error))
+    }
+
     @Test(.tags(.async))
     func `Failed log install retries only on later reconciles`() async {
       let attempts = Mutex(0)

--- a/Tests/SwiftVLCTests/VideoSurfaceRaceTests.swift
+++ b/Tests/SwiftVLCTests/VideoSurfaceRaceTests.swift
@@ -32,7 +32,10 @@ import AppKit
 /// server so the macOS vout never fully spins up — these tests still
 /// cover the attach/detach ordering that the bug lived in.
 extension Integration {
-  @Suite(.tags(.mainActor))
+  @Suite(
+    .tags(.mainActor),
+    .enabled(if: TestCondition.canPlayMedia, "Requires video output (skipped on CI)")
+  )
   @MainActor struct VideoSurfaceRaceTests {
     /// Scenario (a): attach → play → mid-render detach → drop surface →
     /// drop player. The detach is called explicitly, matching the

--- a/Tests/SwiftVLCTests/VideoSurfaceRaceTests.swift
+++ b/Tests/SwiftVLCTests/VideoSurfaceRaceTests.swift
@@ -167,21 +167,21 @@ extension Integration {
       player.stop()
     }
 
-    /// Scenario (f): host the surface in a real AppKit window (macOS
-    /// only). `NSWindow.contentView = surface` triggers the
-    /// view-hierarchy wiring that libVLC's vout expects, and dropping
-    /// the window exercises the real dismiss path. Closest a headless
-    /// test can get to the Showcase runtime.
-    ///
-    /// Disabled on CI: GitHub Actions' `macos-latest` runners are
-    /// paravirtualized M2 instances that lack
-    /// `AppleM2ScalerParavirtDriver`. libVLC's h264 decoder tries to
-    /// allocate hardware-backed frame buffers, `IOServiceMatching`
-    /// fails, and the process aborts before any test assertion can
-    /// run. The test passes locally against a real macOS GPU and is
-    /// kept around for manual runs; a proper equivalent for CI belongs
-    /// in the `SwiftVLCShowcaseUITests` target, which hosts the real
-    /// Showcase app with a real `NSApplication`.
+    // Scenario (f): host the surface in a real AppKit window (macOS
+    // only). `NSWindow.contentView = surface` triggers the
+    // view-hierarchy wiring that libVLC's vout expects, and dropping
+    // the window exercises the real dismiss path. Closest a headless
+    // test can get to the Showcase runtime.
+    //
+    // Disabled on CI: GitHub Actions' `macos-latest` runners are
+    // paravirtualized M2 instances that lack
+    // `AppleM2ScalerParavirtDriver`. libVLC's h264 decoder tries to
+    // allocate hardware-backed frame buffers, `IOServiceMatching`
+    // fails, and the process aborts before any test assertion can
+    // run. The test passes locally against a real macOS GPU and is
+    // kept around for manual runs; a proper equivalent for CI belongs
+    // in the `SwiftVLCShowcaseUITests` target, which hosts the real
+    // Showcase app with a real `NSApplication`.
     #if canImport(AppKit)
     @Test(.disabled("CI runners lack AppleM2ScalerParavirtDriver; run locally or via UI-test target"))
     func `NSWindow hosted surface attach play drop window 10 iterations`() async throws {

--- a/scripts/ci-use-released-xcframework.sh
+++ b/scripts/ci-use-released-xcframework.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
-# ci-use-released-xcframework.sh — Swap Package.swift's libvlc binaryTarget
-# from the local-path form to the url+checksum form from the latest release,
-# so CI can resolve the xcframework via SPM just like a downstream consumer
-# pinning that tag would.
+# ci-use-released-xcframework.sh — Rewrite Package.swift's libvlc
+# binaryTarget to the url+checksum form from the latest release, so CI can
+# resolve the xcframework via SPM just like a downstream consumer pinning
+# that tag would.
 #
 # Only the binaryTarget is rewritten; other Package.swift changes on the
 # branch (swiftSettings, new targets, platform bumps) are preserved.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,12 +5,11 @@
 # Prerequisites:
 #   - ./scripts/build-libvlc.sh --all  (produces Vendor/libvlc.xcframework)
 #   - gh authed (gh auth login)
-#   - Clean Package.swift + Showcase project on main (unless --allow-dirty-branch)
+#   - Clean Package.swift + Showcase project on main
 #
 # Usage:
 #   ./scripts/release.sh 0.1.0
 #   ./scripts/release.sh 0.1.0 --dry-run            # strip/zip/checksum only, no push
-#   ./scripts/release.sh 0.1.0 --allow-dirty-branch # skip the "on main" check
 #
 set -euo pipefail
 
@@ -35,12 +34,14 @@ EXPECTED_SLICES=(
 
 VERSION=""
 DRY_RUN=false
-ALLOW_DIRTY_BRANCH=false
 
 for arg in "$@"; do
   case "$arg" in
     --dry-run)            DRY_RUN=true ;;
-    --allow-dirty-branch) ALLOW_DIRTY_BRANCH=true ;;
+    --allow-dirty-branch)
+      echo "Error: --allow-dirty-branch is no longer supported." >&2
+      echo "  Releases advance origin/main and must be run from main." >&2
+      exit 1 ;;
     --help|-h)
       sed -n 's/^# \{0,1\}//p' "$0" | sed -n '/^Usage:/,/^$/p'
       exit 0 ;;
@@ -57,7 +58,7 @@ for arg in "$@"; do
 done
 
 if [[ -z "$VERSION" ]]; then
-  echo "Usage: $0 <version> [--dry-run] [--allow-dirty-branch]" >&2
+  echo "Usage: $0 <version> [--dry-run]" >&2
   echo "  e.g. $0 0.1.0" >&2
   exit 1
 fi
@@ -68,6 +69,42 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT_DIR"
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
+
+WORK_DIR=""
+RELEASE_RESTORE_DIR=""
+RELEASE_RESTORE_FILES=false
+
+cleanup() {
+  local status=$?
+
+  if [[ "$RELEASE_RESTORE_FILES" == true ]]; then
+    if [[ -n "$RELEASE_RESTORE_DIR" && -f "$RELEASE_RESTORE_DIR/Package.swift" ]]; then
+      cp "$RELEASE_RESTORE_DIR/Package.swift" Package.swift
+    fi
+    if [[ -n "$RELEASE_RESTORE_DIR" && -f "$RELEASE_RESTORE_DIR/project.pbxproj" ]]; then
+      cp "$RELEASE_RESTORE_DIR/project.pbxproj" "$SHOWCASE_PROJECT"
+    fi
+    git reset -q -- Package.swift "$SHOWCASE_PROJECT" 2>/dev/null || true
+    if [[ "$status" -ne 0 ]]; then
+      echo "Restored Package.swift and $SHOWCASE_PROJECT after failed release rewrite." >&2
+    fi
+  fi
+
+  if [[ -n "$WORK_DIR" ]]; then
+    rm -rf "$WORK_DIR"
+  fi
+  if [[ -n "$RELEASE_RESTORE_DIR" ]]; then
+    rm -rf "$RELEASE_RESTORE_DIR"
+  fi
+}
+trap cleanup EXIT
+
+begin_release_file_restore() {
+  RELEASE_RESTORE_DIR=$(mktemp -d)
+  cp Package.swift "$RELEASE_RESTORE_DIR/Package.swift"
+  cp "$SHOWCASE_PROJECT" "$RELEASE_RESTORE_DIR/project.pbxproj"
+  RELEASE_RESTORE_FILES=true
+}
 
 switch_package_to_release_url() {
   RELEASE_URL="$RELEASE_URL" CHECKSUM="$CHECKSUM" python3 - <<'PYEOF'
@@ -109,14 +146,14 @@ PYEOF
 }
 
 switch_showcase_to_release_version() {
-  RELEASE_VERSION="$VERSION" python3 - <<'PYEOF'
+  RELEASE_VERSION="$VERSION" SHOWCASE_PROJECT="$SHOWCASE_PROJECT" python3 - <<'PYEOF'
 import os
 import re
 import sys
 import tempfile
 
 version = os.environ["RELEASE_VERSION"]
-path = "Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj"
+path = os.environ["SHOWCASE_PROJECT"]
 
 with open(path, "r") as f:
     text = f.read()
@@ -216,10 +253,9 @@ if [[ "$DRY_RUN" == false ]]; then
   fi
 
   CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-  if [[ "$CURRENT_BRANCH" != "main" && "$ALLOW_DIRTY_BRANCH" == false ]]; then
-    echo "Error: on branch '$CURRENT_BRANCH', not 'main'." >&2
-    echo "  Releases should usually be cut from main." >&2
-    echo "  Pass --allow-dirty-branch to override." >&2
+  if [[ "$CURRENT_BRANCH" != "main" ]]; then
+    echo "Error: refusing to release from branch '$CURRENT_BRANCH'." >&2
+    echo "  Release commits advance origin/main, so rerun from main." >&2
     exit 1
   fi
 
@@ -247,7 +283,6 @@ fi
 # ── Strip ─────────────────────────────────────────────────────────────────────
 
 WORK_DIR=$(mktemp -d)
-trap 'rm -rf "$WORK_DIR"' EXIT
 
 echo "Copying xcframework to temp dir..."
 cp -R "$XCFW_PATH" "$WORK_DIR/libvlc.xcframework"
@@ -328,6 +363,8 @@ fi
 echo ""
 echo "Creating release commit on $CURRENT_BRANCH..."
 
+begin_release_file_restore
+
 echo "Pointing Package.swift at $RELEASE_URL..."
 switch_package_to_release_url
 
@@ -347,6 +384,7 @@ fi
 
 git add Package.swift "$SHOWCASE_PROJECT"
 git commit --quiet -m "Release $TAG"
+RELEASE_RESTORE_FILES=false
 TAG_COMMIT=$(git rev-parse HEAD)
 git tag "$TAG" "$TAG_COMMIT"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,7 +5,7 @@
 # Prerequisites:
 #   - ./scripts/build-libvlc.sh --all  (produces Vendor/libvlc.xcframework)
 #   - gh authed (gh auth login)
-#   - Clean working tree on main (unless --allow-dirty-branch)
+#   - Clean Package.swift + Showcase project on main (unless --allow-dirty-branch)
 #
 # Usage:
 #   ./scripts/release.sh 0.1.0
@@ -16,10 +16,11 @@ set -euo pipefail
 
 REPO="harflabs/SwiftVLC"
 XCFW_PATH="Vendor/libvlc.xcframework"
+SHOWCASE_PROJECT="Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj"
 ZIP_NAME="libvlc.xcframework.zip"
 MAX_SIZE=$((2 * 1024 * 1024 * 1024))  # 2 GB (GitHub release asset limit)
 
-# All 5 slices the xcframework must contain. If a slice is missing, the
+# All 6 slices the xcframework must contain. If a slice is missing, the
 # release would ship a partial artifact that fails on one of iOS/tvOS/macOS/Catalyst.
 EXPECTED_SLICES=(
   "ios-arm64"
@@ -66,6 +67,116 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT_DIR"
 
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+switch_package_to_release_url() {
+  RELEASE_URL="$RELEASE_URL" CHECKSUM="$CHECKSUM" python3 - <<'PYEOF'
+import os
+import re
+import sys
+import tempfile
+
+url = os.environ["RELEASE_URL"]
+checksum = os.environ["CHECKSUM"]
+path = "Package.swift"
+
+with open(path, "r") as f:
+    text = f.read()
+
+pattern = r'\.binaryTarget\(\s*name:\s*"libvlc"[^)]*\)'
+replacement = (
+    '.binaryTarget(\n'
+    '      name: "libvlc",\n'
+    f'      url: "{url}",\n'
+    f'      checksum: "{checksum}"\n'
+    '    )'
+)
+result, n = re.subn(pattern, replacement, text, count=1, flags=re.DOTALL)
+if n == 0:
+    print("ERROR: binaryTarget pattern not found in Package.swift", file=sys.stderr)
+    sys.exit(1)
+
+fd, tmp = tempfile.mkstemp(dir=".", prefix=".Package.swift.", suffix=".tmp")
+try:
+    with os.fdopen(fd, "w") as f:
+        f.write(result)
+    os.replace(tmp, path)
+except Exception:
+    if os.path.exists(tmp):
+        os.unlink(tmp)
+    raise
+PYEOF
+}
+
+switch_showcase_to_release_version() {
+  RELEASE_VERSION="$VERSION" python3 - <<'PYEOF'
+import os
+import re
+import sys
+import tempfile
+
+version = os.environ["RELEASE_VERSION"]
+path = "Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj"
+
+with open(path, "r") as f:
+    text = f.read()
+
+local_block = """/* Begin XCLocalSwiftPackageReference section */
+\t\tBA000001 /* XCLocalSwiftPackageReference \"..\" */ = {
+\t\t\tisa = XCLocalSwiftPackageReference;
+\t\t\trelativePath = ..;
+\t\t};
+/* End XCLocalSwiftPackageReference section */"""
+
+remote_block = f"""/* Begin XCRemoteSwiftPackageReference section */
+\t\tBA000001 /* XCRemoteSwiftPackageReference \"SwiftVLC\" */ = {{
+\t\t\tisa = XCRemoteSwiftPackageReference;
+\t\t\trepositoryURL = \"https://github.com/harflabs/SwiftVLC\";
+\t\t\trequirement = {{
+\t\t\t\tkind = exactVersion;
+\t\t\t\tversion = {version};
+\t\t\t}};
+\t\t}};
+/* End XCRemoteSwiftPackageReference section */"""
+
+remote_pattern = re.compile(
+    r'/\* Begin XCRemoteSwiftPackageReference section \*/\n'
+    r'\t\tBA000001 /\* XCRemoteSwiftPackageReference "SwiftVLC" \*/ = \{\n'
+    r'\t\t\tisa = XCRemoteSwiftPackageReference;\n'
+    r'\t\t\trepositoryURL = "https://github.com/harflabs/SwiftVLC";\n'
+    r'\t\t\trequirement = \{\n'
+    r'\t\t\t\tkind = (?:upToNextMajorVersion|exactVersion);\n'
+    r'\t\t\t\t(?:minimumVersion|version) = [0-9.]+;\n'
+    r'\t\t\t\};\n'
+    r'\t\t\};\n'
+    r'/\* End XCRemoteSwiftPackageReference section \*/'
+)
+
+if local_block in text:
+    result = text.replace(local_block, remote_block, 1)
+else:
+    result, n = remote_pattern.subn(remote_block, text, count=1)
+    if n == 0:
+        print("ERROR: Showcase package reference block not found", file=sys.stderr)
+        sys.exit(1)
+
+result = result.replace(
+    'BA000001 /* XCLocalSwiftPackageReference ".." */',
+    'BA000001 /* XCRemoteSwiftPackageReference "SwiftVLC" */',
+)
+
+fd, tmp = tempfile.mkstemp(dir=".", prefix=".SwiftVLCShowcase.", suffix=".tmp")
+try:
+    with os.fdopen(fd, "w") as f:
+        f.write(result)
+    os.replace(tmp, path)
+except Exception:
+    if os.path.exists(tmp):
+        os.unlink(tmp)
+    raise
+PYEOF
+}
+
 # ── Preflight ─────────────────────────────────────────────────────────────────
 
 if [[ ! -d "$XCFW_PATH" ]]; then
@@ -98,8 +209,9 @@ if [[ "$DRY_RUN" == false ]]; then
     exit 1
   fi
 
-  if [[ -n "$(git status --porcelain Package.swift)" ]]; then
-    echo "Error: Package.swift has uncommitted changes. Commit or stash first." >&2
+  if [[ -n "$(git status --porcelain -- Package.swift "$SHOWCASE_PROJECT")" ]]; then
+    echo "Error: Package.swift or $SHOWCASE_PROJECT has uncommitted changes." >&2
+    echo "  Commit or stash them first." >&2
     exit 1
   fi
 
@@ -117,28 +229,25 @@ if [[ "$DRY_RUN" == false ]]; then
     echo "    git tag -d $TAG && git push origin :refs/tags/$TAG" >&2
     exit 1
   fi
-fi
 
-ORIGINAL_HEAD=""
-RELEASE_COMPLETE=false
-
-# Cleanup on error or interrupt: if we made a temp commit but didn't finish the
-# release, reset the branch back so the user's working state is undamaged. The
-# local tag (if created) is left alone — user can decide whether to retry or
-# delete it.
-cleanup_on_exit() {
-  if [[ "$RELEASE_COMPLETE" == true ]]; then return; fi
-  if [[ -n "$ORIGINAL_HEAD" ]] && [[ "$(git rev-parse HEAD 2>/dev/null)" != "$ORIGINAL_HEAD" ]]; then
-    echo ""
-    echo "Release aborted. Restoring branch to $ORIGINAL_HEAD..." >&2
-    git reset --hard "$ORIGINAL_HEAD" >/dev/null 2>&1 || true
+  if git ls-remote --exit-code --tags origin "refs/tags/$TAG" &>/dev/null; then
+    echo "Error: tag '$TAG' already exists on origin." >&2
+    echo "  Finish that release or delete the remote tag before retrying:" >&2
+    echo "    git push origin :refs/tags/$TAG" >&2
+    exit 1
   fi
-}
+
+  if gh release view "$TAG" --repo "$REPO" &>/dev/null; then
+    echo "Error: GitHub Release '$TAG' already exists." >&2
+    echo "  Delete it first or pick a new version." >&2
+    exit 1
+  fi
+fi
 
 # ── Strip ─────────────────────────────────────────────────────────────────────
 
 WORK_DIR=$(mktemp -d)
-trap 'rm -rf "$WORK_DIR"; cleanup_on_exit' EXIT
+trap 'rm -rf "$WORK_DIR"' EXIT
 
 echo "Copying xcframework to temp dir..."
 cp -R "$XCFW_PATH" "$WORK_DIR/libvlc.xcframework"
@@ -192,89 +301,57 @@ if [[ "$DRY_RUN" == true ]]; then
   echo "    url: \"$RELEASE_URL\","
   echo "    checksum: \"$CHECKSUM\""
   echo "  )"
+  echo ""
+  echo "Showcase package requirement:"
+  echo "  kind = exactVersion"
+  echo "  version = $VERSION"
   exit 0
 fi
 
-# ── Tag-only release: detached commit, nothing lands on main ────────────────
+# ── Release commit on main ───────────────────────────────────────────────────
 #
-# main (and every branch) stays on the local-path binaryTarget form so that
-# `git clone && ./scripts/setup-dev.sh && swift build` just works. The tag
-# itself points at a one-off commit where Package.swift has been rewritten
-# to the remote url+checksum form — that's the commit SPM sees when a
-# consumer pins by version.
+# main should always resolve the most recently published xcframework, and the
+# Showcase app should always resolve the matching Swift package release. Local
+# development can flip both back to repo-local sources via `setup-dev.sh`.
 #
 # Mechanics:
-#   1. Record the current HEAD.
-#   2. Rewrite Package.swift to url+checksum, commit.
-#   3. Tag that commit.
-#   4. `git reset --hard` the branch back to step 1's HEAD — wipes the
-#      commit from branch history, but the tag keeps it alive.
-#   5. Push the tag only (never `git push origin HEAD`).
+#   1. Rewrite Package.swift and the Showcase app, commit, and tag.
+#   2. Push the tag first so GitHub can attach the release asset to the exact
+#      commit without advancing origin/main yet.
+#   3. Create the GitHub Release and upload the zip.
+#   4. Fast-forward origin/main to the same commit, so main always points at
+#      the latest published binary and Showcase package version.
 #
-# If any step fails, the EXIT trap resets the branch so you're never left
-# with a dangling dev-only commit on main.
-
-ORIGINAL_HEAD=$(git rev-parse HEAD)
+# If the tag push succeeds but later steps fail, origin/main is still untouched.
+# Finish the GitHub Release (or delete the tag) and then retry the main push.
 
 echo ""
-echo "Creating temp release commit (will not be pushed to $CURRENT_BRANCH)..."
+echo "Creating release commit on $CURRENT_BRANCH..."
 
-# Atomic write: tempfile + os.replace, so an interrupted rewrite can't corrupt
-# the manifest.
-RELEASE_URL="$RELEASE_URL" CHECKSUM="$CHECKSUM" python3 - <<'PYEOF'
-import os
-import re
-import sys
-import tempfile
+echo "Pointing Package.swift at $RELEASE_URL..."
+switch_package_to_release_url
 
-url = os.environ["RELEASE_URL"]
-checksum = os.environ["CHECKSUM"]
-path = "Package.swift"
-
-with open(path, "r") as f:
-    text = f.read()
-
-pattern = r'\.binaryTarget\(\s*name:\s*"libvlc"[^)]*\)'
-replacement = (
-    '.binaryTarget(\n'
-    '      name: "libvlc",\n'
-    f'      url: "{url}",\n'
-    f'      checksum: "{checksum}"\n'
-    '    )'
-)
-result, n = re.subn(pattern, replacement, text, count=1, flags=re.DOTALL)
-if n == 0:
-    print("ERROR: binaryTarget pattern not found in Package.swift", file=sys.stderr)
-    sys.exit(1)
-
-fd, tmp = tempfile.mkstemp(dir=".", prefix=".Package.swift.", suffix=".tmp")
-try:
-    with os.fdopen(fd, "w") as f:
-        f.write(result)
-    os.replace(tmp, path)
-except Exception:
-    if os.path.exists(tmp):
-        os.unlink(tmp)
-    raise
-PYEOF
+echo "Pointing Showcase app at SwiftVLC $TAG..."
+switch_showcase_to_release_version
 
 # Sanity-check: a corrupted regex result would wipe the rest of Package.swift.
 if ! grep -q 'name: "CLibVLC"' Package.swift; then
   echo "Error: Package.swift corrupted — CLibVLC target missing." >&2
-  # cleanup_on_exit will restore via git reset on EXIT
   exit 1
 fi
 
-git add Package.swift
-git commit --quiet -m "Release $TAG (detached — not on $CURRENT_BRANCH)"
+if ! grep -q 'kind = exactVersion;' "$SHOWCASE_PROJECT"; then
+  echo "Error: Showcase project was not pinned to an exact SwiftVLC version." >&2
+  exit 1
+fi
+
+git add Package.swift "$SHOWCASE_PROJECT"
+git commit --quiet -m "Release $TAG"
 TAG_COMMIT=$(git rev-parse HEAD)
 git tag "$TAG" "$TAG_COMMIT"
 
-# Restore the branch — the tag now holds the only reference to the commit above.
-git reset --hard "$ORIGINAL_HEAD" >/dev/null
-
 echo "  Tag $TAG → $TAG_COMMIT (Package.swift pinned to $RELEASE_URL)"
-echo "  Branch $CURRENT_BRANCH restored to $ORIGINAL_HEAD"
+echo "  Showcase app → exactVersion $VERSION"
 
 echo "Pushing tag..."
 git push origin "$TAG"
@@ -297,6 +374,11 @@ Pre-built static xcframework for libVLC 4.0.
 SPM resolves this automatically — just add the package dependency.
 EOF
 )"
+
+echo "Pushing $CURRENT_BRANCH to origin/main..."
+git push origin HEAD:main
+
+echo "  origin/main → $TAG_COMMIT"
 
 echo ""
 echo "Release $TAG published: https://github.com/$REPO/releases/tag/$TAG"

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -87,13 +87,13 @@ PYEOF
 }
 
 switch_showcase_to_local_package() {
-  python3 - <<'PYEOF'
+  SHOWCASE_PROJECT="$SHOWCASE_PROJECT" python3 - <<'PYEOF'
 import os
 import re
 import sys
 import tempfile
 
-path = "Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj"
+path = os.environ["SHOWCASE_PROJECT"]
 
 with open(path, "r") as f:
     text = f.read()

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,19 +1,21 @@
 #!/usr/bin/env bash
 #
 # setup-dev.sh — Install the libvlc xcframework locally and point
-# Package.swift at it, so `swift build` / `swift test` work on a fresh clone.
+# Package.swift plus the Showcase app at repo-local sources, so `swift build`
+# / `swift test` and local Showcase development work on a fresh clone.
 #
 # Usage:
 #   ./scripts/setup-dev.sh                  # install latest release (or keep existing)
 #   ./scripts/setup-dev.sh v0.3.0           # pin to a specific release tag
 #   ./scripts/setup-dev.sh --force          # always re-download, even if Vendor/ exists
-#   ./scripts/setup-dev.sh --skip-download  # only flip Package.swift to local path
+#   ./scripts/setup-dev.sh --skip-download  # only flip local references
 #                                             (useful after ./scripts/build-libvlc.sh)
 #
 set -euo pipefail
 
 REPO="harflabs/SwiftVLC"
 XCFW_DIR="Vendor/libvlc.xcframework"
+SHOWCASE_PROJECT="Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj"
 ZIP_NAME="libvlc.xcframework.zip"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -73,6 +75,66 @@ if result == text:
     sys.exit(0)
 
 fd, tmp = tempfile.mkstemp(dir=".", prefix=".Package.swift.", suffix=".tmp")
+try:
+    with os.fdopen(fd, "w") as f:
+        f.write(result)
+    os.replace(tmp, path)
+except Exception:
+    if os.path.exists(tmp):
+        os.unlink(tmp)
+    raise
+PYEOF
+}
+
+switch_showcase_to_local_package() {
+  python3 - <<'PYEOF'
+import os
+import re
+import sys
+import tempfile
+
+path = "Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj"
+
+with open(path, "r") as f:
+    text = f.read()
+
+local_block = """/* Begin XCLocalSwiftPackageReference section */
+\t\tBA000001 /* XCLocalSwiftPackageReference \"..\" */ = {
+\t\t\tisa = XCLocalSwiftPackageReference;
+\t\t\trelativePath = ..;
+\t\t};
+/* End XCLocalSwiftPackageReference section */"""
+
+remote_pattern = re.compile(
+    r'/\* Begin XCRemoteSwiftPackageReference section \*/\n'
+    r'\t\tBA000001 /\* XCRemoteSwiftPackageReference "SwiftVLC" \*/ = \{\n'
+    r'\t\t\tisa = XCRemoteSwiftPackageReference;\n'
+    r'\t\t\trepositoryURL = "https://github.com/harflabs/SwiftVLC";\n'
+    r'\t\t\trequirement = \{\n'
+    r'\t\t\t\tkind = (?:upToNextMajorVersion|exactVersion);\n'
+    r'\t\t\t\t(?:minimumVersion|version) = [0-9.]+;\n'
+    r'\t\t\t\};\n'
+    r'\t\t\};\n'
+    r'/\* End XCRemoteSwiftPackageReference section \*/'
+)
+
+if local_block in text:
+    result = text
+else:
+    result, n = remote_pattern.subn(local_block, text, count=1)
+    if n == 0:
+        print("ERROR: Showcase package reference block not found", file=sys.stderr)
+        sys.exit(1)
+
+result = result.replace(
+    'BA000001 /* XCRemoteSwiftPackageReference "SwiftVLC" */',
+    'BA000001 /* XCLocalSwiftPackageReference ".." */',
+)
+
+if result == text:
+    sys.exit(0)
+
+fd, tmp = tempfile.mkstemp(dir=".", prefix=".SwiftVLCShowcase.", suffix=".tmp")
 try:
     with os.fdopen(fd, "w") as f:
         f.write(result)
@@ -144,6 +206,10 @@ fi
 echo "Pointing Package.swift at $XCFW_DIR..."
 switch_package_to_local_path
 echo "  Package.swift now uses local path."
+
+echo "Pointing Showcase app at the local Swift package checkout..."
+switch_showcase_to_local_package
+echo "  Showcase now uses the repo-local package."
 
 echo ""
 echo "Done. Try:"


### PR DESCRIPTION
## Summary
- update `release.sh` so releases commit the remote xcframework URL/checksum to `main`
- pin the Showcase app to the exact released `SwiftVLC` version during release
- update `setup-dev.sh` to switch both the package and Showcase app back to local sources for repo development
- align README, architecture docs, and CI comments with the new release model
- include the existing SwiftFormat-only cleanup in `VideoSurfaceRaceTests`

## Details
This removes the old tag-only release flow. After these changes, a release commit is created, tagged, published as a GitHub Release, and then pushed to `main`, so `main` always resolves the latest published xcframework.

The Showcase app now follows the same split:
- released states point at the exact released `SwiftVLC` package version
- local development switches the Showcase project back to the repo-local package checkout

## Verification
- `bash -n scripts/release.sh scripts/setup-dev.sh scripts/ci-use-released-xcframework.sh`
- `./scripts/setup-dev.sh --skip-download`
- `swift build`
- `xcodebuild -resolvePackageDependencies -project Showcase/SwiftVLCShowcase.xcodeproj -scheme SwiftVLCShowcase`
- validated the release/local rewrite logic on temporary copies of `Package.swift` and the Showcase project
