### PR TITLE
Document playlist URL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ struct PlayerView: View {
 }
 ```
 
+`Player.play(url:)` expects a direct media stream or file URL. It does
+not auto-resolve `.pls` or classic `.m3u` playlist containers; use
+`MediaListPlayer` or fetch and parse the playlist to its inner stream
+URL before passing it to `Player`. HLS `.m3u8` URLs are supported here
+because they are streaming manifests rather than playlists of separate
+media URLs.
+
 ### Common Operations
 
 ```swift

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -423,7 +423,12 @@ public final class Player {
     try play()
   }
 
-  /// Creates media from a URL and starts playback.
+  /// Creates media from a direct media URL and starts playback.
+  ///
+  /// This does not expand playlist container URLs such as `.pls` or
+  /// classic `.m3u`; use ``MediaListPlayer`` or resolve those files to
+  /// an inner stream URL first. HLS `.m3u8` URLs are valid here because
+  /// they are streaming manifests.
   /// - Throws: `VLCError.mediaCreationFailed` or `VLCError.playbackFailed`.
   public func play(url: URL) throws(VLCError) {
     try play(Media(url: url))

--- a/Sources/SwiftVLC/SwiftVLC.docc/GettingStarted.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/GettingStarted.md
@@ -51,6 +51,13 @@ struct PlayerView: View {
 state through `@Observable`, which is enough for SwiftUI to redraw as
 playback progresses.
 
+``Player/play(url:)`` expects a direct media stream or file URL. It
+does not auto-resolve `.pls` or classic `.m3u` playlist containers; use
+``MediaListPlayer`` or resolve the playlist to its inner stream URL
+before handing it to ``Player``. HLS `.m3u8` URLs are supported here
+because they are streaming manifests rather than playlists of separate
+media URLs.
+
 ## Drive the UI from state
 
 Most controls read a handful of observable properties directly:

--- a/Sources/SwiftVLC/SwiftVLC.docc/MediaPlaylists.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/MediaPlaylists.md
@@ -12,6 +12,13 @@ try list.append(Media(url: url2))
 try list.insert(Media(url: url3), at: 1)
 ```
 
+If the source URL is itself a playlist container, such as `.pls` or
+classic `.m3u`, add that ``Media`` to a ``MediaList`` and play it with
+``MediaListPlayer`` so libVLC can expand the playlist entries. Do not
+pass those playlist container URLs directly to ``Player/play(url:)``.
+HLS `.m3u8` URLs are the exception: they are streaming manifests and
+can be played directly by ``Player``.
+
 ``MediaList`` is `Sendable` and thread-safe. Every mutation acquires
 the underlying libVLC lock automatically.
 


### PR DESCRIPTION
## Summary
- Clarify that `Player.play(url:)` expects direct media URLs and does not auto-resolve `.pls` or classic `.m3u` playlist containers.
- Point playlist container users to `MediaListPlayer` or manual playlist resolution.
- Mirror the guidance in README, DocC getting started, playlist docs, and the API comment.

## Testing
- `swift build`
- `swift test` (fails after building successfully due an existing libVLC assertion in `AudioOutputRaceTests`: `stream->timing.pause_date == VLC_TICK_INVALID` in `dec.c:876`)

Fixes #15