### PR TITLE
Release 0.8.0

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,7 +40,7 @@ jobs:
             actions: read
           settings: |
             system: >
-              This is SwiftVLC — a Swift 6 wrapper around libVLC 4.0 for iOS, macOS, tvOS, and Mac Catalyst.
+              This is SwiftVLC — a Swift 6 wrapper around libVLC 4.0 for iOS, macOS, tvOS, visionOS, and Mac Catalyst.
 
               Key architecture:
               - Sources/CLibVLC/ — C bridging shim with libVLC 4.0 headers

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -48,7 +48,7 @@ flowchart TB
         subgraph Bottom["Supporting Modules"]
             Playlist["Playlist<br/>MediaList · ListPlayer"]
             Discovery["Discovery<br/>LAN/UPnP · Renderer"]
-            PiP["PiP<br/>vmem → PiP API"]
+            PiP["PiP<br/>iOS sample buffers · macOS native drawable"]
             EventBridge["EventBridge<br/>C → AsyncStream"]
         end
     end
@@ -86,7 +86,7 @@ flowchart TB
 | **State** | `@Observable` / `@MainActor` | Automatic SwiftUI integration, thread safety |
 | **Events** | `AsyncStream<PlayerEvent>` | Native structured concurrency, multi-consumer |
 | **Video** | `UIView` / `NSView` via `set_nsobject` | Platform-native rendering, zero-copy |
-| **PiP** | vmem → `CVPixelBuffer` → `AVSampleBufferDisplayLayer` | Full pixel control for PiP API |
+| **PiP** | iOS: vmem → `AVSampleBufferDisplayLayer`; macOS: native drawable PiP | Platform-appropriate PiP control |
 | **Thread Safety** | `Mutex<T>`, `Sendable`, `nonisolated(unsafe)` | Compile-time data race prevention |
 | **Testing** | Swift Testing framework | Modern `@Test`, `#expect`, tags, traits |
 | **Platforms** | iOS 18+, macOS 15+, tvOS 18+, visionOS 2+, Mac Catalyst | Unified SwiftUI minimum |
@@ -106,7 +106,7 @@ Foundation types shared across all modules.
 | `Logging.swift` | `AsyncStream<LogEntry>` | Filterable log stream (debug/notice/warning/error). C shim formats `va_list` before Swift callback. |
 | `Duration+Extensions.swift` | Extensions on `Duration` | `milliseconds`, `microseconds` properties and `formatted` display string |
 
-**Default VLC arguments:** `["--no-video-title-show", "--no-snapshot-preview"]`. `--no-stats` is *not* in the defaults — leaving it on would silently zero every `Media.statistics()` read, which is almost never what a caller wants.
+**Default VLC arguments:** `["--no-video-title-show", "--no-snapshot-preview"]`. `--no-stats` is *not* in the defaults — leaving it on would silently zero every `Media.statistics()` read, which is almost never what a caller wants. On macOS the default keeps VLC's Apple sample-buffer display available for inline playback, including its paired subtitle layer. ``PiPVideoView`` owns a native drawable container and moves that whole container into the system PiP presenter.
 
 ### Player
 
@@ -240,13 +240,14 @@ Network service and renderer discovery.
 
 ### PiP (iOS/macOS only)
 
-Picture-in-Picture via video memory callbacks.
+Picture-in-Picture uses the platform path that best matches libVLC's
+video output.
 
 | File | Type | Purpose |
 |---|---|---|
-| `PiPController.swift` | `@MainActor class PiPController` | Manages `AVPictureInPictureController` lifecycle, timebase sync, playback delegation |
-| `PiPVideoView.swift` | SwiftUI representable | `PiPVideoView(player, controller: $binding)` — hosts the sample buffer display layer |
-| `PixelBufferRenderer.swift` | `class PixelBufferRenderer: Sendable` | vmem callbacks: format → lock → unlock → display. `CVPixelBufferPool` → `CMSampleBuffer` → layer. |
+| `PiPController.swift` | `@MainActor class PiPController` | Manages PiP lifecycle, timebase sync, playback delegation |
+| `PiPVideoView.swift` | SwiftUI representable | `PiPVideoView(player, controller: $binding)` — iOS hosts a sample-buffer layer; macOS reparents libVLC's native drawable into PiP |
+| `PixelBufferRenderer.swift` | `class PixelBufferRenderer: Sendable` | iOS/direct sample-buffer path: format → lock → unlock → display. `CVPixelBufferPool` → `CMSampleBuffer` → layer. |
 
 ---
 
@@ -492,14 +493,15 @@ There is no `CALayer` setup, no `MTKView`, and no `AVPlayerLayer` to configure. 
 
 ## Picture-in-Picture
 
-PiP uses a fundamentally different rendering path than `VideoView`:
+PiP rendering depends on the platform:
 
 | Path | Pipeline |
 |---|---|
 | **VideoView** | `set_nsobject` → VLC renders directly into the view |
-| **PiP** | vmem callbacks → `CVPixelBuffer` → `CMSampleBuffer` → `AVSampleBufferDisplayLayer` → PiP |
+| **PiP on iOS** | vmem callbacks → `CVPixelBuffer` → `CMSampleBuffer` → `AVSampleBufferDisplayLayer` → PiP |
+| **PiP on macOS** | `set_nsobject` drawable → same VLC-owned `NSView` is moved into the system PiP presenter |
 
-### vmem Callback Pipeline
+### iOS/Direct vmem Callback Pipeline
 
 ```mermaid
 flowchart TB
@@ -528,11 +530,24 @@ flowchart TB
 2. **Duration reporting.** Invalidates the PiP controller once the duration becomes known, which is required before the controls can render.
 3. **Playback delegation.** Implements `AVPictureInPictureSampleBufferPlaybackDelegate` so the play, pause, and seek buttons on the PiP window route into the ``Player``.
 4. **State observation.** An observer task distinguishes VLC-initiated state changes from PiP-initiated ones.
-5. **Deferred pause.** Skip-without-blink by deferring the pause via task cancellation.
+5. **Render-size tracking.** The iOS/direct sample-buffer path follows AVKit's render-size callbacks and emits target-sized buffers so live PiP resizing cannot display stale-size frames.
+6. **Deferred pause.** Skip-without-blink by deferring the pause via task cancellation.
+
+On macOS, ``PiPVideoView`` intentionally bypasses SwiftVLC's vmem
+renderer. It gives libVLC a normal `NSView` drawable and deliberately does
+not conform that view to VLC's sample-buffer PiP protocols. Entering PiP
+loads macOS's PiP presenter at runtime and reparents the exact VLC drawable
+view into the floating PiP controller. That keeps video, audio, play/pause
+intent, and time on one VLC timeline while avoiding the macOS AVKit
+sample-buffer `CALayerHost` mirror that can crop at 1:1 layer size instead
+of scaling into the PiP panel.
 
 ### Mutually Exclusive
 
-`VideoView` and `PiPVideoView` are mutually exclusive for a given player: `set_nsobject` and vmem callbacks cannot coexist on the same `libvlc_media_player_t`.
+`VideoView` and `PiPVideoView` are mutually exclusive for a given player.
+On iOS, `set_nsobject` and vmem callbacks cannot coexist on the same
+`libvlc_media_player_t`. On macOS, both views use `set_nsobject`, and
+the most recently attached drawable owns VLC's native video output.
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,7 +58,7 @@ flowchart TB
     end
 
     subgraph XCF["libvlc.xcframework"]
-        Binary["Pre-built libVLC 4.0<br/>iOS · macOS · tvOS · Catalyst<br/>21 system frameworks · 7 system libraries"]
+        Binary["Pre-built libVLC 4.0<br/>iOS · macOS · tvOS · visionOS · Catalyst<br/>21 system frameworks · 7 system libraries"]
     end
 
     App --> SwiftVLC
@@ -89,7 +89,7 @@ flowchart TB
 | **PiP** | vmem → `CVPixelBuffer` → `AVSampleBufferDisplayLayer` | Full pixel control for PiP API |
 | **Thread Safety** | `Mutex<T>`, `Sendable`, `nonisolated(unsafe)` | Compile-time data race prevention |
 | **Testing** | Swift Testing framework | Modern `@Test`, `#expect`, tags, traits |
-| **Platforms** | iOS 18+, macOS 15+, tvOS 18+, Mac Catalyst | Unified SwiftUI minimum |
+| **Platforms** | iOS 18+, macOS 15+, tvOS 18+, visionOS 2+, Mac Catalyst | Unified SwiftUI minimum |
 
 ---
 
@@ -290,7 +290,7 @@ libVLC needs for decoding, rendering, and platform services:
 
 **Libraries:** libbz2, libc++, libiconv, libresolv, libsqlite3, libxml2, libz
 
-\*Platform-conditional: AudioUnit/IOKit/OpenGL are macOS-only; OpenGLES is iOS/tvOS-only.
+\*Platform-conditional: AudioUnit/IOKit/OpenGL are macOS-only; OpenGLES is iOS/tvOS/visionOS-only.
 
 ---
 
@@ -627,7 +627,7 @@ func playAndWaitForState() async throws {
 | Script | Purpose |
 |---|---|
 | `scripts/setup-dev.sh` | First step for local repo work. Downloads the last-released xcframework into `Vendor/`, flips `Package.swift` to the local-path form, and points the Showcase app at the repo-local Swift package. Flags: `--force` (re-download), `--skip-download` (only flip local references). |
-| `scripts/build-libvlc.sh` | Compiles libVLC from VideoLAN source (pinned via `VLC_HASH`) into `Vendor/libvlc.xcframework`. Applies 5 in-tree patches needed for current Xcode (26) and Homebrew libtool (2.5) — see README. |
+| `scripts/build-libvlc.sh` | Compiles libVLC from VideoLAN source (pinned via `VLC_HASH`) into `Vendor/libvlc.xcframework`. Applies the local VLC source patches described in README. |
 | `scripts/fix-duplicate-symbols.sh` | Localizes `_json_parse_error` and `_json_read` in the chromecast plugin, which two VLC plugins each emit. Called automatically by `build-libvlc.sh` and `setup-dev.sh`. |
 | `scripts/release.sh` | Cuts a versioned release, uploads the xcframework asset, pins the Showcase app to that exact Swift package version, and advances `main`. |
 | `scripts/ci-use-released-xcframework.sh` | CI-only. Rewrites the current `Package.swift` `binaryTarget` to the url+checksum of the latest release tag. Run at CI job start so tests resolve against the same binary a downstream consumer would. |
@@ -720,6 +720,7 @@ SwiftVLC/
 │   ├── iOS/                        # Full-featured iOS target/scheme, also enabled for Mac Catalyst
 │   ├── macOS/                      # Native macOS target/scheme with Mac-tailored showcases
 │   ├── tvOS/                       # Native tvOS target/scheme with TV-tailored showcases
+│   ├── visionOS/                   # Native visionOS target/scheme with focused playback coverage
 │   └── UITests/
 │       ├── iOS/                    # Existing UI tests for the iOS/Catalyst showcase
 │       ├── macOS/                  # Empty native macOS UI-test target shell

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
   name: "SwiftVLC",
-  platforms: [.iOS(.v18), .macOS(.v15), .tvOS(.v18), .macCatalyst(.v18)],
+  platforms: [.iOS(.v18), .macOS(.v15), .tvOS(.v18), .visionOS(.v2), .macCatalyst(.v18)],
   products: [
     .library(name: "SwiftVLC", targets: ["SwiftVLC"])
   ],
@@ -16,11 +16,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3")
   ],
   targets: [
-    .binaryTarget(
-      name: "libvlc",
-      url: "https://github.com/harflabs/SwiftVLC/releases/download/v0.7.1/libvlc.xcframework.zip",
-      checksum: "36fcad9c496c76aa481f3ab9c46e58a4252a9a13c5d736b8cca20846be60d66d"
-    ),
+    .binaryTarget(name: "libvlc", path: "Vendor/libvlc.xcframework"),
     .target(
       name: "CLibVLC",
       dependencies: ["libvlc"],
@@ -43,7 +39,7 @@ let package = Package(
         .linkedFramework("IOKit", .when(platforms: [.macOS])),
         .linkedFramework("IOSurface"),
         .linkedFramework("OpenGL", .when(platforms: [.macOS])),
-        .linkedFramework("OpenGLES", .when(platforms: [.iOS, .tvOS])),
+        .linkedFramework("OpenGLES", .when(platforms: [.iOS, .tvOS, .visionOS])),
         .linkedFramework("QuartzCore"),
         .linkedFramework("Security"),
         .linkedFramework("SystemConfiguration"),

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Swift versions](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fharflabs%2FSwiftVLC%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/harflabs/SwiftVLC)
 [![Platforms](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fharflabs%2FSwiftVLC%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/harflabs/SwiftVLC)
 
-A Swift wrapper around [libVLC](https://www.videolan.org/vlc/libvlc.html) for iOS, macOS, tvOS, and Mac Catalyst.
+A Swift wrapper around [libVLC](https://www.videolan.org/vlc/libvlc.html) for iOS, macOS, tvOS, visionOS, and Mac Catalyst.
 
 ## Why?
 
@@ -52,7 +52,7 @@ The existing iOS wrapper, [VLCKit](https://code.videolan.org/videolan/VLCKit), i
 ## Requirements
 
 - Swift 6.3+ / Xcode 26+
-- iOS 18+ / macOS 15+ / tvOS 18+ / Mac Catalyst 18+
+- iOS 18+ / macOS 15+ / tvOS 18+ / visionOS 2+ / Mac Catalyst 18+
 
 ## Installation
 
@@ -141,8 +141,9 @@ The `Showcase/` directory contains separate folders, targets, and schemes for ea
 - **iOS.** The existing full-featured app target, also enabled for Mac Catalyst.
 - **macOS.** Native macOS app target with the same showcase coverage, adapted into sidebar-driven Mac UI.
 - **tvOS.** Native tvOS showcase app target with TV-focused focus navigation and Siri Remote controls.
+- **visionOS.** Native visionOS app target with a focused simple playback showcase.
 
-Showcase UI tests are split the same way under `Showcase/UITests/`: the existing coverage lives in the `iOSUITests` target, while `macOSUITests` and `tvOSUITests` are empty target shells.
+Showcase UI tests live under `Showcase/UITests/`: the existing coverage lives in the `iOSUITests` target, while `macOSUITests` and `tvOSUITests` are empty target shells. The visionOS showcase does not have a UI-test target yet.
 
 ## Testing
 
@@ -186,16 +187,16 @@ brew install autoconf automake libtool cmake pkg-config gettext
 ./scripts/build-libvlc.sh --all
 ```
 
-Expect ~15–20 minutes on a clean run and ~2–7 minutes warm on Apple Silicon. The script clones VLC at a pinned commit into `scripts/.build-libvlc/`, applies the source patches below, builds every contrib (FFmpeg, dav1d, x264, libass, …) per slice, and assembles the result into `Vendor/libvlc.xcframework`.
+Expect a full `--all` build to take tens of minutes on Apple Silicon. The script clones VLC at a pinned commit into `scripts/.build-libvlc/`, applies the source patches below, builds every contrib (FFmpeg, dav1d, x264, libass, …) per slice, and assembles the result into `Vendor/libvlc.xcframework`.
 
 ### Platform selection
 
 | Flag | Platforms |
 |---|---|
 | *(default)* | iOS device + simulator |
-| `--all` | iOS, tvOS, macOS, Mac Catalyst (six slices) |
-| `--ios-only` / `--tvos-only` / `--macos-only` / `--catalyst-only` | Replaces `Vendor/` with that single platform |
-| `--tvos` / `--macos` / `--catalyst` | Adds a platform to the default set |
+| `--all` | iOS, tvOS, visionOS, macOS, Mac Catalyst (eight slices) |
+| `--ios-only` / `--tvos-only` / `--visionos-only` / `--macos-only` / `--catalyst-only` | Replaces `Vendor/` with that single platform |
+| `--tvos` / `--visionos` / `--macos` / `--catalyst` | Adds a platform to the default set |
 | `--clean` / `--clean-build` | Wipe `scripts/.build-libvlc/` (the latter rebuilds afterwards) |
 | `--hash=<sha>` | Override the pinned VLC commit |
 
@@ -203,13 +204,14 @@ Expect ~15–20 minutes on a clean run and ~2–7 minutes warm on Apple Silicon.
 
 ### Source patches
 
-VLC master doesn't build cleanly against current Xcode and Homebrew libtool. The script applies these patches in-tree on every invocation, idempotently:
+VLC master requires a few local patches for SwiftVLC's supported Apple toolchains. The script applies them in-tree on every invocation, idempotently:
 
 1. **Mac Catalyst.** Teaches VLC's build system the `macabi` target triple and guards OpenGLES-only code paths.
-2. **Xcode 26 LDFLAGS.** Adds `-isysroot` to linker invocations so libSystem resolves.
-3. **libtool 2.5 OBJC tag.** Adds `_LIBTOOLFLAGS = --tag=CC` to the `Makefile.am` files that contain `.m` sources. Older libtool versions inferred the tag; 2.5 refuses.
-4. **Rust contribs disabled.** `cargo-c 0.9.29` no longer compiles on recent Rust. The only Rust contrib on Apple is `rav1e` (AV1 *encoder*); `dav1d` handles decoding.
-5. **`dup3` / `pipe2`.** Forced unavailable via autoconf cache vars. iOS Simulator SDK 26 exports these Linux-only syscalls from libSystem, fooling configure into using them.
+2. **visionOS deployment target.** Adds the `xros` target triple so object files are stamped with visionOS 2.0 instead of the installed SDK version.
+3. **Xcode 26 LDFLAGS.** Adds `-isysroot` to linker invocations so libSystem resolves.
+4. **libtool 2.5 OBJC tag.** Adds `_LIBTOOLFLAGS = --tag=CC` to the `Makefile.am` files that contain `.m` sources. Older libtool versions inferred the tag; 2.5 refuses.
+5. **Rust contribs disabled.** `cargo-c 0.9.29` no longer compiles on recent Rust. The only Rust contrib on Apple is `rav1e` (AV1 *encoder*); `dav1d` handles decoding.
+6. **`dup3` / `pipe2`.** Forced unavailable via autoconf cache vars. iOS Simulator SDK 26 exports these Linux-only syscalls from libSystem, fooling configure into using them.
 
 `git reset --hard` only runs when HEAD is not at `VLC_HASH`, so the patches and per-platform build dirs survive repeated runs.
 
@@ -225,7 +227,7 @@ Releases advance `main`: `release.sh` rewrites `Package.swift` to the new remote
 
 What `release.sh` does:
 
-1. Verifies all six platform slices are present in the xcframework.
+1. Verifies all eight platform slices are present in the xcframework.
 2. Copies it to a temp dir, strips debug symbols, zips with `ditto`.
 3. Computes SHA-256 via `swift package compute-checksum`.
 4. Rewrites `Package.swift` to the remote URL and checksum, and pins the Showcase app to `SwiftVLC` exact version `X.Y.Z`.

--- a/Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj
+++ b/Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		B1000001 /* SwiftVLC in Frameworks */ = {isa = PBXBuildFile; productRef = B8000001 /* SwiftVLC */; };
 		B1000002 /* SwiftVLC in Frameworks */ = {isa = PBXBuildFile; productRef = B8000001 /* SwiftVLC */; };
 		B1000003 /* SwiftVLC in Frameworks */ = {isa = PBXBuildFile; productRef = B8000001 /* SwiftVLC */; };
+		B1000004 /* SwiftVLC in Frameworks */ = {isa = PBXBuildFile; productRef = B8000001 /* SwiftVLC */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,6 +41,7 @@
 		B2000007 /* iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2000008 /* macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = macOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2000009 /* tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = tvOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		B2000013 /* visionOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = visionOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2000010 /* iOSUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iOSUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2000011 /* macOSUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = macOSUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2000012 /* tvOSUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = tvOSUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -59,6 +61,7 @@
 		B4000002 /* iOS */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (07E764A82F965C6100828E69 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = iOS; sourceTree = "<group>"; };
 		B4000004 /* macOS */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = macOS; sourceTree = "<group>"; };
 		B4000005 /* tvOS */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = tvOS; sourceTree = "<group>"; };
+		B4000006 /* visionOS */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = visionOS; sourceTree = "<group>"; };
 		B4000010 /* Shared */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Shared; sourceTree = "<group>"; };
 		B4000011 /* iOS */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = iOS; sourceTree = "<group>"; };
 		B4000013 /* macOS */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = macOS; sourceTree = "<group>"; };
@@ -87,6 +90,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				B1000003 /* SwiftVLC in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B3000004 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B1000004 /* SwiftVLC in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -121,6 +132,7 @@
 				B4000002 /* iOS */,
 				B4000004 /* macOS */,
 				B4000005 /* tvOS */,
+				B4000006 /* visionOS */,
 				B4000012 /* UITests */,
 				B4000003 /* Products */,
 			);
@@ -132,6 +144,7 @@
 				B2000007 /* iOS.app */,
 				B2000008 /* macOS.app */,
 				B2000009 /* tvOS.app */,
+				B2000013 /* visionOS.app */,
 				B2000010 /* iOSUITests.xctest */,
 				B2000011 /* macOSUITests.xctest */,
 				B2000012 /* tvOSUITests.xctest */,
@@ -222,6 +235,30 @@
 			);
 			productName = tvOS;
 			productReference = B2000009 /* tvOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+		B5000004 /* visionOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B7000028 /* Build configuration list for PBXNativeTarget "visionOS" */;
+			buildPhases = (
+				B6000008 /* Sources */,
+				B3000004 /* Frameworks */,
+				B6000007 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				B4000006 /* visionOS */,
+				B4000010 /* Shared */,
+			);
+			name = visionOS;
+			packageProductDependencies = (
+				B8000001 /* SwiftVLC */,
+			);
+			productName = visionOS;
+			productReference = B2000013 /* visionOS.app */;
 			productType = "com.apple.product-type.application";
 		};
 		B5000010 /* iOSUITests */ = {
@@ -326,7 +363,7 @@
 			mainGroup = B4000001;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				BA000001 /* XCRemoteSwiftPackageReference "SwiftVLC" */,
+				BA000001 /* XCLocalSwiftPackageReference ".." */,
 			);
 			productRefGroup = B4000003 /* Products */;
 			projectDirPath = "";
@@ -335,6 +372,7 @@
 				B5000001 /* iOS */,
 				B5000002 /* macOS */,
 				B5000003 /* tvOS */,
+				B5000004 /* visionOS */,
 				B5000010 /* iOSUITests */,
 				B5000011 /* macOSUITests */,
 				B5000012 /* tvOSUITests */,
@@ -358,6 +396,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		B6000004 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B6000007 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -403,6 +448,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		B6000006 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B6000008 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -495,12 +547,13 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = auto;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator appletvos appletvsimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator appletvos appletvsimulator xros xrsimulator macosx";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 6.0;
 				TVOS_DEPLOYMENT_TARGET = 18.0;
+				XROS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
 		};
@@ -545,12 +598,13 @@
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				SDKROOT = auto;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator appletvos appletvsimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator appletvos appletvsimulator xros xrsimulator macosx";
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 6.0;
 				TVOS_DEPLOYMENT_TARGET = 18.0;
 				VALIDATE_PRODUCT = YES;
+				XROS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
 		};
@@ -736,6 +790,50 @@
 			};
 			name = Release;
 		};
+		B7000026 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swiftvlc.showcase.visionos;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = xros;
+				SUPPORTED_PLATFORMS = "xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				TARGETED_DEVICE_FAMILY = 7;
+				XROS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		B7000027 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swiftvlc.showcase.visionos;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = xros;
+				SUPPORTED_PLATFORMS = "xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				TARGETED_DEVICE_FAMILY = 7;
+				XROS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
 		B7000030 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -866,6 +964,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		B7000028 /* Build configuration list for PBXNativeTarget "visionOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B7000026 /* Debug */,
+				B7000027 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		B7000034 /* Build configuration list for PBXNativeTarget "macOSUITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -886,21 +993,17 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		BA000001 /* XCRemoteSwiftPackageReference "SwiftVLC" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/harflabs/SwiftVLC";
-			requirement = {
-				kind = exactVersion;
-				version = 0.7.1;
-			};
+/* Begin XCLocalSwiftPackageReference section */
+		BA000001 /* XCLocalSwiftPackageReference ".." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ..;
 		};
-/* End XCRemoteSwiftPackageReference section */
+/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		B8000001 /* SwiftVLC */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BA000001 /* XCRemoteSwiftPackageReference "SwiftVLC" */;
+			package = BA000001 /* XCLocalSwiftPackageReference ".." */;
 			productName = SwiftVLC;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Showcase/SwiftVLCShowcase.xcodeproj/xcshareddata/xcschemes/visionOS.xcscheme
+++ b/Showcase/SwiftVLCShowcase.xcodeproj/xcshareddata/xcschemes/visionOS.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B5000004"
+               BuildableName = "visionOS.app"
+               BlueprintName = "visionOS"
+               ReferencedContainer = "container:SwiftVLCShowcase.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B5000004"
+            BuildableName = "visionOS.app"
+            BlueprintName = "visionOS"
+            ReferencedContainer = "container:SwiftVLCShowcase.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B5000004"
+            BuildableName = "visionOS.app"
+            BlueprintName = "visionOS"
+            ReferencedContainer = "container:SwiftVLCShowcase.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B5000004"
+            BuildableName = "visionOS.app"
+            BlueprintName = "visionOS"
+            ReferencedContainer = "container:SwiftVLCShowcase.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Showcase/SwiftVLCShowcase.xcodeproj/xcshareddata/xcschemes/visionOS.xcscheme
+++ b/Showcase/SwiftVLCShowcase.xcodeproj/xcshareddata/xcschemes/visionOS.xcscheme
@@ -38,8 +38,6 @@
             ReferencedContainer = "container:SwiftVLCShowcase.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <Testables>
-      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Showcase/UITests/iOS/Support/ShowcaseIOSTestCase.swift
+++ b/Showcase/UITests/iOS/Support/ShowcaseIOSTestCase.swift
@@ -1,4 +1,5 @@
 import XCTest
+import UIKit
 
 /// Base class for every iOS showcase UI test.
 ///
@@ -144,6 +145,60 @@ class ShowcaseIOSTestCase: XCTestCase {
     }
   }
 
+  /// Waits until the element's visible screen region contains real video
+  /// pixels instead of the all-black drawable placeholder.
+  func assertRendersNonBlackFrame(
+    _ element: XCUIElement,
+    timeout: TimeInterval,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    let deadline = Date().addingTimeInterval(timeout)
+    var lastNonBlackRatio = 0.0
+    var lastScreenScreenshot: XCUIScreenshot?
+    var lastVideoRegion: UIImage?
+
+    while Date() < deadline {
+      guard element.exists else {
+        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        continue
+      }
+
+      let screenScreenshot = XCUIScreen.main.screenshot()
+      guard let videoRegion = croppedImage(screenScreenshot.image, to: element.frame) else {
+        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        continue
+      }
+
+      lastScreenScreenshot = screenScreenshot
+      lastVideoRegion = videoRegion
+      lastNonBlackRatio = nonBlackSampleRatio(in: videoRegion)
+      if lastNonBlackRatio >= 0.2 {
+        return
+      }
+
+      RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+    }
+
+    if let lastVideoRegion {
+      let attachment = XCTAttachment(image: lastVideoRegion)
+      attachment.name = "black-video-region"
+      attachment.lifetime = .keepAlways
+      add(attachment)
+    }
+    if let lastScreenScreenshot {
+      let attachment = XCTAttachment(screenshot: lastScreenScreenshot)
+      attachment.name = "black-video-full-screen"
+      attachment.lifetime = .keepAlways
+      add(attachment)
+    }
+    XCTFail(
+      "Expected video pixels, but sampled only \(Int(lastNonBlackRatio * 100))% non-black pixels after \(timeout)s",
+      file: file,
+      line: line
+    )
+  }
+
   // MARK: - Fixtures
 
   /// The happy-path fixture: a 10s h264 + aac mp4. Short enough to keep
@@ -166,4 +221,71 @@ class ShowcaseIOSTestCase: XCTestCase {
     }
     fatalError("\(name).\(ext) not found in UI test bundle")
   }
+}
+
+private func nonBlackSampleRatio(in image: UIImage) -> Double {
+  guard let cgImage = image.cgImage else { return 0 }
+
+  let width = cgImage.width
+  let height = cgImage.height
+  guard width > 0, height > 0 else { return 0 }
+
+  let bytesPerPixel = 4
+  let bytesPerRow = width * bytesPerPixel
+  var pixels = [UInt8](repeating: 0, count: height * bytesPerRow)
+  guard
+    let context = CGContext(
+      data: &pixels,
+      width: width,
+      height: height,
+      bitsPerComponent: 8,
+      bytesPerRow: bytesPerRow,
+      space: CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    )
+  else { return 0 }
+
+  context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+  let xRange = stride(from: 0.2, through: 0.8, by: 0.1)
+  let yRange = stride(from: 0.2, through: 0.8, by: 0.1)
+  var sampled = 0
+  var nonBlack = 0
+
+  for yFraction in yRange {
+    for xFraction in xRange {
+      let x = min(width - 1, max(0, Int(Double(width) * xFraction)))
+      let y = min(height - 1, max(0, Int(Double(height) * yFraction)))
+      let offset = y * bytesPerRow + x * bytesPerPixel
+      let red = pixels[offset]
+      let green = pixels[offset + 1]
+      let blue = pixels[offset + 2]
+      sampled += 1
+      if max(red, green, blue) > 40 {
+        nonBlack += 1
+      }
+    }
+  }
+
+  return sampled == 0 ? 0 : Double(nonBlack) / Double(sampled)
+}
+
+private func croppedImage(_ image: UIImage, to frame: CGRect) -> UIImage? {
+  guard let cgImage = image.cgImage else { return nil }
+
+  let imageBounds = CGRect(origin: .zero, size: image.size)
+  let pointRect = frame.intersection(imageBounds)
+  guard pointRect.width > 0, pointRect.height > 0 else { return nil }
+
+  let scaleX = CGFloat(cgImage.width) / image.size.width
+  let scaleY = CGFloat(cgImage.height) / image.size.height
+  let pixelRect = CGRect(
+    x: pointRect.minX * scaleX,
+    y: pointRect.minY * scaleY,
+    width: pointRect.width * scaleX,
+    height: pointRect.height * scaleY
+  ).integral
+
+  guard let cropped = cgImage.cropping(to: pixelRect) else { return nil }
+  return UIImage(cgImage: cropped, scale: image.scale, orientation: image.imageOrientation)
 }

--- a/Showcase/UITests/iOS/Tests/SimplePlaybackUITests.swift
+++ b/Showcase/UITests/iOS/Tests/SimplePlaybackUITests.swift
@@ -2,9 +2,9 @@ import XCTest
 
 /// Smoke / deep / stress coverage for the SimplePlayback case study.
 ///
-/// Every test launches deep-linked to `SimplePlaybackCase` and asserts both
-/// UI behavior (via accessibility identifiers) and library cleanliness (via
-/// the captured log file).
+/// Tests assert both UI behavior (via accessibility identifiers) and library
+/// cleanliness (via the captured log file). Most launch deep-linked to
+/// `SimplePlaybackCase`; the navigation regression starts at the root list.
 final class SimplePlaybackUITests: ShowcaseIOSTestCase {
   /// Inherits `@MainActor` from `ShowcaseIOSTestCase` so XCUI APIs are
   /// callable directly without isolation hops.
@@ -34,6 +34,7 @@ final class SimplePlaybackUITests: ShowcaseIOSTestCase {
 
     XCTAssertTrue(playPauseButton.waitForExistence(timeout: 5), "Play/pause button never appeared")
     waitForLabel(playPauseButton, equals: "Pause", timeout: 10)
+    assertRendersNonBlackFrame(videoView, timeout: 10)
 
     assertNoLibraryErrors()
   }
@@ -68,6 +69,30 @@ final class SimplePlaybackUITests: ShowcaseIOSTestCase {
     playPauseButton.tap()
     waitForLabel(playPauseButton, equals: "Pause", timeout: 3)
     waitForLabel(currentTime, notEqual: timeAfterSettle, timeout: 5)
+
+    assertNoLibraryErrors()
+  }
+
+  /// Recreates the manual failure mode: open Simple Playback from the root
+  /// list, pop it, then open it again. The video must still render real pixels
+  /// after SwiftUI has dismantled one `VideoSurface` and created another.
+  func test_regression_navigationBackAndForthKeepsVideoRendering() {
+    launchAtRoot()
+
+    openSimplePlaybackFromRoot()
+    XCTAssertTrue(playPauseButton.waitForExistence(timeout: 5))
+    waitForLabel(playPauseButton, equals: "Pause", timeout: 10)
+    waitForLabel(currentTime, notEqual: "00:00", timeout: 10)
+    assertRendersNonBlackFrame(videoView, timeout: 10)
+
+    backButton().tap()
+    XCTAssertTrue(simplePlaybackLink().waitForExistence(timeout: 5))
+
+    openSimplePlaybackFromRoot()
+    XCTAssertTrue(playPauseButton.waitForExistence(timeout: 5))
+    waitForLabel(playPauseButton, equals: "Pause", timeout: 10)
+    waitForLabel(currentTime, notEqual: "00:00", timeout: 10)
+    assertRendersNonBlackFrame(videoView, timeout: 10)
 
     assertNoLibraryErrors()
   }
@@ -162,5 +187,19 @@ final class SimplePlaybackUITests: ShowcaseIOSTestCase {
     }
 
     assertNoLibraryErrors()
+  }
+
+  private func openSimplePlaybackFromRoot() {
+    let link = simplePlaybackLink()
+    XCTAssertTrue(link.waitForExistence(timeout: 5), "Simple Playback link never appeared")
+    link.tap()
+  }
+
+  private func simplePlaybackLink() -> XCUIElement {
+    app.buttons["Simple playback"].firstMatch
+  }
+
+  private func backButton() -> XCUIElement {
+    app.navigationBars.buttons.element(boundBy: 0)
   }
 }

--- a/Showcase/UITests/macOS/PiPUITests.swift
+++ b/Showcase/UITests/macOS/PiPUITests.swift
@@ -1,0 +1,43 @@
+import AVKit
+import XCTest
+
+@MainActor
+final class MacOSPiPUITests: XCTestCase {
+  func test_startPiPButtonStartsPiPWhenSystemSupportsPiP() throws {
+    guard AVPictureInPictureController.isPictureInPictureSupported() else {
+      throw XCTSkip("macOS Picture in Picture is not supported in this environment.")
+    }
+
+    let app = XCUIApplication()
+    app.launchArguments += [
+      "-UITestMode", "YES",
+      "-UITestRoute", "PiP",
+      "-UITestFixtureURL", Self.fixtureURL.path
+    ]
+    app.launch()
+    defer { app.terminate() }
+
+    let toggleButton = app.buttons["macos.pip.toggle"]
+    XCTAssertTrue(toggleButton.waitForExistence(timeout: 10), "Start PiP button never appeared.")
+
+    let enabled = NSPredicate(format: "isEnabled == true")
+    expectation(for: enabled, evaluatedWith: toggleButton)
+    waitForExpectations(timeout: 20)
+
+    toggleButton.click()
+
+    let activeValue = app.staticTexts["macos.pip.active.value"]
+    XCTAssertTrue(activeValue.waitForExistence(timeout: 5), "PiP active status never appeared.")
+
+    let active = NSPredicate(format: "label == %@", "Yes")
+    expectation(for: active, evaluatedWith: activeValue)
+    waitForExpectations(timeout: 10)
+  }
+
+  private static var fixtureURL: URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("iOS/Fixtures/test.mp4")
+  }
+}

--- a/Showcase/iOS/ShowcaseApp.swift
+++ b/Showcase/iOS/ShowcaseApp.swift
@@ -1,9 +1,11 @@
 import AVFoundation
 import SwiftUI
+import SwiftVLC
 
 @main
 struct ShowcaseApp: App {
   init() {
+    VLCInstance.prewarmShared()
     try? AVAudioSession.sharedInstance().setCategory(.playback)
     try? AVAudioSession.sharedInstance().setActive(true)
     UITestSupport.startLogMirrorIfRequested()

--- a/Showcase/macOS/CaseStudies/06-Advanced-PiP.swift
+++ b/Showcase/macOS/CaseStudies/06-Advanced-PiP.swift
@@ -8,8 +8,8 @@ struct MacPiPCase: View {
   var body: some View {
     MacShowcaseContent(
       title: "Picture in Picture",
-      summary: "Use PiPVideoView when the app needs an AVPictureInPictureController-compatible video surface.",
-      usage: "Start playback, then use the Picture in Picture control to hand the PiPVideoView surface to AppKit's PiP controller."
+      summary: "Use PiPVideoView when the app needs a Picture in Picture-capable video surface.",
+      usage: "Start playback, then use the Picture in Picture control to move the native video surface into macOS PiP."
     ) {
       VStack(spacing: 16) {
         PiPVideoView(player, controller: $controller)
@@ -23,6 +23,7 @@ struct MacPiPCase: View {
         MacSection(title: "Picture in Picture") {
           if let controller {
             Button(controller.isActive ? "Stop PiP" : "Start PiP", systemImage: "pip") { controller.toggle() }
+              .accessibilityIdentifier("macos.pip.toggle")
               .disabled(!controller.isPossible)
           } else {
             ProgressView("Preparing...")
@@ -33,11 +34,24 @@ struct MacPiPCase: View {
       MacSection(title: "Controller") {
         MacMetricGrid {
           MacMetricRow(title: "Ready", value: controller == nil ? "No" : "Yes")
-          MacMetricRow(title: "Possible", value: controller?.isPossible == true ? "Yes" : "No")
-          MacMetricRow(title: "Active", value: controller?.isActive == true ? "Yes" : "No")
+          MacMetricRow(
+            title: "Possible",
+            value: controller?.isPossible == true ? "Yes" : "No",
+            valueIdentifier: "macos.pip.possible.value"
+          )
+          MacMetricRow(
+            title: "Active",
+            value: controller?.isActive == true ? "Yes" : "No",
+            valueIdentifier: "macos.pip.active.value"
+          )
         }
       }
-      MacLibrarySurface(symbols: ["PiPVideoView", "PiPController.toggle()"])
+      MacLibrarySurface(
+        symbols: [
+          "PiPVideoView",
+          "PiPController.toggle()"
+        ]
+      )
     }
     .task { try? player.play(url: MacTestMedia.demo) }
     .onDisappear { player.stop() }

--- a/Showcase/macOS/Internal/MacShowcaseChrome.swift
+++ b/Showcase/macOS/Internal/MacShowcaseChrome.swift
@@ -99,7 +99,10 @@ struct MacPlaybackControls: View {
         Button {
           player.togglePlayPause()
         } label: {
-          Label(player.isPlaying ? "Pause" : "Play", systemImage: player.isPlaying ? "pause.fill" : "play.fill")
+          Label(
+            player.isPlaybackRequestedActive ? "Pause" : "Play",
+            systemImage: player.isPlaybackRequestedActive ? "pause.fill" : "play.fill"
+          )
         }
         .keyboardShortcut(.space, modifiers: [])
 
@@ -142,11 +145,24 @@ struct MacMetricGrid<Content: View>: View {
 struct MacMetricRow: View {
   let title: String
   let value: String
+  var valueIdentifier: String?
 
   var body: some View {
     GridRow {
       Text(title)
         .foregroundStyle(.secondary)
+      valueText
+    }
+  }
+
+  @ViewBuilder
+  private var valueText: some View {
+    if let valueIdentifier {
+      Text(value)
+        .textSelection(.enabled)
+        .fixedSize(horizontal: false, vertical: true)
+        .accessibilityIdentifier(valueIdentifier)
+    } else {
       Text(value)
         .textSelection(.enabled)
         .fixedSize(horizontal: false, vertical: true)

--- a/Showcase/visionOS/ShowcaseApp.swift
+++ b/Showcase/visionOS/ShowcaseApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+@main
+struct VisionShowcaseApp: App {
+  var body: some Scene {
+    WindowGroup {
+      SimplePlaybackView()
+        .tint(.orange)
+    }
+    .defaultSize(width: 960, height: 640)
+  }
+}

--- a/Showcase/visionOS/SimplePlaybackView.swift
+++ b/Showcase/visionOS/SimplePlaybackView.swift
@@ -1,0 +1,122 @@
+import Foundation
+import SwiftUI
+import SwiftVLC
+
+struct SimplePlaybackView: View {
+  @State private var player = Player()
+  @State private var playbackError: String?
+
+  var body: some View {
+    VStack(spacing: 18) {
+      header
+
+      VideoView(player)
+        .aspectRatio(16 / 9, contentMode: .fit)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.black)
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .accessibilityIdentifier(AccessibilityID.SimplePlayback.videoView)
+
+      controls
+    }
+    .padding(24)
+    .task { startPlayback() }
+    .onDisappear { player.stop() }
+  }
+
+  private var header: some View {
+    HStack(alignment: .firstTextBaseline) {
+      Text("Simple Playback")
+        .font(.title2.bold())
+
+      Spacer()
+
+      Label(player.state.description.capitalized, systemImage: "waveform")
+        .font(.subheadline.weight(.semibold))
+        .foregroundStyle(.secondary)
+        .labelStyle(.titleAndIcon)
+    }
+  }
+
+  private var controls: some View {
+    VStack(spacing: 12) {
+      HStack(spacing: 12) {
+        Button(action: playPauseButtonTapped) {
+          Label(player.isPlaying ? "Pause" : "Play", systemImage: player.isPlaying ? "pause.fill" : "play.fill")
+        }
+        .buttonStyle(.borderedProminent)
+        .accessibilityIdentifier(AccessibilityID.SimplePlayback.playPauseButton)
+
+        Button(action: stopButtonTapped) {
+          Label("Stop", systemImage: "stop.fill")
+        }
+        .buttonStyle(.bordered)
+
+        Spacer()
+
+        Text(Self.format(player.currentTime))
+          .monospacedDigit()
+          .accessibilityIdentifier(AccessibilityID.SimplePlayback.currentTime)
+
+        Text("/")
+          .foregroundStyle(.tertiary)
+
+        Text(player.duration.map(Self.format) ?? "--:--")
+          .monospacedDigit()
+          .foregroundStyle(.secondary)
+          .accessibilityIdentifier(AccessibilityID.SimplePlayback.duration)
+      }
+
+      ProgressView(value: playbackProgress)
+        .progressViewStyle(.linear)
+
+      if let playbackError {
+        Text(playbackError)
+          .font(.footnote)
+          .foregroundStyle(.red)
+          .frame(maxWidth: .infinity, alignment: .leading)
+      }
+    }
+    .padding(16)
+    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+  }
+
+  private var playbackProgress: Double {
+    min(max(player.position, 0), 1)
+  }
+
+  private func startPlayback() {
+    do {
+      try player.play(url: VisionTestMedia.demo)
+      playbackError = nil
+    } catch {
+      playbackError = "Unable to play bundled demo media."
+    }
+  }
+
+  private func playPauseButtonTapped() {
+    player.togglePlayPause()
+  }
+
+  private func stopButtonTapped() {
+    player.stop()
+  }
+
+  private static func format(_ duration: Duration) -> String {
+    let seconds = max(0, Int(duration.components.seconds))
+    if seconds >= 3600 {
+      return String(format: "%d:%02d:%02d", seconds / 3600, seconds / 60 % 60, seconds % 60)
+    }
+    return String(format: "%02d:%02d", seconds / 60, seconds % 60)
+  }
+}
+
+private enum VisionTestMedia {
+  static var demo: URL {
+    if let override = LaunchArguments.fixtureURLValue { return override }
+    guard let url = Bundle.main.url(forResource: "demo", withExtension: "mkv") else {
+      preconditionFailure("Missing bundled media resource: demo.mkv")
+    }
+    return url
+  }
+}

--- a/Sources/SwiftVLC/Core/VLCInstance.swift
+++ b/Sources/SwiftVLC/Core/VLCInstance.swift
@@ -18,6 +18,31 @@ public final class VLCInstance: Sendable {
   /// Triggers a fatal error if libVLC cannot be initialized (e.g. missing plugins).
   public static let shared = VLCInstance()
 
+  /// Starts initializing ``shared`` on a background task.
+  ///
+  /// The first libVLC instance performs one-time plugin and decoder setup that
+  /// can be expensive on iOS. Calling this from application launch lets that
+  /// work happen before the first player view is pushed, instead of blocking the
+  /// main actor when `Player()` first touches ``shared``.
+  ///
+  /// Keep the returned task if you want to await readiness before presenting
+  /// playback UI; otherwise it is safe to fire and forget.
+  @discardableResult
+  public static func prewarmShared(priority: TaskPriority = .utility) -> Task<VLCInstance, Never> {
+    Task.detached(priority: priority) {
+      VLCInstance.shared
+    }
+  }
+
+  /// Initializes and returns ``shared`` from a background task.
+  ///
+  /// Use this when an app has an explicit loading phase and wants to guarantee
+  /// the shared libVLC instance is ready before constructing a default
+  /// ``Player``.
+  public static func prepareShared(priority: TaskPriority = .utility) async -> VLCInstance {
+    await prewarmShared(priority: priority).value
+  }
+
   /// Default libVLC arguments used by ``shared``.
   ///
   /// Intentionally excludes `--no-stats`: disabling stats globally would

--- a/Sources/SwiftVLC/Core/VLCInstance.swift
+++ b/Sources/SwiftVLC/Core/VLCInstance.swift
@@ -10,7 +10,7 @@ import Darwin
 ///
 /// Create a custom instance with specific arguments if needed:
 /// ```swift
-/// let instance = try VLCInstance(arguments: ["--verbose=2"])
+/// let instance = try VLCInstance(arguments: VLCInstance.defaultArguments + ["--verbose=2"])
 /// ```
 public final class VLCInstance: Sendable {
   /// The default shared instance, created with ``defaultArguments``.
@@ -31,6 +31,48 @@ public final class VLCInstance: Sendable {
   ]
 
   nonisolated(unsafe) let pointer: OpaquePointer // libvlc_instance_t*
+  let arguments: [String]
+
+  var usesPiPSafeDarwinDisplay: Bool {
+    #if os(macOS)
+    guard !Self.containsOption(named: "no-video", in: arguments) else { return false }
+    let forcesLegacyDisplay = Self.containsOption(
+      named: "force-darwin-legacy-display",
+      in: arguments
+    )
+    guard let vout = Self.lastOptionValue(named: "vout", in: arguments) else {
+      return !forcesLegacyDisplay
+    }
+    return ["macosx", "vout_macosx"].contains(vout)
+    #else
+    true
+    #endif
+  }
+
+  private static func containsOption(named name: String, in arguments: [String]) -> Bool {
+    let longName = "--\(name)"
+    let assignmentPrefix = "\(longName)="
+    return arguments.contains {
+      $0 == longName || $0.hasPrefix(assignmentPrefix)
+    }
+  }
+
+  private static func lastOptionValue(named name: String, in arguments: [String]) -> String? {
+    var value: String?
+    let longName = "--\(name)"
+    let assignmentPrefix = "\(longName)="
+
+    for index in arguments.indices {
+      let argument = arguments[index]
+      if argument.hasPrefix(assignmentPrefix) {
+        value = String(argument.dropFirst(assignmentPrefix.count))
+      } else if argument == longName, arguments.indices.contains(index + 1) {
+        value = arguments[index + 1]
+      }
+    }
+
+    return value
+  }
 
   /// Multiplexes the single libVLC log callback to any number of Swift
   /// `logStream` consumers. Lazily installs/uninstalls the underlying
@@ -59,6 +101,8 @@ public final class VLCInstance: Sendable {
   ///   `"--no-snapshot-preview"`, `"--no-stats"`.
   /// - Throws: `VLCError.instanceCreationFailed` if libVLC cannot be initialized.
   public init(arguments: [String] = VLCInstance.defaultArguments) throws(VLCError) {
+    self.arguments = arguments
+
     // Convert Swift strings to C strings for libvlc_new.
     // strdup allocates; freed in defer after libvlc_new copies them.
     let cArgs = arguments.map { strdup($0) }

--- a/Sources/SwiftVLC/Media/Media.swift
+++ b/Sources/SwiftVLC/Media/Media.swift
@@ -1,5 +1,6 @@
 import CLibVLC
 import Foundation
+import Synchronization
 
 /// The type of a media source as reported by libVLC.
 public enum MediaType: Sendable, Hashable, CustomStringConvertible {
@@ -111,6 +112,7 @@ public final class Media: Sendable {
     let media = pointer
     let em = libvlc_media_event_manager(media)!
     let instancePtr = instance.pointer
+    let operationRef = ParseOperationRef()
 
     // `onCancel` is a `@Sendable` closure and `OpaquePointer` isn't
     // Sendable, so bind the pointers to `nonisolated(unsafe)` locals —
@@ -123,9 +125,43 @@ public final class Media: Sendable {
 
     let result: Result<Metadata, VLCError> = await withTaskCancellationHandler {
       await withCheckedContinuation { cont in
-        let box = Unmanaged.passRetained(ParseContinuation(continuation: cont, media: media)).toOpaque()
+        let operation = ParseOperation(
+          continuation: cont,
+          media: media,
+          eventManager: em,
+          instance: instancePtr
+        )
+        operationRef.store(operation)
 
-        libvlc_event_attach(em, Int32(libvlc_MediaParsedChanged.rawValue), parseCallback, box)
+        if Task.isCancelled {
+          operation.cancel()
+          return
+        }
+
+        let box = Unmanaged.passRetained(operation).toOpaque()
+
+        guard libvlc_event_attach(em, Int32(libvlc_MediaParsedChanged.rawValue), parseCallback, box) == 0 else {
+          Unmanaged<ParseOperation>.fromOpaque(box).release()
+          operation.finishWithoutRequest(
+            with: .failure(.parseFailed(reason: "attach parsed callback"))
+          )
+          return
+        }
+
+        guard operation.installCallbackBox(box) else {
+          libvlc_event_detach(em, Int32(libvlc_MediaParsedChanged.rawValue), parseCallback, box)
+          Unmanaged<ParseOperation>.fromOpaque(box).release()
+          return
+        }
+
+        if Task.isCancelled {
+          operation.cancel()
+          return
+        }
+
+        guard operation.beginRequest() else {
+          return
+        }
 
         let timeoutMs = Int32(timeout.milliseconds)
         let flags = libvlc_media_parse_flag_t(
@@ -133,16 +169,26 @@ public final class Media: Sendable {
         )
         let rc = libvlc_media_parse_request(instancePtr, media, flags, timeoutMs)
         if rc != 0 {
-          libvlc_event_detach(em, Int32(libvlc_MediaParsedChanged.rawValue), parseCallback, box)
-          Unmanaged<ParseContinuation>.fromOpaque(box).release()
-          cont.resume(returning: .failure(.parseFailed(reason: "parse request rejected")))
+          operation.finishWithoutRequest(
+            with: .failure(.parseFailed(reason: "parse request rejected"))
+          )
+          return
+        }
+
+        if Task.isCancelled {
+          operation.cancel()
         }
       }
     } onCancel: {
       // Stop the in-progress parse. VLC will fire MediaParsedChanged
       // with a failed status, which resumes the continuation.
-      libvlc_media_parse_stop(cancelInstance, cancelMedia)
+      if let operation = operationRef.value() {
+        operation.cancel()
+      } else {
+        libvlc_media_parse_stop(cancelInstance, cancelMedia)
+      }
     }
+    operationRef.value()?.cleanupAfterCompletion()
     return try result.get()
   }
 
@@ -296,13 +342,172 @@ public final class Media: Sendable {
 
 // MARK: - Parse Internals
 
-private final class ParseContinuation: Sendable {
-  let continuation: CheckedContinuation<Result<Metadata, VLCError>, Never>
-  nonisolated(unsafe) let media: OpaquePointer
+private final class ParseOperationRef: Sendable {
+  private let storage = Mutex<ParseOperation?>(nil)
 
-  init(continuation: CheckedContinuation<Result<Metadata, VLCError>, Never>, media: OpaquePointer) {
-    self.continuation = continuation
+  func store(_ operation: ParseOperation) {
+    storage.withLock { $0 = operation }
+  }
+
+  func value() -> ParseOperation? {
+    storage.withLock { $0 }
+  }
+}
+
+private final class ParseOperation: Sendable {
+  private struct State: @unchecked Sendable {
+    var continuation: CheckedContinuation<Result<Metadata, VLCError>, Never>?
+    var callbackBox: UnsafeMutableRawPointer?
+    var eventAttached = false
+    var requestStarted = false
+    var isCancellationRequested = false
+    var isUserFinished = false
+    var isCleanedUp = false
+  }
+
+  private struct Cleanup: @unchecked Sendable {
+    let callbackBox: UnsafeMutableRawPointer?
+    let shouldDetachEvent: Bool
+  }
+
+  private struct Resume: @unchecked Sendable {
+    let continuation: CheckedContinuation<Result<Metadata, VLCError>, Never>
+    let result: Result<Metadata, VLCError>
+  }
+
+  nonisolated(unsafe) let media: OpaquePointer
+  private nonisolated(unsafe) let eventManager: OpaquePointer
+  private nonisolated(unsafe) let instance: OpaquePointer
+  private let state: Mutex<State>
+
+  init(
+    continuation: CheckedContinuation<Result<Metadata, VLCError>, Never>,
+    media: OpaquePointer,
+    eventManager: OpaquePointer,
+    instance: OpaquePointer
+  ) {
     self.media = media
+    self.eventManager = eventManager
+    self.instance = instance
+    libvlc_media_retain(media)
+    state = Mutex(State(continuation: continuation))
+  }
+
+  deinit {
+    libvlc_media_release(media)
+  }
+
+  func installCallbackBox(_ box: UnsafeMutableRawPointer) -> Bool {
+    state.withLock { state -> Bool in
+      guard !state.isCleanedUp, !state.isUserFinished else { return false }
+      state.callbackBox = box
+      state.eventAttached = true
+      return true
+    }
+  }
+
+  func beginRequest() -> Bool {
+    state.withLock { state -> Bool in
+      guard !state.isCleanedUp, !state.isUserFinished else { return false }
+      state.requestStarted = true
+      return true
+    }
+  }
+
+  func cancel() {
+    let resumeOrStop = state.withLock { state -> (Resume?, Bool) in
+      guard !state.isUserFinished else { return (nil, false) }
+      state.isCancellationRequested = true
+      guard state.requestStarted else {
+        return (
+          finishUserLocked(
+            &state,
+            with: .failure(.parseFailed(reason: "cancelled"))
+          ),
+          false
+        )
+      }
+      return (nil, true)
+    }
+
+    if resumeOrStop.1 {
+      libvlc_media_parse_stop(instance, media)
+    }
+    if let resume = resumeOrStop.0 {
+      resume.continuation.resume(returning: resume.result)
+    }
+  }
+
+  func finishWithoutRequest(with result: Result<Metadata, VLCError>) {
+    let resume = state.withLock { state -> Resume? in
+      finishUserLocked(&state, with: result)
+    }
+    if let resume {
+      resume.continuation.resume(returning: resume.result)
+    }
+  }
+
+  func finishFromLibVLC(with result: Result<Metadata, VLCError>) {
+    let resume = state.withLock { state -> Resume? in
+      guard !state.isCleanedUp else { return nil }
+      return finishUserLocked(&state, with: result)
+    }
+    if let resume {
+      resume.continuation.resume(returning: resume.result)
+    }
+  }
+
+  func cleanupAfterCompletion() {
+    let cleanup = state.withLock { state -> Cleanup? in
+      makeCleanupLocked(&state)
+    }
+    performCleanup(cleanup)
+  }
+
+  private func finishUserLocked(
+    _ state: inout State,
+    with result: Result<Metadata, VLCError>
+  ) -> Resume? {
+    guard !state.isUserFinished, let continuation = state.continuation else {
+      return nil
+    }
+    state.isUserFinished = true
+    state.continuation = nil
+    let finalResult: Result<Metadata, VLCError> = state.isCancellationRequested
+      ? .failure(.parseFailed(reason: "cancelled"))
+      : result
+    return Resume(continuation: continuation, result: finalResult)
+  }
+
+  private func makeCleanupLocked(_ state: inout State) -> Cleanup? {
+    guard !state.isCleanedUp else { return nil }
+    state.isCleanedUp = true
+
+    let cleanup = Cleanup(
+      callbackBox: state.callbackBox,
+      shouldDetachEvent: state.eventAttached
+    )
+
+    state.callbackBox = nil
+    state.eventAttached = false
+    state.requestStarted = false
+    return cleanup
+  }
+
+  private func performCleanup(_ cleanup: Cleanup?) {
+    guard let cleanup else { return }
+    if cleanup.shouldDetachEvent, let box = cleanup.callbackBox {
+      libvlc_event_detach(
+        eventManager,
+        Int32(libvlc_MediaParsedChanged.rawValue),
+        parseCallback,
+        box
+      )
+    }
+
+    if let box = cleanup.callbackBox {
+      Unmanaged<ParseOperation>.fromOpaque(box).release()
+    }
   }
 }
 
@@ -310,25 +515,21 @@ private func parseCallback(
   event: UnsafePointer<libvlc_event_t>?,
   opaque: UnsafeMutableRawPointer?
 ) {
-  guard event != nil, let opaque else { return }
+  guard let event, let opaque else { return }
 
-  let box = Unmanaged<ParseContinuation>.fromOpaque(opaque)
-  let ctx = box.takeUnretainedValue()
-  let em = libvlc_media_event_manager(ctx.media)!
+  let operation = Unmanaged<ParseOperation>.fromOpaque(opaque).takeUnretainedValue()
+  let status = libvlc_media_parsed_status_t(
+    rawValue: UInt32(event.pointee.u.media_parsed_changed.new_status)
+  )
 
-  // Detach immediately: one-shot.
-  libvlc_event_detach(em, Int32(libvlc_MediaParsedChanged.rawValue), parseCallback, opaque)
-  box.release()
-
-  let status = libvlc_media_get_parsed_status(ctx.media)
-
-  switch status {
+  let result: Result<Metadata, VLCError> = switch status {
   case libvlc_media_parsed_status_done:
-    let metadata = Metadata(from: ctx.media)
-    ctx.continuation.resume(returning: .success(metadata))
+    .success(Metadata(from: operation.media))
   case libvlc_media_parsed_status_timeout:
-    ctx.continuation.resume(returning: .failure(.parseTimeout))
+    .failure(.parseTimeout)
   default:
-    ctx.continuation.resume(returning: .failure(.parseFailed(reason: "status: \(status.rawValue)")))
+    .failure(.parseFailed(reason: "status: \(status.rawValue)"))
   }
+
+  operation.finishFromLibVLC(with: result)
 }

--- a/Sources/SwiftVLC/Media/ThumbnailRequest.swift
+++ b/Sources/SwiftVLC/Media/ThumbnailRequest.swift
@@ -31,9 +31,9 @@ public enum ThumbnailSeekMode: Sendable, Hashable {
 extension Media {
   /// Generates a thumbnail at the specified time.
   ///
-  /// Supports cooperative cancellation: cancelling the parent `Task`
-  /// aborts the in-flight thumbnail request via
-  /// `libvlc_media_thumbnail_request_destroy`.
+  /// Supports cooperative cancellation. If libVLC has already accepted
+  /// the request, SwiftVLC waits for its terminal thumbnail event before
+  /// returning so callback and request teardown are complete.
   ///
   /// - Parameters:
   ///   - time: Time position to capture the thumbnail.
@@ -83,6 +83,7 @@ extension Media {
       await withCheckedContinuation { cont in
         let operation = ThumbnailOperation(
           continuation: cont,
+          media: media,
           eventManager: em
         )
         operationRef.store(operation)
@@ -96,14 +97,16 @@ extension Media {
             box
           ) == 0 else {
           Unmanaged<ThumbnailOperation>.fromOpaque(box).release()
-          operation.finish(with: .failure(.operationFailed("Generate thumbnail: attach callback")))
+          operation.finishWithoutRequest(
+            with: .failure(.operationFailed("Generate thumbnail: attach callback"))
+          )
           return
         }
 
         guard operation.installCallbackBox(box) else {
           // The operation was already finished (typically by `onCancel`
           // racing between `passRetained` above and this check), so
-          // `finish()` didn't see a `callbackBox` to release. We own
+          // `cancel()` didn't see a `callbackBox` to release. We own
           // the retain here and must release it ourselves, or the
           // `ThumbnailOperation` (with its `CheckedContinuation` /
           // `Mutex` state) leaks.
@@ -122,6 +125,10 @@ extension Media {
           return
         }
 
+        guard operation.beginRequestCreation() else {
+          return
+        }
+
         guard
           let request = libvlc_media_thumbnail_request_by_time(
             instancePtr,
@@ -134,14 +141,17 @@ extension Media {
             libvlc_picture_Png,
             timeout.milliseconds
           ) else {
-          operation.finish(with: .failure(.operationFailed("Generate thumbnail")))
+          if Task.isCancelled {
+            operation.cancel()
+          }
+          operation.finishRequestCreation(with: nil)
           return
         }
 
-        guard operation.storeRequest(request) else {
-          libvlc_media_thumbnail_request_destroy(request)
-          return
+        if Task.isCancelled {
+          operation.cancel()
         }
+        operation.finishRequestCreation(with: request)
 
         if Task.isCancelled {
           operation.cancel()
@@ -150,6 +160,7 @@ extension Media {
     } onCancel: {
       operationRef.value()?.cancel()
     }
+    operationRef.value()?.cleanupAfterCompletion()
     await coordinator.release()
     return try result.get()
   }
@@ -274,68 +285,162 @@ private final class ThumbnailOperation: Sendable {
     var request: OpaquePointer?
     var callbackBox: UnsafeMutableRawPointer?
     var eventAttached = false
-    var isFinished = false
+    var requestCreationInFlight = false
+    var pendingLibVLCResult: Result<Data, VLCError>?
+    var isCancellationRequested = false
+    var isUserFinished = false
+    var isCleanedUp = false
   }
 
-  private struct Cleanup {
-    let continuation: CheckedContinuation<Result<Data, VLCError>, Never>?
+  private struct Cleanup: @unchecked Sendable {
     let request: OpaquePointer?
     let callbackBox: UnsafeMutableRawPointer?
     let shouldDetachEvent: Bool
   }
 
+  private struct Resume: @unchecked Sendable {
+    let continuation: CheckedContinuation<Result<Data, VLCError>, Never>
+    let result: Result<Data, VLCError>
+  }
+
   nonisolated(unsafe) let eventManager: OpaquePointer
+  private nonisolated(unsafe) let media: OpaquePointer
   private let state: Mutex<State>
 
   init(
     continuation: CheckedContinuation<Result<Data, VLCError>, Never>,
+    media: OpaquePointer,
     eventManager: OpaquePointer
   ) {
+    self.media = media
     self.eventManager = eventManager
+    libvlc_media_retain(media)
     state = Mutex(State(continuation: continuation))
+  }
+
+  deinit {
+    libvlc_media_release(media)
   }
 
   func installCallbackBox(_ box: UnsafeMutableRawPointer) -> Bool {
     state.withLock { state -> Bool in
-      guard !state.isFinished else { return false }
+      guard !state.isCleanedUp, !state.isUserFinished else { return false }
       state.callbackBox = box
       state.eventAttached = true
       return true
     }
   }
 
-  func storeRequest(_ request: OpaquePointer) -> Bool {
+  func beginRequestCreation() -> Bool {
     state.withLock { state -> Bool in
-      guard !state.isFinished else { return false }
-      state.request = request
+      guard !state.isCleanedUp, !state.isUserFinished else { return false }
+      state.requestCreationInFlight = true
       return true
     }
   }
 
-  func cancel() {
-    finish(with: .failure(.operationFailed("Generate thumbnail: cancelled")))
+  func finishRequestCreation(with request: OpaquePointer?) {
+    let resume = state.withLock { state -> Resume? in
+      state.requestCreationInFlight = false
+
+      guard let request else {
+        return finishUserLocked(
+          &state,
+          with: .failure(.operationFailed("Generate thumbnail"))
+        )
+      }
+
+      state.request = request
+      guard let pendingResult = state.pendingLibVLCResult else { return nil }
+      state.pendingLibVLCResult = nil
+      return finishUserLocked(&state, with: pendingResult)
+    }
+    if let resume {
+      resume.continuation.resume(returning: resume.result)
+    }
   }
 
-  func finish(with result: Result<Data, VLCError>) {
-    let cleanup = state.withLock { state -> Cleanup? in
-      guard !state.isFinished else { return nil }
-      state.isFinished = true
-
-      let cleanup = Cleanup(
-        continuation: state.continuation,
-        request: state.request,
-        callbackBox: state.callbackBox,
-        shouldDetachEvent: state.eventAttached
-      )
-
-      state.continuation = nil
-      state.request = nil
-      state.callbackBox = nil
-      state.eventAttached = false
-      return cleanup
+  func finishWithoutRequest(with result: Result<Data, VLCError>) {
+    let resume = state.withLock { state -> Resume? in
+      finishUserLocked(&state, with: result)
     }
-    guard let cleanup else { return }
+    if let resume {
+      resume.continuation.resume(returning: resume.result)
+    }
+  }
 
+  func cancel() {
+    let resume = state.withLock { state -> Resume? in
+      guard !state.isUserFinished else { return nil }
+      state.isCancellationRequested = true
+      if state.request != nil || state.requestCreationInFlight {
+        return nil
+      }
+      return finishUserLocked(
+        &state,
+        with: .failure(.operationFailed("Generate thumbnail: cancelled"))
+      )
+    }
+    if let resume {
+      resume.continuation.resume(returning: resume.result)
+    }
+  }
+
+  func finishFromLibVLC(with result: Result<Data, VLCError>) {
+    let resume = state.withLock { state -> Resume? in
+      guard !state.isCleanedUp else { return nil }
+      if state.requestCreationInFlight, state.request == nil {
+        state.pendingLibVLCResult = result
+        return nil
+      }
+      return finishUserLocked(&state, with: result)
+    }
+    if let resume {
+      resume.continuation.resume(returning: resume.result)
+    }
+  }
+
+  func cleanupAfterCompletion() {
+    let cleanup = state.withLock { state -> Cleanup? in
+      makeCleanupLocked(&state)
+    }
+    performCleanup(cleanup)
+  }
+
+  private func finishUserLocked(
+    _ state: inout State,
+    with result: Result<Data, VLCError>
+  ) -> Resume? {
+    guard !state.isUserFinished, let continuation = state.continuation else {
+      return nil
+    }
+    state.isUserFinished = true
+    state.continuation = nil
+    let finalResult: Result<Data, VLCError> = state.isCancellationRequested
+      ? .failure(.operationFailed("Generate thumbnail: cancelled"))
+      : result
+    return Resume(continuation: continuation, result: finalResult)
+  }
+
+  private func makeCleanupLocked(_ state: inout State) -> Cleanup? {
+    guard !state.isCleanedUp else { return nil }
+    state.isCleanedUp = true
+
+    let cleanup = Cleanup(
+      request: state.request,
+      callbackBox: state.callbackBox,
+      shouldDetachEvent: state.eventAttached
+    )
+
+    state.request = nil
+    state.callbackBox = nil
+    state.eventAttached = false
+    state.requestCreationInFlight = false
+    return cleanup
+  }
+
+  private func performCleanup(_ cleanup: Cleanup?) {
+    guard let cleanup else { return }
     if cleanup.shouldDetachEvent, let box = cleanup.callbackBox {
       libvlc_event_detach(
         eventManager,
@@ -348,8 +453,6 @@ private final class ThumbnailOperation: Sendable {
     if let request = cleanup.request {
       libvlc_media_thumbnail_request_destroy(request)
     }
-
-    cleanup.continuation?.resume(returning: result)
 
     if let box = cleanup.callbackBox {
       Unmanaged<ThumbnailOperation>.fromOpaque(box).release()
@@ -377,5 +480,5 @@ private func thumbnailCallback(
     resumeValue = .failure(.operationFailed("Generate thumbnail: no image produced"))
   }
 
-  operation.finish(with: resumeValue)
+  operation.finishFromLibVLC(with: resumeValue)
 }

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -69,7 +69,9 @@ public final class PiPController: NSObject {
   @ObservationIgnored
   private var pipController: AVPictureInPictureController?
   @ObservationIgnored
-  private var rendererOpaque: Unmanaged<PixelBufferRenderer>?
+  private var rendererContext: PixelBufferRendererCallbackContext?
+  @ObservationIgnored
+  private var rendererOpaque: UnsafeMutableRawPointer?
   @ObservationIgnored
   private var controlTimebase: CMTimebase?
   @ObservationIgnored
@@ -228,13 +230,26 @@ public final class PiPController: NSObject {
     #if os(macOS)
     nativeBackend?.owner = nil
     #endif
-    if let rendererOpaque {
-      libvlc_video_set_callbacks(player.pointer, nil, nil, nil, nil)
-      libvlc_video_set_format_callbacks(player.pointer, nil, nil)
-      rendererOpaque.release()
-    }
     renderer.setDisplayLayer(nil)
     renderer.setTimebase(nil)
+    if let rendererContext, let rendererOpaque {
+      let nativeState = PlayerState(from: libvlc_media_player_get_state(player.pointer))
+      let mayHaveInheritedCallbacks = switch nativeState {
+      case .idle, .stopped, .error:
+        player.isPlaybackRequestedActive
+      case .opening, .buffering, .playing, .paused, .stopping:
+        true
+      }
+      libvlc_video_set_callbacks(player.pointer, nil, nil, nil, nil)
+      libvlc_video_set_format_callbacks(player.pointer, nil, nil)
+      rendererContext.requestRetirement(
+        opaque: rendererOpaque,
+        deferIfVoutMayBeOpening: mayHaveInheritedCallbacks
+      )
+      if mayHaveInheritedCallbacks {
+        scheduleRetiredRendererContextRelease(rendererContext, opaque: rendererOpaque)
+      }
+    }
   }
 
   // MARK: - Public API
@@ -302,9 +317,11 @@ public final class PiPController: NSObject {
   }
 
   private func attachCallbacks() {
-    let opaque = Unmanaged.passRetained(renderer)
-    rendererOpaque = opaque
-    let ptr = opaque.toOpaque()
+    let context = PixelBufferRendererCallbackContext(renderer: renderer)
+    let retained = Unmanaged.passRetained(context)
+    rendererContext = context
+    let ptr = retained.toOpaque()
+    rendererOpaque = ptr
 
     // Set the opaque pointer for vmem callbacks
     libvlc_video_set_callbacks(
@@ -320,6 +337,26 @@ public final class PiPController: NSObject {
       pixelBufferFormatCallback,
       pixelBufferCleanupCallback
     )
+  }
+
+  private func scheduleRetiredRendererContextRelease(
+    _ context: PixelBufferRendererCallbackContext,
+    opaque: UnsafeMutableRawPointer
+  ) {
+    guard let retainedPlayer = libvlc_media_player_retain(player.pointer) else {
+      context.releaseRetiredOpaqueRetainIfNoOpenVout(opaque: opaque)
+      return
+    }
+    nonisolated(unsafe) let playerPointer = retainedPlayer
+    nonisolated(unsafe) let contextOpaque = opaque
+
+    DispatchQueue.global(qos: .utility).async {
+      context.releaseRetiredOpaqueRetainWhenPlayerIsQuiescent(
+        opaque: contextOpaque,
+        player: playerPointer
+      )
+      libvlc_media_player_release(playerPointer)
+    }
   }
 
   private func setupPiPController() {

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -815,6 +815,8 @@ public final class PiPController: NSObject {
 // MARK: - AVPictureInPictureControllerDelegate
 
 extension PiPController: AVPictureInPictureControllerDelegate {
+  /// Synchronizes playback state just before AVKit transitions into
+  /// Picture in Picture.
   public nonisolated func pictureInPictureControllerWillStartPictureInPicture(
     _: AVPictureInPictureController
   ) {

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -4,18 +4,19 @@ import AVKit
 import CLibVLC
 import Dispatch
 import Observation
+import Synchronization
 
 /// Controls Picture-in-Picture playback for a ``Player``.
 ///
-/// `PiPController` routes video through libVLC's vmem callbacks and an
-/// `AVSampleBufferDisplayLayer`, which is the only rendering path
-/// AVKit's PiP can attach to. A `PiPController` replaces the default
-/// `VideoView` pipeline: do not use both on the same player.
+/// When instantiated directly, `PiPController` routes video through
+/// libVLC's vmem callbacks and an `AVSampleBufferDisplayLayer`. That
+/// sample-buffer path replaces the default `VideoView` pipeline: do
+/// not use both on the same player.
 ///
 /// Most apps should prefer ``PiPVideoView``, which creates and owns a
-/// `PiPController` behind a single SwiftUI view. Instantiate
-/// `PiPController` directly only when you need fine-grained control
-/// over the layer's placement or lifecycle.
+/// `PiPController` behind a single SwiftUI view. On macOS that view owns
+/// VLC's native drawable container and moves the whole container into the
+/// system PiP presenter, avoiding AVKit's sample-buffer mirror path.
 ///
 /// ```swift
 /// let controller = PiPController(player: player)
@@ -26,14 +27,18 @@ import Observation
 @MainActor
 public final class PiPController: NSObject {
   struct PlaybackDriver {
-    let pause: @MainActor () -> Void
-    let resume: @MainActor () -> Void
+    let pause: @MainActor () -> Bool
+    let resume: @MainActor () -> Bool
+    let cancelPendingPause: @MainActor () -> Void
+    let shouldResume: @MainActor () -> Bool
     let seek: @MainActor (Duration) -> Void
 
     static func live(player: Player) -> Self {
       Self(
-        pause: { player.pause() },
-        resume: { player.resume() },
+        pause: { player.issuePause() },
+        resume: { player.issueResume() },
+        cancelPendingPause: { player.cancelPendingPause() },
+        shouldResume: { player.shouldResumeForExternalPlayRequest },
         seek: { player.seek(to: $0) }
       )
     }
@@ -70,9 +75,15 @@ public final class PiPController: NSObject {
   @ObservationIgnored
   private var stateObserverTask: Task<Void, Never>?
   @ObservationIgnored
+  private var playbackIntentObserverTask: Task<Void, Never>?
+  @ObservationIgnored
   private var possibleObservation: NSKeyValueObservation?
   @ObservationIgnored
   private var activeObservation: NSKeyValueObservation?
+  #if os(macOS)
+  @ObservationIgnored
+  private var nativeBackend: MacNativePiPBackend?
+  #endif
 
   /// Playback state as PiP sees it. Updated synchronously in
   /// `setPlaying` (PiP-initiated) and by the observer (VLC-initiated,
@@ -82,6 +93,13 @@ public final class PiPController: NSObject {
   /// `setPlaying` and would otherwise see stale values.
   @ObservationIgnored
   fileprivate var pipPlaybackActive: Bool = false
+  /// Desired playback state from the PiP controls while libVLC is still
+  /// catching up. During this window player events can still report the
+  /// old state, so the event observer must not overwrite
+  /// `pipPlaybackActive` until native playback reaches the requested
+  /// state or exits playback entirely.
+  @ObservationIgnored
+  private var pendingPiPPlaybackState: Bool?
 
   /// Debounced pause task. AVKit can transiently report "paused" during
   /// skip and PiP transitions; issuing a real libVLC pause for those
@@ -148,7 +166,32 @@ public final class PiPController: NSObject {
     attachCallbacks()
     setupPiPController()
     startStateObserver()
+    startPlaybackIntentObserver()
   }
+
+  #if os(macOS)
+  init(
+    player: Player,
+    nativeBackend: MacNativePiPBackend
+  ) {
+    self.player = player
+    playbackDriver = .live(player: player)
+    pauseDebounce = .milliseconds(250)
+    displayLayer = AVSampleBufferDisplayLayer()
+    renderer = PixelBufferRenderer(displayLayer: displayLayer)
+    playbackDelegateProxy = PiPPlaybackDelegateProxy()
+    self.nativeBackend = nativeBackend
+
+    super.init()
+
+    playbackDelegateProxy.owner = self
+    nativeBackend.owner = self
+    updatePiPPossible(nativeBackend.isPossible)
+    updatePiPActive(nativeBackend.isActive)
+    startStateObserver()
+    startPlaybackIntentObserver()
+  }
+  #endif
 
   init(
     player: Player,
@@ -173,29 +216,50 @@ public final class PiPController: NSObject {
     attachCallbacks()
     setupPiPController()
     startStateObserver()
+    startPlaybackIntentObserver()
   }
 
   isolated deinit {
     cancelDeferredPause()
     stateObserverTask?.cancel()
+    playbackIntentObserverTask?.cancel()
     possibleObservation = nil
     activeObservation = nil
-    libvlc_video_set_callbacks(player.pointer, nil, nil, nil, nil)
-    libvlc_video_set_format_callbacks(player.pointer, nil, nil)
-    rendererOpaque?.release()
+    #if os(macOS)
+    nativeBackend?.owner = nil
+    #endif
+    if let rendererOpaque {
+      libvlc_video_set_callbacks(player.pointer, nil, nil, nil, nil)
+      libvlc_video_set_format_callbacks(player.pointer, nil, nil)
+      rendererOpaque.release()
+    }
     renderer.setDisplayLayer(nil)
     renderer.setTimebase(nil)
   }
 
   // MARK: - Public API
 
-  /// Starts Picture-in-Picture if possible.
+  /// Starts Picture-in-Picture if possible and media is loaded.
   public func start() {
-    pipController?.startPictureInPicture()
+    #if os(macOS)
+    if let nativeBackend {
+      nativeBackend.start()
+      return
+    }
+    #endif
+    guard let pipController else { return }
+    guard player.currentMedia != nil else { return }
+    pipController.startPictureInPicture()
   }
 
   /// Stops Picture-in-Picture.
   public func stop() {
+    #if os(macOS)
+    if let nativeBackend {
+      nativeBackend.stop()
+      return
+    }
+    #endif
     pipController?.stopPictureInPicture()
   }
 
@@ -318,6 +382,16 @@ public final class PiPController: NSObject {
     self.isActive = isActive
   }
 
+  private func invalidatePictureInPicturePlaybackState() {
+    #if os(macOS)
+    if let nativeBackend {
+      nativeBackend.invalidatePlaybackState()
+      return
+    }
+    #endif
+    pipController?.invalidatePlaybackState()
+  }
+
   private func cancelDeferredPause() {
     deferredPauseGeneration &+= 1
     deferredPauseTask?.cancel()
@@ -347,10 +421,12 @@ public final class PiPController: NSObject {
 
         switch player.state {
         case .playing:
-          didIssueDeferredPause = true
           deferredPauseTask = nil
-          playbackDriver.pause()
-          return
+          if playbackDriver.pause() {
+            didIssueDeferredPause = true
+            return
+          }
+          continue
         case .opening, .buffering:
           // Avoid pausing libVLC while it is still stabilizing input state.
           // Keep waiting unless AVKit changes its mind first.
@@ -363,41 +439,33 @@ public final class PiPController: NSObject {
     }
   }
 
-  private func resumeIfNeeded() {
-    let shouldResume = didIssueDeferredPause || player.state == .paused
+  private func requestResumeIfNeeded() -> (needed: Bool, accepted: Bool) {
+    let shouldResume = didIssueDeferredPause || playbackDriver.shouldResume()
     didIssueDeferredPause = false
-    guard shouldResume else { return }
-    playbackDriver.resume()
+    guard shouldResume else { return (needed: false, accepted: false) }
+    return (needed: true, accepted: playbackDriver.resume())
   }
 
   // MARK: - State Observation
 
   /// Drives the control timebase and PiP UI from player events.
   ///
-  /// The previous implementation wrapped each iteration in
-  /// `withCheckedContinuation { withObservationTracking { … } }`, with a
-  /// `guard let self else { return }` hoisted above the `await`. Swift
-  /// scopes guard-let bindings to the enclosing block, so the strong
-  /// `self` binding lived across the suspension and was captured into
-  /// the task's suspended frame. With external strong references gone,
-  /// the suspended frame became the last holder, and nothing could wake
-  /// the continuation — the observation's `onChange` was itself behind
-  /// the continuation the controller was waiting on. The PiPController
-  /// pinned itself until the process exited.
-  ///
   /// The shape below matches `Player.startEventConsumer`: subscribe to
   /// `player.events` (the same broadcaster that drives `Player`'s own
   /// `@Observable` state), pull events via `for await`, and bind `self`
   /// strongly *inside* the loop body where the binding lifetime is a
-  /// single iteration. The implicit suspension between events runs with
-  /// only a weak reference in scope, so the task never prevents
-  /// deinit — when the controller is dropped, the bridge finishes the
-  /// stream (via `Player.deinit`) or the task sees cancellation, and
-  /// the loop exits.
+  /// single iteration. The implicit suspension between events keeps only
+  /// a weak reference in scope, so the observer task never prevents the
+  /// controller from deinitializing.
   private func startStateObserver() {
     let events = player.events
+    let initialActive = player.isPlaybackRequestedActive
+    let initialNativeActive = player.isActive
+    pipPlaybackActive = initialActive
+    syncTimebase(playing: initialNativeActive)
+
     stateObserverTask = Task { @MainActor [weak self] in
-      var wasActive = false
+      var wasActive = initialNativeActive
       var lastDurationMs: Int64?
       var lastRate: Float = 1.0
       for await _ in events {
@@ -410,20 +478,14 @@ public final class PiPController: NSObject {
         // State transition: sync the timebase rate.
         if active != wasActive {
           wasActive = active
-          syncTimebase(playing: active)
+          let didAcceptNativeState = handleObservedPlaybackActivity(active)
 
-          if active {
-            didIssueDeferredPause = false
+          if didAcceptNativeState {
+            syncTimebase(playing: active)
           }
 
-          // Only update pipPlaybackActive and notify PiP for
-          // VLC-initiated changes (end-of-media, error). For
-          // PiP-initiated changes (from setPlaying), the value is
-          // already correct; overriding it with VLC's delayed state
-          // causes the PiP button to blink.
-          if active != pipPlaybackActive {
-            pipPlaybackActive = active
-            pipController?.invalidatePlaybackState()
+          if didAcceptNativeState, active {
+            didIssueDeferredPause = false
           }
         }
 
@@ -437,7 +499,7 @@ public final class PiPController: NSObject {
         // timebase rate matters).
         if rate != lastRate {
           lastRate = rate
-          if pipPlaybackActive, let tb = controlTimebase {
+          if active, let tb = controlTimebase {
             CMTimebaseSetRate(tb, rate: Float64(rate))
           }
         }
@@ -445,7 +507,7 @@ public final class PiPController: NSObject {
         // Duration became known or changed: re-query timeRange.
         if durationMs != lastDurationMs {
           lastDurationMs = durationMs
-          pipController?.invalidatePlaybackState()
+          invalidatePictureInPicturePlaybackState()
         }
 
         // Sync timebase when player position diverges significantly
@@ -466,21 +528,139 @@ public final class PiPController: NSObject {
     }
   }
 
+  private func startPlaybackIntentObserver() {
+    let intents = player.playbackIntentEvents
+    playbackIntentObserverTask = Task { @MainActor [weak self] in
+      for await active in intents {
+        guard let self else { return }
+        handlePlaybackIntentChanged(active)
+      }
+    }
+  }
+
+  private func handlePlaybackIntentChanged(_ active: Bool) {
+    if let pendingPiPPlaybackState, pendingPiPPlaybackState != active {
+      self.pendingPiPPlaybackState = active
+    }
+    if pipPlaybackActive != active {
+      pipPlaybackActive = active
+    }
+    if active {
+      cancelDeferredPause()
+      didIssueDeferredPause = false
+    }
+    // Playback intent drives the PiP button state, but the display
+    // timebase must follow native playback. If libVLC has not actually
+    // paused yet, stopping this timebase freezes video while audio keeps
+    // running.
+    syncTimebase(playing: player.isActive)
+    invalidatePictureInPicturePlaybackState()
+  }
+
   fileprivate func handleSetPlaying(_ playing: Bool) {
     cancelDeferredPause()
 
     // Set immediately so isPlaybackPaused returns the correct value
     // when PiP queries it right after this call (before VLC catches up).
     pipPlaybackActive = playing
+    pendingPiPPlaybackState = playing
 
     if playing {
-      resumeIfNeeded()
+      playbackDriver.cancelPendingPause()
+      let resumeRequest = requestResumeIfNeeded()
+      if resumeRequest.needed, !resumeRequest.accepted {
+        pendingPiPPlaybackState = nil
+        player.setPlaybackIntentFromExternalControl(player.isActive)
+        pipPlaybackActive = player.isPlaybackRequestedActive
+      } else if player.isActive, !resumeRequest.needed {
+        player.setPlaybackIntentFromExternalControl(true)
+        pendingPiPPlaybackState = nil
+      } else {
+        player.setPlaybackIntentFromExternalControl(true)
+      }
     } else {
+      player.setPlaybackIntentFromExternalControl(false)
       scheduleDeferredPause()
+      if !player.isActive {
+        pendingPiPPlaybackState = nil
+      }
     }
 
-    syncTimebase(playing: playing)
-    pipController?.invalidatePlaybackState()
+    syncTimebase(playing: player.isActive)
+    invalidatePictureInPicturePlaybackState()
+  }
+
+  @discardableResult
+  private func handleObservedPlaybackActivity(_ active: Bool) -> Bool {
+    if let pendingPiPPlaybackState {
+      if active == pendingPiPPlaybackState {
+        self.pendingPiPPlaybackState = nil
+        if pipPlaybackActive != active {
+          pipPlaybackActive = active
+        }
+        invalidatePictureInPicturePlaybackState()
+        return true
+      }
+
+      switch player.state {
+      case .idle, .stopped, .stopping, .error:
+        self.pendingPiPPlaybackState = nil
+        if pipPlaybackActive != false {
+          pipPlaybackActive = false
+          invalidatePictureInPicturePlaybackState()
+        }
+        return true
+      default:
+        break
+      }
+      return false
+    }
+
+    // Only update pipPlaybackActive and notify PiP for VLC-initiated
+    // changes (end-of-media, error, or external app controls). For
+    // PiP-initiated changes (from setPlaying), the pending state above
+    // keeps the UI stable while libVLC catches up.
+    if active != pipPlaybackActive {
+      pipPlaybackActive = active
+      invalidatePictureInPicturePlaybackState()
+    }
+    return true
+  }
+
+  private func syncPlaybackStateForPictureInPicture() {
+    guard pendingPiPPlaybackState == nil else { return }
+    let active = player.isPlaybackRequestedActive
+    if pipPlaybackActive != active {
+      pipPlaybackActive = active
+    }
+    if active {
+      didIssueDeferredPause = false
+    }
+    syncTimebase(playing: player.isActive)
+  }
+
+  #if os(macOS)
+  func handleNativePictureInPictureReady() {
+    updatePiPPossible(nativeBackend?.isPossible == true)
+  }
+
+  func handleNativePictureInPictureActiveChanged(_ isActive: Bool) {
+    updatePiPActive(isActive)
+  }
+
+  func handleNativePictureInPictureSetPlaying(_ playing: Bool) {
+    handleSetPlaying(playing)
+  }
+  #endif
+
+  fileprivate func handleRenderSizeTransition(_ size: CMVideoDimensions) {
+    #if os(macOS)
+    guard nativeBackend == nil else { return }
+    renderer.setRenderSize(size)
+    renderer.flushDisplayLayer()
+    #else
+    _ = size
+    #endif
   }
 
   fileprivate func handleSkip(
@@ -507,7 +687,7 @@ public final class PiPController: NSObject {
         seconds: Double(targetMs) / 1000.0,
         preferredTimescale: 1000
       ))
-      CMTimebaseSetRate(tb, rate: pipPlaybackActive ? Float64(player.rate) : 0.0)
+      CMTimebaseSetRate(tb, rate: player.isActive ? Float64(player.rate) : 0.0)
     }
 
     completionHandler()
@@ -570,20 +750,51 @@ public final class PiPController: NSObject {
     handleSetPlaying(playing)
   }
 
+  func _pipPlaybackActiveForTesting() -> Bool {
+    pipPlaybackActive
+  }
+
+  func _pendingPiPPlaybackStateForTesting() -> Bool? {
+    pendingPiPPlaybackState
+  }
+
+  func _handleObservedPlaybackActivityForTesting(_ active: Bool) {
+    handleObservedPlaybackActivity(active)
+  }
+
+  func _controlTimebaseRateForTesting() -> Double? {
+    controlTimebase.map { CMTimebaseGetRate($0) }
+  }
+
   func _skipByIntervalForTesting(_ skipInterval: CMTime) {
     handleSkip(by: skipInterval) {}
+  }
+
+  func _renderSizeForTesting() -> CMVideoDimensions? {
+    renderer.state.withLock { $0.renderSize }
   }
 }
 
 // MARK: - AVPictureInPictureControllerDelegate
 
 extension PiPController: AVPictureInPictureControllerDelegate {
+  public nonisolated func pictureInPictureControllerWillStartPictureInPicture(
+    _: AVPictureInPictureController
+  ) {
+    pipMainActorSync {
+      syncPlaybackStateForPictureInPicture()
+      invalidatePictureInPicturePlaybackState()
+    }
+  }
+
   /// Mirrors AVKit's active flag into Observation so SwiftUI can keep
   /// button labels and status UI in sync with system-driven PiP changes.
   public nonisolated func pictureInPictureControllerDidStartPictureInPicture(
     _: AVPictureInPictureController
   ) {
     pipMainActorSync {
+      syncPlaybackStateForPictureInPicture()
+      invalidatePictureInPicturePlaybackState()
       updatePiPActive(true)
     }
   }
@@ -626,8 +837,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
 /// controller weakly, and AVKit's retention of the proxy is harmless.
 ///
 /// The forwarders run on whatever thread AVKit invokes them on. Each
-/// one hops to the main actor before reading or mutating the owner,
-/// matching the previous in-class implementation.
+/// one hops to the main actor before reading or mutating the owner.
 private final class PiPPlaybackDelegateProxy: NSObject, AVPictureInPictureSampleBufferPlaybackDelegate, @unchecked Sendable {
   /// `@unchecked Sendable` is the narrow concession that lets AVKit
   /// hand the proxy between threads. The owner field is the only state,
@@ -695,14 +905,18 @@ private final class PiPPlaybackDelegateProxy: NSObject, AVPictureInPictureSample
 
   func pictureInPictureController(
     _: AVPictureInPictureController,
-    didTransitionToRenderSize _: CMVideoDimensions
-  ) {}
+    didTransitionToRenderSize size: CMVideoDimensions
+  ) {
+    pipMainActorSync { [weak self] in
+      self?.owner?.handleRenderSizeTransition(size)
+    }
+  }
 }
 
 /// AVKit may invoke the proxy's callbacks from non-main threads but
 /// expects synchronous answers. Bounce onto the main actor without
 /// routing through an async task so the answer is immediate.
-private func pipMainActorSync<T: Sendable>(
+func pipMainActorSync<T: Sendable>(
   _ body: @MainActor @Sendable () -> T
 ) -> T {
   if Thread.isMainThread {

--- a/Sources/SwiftVLC/PiP/PiPVideoView.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView.swift
@@ -139,11 +139,11 @@ private final class SampleBufferVideoView: UIView {
 
 #elseif os(macOS)
 import AppKit
-import AVFoundation
+import CLibVLC
 import SwiftUI
 
-/// A SwiftUI view that renders video via `AVSampleBufferDisplayLayer`,
-/// enabling Picture-in-Picture support on macOS.
+/// A SwiftUI view that renders video through libVLC's native drawable
+/// output and moves that drawable into macOS Picture-in-Picture.
 public struct PiPVideoView: NSViewRepresentable {
   private let player: Player
   private let controllerBinding: Binding<PiPController?>?
@@ -158,13 +158,12 @@ public struct PiPVideoView: NSViewRepresentable {
   }
 
   public func makeNSView(context: Context) -> NSView {
-    let controller = PiPController(player: player)
-    let displayLayer = controller.layer
+    let container = MacNativePiPHostView()
+    container.attach(to: player)
 
-    let container = SampleBufferVideoView(displayLayer: displayLayer)
+    let controller = PiPController(player: player, nativeBackend: container.nativePiPBackend)
 
     context.coordinator.pipController = controller
-    context.coordinator.displayLayer = displayLayer
     context.coordinator.player = player
 
     pushControllerBinding(controller, via: context.coordinator)
@@ -173,27 +172,29 @@ public struct PiPVideoView: NSViewRepresentable {
   }
 
   public func updateNSView(_ nsView: NSView, context: Context) {
-    guard let container = nsView as? SampleBufferVideoView else { return }
+    guard let container = nsView as? MacNativePiPHostView else { return }
     if context.coordinator.player !== player {
       context.coordinator.pipController?.stop()
+      container.detach()
+      container.attach(to: player)
 
-      let controller = PiPController(player: player)
-      let displayLayer = controller.layer
-      container.setDisplayLayer(displayLayer)
+      let controller = PiPController(player: player, nativeBackend: container.nativePiPBackend)
 
       context.coordinator.player = player
       context.coordinator.pipController = controller
-      context.coordinator.displayLayer = displayLayer
     }
 
     pushControllerBinding(context.coordinator.pipController, via: context.coordinator)
   }
 
-  public static func dismantleNSView(_: NSView, coordinator: Coordinator) {
+  public static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
     coordinator.pipController?.stop()
-    coordinator.displayLayer?.removeFromSuperlayer()
+    (nsView as? MacNativePiPHostView)?.detach()
     coordinator.pipController = nil
-    coordinator.displayLayer = nil
+    if let binding = coordinator.controllerBinding {
+      Task { @MainActor in binding.wrappedValue = nil }
+      coordinator.controllerBinding = nil
+    }
   }
 
   public func makeCoordinator() -> Coordinator {
@@ -202,13 +203,12 @@ public struct PiPVideoView: NSViewRepresentable {
 
   /// Internal state for the SwiftUI view's lifecycle.
   ///
-  /// Retains the ``PiPController`` and its display layer so they survive
-  /// view updates and are cleaned up on dismantle.
+  /// Retains the ``PiPController`` so it survives view updates and is
+  /// cleaned up on dismantle.
   @MainActor
   public final class Coordinator {
     weak var player: Player?
     var pipController: PiPController?
-    var displayLayer: AVSampleBufferDisplayLayer?
     var controllerBinding: Binding<PiPController?>?
   }
 
@@ -222,14 +222,27 @@ public struct PiPVideoView: NSViewRepresentable {
   }
 }
 
-private final class SampleBufferVideoView: NSView {
-  private var displayLayer: AVSampleBufferDisplayLayer?
+/// SwiftUI owns this root view; VLC mutates the child drawable view.
+/// Keeping those responsibilities separate avoids AppKit's unsupported
+/// "add PiP internals directly under NSHostingController.view" path.
+final class MacNativePiPHostView: NSView {
+  let drawableView = MacNativePiPDrawableView()
 
-  init(displayLayer: AVSampleBufferDisplayLayer) {
-    super.init(frame: .zero)
+  var nativePiPBackend: MacNativePiPBackend {
+    drawableView.nativePiPBackend
+  }
+
+  override init(frame frameRect: NSRect) {
+    super.init(frame: frameRect)
     wantsLayer = true
+    autoresizesSubviews = true
     layer?.backgroundColor = NSColor.black.cgColor
-    setDisplayLayer(displayLayer)
+    layer?.masksToBounds = true
+
+    nativePiPBackend.hostView = self
+    drawableView.frame = bounds
+    drawableView.autoresizingMask = [.width, .height]
+    addSubview(drawableView)
   }
 
   @available(*, unavailable)
@@ -237,20 +250,623 @@ private final class SampleBufferVideoView: NSView {
     fatalError()
   }
 
-  func setDisplayLayer(_ displayLayer: AVSampleBufferDisplayLayer) {
-    self.displayLayer?.removeFromSuperlayer()
-    self.displayLayer = displayLayer
-    layer?.addSublayer(displayLayer)
+  func attach(to player: Player) {
+    drawableView.attach(to: player)
+  }
+
+  func detach() {
+    drawableView.detach()
+  }
+
+  func restoreDrawableView(_ drawableView: MacNativePiPDrawableView) {
+    if drawableView.superview !== self {
+      drawableView.removeFromSuperview()
+      addSubview(drawableView)
+    }
+
+    drawableView.autoresizingMask = [.width, .height]
+    drawableView.frame = bounds
+    drawableView.restoreVLCContentLayout()
     needsLayout = true
     layoutSubtreeIfNeeded()
+    drawableView.restoreVLCContentLayout()
+
+    DispatchQueue.main.async { [weak self, weak drawableView] in
+      guard let self, let drawableView, drawableView.superview === self else { return }
+      drawableView.frame = bounds
+      drawableView.restoreVLCContentLayout()
+    }
   }
 
   override func layout() {
     super.layout()
+    guard drawableView.superview === self else { return }
     CATransaction.begin()
     CATransaction.setDisableActions(true)
-    displayLayer?.frame = bounds
+    drawableView.frame = bounds
     CATransaction.commit()
+  }
+}
+
+final class MacNativePiPDrawableView: NSView {
+  let nativePiPBackend = MacNativePiPBackend()
+  private weak var attachedPlayer: Player?
+  private var lastBounds: CGRect = .zero
+
+  init() {
+    super.init(frame: .zero)
+    wantsLayer = true
+    autoresizesSubviews = true
+    layer?.backgroundColor = NSColor.black.cgColor
+    layer?.masksToBounds = true
+    nativePiPBackend.drawableView = self
+  }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError()
+  }
+
+  func attach(to player: Player) {
+    guard attachedPlayer !== player else { return }
+    attachedPlayer?.setDrawable(nil)
+    attachedPlayer = player
+    nativePiPBackend.attach(to: player)
+    player.setDrawable(self)
+  }
+
+  func detach() {
+    guard let player = attachedPlayer else { return }
+    nativePiPBackend.stop()
+    player.setDrawable(nil)
+    nativePiPBackend.detach()
+    attachedPlayer = nil
+    lastBounds = .zero
+  }
+
+  @objc(addVoutSubview:)
+  func addVoutSubview(_ subview: NSView) {
+    if subview.superview !== self {
+      subview.removeFromSuperview()
+      addSubview(subview)
+    }
+    configureVLCSubview(subview)
+    restoreVLCContentLayout()
+  }
+
+  @objc(removeVoutSubview:)
+  func removeVoutSubview(_ subview: NSView) {
+    guard subview.superview === self else { return }
+    subview.removeFromSuperview()
+  }
+
+  override func didAddSubview(_ subview: NSView) {
+    super.didAddSubview(subview)
+    configureVLCSubview(subview)
+    layoutVLCContent()
+  }
+
+  override func layout() {
+    super.layout()
+
+    if let player = attachedPlayer, lastBounds == .zero, bounds.width > 0, bounds.height > 0 {
+      player.setDrawable(self)
+    }
+    if bounds.width > 0, bounds.height > 0 {
+      lastBounds = bounds
+    }
+
+    layoutVLCContent()
+  }
+
+  private func configureVLCSubview(_ subview: NSView) {
+    subview.autoresizingMask = [.width, .height]
+  }
+
+  func restoreVLCContentLayout() {
+    needsLayout = true
+    layoutSubtreeIfNeeded()
+    layoutVLCContent()
+  }
+
+  private func layoutVLCContent() {
+    CATransaction.begin()
+    CATransaction.setDisableActions(true)
+    for subview in subviews {
+      configureVLCSubview(subview)
+      subview.frame = bounds
+      subview.needsLayout = true
+      subview.layoutSubtreeIfNeeded()
+      reshapeVLCSubviewIfNeeded(subview)
+      subview.layer?.frame = subview.bounds
+      subview.layer?.setNeedsDisplay()
+    }
+    layer?.sublayers?.forEach {
+      $0.frame = bounds
+      $0.setNeedsDisplay()
+    }
+    CATransaction.commit()
+  }
+}
+
+private let macNativePiPOpenGLReshapeSelector = NSSelectorFromString("reshape")
+
+@MainActor
+private func reshapeVLCSubviewIfNeeded(_ subview: NSView) {
+  guard
+    subview.responds(to: macNativePiPOpenGLReshapeSelector),
+    subview.bounds.width > 0,
+    subview.bounds.height > 0
+  else { return }
+  _ = subview.perform(macNativePiPOpenGLReshapeSelector)
+}
+
+@MainActor
+final class MacNativePiPBackend: NSObject, @unchecked Sendable {
+  let mediaController = MacNativePiPMediaController()
+  weak var owner: PiPController?
+  weak var hostView: MacNativePiPHostView?
+  weak var drawableView: MacNativePiPDrawableView?
+
+  private let presenter = MacPrivatePiPPresenter()
+  private(set) var isPossible = false
+  private(set) var isActive = false
+
+  func attach(to player: Player) {
+    mediaController.player = player
+    refreshPossible()
+  }
+
+  func detach() {
+    presenter.stop()
+    mediaController.player = nil
+    setPossible(false)
+    setActive(false)
+  }
+
+  func start() {
+    guard mediaController.player?.currentMedia != nil else {
+      return
+    }
+
+    refreshPossible()
+    guard
+      isPossible,
+      let hostView,
+      let drawableView,
+      let player = mediaController.player
+    else {
+      return
+    }
+
+    let didStart = presenter.start(
+      player: player,
+      hostView: hostView,
+      drawableView: drawableView,
+      mediaController: mediaController,
+      onActiveChanged: { [weak self] isActive in
+        self?.setActive(isActive)
+      },
+      onPlay: { [weak self] in
+        self?.handleSetPlaying(true)
+      },
+      onPause: { [weak self] in
+        self?.handleSetPlaying(false)
+      }
+    )
+
+    if !didStart {
+      setPossible(false)
+    }
+  }
+
+  func stop() {
+    presenter.stop()
+  }
+
+  func invalidatePlaybackState() {
+    presenter.updatePlaybackState(isPlaying: mediaController.isMediaPlaying())
+  }
+
+  private func refreshPossible() {
+    setPossible(
+      mediaController.player?.instance.usesPiPSafeDarwinDisplay == true
+        && MacPrivatePiPPresenter.isRuntimeAvailable
+    )
+  }
+
+  private func setPossible(_ isPossible: Bool) {
+    guard self.isPossible != isPossible else { return }
+    self.isPossible = isPossible
+    Task { @MainActor [weak owner] in
+      owner?.handleNativePictureInPictureReady()
+    }
+  }
+
+  private func setActive(_ isActive: Bool) {
+    guard self.isActive != isActive else { return }
+    self.isActive = isActive
+    Task { @MainActor [weak owner] in
+      owner?.handleNativePictureInPictureActiveChanged(isActive)
+    }
+  }
+
+  private func handleSetPlaying(_ playing: Bool) {
+    if let owner {
+      owner.handleNativePictureInPictureSetPlaying(playing)
+    } else if playing {
+      mediaController.play()
+    } else {
+      mediaController.pause()
+    }
+  }
+}
+
+/// macOS's public sample-buffer PiP path mirrors `AVSampleBufferDisplayLayer`
+/// through a `CALayerHost`; on affected macOS releases that mirror renders at
+/// 1:1 and crops the video. The private PiP presenter reparents the real VLC
+/// drawable instead, which matches the approach used by native macOS players
+/// such as IINA. Load it dynamically so unsupported systems simply report PiP
+/// unavailable instead of linking a private framework.
+@MainActor
+private final class MacPrivatePiPPresenter {
+  static var isRuntimeAvailable: Bool {
+    makePictureInPictureViewController() != nil
+  }
+
+  private weak var hostView: MacNativePiPHostView?
+  private weak var drawableView: MacNativePiPDrawableView?
+  private var pictureInPictureViewController: NSViewController?
+  private var contentViewController: NSViewController?
+  private var delegate: MacPrivatePiPDelegate?
+  private var onActiveChanged: (@MainActor @Sendable (Bool) -> Void)?
+
+  var isActive: Bool {
+    pictureInPictureViewController != nil
+  }
+
+  func start(
+    player: Player,
+    hostView: MacNativePiPHostView,
+    drawableView: MacNativePiPDrawableView,
+    mediaController: MacNativePiPMediaController,
+    onActiveChanged: @escaping @MainActor @Sendable (Bool) -> Void,
+    onPlay: @escaping @MainActor @Sendable () -> Void,
+    onPause: @escaping @MainActor @Sendable () -> Void
+  ) -> Bool {
+    if isActive {
+      updatePlaybackState(isPlaying: mediaController.isMediaPlaying())
+      return true
+    }
+
+    guard let pictureInPictureViewController = Self.makePictureInPictureViewController() else { return false }
+
+    self.hostView = hostView
+    self.drawableView = drawableView
+    self.pictureInPictureViewController = pictureInPictureViewController
+    self.onActiveChanged = onActiveChanged
+
+    let delegate = MacPrivatePiPDelegate()
+    delegate.shouldClose = { [weak self] in
+      self?.prepareForClose()
+      return true
+    }
+    delegate.willClose = { [weak self] in
+      self?.prepareForClose()
+    }
+    delegate.didClose = { [weak self] in
+      self?.finish()
+    }
+    delegate.play = onPlay
+    delegate.pause = onPause
+    delegate.stop = onPause
+    self.delegate = delegate
+
+    let contentViewController = NSViewController()
+    drawableView.removeFromSuperview()
+    drawableView.frame = NSRect(origin: .zero, size: normalizedContentSize(from: hostView.bounds.size))
+    drawableView.autoresizingMask = [.width, .height]
+    contentViewController.view = drawableView
+    self.contentViewController = contentViewController
+
+    guard
+      configure(
+        pictureInPictureViewController,
+        player: player,
+        hostView: hostView,
+        isPlaying: mediaController.isMediaPlaying()
+      ) else {
+      finish()
+      return false
+    }
+
+    _ = pictureInPictureViewController.perform(
+      MacPrivatePiPSelector.present,
+      with: contentViewController
+    )
+    onActiveChanged(true)
+    return true
+  }
+
+  func stop() {
+    guard let pictureInPictureViewController else {
+      finish()
+      return
+    }
+
+    prepareForClose()
+    if let contentViewController {
+      pictureInPictureViewController.dismiss(contentViewController)
+    } else {
+      finish()
+    }
+  }
+
+  func updatePlaybackState(isPlaying: Bool) {
+    guard let pictureInPictureViewController else { return }
+    setPrivateValue(
+      isPlaying,
+      forKey: "playing",
+      requiring: MacPrivatePiPSelector.setPlaying,
+      on: pictureInPictureViewController
+    )
+  }
+
+  @discardableResult
+  private func prepareForClose() -> Bool {
+    guard let pictureInPictureViewController, let hostView else { return true }
+    let replacementRect = hostView.convert(hostView.bounds, to: nil)
+    let didSetWindow = setPrivateValue(
+      hostView.window,
+      forKey: "replacementWindow",
+      requiring: MacPrivatePiPSelector.setReplacementWindow,
+      on: pictureInPictureViewController
+    )
+    let didSetRect = setPrivateValue(
+      NSValue(rect: replacementRect),
+      forKey: "replacementRect",
+      requiring: MacPrivatePiPSelector.setReplacementRect,
+      on: pictureInPictureViewController
+    )
+    return didSetWindow && didSetRect
+  }
+
+  private func finish() {
+    guard pictureInPictureViewController != nil else { return }
+
+    let hostView = hostView
+    let drawableView = drawableView
+
+    contentViewController?.view = NSView(frame: .zero)
+    if let hostView, let drawableView {
+      hostView.restoreDrawableView(drawableView)
+    }
+
+    pictureInPictureViewController = nil
+    contentViewController = nil
+    delegate = nil
+    self.hostView = nil
+    self.drawableView = nil
+
+    onActiveChanged?(false)
+    onActiveChanged = nil
+  }
+
+  private func configure(
+    _ pictureInPictureViewController: NSViewController,
+    player: Player,
+    hostView: MacNativePiPHostView,
+    isPlaying: Bool
+  ) -> Bool {
+    pictureInPictureViewController.title = player.currentMedia?.mrl ?? "SwiftVLC"
+    let didSetDelegate = setPrivateValue(
+      delegate,
+      forKey: "delegate",
+      requiring: MacPrivatePiPSelector.setDelegate,
+      on: pictureInPictureViewController
+    )
+    let didSetWindow = setPrivateValue(
+      hostView.window,
+      forKey: "replacementWindow",
+      requiring: MacPrivatePiPSelector.setReplacementWindow,
+      on: pictureInPictureViewController
+    )
+    let didSetPlaying = setPrivateValue(
+      isPlaying,
+      forKey: "playing",
+      requiring: MacPrivatePiPSelector.setPlaying,
+      on: pictureInPictureViewController
+    )
+    let didSetRect = setPrivateValue(
+      NSValue(rect: hostView.convert(hostView.bounds, to: nil)),
+      forKey: "replacementRect",
+      requiring: MacPrivatePiPSelector.setReplacementRect,
+      on: pictureInPictureViewController
+    )
+    let didSetAspectRatio = setPrivateValue(
+      NSValue(size: normalizedContentSize(from: hostView.bounds.size)),
+      forKey: "aspectRatio",
+      requiring: MacPrivatePiPSelector.setAspectRatio,
+      on: pictureInPictureViewController
+    )
+
+    return didSetDelegate
+      && didSetWindow
+      && didSetPlaying
+      && didSetRect
+      && didSetAspectRatio
+  }
+
+  private func normalizedContentSize(from size: CGSize) -> CGSize {
+    guard size.width.isFinite, size.height.isFinite, size.width >= 16, size.height >= 16 else {
+      return CGSize(width: 16, height: 9)
+    }
+    return CGSize(width: ceil(size.width), height: ceil(size.height))
+  }
+
+  private static func makePictureInPictureViewController() -> NSViewController? {
+    guard let type = loadPictureInPictureViewControllerType() else { return nil }
+    let controller = type.init(nibName: nil, bundle: nil)
+    guard MacPrivatePiPSelector.required.allSatisfy({ controller.responds(to: $0) }) else {
+      return nil
+    }
+    return controller
+  }
+
+  private static func loadPictureInPictureViewControllerType() -> NSViewController.Type? {
+    guard
+      let bundle = Bundle(path: "/System/Library/PrivateFrameworks/PIP.framework"),
+      bundle.isLoaded || bundle.load()
+    else {
+      return nil
+    }
+    return NSClassFromString("PIPViewController") as? NSViewController.Type
+  }
+}
+
+private enum MacPrivatePiPSelector {
+  static let present = NSSelectorFromString("presentViewControllerAsPictureInPicture:")
+  static let setDelegate = NSSelectorFromString("setDelegate:")
+  static let setReplacementWindow = NSSelectorFromString("setReplacementWindow:")
+  static let setReplacementRect = NSSelectorFromString("setReplacementRect:")
+  static let setPlaying = NSSelectorFromString("setPlaying:")
+  static let setAspectRatio = NSSelectorFromString("setAspectRatio:")
+
+  static let required = [
+    present,
+    setDelegate,
+    setReplacementWindow,
+    setReplacementRect,
+    setPlaying,
+    setAspectRatio
+  ]
+}
+
+@discardableResult
+private func setPrivateValue(
+  _ value: Any?,
+  forKey key: String,
+  requiring selector: Selector,
+  on object: NSObject
+) -> Bool {
+  guard object.responds(to: selector) else { return false }
+  object.setValue(value, forKey: key)
+  return true
+}
+
+private final class MacPrivatePiPDelegate: NSObject, @unchecked Sendable {
+  var shouldClose: @MainActor @Sendable () -> Bool = { true }
+  var willClose: @MainActor @Sendable () -> Void = {}
+  var didClose: @MainActor @Sendable () -> Void = {}
+  var play: @MainActor @Sendable () -> Void = {}
+  var pause: @MainActor @Sendable () -> Void = {}
+  var stop: @MainActor @Sendable () -> Void = {}
+
+  @objc(pipShouldClose:)
+  func pipShouldClose(_: NSObject) -> Bool {
+    pipMainActorSync { [weak self] in
+      self?.shouldClose() ?? true
+    }
+  }
+
+  @objc(pipWillClose:)
+  func pipWillClose(_: NSObject) {
+    Task { @MainActor [weak self] in
+      self?.willClose()
+    }
+  }
+
+  @objc(pipDidClose:)
+  func pipDidClose(_: NSObject) {
+    Task { @MainActor [weak self] in
+      self?.didClose()
+    }
+  }
+
+  @objc(pipActionPlay:)
+  func pipActionPlay(_: NSObject) {
+    Task { @MainActor [weak self] in
+      self?.play()
+    }
+  }
+
+  @objc(pipActionPause:)
+  func pipActionPause(_: NSObject) {
+    Task { @MainActor [weak self] in
+      self?.pause()
+    }
+  }
+
+  @objc(pipActionStop:)
+  func pipActionStop(_: NSObject) {
+    Task { @MainActor [weak self] in
+      self?.stop()
+    }
+  }
+}
+
+final class MacNativePiPMediaController: NSObject, @unchecked Sendable {
+  weak var player: Player?
+
+  @objc func play() {
+    Task { @MainActor [weak self] in
+      guard let player = self?.player else { return }
+      if player.state == .idle || player.state == .stopped {
+        try? player.play()
+      } else {
+        player.resume()
+      }
+    }
+  }
+
+  @objc func pause() {
+    Task { @MainActor [weak self] in
+      self?.player?.pause()
+    }
+  }
+
+  @objc(seekBy:completion:)
+  func seek(by offset: Int64, completion: (() -> Void)?) {
+    nonisolated(unsafe) let completion = completion
+    Task { @MainActor [weak self] in
+      guard let player = self?.player else {
+        completion?()
+        return
+      }
+
+      let duration = player.duration?.milliseconds ?? Int64.max
+      let target = max(0, min(player.currentTime.milliseconds + offset, duration))
+      player.seek(to: .milliseconds(target))
+      completion?()
+    }
+  }
+
+  @objc func mediaLength() -> Int64 {
+    pipMainActorSync { [weak self] in
+      guard let player = self?.player else { return 0 }
+      return max(libvlc_media_player_get_length(player.pointer), 0)
+    }
+  }
+
+  @objc func mediaTime() -> Int64 {
+    pipMainActorSync { [weak self] in
+      guard let player = self?.player else { return 0 }
+      return max(libvlc_media_player_get_time(player.pointer), 0)
+    }
+  }
+
+  @objc func isMediaSeekable() -> Bool {
+    pipMainActorSync { [weak self] in
+      guard let player = self?.player else { return false }
+      return libvlc_media_player_is_seekable(player.pointer)
+    }
+  }
+
+  @objc func isMediaPlaying() -> Bool {
+    pipMainActorSync { [weak self] in
+      guard let player = self?.player else { return false }
+      return player.isPlaybackRequestedActive
+    }
   }
 }
 

--- a/Sources/SwiftVLC/PiP/PiPVideoView.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView.swift
@@ -309,16 +309,17 @@ final class MacNativePiPDrawableView: NSView {
 
   func attach(to player: Player) {
     guard attachedPlayer !== player else { return }
-    attachedPlayer?.setDrawable(nil)
+    attachedPlayer?.releaseDrawableOwnership(self)
     attachedPlayer = player
     nativePiPBackend.attach(to: player)
-    player.setDrawable(self)
+    player.claimDrawableOwnership(self)
+    player.setDrawable(self, owner: self)
   }
 
   func detach() {
     guard let player = attachedPlayer else { return }
     nativePiPBackend.stop()
-    player.setDrawable(nil)
+    player.releaseDrawableOwnership(self)
     nativePiPBackend.detach()
     attachedPlayer = nil
     lastBounds = .zero
@@ -349,8 +350,14 @@ final class MacNativePiPDrawableView: NSView {
   override func layout() {
     super.layout()
 
-    if let player = attachedPlayer, lastBounds == .zero, bounds.width > 0, bounds.height > 0 {
-      player.setDrawable(self)
+    if let player = attachedPlayer,
+       player.isDrawableOwner(self),
+       !player.isCurrentDrawable(self),
+       lastBounds == .zero,
+       bounds.width > 0,
+       bounds.height > 0
+    {
+      player.setDrawable(self, owner: self)
     }
     if bounds.width > 0, bounds.height > 0 {
       lastBounds = bounds

--- a/Sources/SwiftVLC/PiP/PiPVideoView.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView.swift
@@ -174,7 +174,6 @@ public struct PiPVideoView: NSViewRepresentable {
   public func updateNSView(_ nsView: NSView, context: Context) {
     guard let container = nsView as? MacNativePiPHostView else { return }
     if context.coordinator.player !== player {
-      context.coordinator.pipController?.stop()
       container.detach()
       container.attach(to: player)
 
@@ -188,8 +187,11 @@ public struct PiPVideoView: NSViewRepresentable {
   }
 
   public static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
-    coordinator.pipController?.stop()
-    (nsView as? MacNativePiPHostView)?.detach()
+    if let container = nsView as? MacNativePiPHostView {
+      container.detach()
+    } else {
+      coordinator.pipController?.stop()
+    }
     coordinator.pipController = nil
     if let binding = coordinator.controllerBinding {
       Task { @MainActor in binding.wrappedValue = nil }
@@ -318,7 +320,6 @@ final class MacNativePiPDrawableView: NSView {
 
   func detach() {
     guard let player = attachedPlayer else { return }
-    nativePiPBackend.stop()
     player.releaseDrawableOwnership(self)
     nativePiPBackend.detach()
     attachedPlayer = nil
@@ -527,9 +528,11 @@ private final class MacPrivatePiPPresenter {
   private var contentViewController: NSViewController?
   private var delegate: MacPrivatePiPDelegate?
   private var onActiveChanged: (@MainActor @Sendable (Bool) -> Void)?
+  private var dismissalCompletion: MacPrivatePiPDismissCompletion?
+  private var isClosing = false
 
   var isActive: Bool {
-    pictureInPictureViewController != nil
+    pictureInPictureViewController != nil && !isClosing
   }
 
   func start(
@@ -541,6 +544,7 @@ private final class MacPrivatePiPPresenter {
     onPlay: @escaping @MainActor @Sendable () -> Void,
     onPause: @escaping @MainActor @Sendable () -> Void
   ) -> Bool {
+    guard !isClosing else { return false }
     if isActive {
       updatePlaybackState(isPlaying: mediaController.isMediaPlaying())
       return true
@@ -555,11 +559,10 @@ private final class MacPrivatePiPPresenter {
 
     let delegate = MacPrivatePiPDelegate()
     delegate.shouldClose = { [weak self] in
-      self?.prepareForClose()
-      return true
+      self?.beginClose() ?? true
     }
     delegate.willClose = { [weak self] in
-      self?.prepareForClose()
+      _ = self?.beginClose()
     }
     delegate.didClose = { [weak self] in
       self?.finish()
@@ -600,9 +603,17 @@ private final class MacPrivatePiPPresenter {
       finish()
       return
     }
+    guard !isClosing else { return }
 
-    prepareForClose()
-    if let contentViewController {
+    _ = beginClose()
+    if dismissUsingPrivateAPI(pictureInPictureViewController) {
+      return
+    }
+
+    if
+      let contentViewController,
+      contentViewController.presentingViewController === pictureInPictureViewController
+    {
       pictureInPictureViewController.dismiss(contentViewController)
     } else {
       finish()
@@ -617,6 +628,13 @@ private final class MacPrivatePiPPresenter {
       requiring: MacPrivatePiPSelector.setPlaying,
       on: pictureInPictureViewController
     )
+  }
+
+  @discardableResult
+  private func beginClose() -> Bool {
+    guard pictureInPictureViewController != nil else { return true }
+    isClosing = true
+    return prepareForClose()
   }
 
   @discardableResult
@@ -638,8 +656,26 @@ private final class MacPrivatePiPPresenter {
     return didSetWindow && didSetRect
   }
 
+  private func dismissUsingPrivateAPI(_ pictureInPictureViewController: NSViewController) -> Bool {
+    guard pictureInPictureViewController.responds(to: MacPrivatePiPSelector.dismiss) else {
+      return false
+    }
+
+    let completion: MacPrivatePiPDismissCompletion = { [weak self] in
+      Task { @MainActor in
+        self?.finish()
+      }
+    }
+    dismissalCompletion = completion
+    _ = pictureInPictureViewController.perform(
+      MacPrivatePiPSelector.dismiss,
+      with: completion
+    )
+    return true
+  }
+
   private func finish() {
-    guard pictureInPictureViewController != nil else { return }
+    guard pictureInPictureViewController != nil || isClosing else { return }
 
     let hostView = hostView
     let drawableView = drawableView
@@ -652,6 +688,8 @@ private final class MacPrivatePiPPresenter {
     pictureInPictureViewController = nil
     contentViewController = nil
     delegate = nil
+    dismissalCompletion = nil
+    isClosing = false
     self.hostView = nil
     self.drawableView = nil
 
@@ -731,8 +769,11 @@ private final class MacPrivatePiPPresenter {
   }
 }
 
+private typealias MacPrivatePiPDismissCompletion = @convention(block) () -> Void
+
 private enum MacPrivatePiPSelector {
   static let present = NSSelectorFromString("presentViewControllerAsPictureInPicture:")
+  static let dismiss = NSSelectorFromString("dismissPictureInPictureWithCompletionHandler:")
   static let setDelegate = NSSelectorFromString("setDelegate:")
   static let setReplacementWindow = NSSelectorFromString("setReplacementWindow:")
   static let setReplacementRect = NSSelectorFromString("setReplacementRect:")

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer.swift
@@ -1,6 +1,7 @@
 #if os(iOS) || os(macOS)
 import AVFoundation
 import CLibVLC
+import CoreImage
 import CoreMedia
 import CoreVideo
 import Synchronization
@@ -18,6 +19,11 @@ final class PixelBufferRenderer: Sendable {
     var pool: CVPixelBufferPool?
     var width: Int = 0
     var height: Int = 0
+    var renderSize: CMVideoDimensions?
+    var renderPool: CVPixelBufferPool?
+    var renderPoolWidth: Int = 0
+    var renderPoolHeight: Int = 0
+    var renderGeneration: UInt64 = 0
     /// The display layer is held inside a class box rather than as a
     /// direct `weak var` on the struct. `Mutex` stores `State` in raw
     /// managed memory and any `withLock { $0 }` read produces a struct
@@ -34,6 +40,8 @@ final class PixelBufferRenderer: Sendable {
   }
 
   let state: Mutex<State>
+  private let ciContext = CIContext(options: [.cacheIntermediates: false])
+  private let colorSpace = CGColorSpaceCreateDeviceRGB()
 
   init(displayLayer: AVSampleBufferDisplayLayer) {
     state = Mutex(State(displayLayer: displayLayer))
@@ -45,6 +53,123 @@ final class PixelBufferRenderer: Sendable {
 
   func setTimebase(_ tb: CMTimebase?) {
     state.withLock { $0.timebase = tb }
+  }
+
+  func setRenderSize(_ size: CMVideoDimensions?) {
+    state.withLock {
+      guard $0.renderSize?.width != size?.width || $0.renderSize?.height != size?.height else {
+        return
+      }
+      $0.renderSize = size
+      $0.renderPool = nil
+      $0.renderPoolWidth = 0
+      $0.renderPoolHeight = 0
+      $0.renderGeneration &+= 1
+    }
+  }
+
+  func flushDisplayLayer() {
+    let layer = state.withLock { $0.displayLayer.layer }
+    DispatchQueue.main.async { [layer] in
+      layer?.sampleBufferRenderer.flush()
+    }
+  }
+
+  func outputPixelBuffer(from source: CVPixelBuffer) -> (buffer: CVPixelBuffer, generation: UInt64)? {
+    let (target, generation) = state.withLock { ($0.renderSize, $0.renderGeneration) }
+    guard
+      let target,
+      target.width > 0,
+      target.height > 0
+    else {
+      return (source, generation)
+    }
+
+    let width = Int(target.width)
+    let height = Int(target.height)
+    if CVPixelBufferGetWidth(source) == width, CVPixelBufferGetHeight(source) == height {
+      return (source, generation)
+    }
+
+    guard let output = makeRenderPixelBuffer(width: width, height: height) else {
+      return nil
+    }
+
+    let sourceWidth = CGFloat(CVPixelBufferGetWidth(source))
+    let sourceHeight = CGFloat(CVPixelBufferGetHeight(source))
+    let targetWidth = CGFloat(width)
+    let targetHeight = CGFloat(height)
+    guard sourceWidth > 0, sourceHeight > 0 else { return (source, generation) }
+
+    let scale = min(targetWidth / sourceWidth, targetHeight / sourceHeight)
+    let fittedWidth = sourceWidth * scale
+    let fittedHeight = sourceHeight * scale
+    let offsetX = (targetWidth - fittedWidth) / 2
+    let offsetY = (targetHeight - fittedHeight) / 2
+
+    let transform = CGAffineTransform(
+      a: scale,
+      b: 0,
+      c: 0,
+      d: scale,
+      tx: offsetX,
+      ty: offsetY
+    )
+    let frame = CGRect(x: 0, y: 0, width: targetWidth, height: targetHeight)
+    let background = CIImage(color: CIColor(red: 0, green: 0, blue: 0, alpha: 1))
+      .cropped(to: frame)
+    let image = CIImage(cvPixelBuffer: source)
+      .transformed(by: transform)
+      .composited(over: background)
+
+    ciContext.render(image, to: output, bounds: frame, colorSpace: colorSpace)
+    return (output, generation)
+  }
+
+  func canEnqueueFrame(generation: UInt64, on layer: AVSampleBufferDisplayLayer) -> Bool {
+    state.withLock {
+      $0.renderGeneration == generation && $0.displayLayer.layer === layer
+    }
+  }
+
+  private func makeRenderPixelBuffer(width: Int, height: Int) -> CVPixelBuffer? {
+    let pool = state.withLock { state -> CVPixelBufferPool? in
+      if state.renderPoolWidth == width, state.renderPoolHeight == height, let pool = state.renderPool {
+        return pool
+      }
+
+      let attrs: [String: Any] = [
+        kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+        kCVPixelBufferWidthKey as String: width,
+        kCVPixelBufferHeightKey as String: height,
+        kCVPixelBufferIOSurfacePropertiesKey as String: [:] as [String: Any],
+        kCVPixelBufferCGImageCompatibilityKey as String: true,
+        kCVPixelBufferCGBitmapContextCompatibilityKey as String: true
+      ]
+      let poolAttrs: [String: Any] = [
+        kCVPixelBufferPoolMinimumBufferCountKey as String: 3
+      ]
+
+      var newPool: CVPixelBufferPool?
+      let status = CVPixelBufferPoolCreate(
+        kCFAllocatorDefault,
+        poolAttrs as CFDictionary,
+        attrs as CFDictionary,
+        &newPool
+      )
+      guard status == kCVReturnSuccess, let newPool else { return nil }
+
+      state.renderPool = newPool
+      state.renderPoolWidth = width
+      state.renderPoolHeight = height
+      return newPool
+    }
+
+    guard let pool else { return nil }
+    var pixelBuffer: CVPixelBuffer?
+    let status = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &pixelBuffer)
+    guard status == kCVReturnSuccess else { return nil }
+    return pixelBuffer
   }
 }
 
@@ -177,10 +302,14 @@ func pixelBufferDisplayCallback(
   // `takeRetainedValue` balances the `passRetained` in `pixelBufferLockCallback`.
   let pb = Unmanaged<AnyObject>.fromOpaque(picture).takeRetainedValue() as! CVPixelBuffer
 
+  guard let output = renderer.outputPixelBuffer(from: pb) else { return }
+  let outputBuffer = output.buffer
+  let renderGeneration = output.generation
+
   var formatDesc: CMVideoFormatDescription?
   let fmtStatus = CMVideoFormatDescriptionCreateForImageBuffer(
     allocator: kCFAllocatorDefault,
-    imageBuffer: pb,
+    imageBuffer: outputBuffer,
     formatDescriptionOut: &formatDesc
   )
   guard fmtStatus == noErr, let desc = formatDesc else { return }
@@ -204,7 +333,7 @@ func pixelBufferDisplayCallback(
   var sampleBuffer: CMSampleBuffer?
   let sbStatus = CMSampleBufferCreateReadyWithImageBuffer(
     allocator: kCFAllocatorDefault,
-    imageBuffer: pb,
+    imageBuffer: outputBuffer,
     formatDescription: desc,
     sampleTiming: &timingInfo,
     sampleBufferOut: &sampleBuffer
@@ -213,7 +342,8 @@ func pixelBufferDisplayCallback(
 
   // CMSampleBuffer is a CF type that lacks Sendable conformance but is thread-safe for read access
   nonisolated(unsafe) let sample = sb
-  DispatchQueue.main.async { [layer] in
+  DispatchQueue.main.async { [layer, renderer] in
+    guard renderer.canEnqueueFrame(generation: renderGeneration, on: layer) else { return }
     let renderer = layer.sampleBufferRenderer
     if renderer.status == .failed {
       renderer.flush()
@@ -228,7 +358,13 @@ func pixelBufferCleanupCallback(opaque: UnsafeMutableRawPointer?) {
 
   let renderer = Unmanaged<PixelBufferRenderer>.fromOpaque(opaque).takeUnretainedValue()
 
-  renderer.state.withLock { $0.pool = nil }
+  renderer.state.withLock {
+    $0.pool = nil
+    $0.renderPool = nil
+    $0.renderPoolWidth = 0
+    $0.renderPoolHeight = 0
+    $0.renderGeneration &+= 1
+  }
 }
 
 #endif

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer.swift
@@ -4,7 +4,23 @@ import CLibVLC
 import CoreImage
 import CoreMedia
 import CoreVideo
+import Darwin
+import Foundation
 import Synchronization
+
+private let pixelBufferRendererPictureBufferCount: UInt32 = 3
+
+/// Carries media objects onto the serial enqueue queue. The queue only reads
+/// these references; ownership is transferred to the layer when enqueued.
+private final class EnqueuedSampleBuffer: @unchecked Sendable {
+  let layer: AVSampleBufferDisplayLayer
+  let sample: CMSampleBuffer
+
+  init(layer: AVSampleBufferDisplayLayer, sample: CMSampleBuffer) {
+    self.layer = layer
+    self.sample = sample
+  }
+}
 
 /// Renders libVLC video frames into `CVPixelBuffer`s via vmem callbacks,
 /// then enqueues them as `CMSampleBuffer`s onto an `AVSampleBufferDisplayLayer`.
@@ -42,6 +58,7 @@ final class PixelBufferRenderer: Sendable {
   let state: Mutex<State>
   private let ciContext = CIContext(options: [.cacheIntermediates: false])
   private let colorSpace = CGColorSpaceCreateDeviceRGB()
+  private let enqueueQueue = DispatchQueue(label: "org.swiftvlc.pixel-buffer-renderer.enqueue")
 
   init(displayLayer: AVSampleBufferDisplayLayer) {
     state = Mutex(State(displayLayer: displayLayer))
@@ -132,6 +149,26 @@ final class PixelBufferRenderer: Sendable {
     }
   }
 
+  func enqueue(
+    _ sample: CMSampleBuffer,
+    generation: UInt64,
+    on layer: AVSampleBufferDisplayLayer
+  ) {
+    let enqueued = EnqueuedSampleBuffer(layer: layer, sample: sample)
+
+    enqueueQueue.async { [enqueued, self] in
+      guard canEnqueueFrame(generation: generation, on: enqueued.layer) else { return }
+
+      let sampleBufferRenderer = enqueued.layer.sampleBufferRenderer
+      if sampleBufferRenderer.status == .failed {
+        sampleBufferRenderer.flush()
+      }
+      guard sampleBufferRenderer.isReadyForMoreMediaData else { return }
+
+      sampleBufferRenderer.enqueue(enqueued.sample)
+    }
+  }
+
   private func makeRenderPixelBuffer(width: Int, height: Int) -> CVPixelBuffer? {
     let pool = state.withLock { state -> CVPixelBufferPool? in
       if state.renderPoolWidth == width, state.renderPoolHeight == height, let pool = state.renderPool {
@@ -173,6 +210,156 @@ final class PixelBufferRenderer: Sendable {
   }
 }
 
+/// Stable object passed to libVLC's vmem callbacks.
+///
+/// libVLC copies the callback function pointers and `opaque` value into
+/// the vmem video output when that output opens. Clearing the media
+/// player's callback variables later does not update an already-open
+/// vout, so this context must stay alive until that vout calls the
+/// cleanup callback.
+final class PixelBufferRendererCallbackContext: Sendable {
+  private struct CallbackEntry {
+    var renderer: PixelBufferRenderer?
+  }
+
+  private struct State: @unchecked Sendable {
+    var renderer: PixelBufferRenderer?
+    var activeCallbacks = 0
+    var voutOpen = false
+    var retirementRequested = false
+    var deferReleaseUntilQuiescent = false
+    var opaqueRetainReleased = false
+  }
+
+  private let state: Mutex<State>
+
+  init(renderer: PixelBufferRenderer) {
+    state = Mutex(State(renderer: renderer))
+  }
+
+  var hasOpenVoutForTesting: Bool {
+    state.withLock { $0.voutOpen }
+  }
+
+  func withRenderer<T>(
+    opaque: UnsafeMutableRawPointer,
+    _ body: (PixelBufferRenderer) -> T
+  ) -> T? {
+    guard let entry = beginCallback() else { return nil }
+    defer { endCallback(opaque: opaque) }
+    guard let renderer = entry.renderer else { return nil }
+    return body(renderer)
+  }
+
+  func noteVoutOpened() {
+    state.withLock {
+      guard !$0.opaqueRetainReleased else { return }
+      $0.voutOpen = true
+    }
+  }
+
+  func noteVoutClosed(opaque: UnsafeMutableRawPointer) {
+    state.withLock {
+      $0.voutOpen = false
+    }
+    releaseOpaqueRetainIfNeeded(opaque: opaque)
+  }
+
+  func requestRetirement(
+    opaque: UnsafeMutableRawPointer,
+    deferIfVoutMayBeOpening: Bool
+  ) {
+    let shouldRelease = state.withLock { state -> Bool in
+      guard !state.opaqueRetainReleased else { return false }
+      state.retirementRequested = true
+      state.deferReleaseUntilQuiescent =
+        state.deferReleaseUntilQuiescent || deferIfVoutMayBeOpening
+      // In-flight callbacks already hold a strong local renderer from
+      // `beginCallback`. Future callbacks should see a live context but no
+      // renderer, so a late libVLC call becomes a no-op instead of touching
+      // deinitializing PiP state.
+      state.renderer = nil
+      guard !state.deferReleaseUntilQuiescent else { return false }
+      guard state.activeCallbacks == 0, !state.voutOpen else { return false }
+      state.opaqueRetainReleased = true
+      return true
+    }
+    if shouldRelease {
+      Unmanaged<PixelBufferRendererCallbackContext>.fromOpaque(opaque).release()
+    }
+  }
+
+  @discardableResult
+  func releaseRetiredOpaqueRetainIfNoOpenVout(opaque: UnsafeMutableRawPointer) -> Bool {
+    releaseOpaqueRetainIfNeeded(opaque: opaque)
+  }
+
+  func releaseRetiredOpaqueRetainWhenPlayerIsQuiescent(
+    opaque: UnsafeMutableRawPointer,
+    player: OpaquePointer
+  ) {
+    usleep(100_000)
+
+    let deadline = CFAbsoluteTimeGetCurrent() + 5
+    while CFAbsoluteTimeGetCurrent() < deadline {
+      let nativeState = PlayerState(from: libvlc_media_player_get_state(player))
+      switch nativeState {
+      case .idle, .stopped, .error:
+        releaseRetiredOpaqueRetainIfNoOpenVout(opaque: opaque)
+        return
+      case .opening, .buffering, .playing, .paused, .stopping:
+        break
+      }
+      usleep(20000)
+    }
+
+    releaseRetiredOpaqueRetainIfNoOpenVout(opaque: opaque)
+  }
+
+  private func beginCallback() -> CallbackEntry? {
+    state.withLock { state -> CallbackEntry? in
+      guard !state.opaqueRetainReleased else { return nil }
+      state.activeCallbacks += 1
+      return CallbackEntry(renderer: state.renderer)
+    }
+  }
+
+  private func endCallback(opaque: UnsafeMutableRawPointer) {
+    let shouldRelease = state.withLock { state -> Bool in
+      state.activeCallbacks -= 1
+      guard state.activeCallbacks == 0 else { return false }
+      guard state.retirementRequested, !state.voutOpen, !state.opaqueRetainReleased else {
+        return false
+      }
+      guard !state.deferReleaseUntilQuiescent else { return false }
+      state.renderer = nil
+      state.opaqueRetainReleased = true
+      return true
+    }
+    if shouldRelease {
+      Unmanaged<PixelBufferRendererCallbackContext>.fromOpaque(opaque).release()
+    }
+  }
+
+  @discardableResult
+  private func releaseOpaqueRetainIfNeeded(
+    opaque: UnsafeMutableRawPointer
+  ) -> Bool {
+    let shouldRelease = state.withLock { state -> Bool in
+      guard state.retirementRequested, !state.opaqueRetainReleased else { return false }
+      guard state.activeCallbacks == 0, !state.voutOpen else { return false }
+      state.deferReleaseUntilQuiescent = false
+      state.renderer = nil
+      state.opaqueRetainReleased = true
+      return true
+    }
+    if shouldRelease {
+      Unmanaged<PixelBufferRendererCallbackContext>.fromOpaque(opaque).release()
+    }
+    return shouldRelease
+  }
+}
+
 /// Class wrapper around `weak var layer` so the ObjC weak-reference
 /// table sees a single stable address regardless of how `State` is
 /// copied in and out of the surrounding `Mutex`.
@@ -184,6 +371,13 @@ final class DisplayLayerBox: @unchecked Sendable {
 }
 
 // MARK: - Free Function Callbacks
+
+private func pixelBufferCallbackContext(
+  from opaque: UnsafeMutableRawPointer?
+) -> PixelBufferRendererCallbackContext? {
+  guard let opaque else { return nil }
+  return Unmanaged<PixelBufferRendererCallbackContext>.fromOpaque(opaque).takeUnretainedValue()
+}
 
 /// Format callback, invoked by libVLC when video format is negotiated.
 /// Overrides chroma to BGRA and creates a `CVPixelBufferPool`.
@@ -201,55 +395,62 @@ func pixelBufferFormatCallback(
 
   // libVLC populates `*opaque` with the context we passed to
   // `libvlc_video_set_callbacks`. Guard against an unattached context.
-  guard let rendererBox = opaque.pointee else { return 0 }
-  let renderer = Unmanaged<PixelBufferRenderer>.fromOpaque(rendererBox).takeUnretainedValue()
+  guard
+    let contextOpaque = opaque.pointee,
+    let context = pixelBufferCallbackContext(from: contextOpaque)
+  else { return 0 }
 
-  let w = Int(width.pointee)
-  let h = Int(height.pointee)
+  return context.withRenderer(opaque: contextOpaque) { renderer -> UInt32 in
+    let w = Int(width.pointee)
+    let h = Int(height.pointee)
 
-  // Force BGRA: native to iOS, no color space conversion needed.
-  let bgra: (CChar, CChar, CChar, CChar) = (0x42, 0x47, 0x52, 0x41) // "BGRA"
-  chroma[0] = bgra.0
-  chroma[1] = bgra.1
-  chroma[2] = bgra.2
-  chroma[3] = bgra.3
+    // Force BGRA: native to iOS, no color space conversion needed.
+    let bgra: (CChar, CChar, CChar, CChar) = (0x42, 0x47, 0x52, 0x41) // "BGRA"
+    chroma[0] = bgra.0
+    chroma[1] = bgra.1
+    chroma[2] = bgra.2
+    chroma[3] = bgra.3
 
-  // Create CVPixelBufferPool
-  let poolAttrs: [String: Any] = [
-    kCVPixelBufferPoolMinimumBufferCountKey as String: 3
-  ]
-  let pixelBufferAttrs: [String: Any] = [
-    kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
-    kCVPixelBufferWidthKey as String: w,
-    kCVPixelBufferHeightKey as String: h,
-    kCVPixelBufferIOSurfacePropertiesKey as String: [:] as [String: Any]
-  ]
+    // Create CVPixelBufferPool
+    let poolAttrs: [String: Any] = [
+      kCVPixelBufferPoolMinimumBufferCountKey as String: 3
+    ]
+    let pixelBufferAttrs: [String: Any] = [
+      kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+      kCVPixelBufferWidthKey as String: w,
+      kCVPixelBufferHeightKey as String: h,
+      kCVPixelBufferIOSurfacePropertiesKey as String: [:] as [String: Any],
+      kCVPixelBufferCGImageCompatibilityKey as String: true,
+      kCVPixelBufferCGBitmapContextCompatibilityKey as String: true
+    ]
 
-  var newPool: CVPixelBufferPool?
-  let status = CVPixelBufferPoolCreate(
-    kCFAllocatorDefault,
-    poolAttrs as CFDictionary,
-    pixelBufferAttrs as CFDictionary,
-    &newPool
-  )
-  guard status == kCVReturnSuccess, let pool = newPool else { return 0 }
+    var newPool: CVPixelBufferPool?
+    let status = CVPixelBufferPoolCreate(
+      kCFAllocatorDefault,
+      poolAttrs as CFDictionary,
+      pixelBufferAttrs as CFDictionary,
+      &newPool
+    )
+    guard status == kCVReturnSuccess, let pool = newPool else { return 0 }
 
-  // Get actual bytesPerRow from a real buffer so VLC pitch matches exactly
-  var testBuffer: CVPixelBuffer?
-  CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &testBuffer)
-  guard let tb = testBuffer else { return 0 }
-  let actualPitch = CVPixelBufferGetBytesPerRow(tb)
+    // Get actual bytesPerRow from a real buffer so VLC pitch matches exactly
+    var testBuffer: CVPixelBuffer?
+    CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &testBuffer)
+    guard let tb = testBuffer else { return 0 }
+    let actualPitch = CVPixelBufferGetBytesPerRow(tb)
 
-  pitches.pointee = UInt32(actualPitch)
-  lines.pointee = UInt32(h)
+    pitches.pointee = UInt32(actualPitch)
+    lines.pointee = UInt32(h)
 
-  renderer.state.withLock {
-    $0.pool = pool
-    $0.width = w
-    $0.height = h
-  }
+    renderer.state.withLock {
+      $0.pool = pool
+      $0.width = w
+      $0.height = h
+    }
+    context.noteVoutOpened()
 
-  return 1 // number of picture buffers (1 plane for BGRA)
+    return pixelBufferRendererPictureBufferCount
+  } ?? 0
 }
 
 /// Lock callback. Dequeues a `CVPixelBuffer` from the pool for libVLC to write into.
@@ -258,22 +459,23 @@ func pixelBufferLockCallback(
   planes: UnsafeMutablePointer<UnsafeMutableRawPointer?>?
 ) -> UnsafeMutableRawPointer? {
   guard let opaque, let planes else { return nil }
+  guard let context = pixelBufferCallbackContext(from: opaque) else { return nil }
 
-  let renderer = Unmanaged<PixelBufferRenderer>.fromOpaque(opaque).takeUnretainedValue()
+  return context.withRenderer(opaque: opaque) { renderer -> UnsafeMutableRawPointer? in
+    let pool = renderer.state.withLock { $0.pool }
 
-  let pool = renderer.state.withLock { $0.pool }
+    guard let pool else { return nil }
 
-  guard let pool else { return nil }
+    var pixelBuffer: CVPixelBuffer?
+    let status = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &pixelBuffer)
+    guard status == kCVReturnSuccess, let pb = pixelBuffer else { return nil }
 
-  var pixelBuffer: CVPixelBuffer?
-  let status = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &pixelBuffer)
-  guard status == kCVReturnSuccess, let pb = pixelBuffer else { return nil }
+    CVPixelBufferLockBaseAddress(pb, [])
+    planes[0] = CVPixelBufferGetBaseAddress(pb)
 
-  CVPixelBufferLockBaseAddress(pb, [])
-  planes[0] = CVPixelBufferGetBaseAddress(pb)
-
-  let retained = Unmanaged.passRetained(pb as AnyObject)
-  return retained.toOpaque()
+    let retained = Unmanaged.passRetained(pb as AnyObject)
+    return retained.toOpaque()
+  } ?? nil
 }
 
 /// Unlock callback. Unlocks the `CVPixelBuffer` base address.
@@ -296,75 +498,77 @@ func pixelBufferDisplayCallback(
   opaque: UnsafeMutableRawPointer?,
   picture: UnsafeMutableRawPointer?
 ) {
-  guard let opaque, let picture else { return }
-
-  let renderer = Unmanaged<PixelBufferRenderer>.fromOpaque(opaque).takeUnretainedValue()
+  guard let picture else { return }
   // `takeRetainedValue` balances the `passRetained` in `pixelBufferLockCallback`.
   let pb = Unmanaged<AnyObject>.fromOpaque(picture).takeRetainedValue() as! CVPixelBuffer
+  guard let opaque, let context = pixelBufferCallbackContext(from: opaque) else { return }
 
-  guard let output = renderer.outputPixelBuffer(from: pb) else { return }
-  let outputBuffer = output.buffer
-  let renderGeneration = output.generation
+  _ = context.withRenderer(opaque: opaque) { renderer in
+    guard let output = renderer.outputPixelBuffer(from: pb) else { return }
+    let outputBuffer = output.buffer
+    let renderGeneration = output.generation
 
-  var formatDesc: CMVideoFormatDescription?
-  let fmtStatus = CMVideoFormatDescriptionCreateForImageBuffer(
-    allocator: kCFAllocatorDefault,
-    imageBuffer: outputBuffer,
-    formatDescriptionOut: &formatDesc
-  )
-  guard fmtStatus == noErr, let desc = formatDesc else { return }
+    var formatDesc: CMVideoFormatDescription?
+    let fmtStatus = CMVideoFormatDescriptionCreateForImageBuffer(
+      allocator: kCFAllocatorDefault,
+      imageBuffer: outputBuffer,
+      formatDescriptionOut: &formatDesc
+    )
+    guard fmtStatus == noErr, let desc = formatDesc else { return }
 
-  let (timebase, layer) = renderer.state.withLock { ($0.timebase, $0.displayLayer.layer) }
+    let (timebase, layer) = renderer.state.withLock { ($0.timebase, $0.displayLayer.layer) }
 
-  guard let layer else { return }
+    guard let layer else { return }
 
-  let pts: CMTime = if let timebase {
-    CMTimebaseGetTime(timebase)
-  } else {
-    CMClockGetTime(CMClockGetHostTimeClock())
-  }
-
-  var timingInfo = CMSampleTimingInfo(
-    duration: CMTime(value: 1, timescale: 30),
-    presentationTimeStamp: pts,
-    decodeTimeStamp: .invalid
-  )
-
-  var sampleBuffer: CMSampleBuffer?
-  let sbStatus = CMSampleBufferCreateReadyWithImageBuffer(
-    allocator: kCFAllocatorDefault,
-    imageBuffer: outputBuffer,
-    formatDescription: desc,
-    sampleTiming: &timingInfo,
-    sampleBufferOut: &sampleBuffer
-  )
-  guard sbStatus == noErr, let sb = sampleBuffer else { return }
-
-  // CMSampleBuffer is a CF type that lacks Sendable conformance but is thread-safe for read access
-  nonisolated(unsafe) let sample = sb
-  DispatchQueue.main.async { [layer, renderer] in
-    guard renderer.canEnqueueFrame(generation: renderGeneration, on: layer) else { return }
-    let renderer = layer.sampleBufferRenderer
-    if renderer.status == .failed {
-      renderer.flush()
+    let pts: CMTime = if let timebase {
+      CMTimebaseGetTime(timebase)
+    } else {
+      CMClockGetTime(CMClockGetHostTimeClock())
     }
-    renderer.enqueue(sample)
+
+    var timingInfo = CMSampleTimingInfo(
+      duration: CMTime(value: 1, timescale: 30),
+      presentationTimeStamp: pts,
+      decodeTimeStamp: .invalid
+    )
+
+    var sampleBuffer: CMSampleBuffer?
+    let sbStatus = CMSampleBufferCreateReadyWithImageBuffer(
+      allocator: kCFAllocatorDefault,
+      imageBuffer: outputBuffer,
+      formatDescription: desc,
+      sampleTiming: &timingInfo,
+      sampleBufferOut: &sampleBuffer
+    )
+    guard sbStatus == noErr, let sb = sampleBuffer else { return }
+    if
+      let attachments = CMSampleBufferGetSampleAttachmentsArray(
+        sb,
+        createIfNecessary: true
+      ) as? [NSMutableDictionary], let attachment = attachments.first {
+      attachment[kCMSampleAttachmentKey_DisplayImmediately] = true
+    }
+
+    // CMSampleBuffer is a CF type that lacks Sendable conformance but is thread-safe for read access
+    nonisolated(unsafe) let sample = sb
+    renderer.enqueue(sample, generation: renderGeneration, on: layer)
   }
 }
 
 /// Cleanup callback. Releases the pixel buffer pool.
 func pixelBufferCleanupCallback(opaque: UnsafeMutableRawPointer?) {
-  guard let opaque else { return }
+  guard let opaque, let context = pixelBufferCallbackContext(from: opaque) else { return }
 
-  let renderer = Unmanaged<PixelBufferRenderer>.fromOpaque(opaque).takeUnretainedValue()
-
-  renderer.state.withLock {
-    $0.pool = nil
-    $0.renderPool = nil
-    $0.renderPoolWidth = 0
-    $0.renderPoolHeight = 0
-    $0.renderGeneration &+= 1
+  _ = context.withRenderer(opaque: opaque) { renderer in
+    renderer.state.withLock {
+      $0.pool = nil
+      $0.renderPool = nil
+      $0.renderPoolWidth = 0
+      $0.renderPoolHeight = 0
+      $0.renderGeneration &+= 1
+    }
   }
+  context.noteVoutClosed(opaque: opaque)
 }
 
 #endif

--- a/Sources/SwiftVLC/Player/EventBridge.swift
+++ b/Sources/SwiftVLC/Player/EventBridge.swift
@@ -11,6 +11,7 @@ final class EventBridge: Sendable {
   private nonisolated(unsafe) let eventManager: OpaquePointer
   private let store: ContinuationStore
   private nonisolated(unsafe) let storeOpaque: UnsafeMutableRawPointer
+  private let attachedEventTypes: [Int32]
   private let invalidated = Mutex(false)
 
   init(eventManager: OpaquePointer) {
@@ -21,9 +22,13 @@ final class EventBridge: Sendable {
     let opaque = Unmanaged.passRetained(store).toOpaque()
     storeOpaque = opaque
 
+    var attachedEventTypes: [Int32] = []
     for eventType in Self.playerEventTypes {
-      libvlc_event_attach(eventManager, eventType, playerEventCallback, opaque)
+      if libvlc_event_attach(eventManager, eventType, playerEventCallback, opaque) == 0 {
+        attachedEventTypes.append(eventType)
+      }
     }
+    self.attachedEventTypes = attachedEventTypes
   }
 
   deinit {
@@ -42,7 +47,7 @@ final class EventBridge: Sendable {
     }
     guard shouldCleanUp else { return }
 
-    for eventType in Self.playerEventTypes {
+    for eventType in attachedEventTypes {
       libvlc_event_detach(eventManager, eventType, playerEventCallback, storeOpaque)
     }
     store.finishAll()

--- a/Sources/SwiftVLC/Player/EventBridge.swift
+++ b/Sources/SwiftVLC/Player/EventBridge.swift
@@ -8,10 +8,10 @@ import Synchronization
 /// continuations under a `Mutex`, then yields outside the lock to avoid
 /// an AB-BA deadlock with Swift's task-cancellation lock.
 final class EventBridge: Sendable {
-  private nonisolated(unsafe) let eventManager: OpaquePointer
+  private nonisolated(unsafe) var eventManager: OpaquePointer
   private let store: ContinuationStore
   private nonisolated(unsafe) let storeOpaque: UnsafeMutableRawPointer
-  private let attachedEventTypes: [Int32]
+  private nonisolated(unsafe) var attachedEventTypes: [Int32]
   private let invalidated = Mutex(false)
 
   init(eventManager: OpaquePointer) {
@@ -22,13 +22,7 @@ final class EventBridge: Sendable {
     let opaque = Unmanaged.passRetained(store).toOpaque()
     storeOpaque = opaque
 
-    var attachedEventTypes: [Int32] = []
-    for eventType in Self.playerEventTypes {
-      if libvlc_event_attach(eventManager, eventType, playerEventCallback, opaque) == 0 {
-        attachedEventTypes.append(eventType)
-      }
-    }
-    self.attachedEventTypes = attachedEventTypes
+    attachedEventTypes = Self.attachEvents(to: eventManager, opaque: opaque)
   }
 
   deinit {
@@ -47,10 +41,25 @@ final class EventBridge: Sendable {
     }
     guard shouldCleanUp else { return }
 
-    for eventType in attachedEventTypes {
-      libvlc_event_detach(eventManager, eventType, playerEventCallback, storeOpaque)
-    }
+    Self.detachEvents(attachedEventTypes, from: eventManager, opaque: storeOpaque)
+    attachedEventTypes = []
     store.finishAll()
+  }
+
+  /// Moves the existing streams to a replacement native media player.
+  ///
+  /// `Player` recreates its libVLC handle after a stopped drawable-backed
+  /// playback because libVLC keeps a "free vout" whose iOS window provider
+  /// still points at the old UIView. The Swift `Player.events` stream must
+  /// survive that native-handle swap, so this detaches callbacks from the old
+  /// event manager and attaches the same continuation store to the new one.
+  func reattach(to newEventManager: OpaquePointer) {
+    let isInvalidated = invalidated.withLock { $0 }
+    guard !isInvalidated else { return }
+
+    Self.detachEvents(attachedEventTypes, from: eventManager, opaque: storeOpaque)
+    eventManager = newEventManager
+    attachedEventTypes = Self.attachEvents(to: newEventManager, opaque: storeOpaque)
   }
 
   /// Creates a new independent `AsyncStream` for consuming player events.
@@ -104,6 +113,29 @@ final class EventBridge: Sendable {
     libvlc_MediaPlayerProgramSelected,
     libvlc_MediaPlayerProgramUpdated
   ].map { Int32($0.rawValue) }
+
+  private static func attachEvents(
+    to eventManager: OpaquePointer,
+    opaque: UnsafeMutableRawPointer
+  ) -> [Int32] {
+    var attachedEventTypes: [Int32] = []
+    for eventType in playerEventTypes {
+      if libvlc_event_attach(eventManager, eventType, playerEventCallback, opaque) == 0 {
+        attachedEventTypes.append(eventType)
+      }
+    }
+    return attachedEventTypes
+  }
+
+  private static func detachEvents(
+    _ eventTypes: [Int32],
+    from eventManager: OpaquePointer,
+    opaque: UnsafeMutableRawPointer
+  ) {
+    for eventType in eventTypes {
+      libvlc_event_detach(eventManager, eventType, playerEventCallback, opaque)
+    }
+  }
 }
 
 // MARK: - Continuation Store

--- a/Sources/SwiftVLC/Player/EventBridge.swift
+++ b/Sources/SwiftVLC/Player/EventBridge.swift
@@ -157,6 +157,55 @@ private final class ContinuationStore: Sendable {
   }
 }
 
+// MARK: - Async Broadcaster
+
+/// Small multi-consumer broadcaster for player-owned state that is not
+/// emitted by libVLC. It mirrors `ContinuationStore`'s lock discipline:
+/// copy continuations while locked, then yield outside the lock.
+final class AsyncBroadcaster<Element: Sendable>: Sendable {
+  private struct State {
+    var nextID: Int = 0
+    var continuations: [Int: AsyncStream<Element>.Continuation] = [:]
+  }
+
+  private let state = Mutex(State())
+
+  func makeStream(bufferingNewest count: Int = 16) -> AsyncStream<Element> {
+    let store = self
+    let (stream, continuation) = AsyncStream<Element>.makeStream(
+      bufferingPolicy: .bufferingNewest(count)
+    )
+    let id = state.withLock { state in
+      let id = state.nextID
+      state.nextID += 1
+      state.continuations[id] = continuation
+      return id
+    }
+    continuation.onTermination = { _ in
+      store.state.withLock { _ = $0.continuations.removeValue(forKey: id) }
+    }
+    return stream
+  }
+
+  func broadcast(_ value: Element) {
+    let snapshot = state.withLock { Array($0.continuations.values) }
+    for continuation in snapshot {
+      continuation.yield(value)
+    }
+  }
+
+  func finishAll() {
+    let snapshot = state.withLock { state -> [AsyncStream<Element>.Continuation] in
+      let values = Array(state.continuations.values)
+      state.continuations.removeAll()
+      return values
+    }
+    for continuation in snapshot {
+      continuation.finish()
+    }
+  }
+}
+
 // MARK: - C Callback (free function)
 
 /// Free function invoked on libVLC's internal event thread.

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -15,8 +15,8 @@ import Observation
 ///     var body: some View {
 ///         VideoView(player)
 ///         Text(player.state.description)
-///         Button(player.isPlaying ? "Pause" : "Play") {
-///             player.isPlaying ? player.pause() : try? player.play()
+///         Button(player.isPlaybackRequestedActive ? "Pause" : "Play") {
+///             player.togglePlayPause()
 ///         }
 ///     }
 /// }
@@ -33,6 +33,17 @@ public final class Player {
 
   /// Current playback state.
   public private(set) var state: PlayerState = .idle
+
+  /// Whether playback controls should currently present the media as
+  /// active.
+  ///
+  /// libVLC state changes are asynchronous: a pause request can remain
+  /// in flight while the native player still reports `.playing`, and a
+  /// resume request can remain in flight while it still reports
+  /// `.paused`. This property follows the user's latest playback intent
+  /// synchronously so transport controls, including Picture in Picture,
+  /// stay visually aligned while libVLC catches up.
+  public private(set) var isPlaybackRequestedActive: Bool = false
 
   /// Current playback time.
   public private(set) var currentTime: Duration = .zero
@@ -267,12 +278,7 @@ public final class Player {
   /// Whether playback is active (playing or buffering during playback).
   public var isActive: Bool {
     access(keyPath: \.isActive)
-    return switch state {
-    case .playing, .opening, .buffering:
-      true
-    default:
-      false
-    }
+    return state.isActive
   }
 
   /// Convenience access to current media statistics.
@@ -288,10 +294,15 @@ public final class Player {
     eventBridge.makeStream()
   }
 
+  nonisolated var playbackIntentEvents: AsyncStream<Bool> {
+    playbackIntentBridge.makeStream()
+  }
+
   // MARK: - Internal
 
   nonisolated(unsafe) let pointer: OpaquePointer // libvlc_media_player_t*
   private let eventBridge: EventBridge
+  private nonisolated let playbackIntentBridge: AsyncBroadcaster<Bool>
   private var eventTask: Task<Void, Never>?
   private var _position: Double = 0
   private var _equalizer: Equalizer?
@@ -341,11 +352,13 @@ public final class Player {
     eventBridge = EventBridge(
       eventManager: libvlc_media_player_event_manager(p)!
     )
+    playbackIntentBridge = AsyncBroadcaster()
     startEventConsumer()
   }
 
   isolated deinit {
     eventTask?.cancel()
+    playbackIntentBridge.finishAll()
     // Tell libVLC to forget the drawable *before* release so the
     // vout thread observes a nil pointer rather than dereferencing a
     // view that is about to be released when `self`'s storage is torn
@@ -450,54 +463,122 @@ public final class Player {
   /// - Throws: `VLCError.playbackFailed` if playback cannot start.
   public func play() throws(VLCError) {
     if libvlc_media_player_play(pointer) == -1 {
+      publishPlaybackIntent(false)
       let reason = libvlc_errmsg().map { String(cString: $0) } ?? "unknown"
       throw .playbackFailed(reason: reason)
     }
+    publishPlaybackIntent(true)
   }
 
   /// Pauses playback.
   ///
-  /// No-op until libVLC has reached a stable, pausable `.playing`
-  /// state. With real audio output, the first audio timestamp must also
-  /// have advanced beyond zero; pausing before that point can leave
-  /// libVLC's aout stream with stale pause timing.
+  /// If libVLC is visually playing but has not yet reached a stable,
+  /// pausable state, SwiftVLC keeps the pause request pending and issues
+  /// it once the native player reports that pausing is safe. With real
+  /// audio output, the first audio timestamp must also have advanced
+  /// beyond zero; pausing before that point can leave libVLC's aout
+  /// stream with stale pause timing.
   public func pause() {
-    guard pauseTransition == nil else {
-      deferredPauseCommand = .pause
-      return
-    }
-    guard
-      state == .playing,
-      isPausable,
-      canIssueNativePause
-    else { return }
-
-    pauseTransition = .pausing
-    deferredPauseCommand = nil
-    libvlc_media_player_set_pause(pointer, 1)
+    _ = issuePause()
   }
 
   /// Resumes playback from pause.
   public func resume() {
+    _ = issueResume()
+  }
+
+  @discardableResult
+  func issuePause() -> Bool {
+    guard pauseTransition == nil else {
+      deferredPauseCommand = .pause
+      publishPlaybackIntent(false)
+      return false
+    }
+    switch state {
+    case .playing:
+      break
+    case .opening, .buffering:
+      deferredPauseCommand = .pause
+      publishPlaybackIntent(false)
+      return false
+    case .paused:
+      publishPlaybackIntent(false)
+      return false
+    default:
+      return false
+    }
+    refreshNativeStateIfNeeded()
+    guard isPausable, canIssueNativePause else {
+      deferredPauseCommand = .pause
+      publishPlaybackIntent(false)
+      return false
+    }
+
+    pauseTransition = .pausing
+    deferredPauseCommand = nil
+    publishPlaybackIntent(false)
+    libvlc_media_player_set_pause(pointer, 1)
+    return true
+  }
+
+  @discardableResult
+  func issueResume() -> Bool {
     guard pauseTransition == nil else {
       deferredPauseCommand = .resume
-      return
+      publishPlaybackIntent(true)
+      return true
     }
-    guard nativePlaybackState == .paused else { return }
+    if deferredPauseCommand == .pause {
+      deferredPauseCommand = nil
+      publishPlaybackIntent(true)
+      return true
+    }
+    cancelPendingPause()
+    let nativeState = nativePlaybackState
+    guard nativeState == .paused else {
+      if state == .paused, nativeState.isActive {
+        publishPlaybackState(nativeState)
+        publishPlaybackIntent(true)
+        return true
+      }
+      if state.isActive {
+        publishPlaybackIntent(true)
+        return true
+      }
+      return false
+    }
 
     pauseTransition = .resuming
     deferredPauseCommand = nil
+    publishPlaybackIntent(true)
     libvlc_media_player_set_pause(pointer, 0)
+    return true
+  }
+
+  func cancelPendingPause() {
+    if deferredPauseCommand == .pause {
+      deferredPauseCommand = nil
+      publishPlaybackIntent(true)
+    }
+  }
+
+  var shouldResumeForExternalPlayRequest: Bool {
+    pauseTransition == .pausing
+      || state == .paused
+      || (!isPlaybackRequestedActive && state.isActive)
+      || nativePlaybackState == .paused
   }
 
   /// Toggles between playing and paused, or starts playback from an
-  /// idle or stopped state. No-op in transient states (`.opening`,
-  /// `.buffering`, `.stopping`, `.error`).
+  /// idle or stopped state. Pause requests during opening or buffering
+  /// are queued until libVLC reaches a stable pausable state. No-op in
+  /// terminal or invalid transient states (`.stopping`, `.error`).
   ///
-  /// Dispatches on the observed ``state`` rather than calling
-  /// `libvlc_media_player_pause` (which is itself a toggle). The naked
-  /// toggle is unsafe mid-transition: interleaving a pause-toggle with
-  /// the audio output's opening path corrupts
+  /// Dispatches through explicit pause/resume requests using the
+  /// observed ``state`` and the current playback intent, rather than
+  /// calling `libvlc_media_player_pause` (which is itself a toggle). The
+  /// naked toggle is unsafe mid-transition: interleaving a pause-toggle
+  /// with the audio output's opening path corrupts
   /// `stream->timing.pause_date` and trips the upstream assertion
   /// `stream->timing.pause_date == VLC_TICK_INVALID` in
   /// `src/audio_output/dec.c:876`, killing the process. The usual repro
@@ -505,16 +586,16 @@ public final class Player {
   /// `.task { try? player.play(url:) }` begins.
   public func togglePlayPause() {
     switch state {
-    case .playing:
-      pause()
-    case .paused:
-      resume()
     case .idle, .stopped:
       try? play()
-    case .opening, .buffering, .stopping, .error:
-      // Transient state. libVLC isn't ready to accept a pause-toggle
-      // safely; ignore the input rather than corrupting its internal
-      // audio-output state.
+    case .playing, .opening, .buffering, .paused:
+      if isPlaybackRequestedActive {
+        pause()
+      } else {
+        resume()
+      }
+    case .stopping, .error:
+      // There is no stable playback target for a pause/resume command.
       break
     }
   }
@@ -526,6 +607,7 @@ public final class Player {
     }
     pauseTransition = nil
     deferredPauseCommand = nil
+    publishPlaybackIntent(false)
     libvlc_media_player_stop_async(pointer)
   }
 
@@ -1129,10 +1211,9 @@ public final class Player {
   private func handleEvent(_ event: PlayerEvent) {
     switch event {
     case .stateChanged(let newState):
-      state = newState
+      publishPlaybackState(newState)
       updatePauseTransition(for: newState)
-      withMutation(keyPath: \.isPlaying) {}
-      withMutation(keyPath: \.isActive) {}
+      reconcilePlaybackIntent(for: newState)
       if case .stopped = newState {
         currentTime = .zero
         bufferFill = 0
@@ -1150,9 +1231,14 @@ public final class Player {
       // transition catches those cases. It's three C calls and is
       // idempotent when the events do fire.
       refreshNativeStateIfNeeded()
+      performDeferredPauseCommandIfNeeded()
 
     case .timeChanged(let time):
       currentTime = time
+      if duration == nil || !isSeekable || !isPausable {
+        refreshNativeStateIfNeeded()
+      }
+      performDeferredPauseCommandIfNeeded()
 
     case .positionChanged(let pos):
       withMutation(keyPath: \.position) {
@@ -1167,6 +1253,7 @@ public final class Player {
 
     case .pausableChanged(let pausable):
       isPausable = pausable
+      performDeferredPauseCommandIfNeeded()
 
     case .tracksChanged:
       refreshTracks()
@@ -1178,10 +1265,10 @@ public final class Player {
       notifyMediaDependentObservables()
 
     case .encounteredError:
-      state = .error
+      publishPlaybackState(.error)
       pauseTransition = nil
-      withMutation(keyPath: \.isPlaying) {}
-      withMutation(keyPath: \.isActive) {}
+      deferredPauseCommand = nil
+      reconcilePlaybackIntent(for: .error)
 
     case .bufferingProgress(let pct):
       // Fill level is useful in every state, so update regardless. A
@@ -1192,8 +1279,8 @@ public final class Player {
       switch state {
       case .idle, .opening, .buffering:
         if state != .buffering {
-          state = .buffering
-          withMutation(keyPath: \.isActive) {}
+          publishPlaybackState(.buffering)
+          reconcilePlaybackIntent(for: .buffering)
         }
       default:
         break
@@ -1233,6 +1320,37 @@ public final class Player {
     }
   }
 
+  private func publishPlaybackState(_ newState: PlayerState) {
+    state = newState
+    withMutation(keyPath: \.isPlaying) {}
+    withMutation(keyPath: \.isActive) {}
+  }
+
+  private func publishPlaybackIntent(_ active: Bool) {
+    guard isPlaybackRequestedActive != active else { return }
+    isPlaybackRequestedActive = active
+    playbackIntentBridge.broadcast(active)
+  }
+
+  func setPlaybackIntentFromExternalControl(_ active: Bool) {
+    publishPlaybackIntent(active)
+  }
+
+  private func reconcilePlaybackIntent(for state: PlayerState) {
+    switch state {
+    case .opening, .buffering, .playing:
+      guard pauseTransition != .pausing, deferredPauseCommand != .pause else { return }
+      publishPlaybackIntent(true)
+
+    case .paused:
+      guard pauseTransition != .resuming, deferredPauseCommand != .resume else { return }
+      publishPlaybackIntent(false)
+
+    case .idle, .stopped, .stopping, .error:
+      publishPlaybackIntent(false)
+    }
+  }
+
   private func updatePauseTransition(for newState: PlayerState) {
     switch (pauseTransition, newState) {
     case (.pausing, .paused), (.resuming, .playing):
@@ -1262,6 +1380,7 @@ public final class Player {
   private func resetMediaDerivedState() {
     pauseTransition = nil
     deferredPauseCommand = nil
+    publishPlaybackIntent(false)
     currentTime = .zero
     duration = nil
     isSeekable = false
@@ -1300,10 +1419,10 @@ public final class Player {
 
   /// Reads length / seekable / pausable directly from libVLC and
   /// publishes any changes to the matching observable property. Called
-  /// on every state transition as a resilient companion to
-  /// `MediaPlayerLengthChanged` / `SeekableChanged` / `PausableChanged`,
-  /// which are not guaranteed to fire on the player's event manager for
-  /// every media.
+  /// on state transitions and early time updates as a resilient companion
+  /// to `MediaPlayerLengthChanged` / `SeekableChanged` /
+  /// `PausableChanged`, which are not guaranteed to fire on the player's
+  /// event manager for every media.
   private func refreshNativeStateIfNeeded() {
     if duration == nil {
       let ms = libvlc_media_player_get_length(pointer)
@@ -1360,8 +1479,13 @@ public final class Player {
     handleEvent(event)
   }
 
+  func _hasDeferredPauseForTesting() -> Bool {
+    deferredPauseCommand == .pause
+  }
+
   func _setStateForTesting(
     state: PlayerState? = nil,
+    isPlaybackRequestedActive: Bool? = nil,
     currentTime: Duration? = nil,
     duration: Duration? = nil,
     position: Double? = nil,
@@ -1370,6 +1494,10 @@ public final class Player {
   ) {
     if let state {
       self.state = state
+      publishPlaybackIntent(state.isActive)
+    }
+    if let isPlaybackRequestedActive {
+      publishPlaybackIntent(isPlaybackRequestedActive)
     }
     if let currentTime {
       self.currentTime = currentTime

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -1114,8 +1114,9 @@ public final class Player {
     // Capture eventBridge strongly and self weakly to avoid the retain
     // cycle Player → eventTask → Player.
     let bridge = eventBridge
+    let stream = bridge.makeStream()
     eventTask = Task { [weak self] in
-      for await event in bridge.makeStream() {
+      for await event in stream {
         guard !Task.isCancelled else { return }
         self?.handleEvent(event)
         // Yield after each event so other main-actor work (UI updates,
@@ -1352,7 +1353,6 @@ public final class Player {
       currentMedia = nil
       return
     }
-    libvlc_media_retain(media)
     currentMedia = Media(retaining: media)
   }
 

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -297,6 +297,18 @@ public final class Player {
   private var _equalizer: Equalizer?
   private var _volume: Float = 1.0
   private var _isMuted: Bool = false
+  private enum PauseTransition {
+    case pausing
+    case resuming
+  }
+
+  private enum DeferredPauseCommand {
+    case pause
+    case resume
+  }
+
+  private var pauseTransition: PauseTransition?
+  private var deferredPauseCommand: DeferredPauseCommand?
   /// Shadow of the string last passed to `Marquee.setText`. libVLC's text
   /// renderer keys its glyph-bitmap cache on the text string, so a style-
   /// only write (color/opacity/fontSize) hits the cached entry and draws
@@ -444,12 +456,37 @@ public final class Player {
   }
 
   /// Pauses playback.
+  ///
+  /// No-op until libVLC has reached a stable, pausable `.playing`
+  /// state. With real audio output, the first audio timestamp must also
+  /// have advanced beyond zero; pausing before that point can leave
+  /// libVLC's aout stream with stale pause timing.
   public func pause() {
+    guard pauseTransition == nil else {
+      deferredPauseCommand = .pause
+      return
+    }
+    guard
+      state == .playing,
+      isPausable,
+      canIssueNativePause
+    else { return }
+
+    pauseTransition = .pausing
+    deferredPauseCommand = nil
     libvlc_media_player_set_pause(pointer, 1)
   }
 
   /// Resumes playback from pause.
   public func resume() {
+    guard pauseTransition == nil else {
+      deferredPauseCommand = .resume
+      return
+    }
+    guard nativePlaybackState == .paused else { return }
+
+    pauseTransition = .resuming
+    deferredPauseCommand = nil
     libvlc_media_player_set_pause(pointer, 0)
   }
 
@@ -484,6 +521,11 @@ public final class Player {
 
   /// Stops playback asynchronously.
   public func stop() {
+    if pauseTransition == .pausing || nativePlaybackState == .paused {
+      libvlc_media_player_set_pause(pointer, 0)
+    }
+    pauseTransition = nil
+    deferredPauseCommand = nil
     libvlc_media_player_stop_async(pointer)
   }
 
@@ -1049,6 +1091,23 @@ public final class Player {
 
   // MARK: - Event Consumer
 
+  private var nativePlaybackState: PlayerState {
+    PlayerState(from: libvlc_media_player_get_state(pointer))
+  }
+
+  private var canIssueNativePause: Bool {
+    if libvlc_media_player_get_time(pointer) > 0 {
+      return true
+    }
+    // With a real audio output, libVLC can report `.playing` and
+    // pausable before the first audio timestamp has cleared zero. Pausing
+    // in that window leaves the aout stream with a stale pause date and
+    // the next audio block trips libVLC's debug assertion. When audio is
+    // disabled or not initialized, libVLC reports a negative volume
+    // sentinel and no aout stream participates in that assertion.
+    return libvlc_audio_get_volume(pointer) < 0
+  }
+
   /// Consumes the event stream and mirrors each event onto the
   /// `@Observable` properties that SwiftUI binds to.
   private func startEventConsumer() {
@@ -1070,6 +1129,7 @@ public final class Player {
     switch event {
     case .stateChanged(let newState):
       state = newState
+      updatePauseTransition(for: newState)
       withMutation(keyPath: \.isPlaying) {}
       withMutation(keyPath: \.isActive) {}
       if case .stopped = newState {
@@ -1118,6 +1178,7 @@ public final class Player {
 
     case .encounteredError:
       state = .error
+      pauseTransition = nil
       withMutation(keyPath: \.isPlaying) {}
       withMutation(keyPath: \.isActive) {}
 
@@ -1171,7 +1232,35 @@ public final class Player {
     }
   }
 
+  private func updatePauseTransition(for newState: PlayerState) {
+    switch (pauseTransition, newState) {
+    case (.pausing, .paused), (.resuming, .playing):
+      pauseTransition = nil
+      performDeferredPauseCommandIfNeeded()
+    case (_, .idle), (_, .stopped), (_, .stopping), (_, .error):
+      pauseTransition = nil
+      deferredPauseCommand = nil
+    default:
+      break
+    }
+  }
+
+  private func performDeferredPauseCommandIfNeeded() {
+    guard pauseTransition == nil, let command = deferredPauseCommand else {
+      return
+    }
+    deferredPauseCommand = nil
+    switch command {
+    case .pause:
+      pause()
+    case .resume:
+      resume()
+    }
+  }
+
   private func resetMediaDerivedState() {
+    pauseTransition = nil
+    deferredPauseCommand = nil
     currentTime = .zero
     duration = nil
     isSeekable = false

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -15,7 +15,7 @@ import Observation
 ///     var body: some View {
 ///         VideoView(player)
 ///         Text(player.state.description)
-///         Button(player.isPlaybackRequestedActive ? "Pause" : "Play") {
+///         Button(player.isPlaying ? "Pause" : "Play") {
 ///             player.togglePlayPause()
 ///         }
 ///     }
@@ -269,10 +269,15 @@ public final class Player {
 
   // MARK: - Convenience
 
-  /// Whether the player is currently playing.
+  /// Whether transport controls should currently present playback as
+  /// playing.
+  ///
+  /// This follows the latest accepted play/resume/pause intent rather
+  /// than waiting for libVLC's asynchronous ``state`` transitions. Use
+  /// ``state`` when you need the strict native lifecycle state.
   public var isPlaying: Bool {
     access(keyPath: \.isPlaying)
-    return state == .playing
+    return isPlaybackRequestedActive
   }
 
   /// Whether playback is active (playing or buffering during playback).
@@ -300,7 +305,8 @@ public final class Player {
 
   // MARK: - Internal
 
-  nonisolated(unsafe) let pointer: OpaquePointer // libvlc_media_player_t*
+  @ObservationIgnored
+  nonisolated(unsafe) var pointer: OpaquePointer // libvlc_media_player_t*
   private let eventBridge: EventBridge
   private nonisolated let playbackIntentBridge: AsyncBroadcaster<Bool>
   private var eventTask: Task<Void, Never>?
@@ -337,6 +343,11 @@ public final class Player {
   /// across the offloaded release so `libvlc_media_player_release` can
   /// tear down the vout before ARC releases the view.
   var drawable: AnyObject?
+  private var drawableOwner: ObjectIdentifier?
+  var needsDrawableRebindForPlayback = false
+  private var nativePlayerHasHostedDrawable = false
+  private var nativePlayerNeedsReplacementBeforePlayback = false
+  private var retainedDrawablesUntilNativePlayerRelease: [AnyObject] = []
   let instance: VLCInstance
 
   // MARK: - Lifecycle
@@ -344,9 +355,7 @@ public final class Player {
   /// Creates a new player.
   /// - Parameter instance: The VLC instance to use.
   public init(instance: VLCInstance = .shared) {
-    guard let p = libvlc_media_player_new(instance.pointer) else {
-      preconditionFailure("Failed to create libvlc media player. Is the libvlc.xcframework linked correctly?")
-    }
+    let p = Self.makeNativePlayer(instance: instance)
     pointer = p
     self.instance = instance
     eventBridge = EventBridge(
@@ -354,6 +363,13 @@ public final class Player {
     )
     playbackIntentBridge = AsyncBroadcaster()
     startEventConsumer()
+  }
+
+  private static func makeNativePlayer(instance: VLCInstance) -> OpaquePointer {
+    guard let p = libvlc_media_player_new(instance.pointer) else {
+      preconditionFailure("Failed to create libvlc media player. Is the libvlc.xcframework linked correctly?")
+    }
+    return p
   }
 
   isolated deinit {
@@ -386,13 +402,15 @@ public final class Player {
     // narrow, explicit opt-out that matches that contract and avoids a
     // Mutex wrapper or an `@unchecked Sendable` box for a value we
     // never actually touch across threads.
-    nonisolated(unsafe) let drawable = drawable
+    nonisolated(unsafe) let drawables =
+      drawable.map { retainedDrawablesUntilNativePlayerRelease + [$0] }
+      ?? retainedDrawablesUntilNativePlayerRelease
     nonisolated(unsafe) let p = pointer
     DispatchQueue.global(qos: .utility).async {
       bridge.invalidate()
       libvlc_media_player_stop_async(p)
       libvlc_media_player_release(p)
-      _ = drawable
+      _ = drawables
     }
   }
 
@@ -403,8 +421,47 @@ public final class Player {
   /// the duration of the attachment so libVLC's raw `drawable-nsobject`
   /// pointer stays valid against asynchronous reads from the decode
   /// thread. Callers should normally use ``VideoView`` in SwiftUI; this
-  /// is the lower-level seam it builds on.
+  /// is the lower-level API it builds on.
   func setDrawable(_ newDrawable: AnyObject?) {
+    drawableOwner = newDrawable.map(ObjectIdentifier.init)
+    applyDrawable(newDrawable)
+  }
+
+  func claimDrawableOwnership(_ owner: AnyObject) {
+    drawableOwner = ObjectIdentifier(owner)
+  }
+
+  func releaseDrawableOwnership(_ owner: AnyObject) {
+    guard isDrawableOwner(owner) else { return }
+    drawableOwner = nil
+    if isCurrentDrawable(owner) {
+      applyDrawable(nil)
+    }
+  }
+
+  func setDrawable(_ newDrawable: AnyObject, owner: AnyObject) {
+    guard isDrawableOwner(owner) else { return }
+    applyDrawable(newDrawable)
+  }
+
+  func clearDrawable(ifCurrent staleDrawable: AnyObject) {
+    guard isCurrentDrawable(staleDrawable) else { return }
+    if drawableOwner == ObjectIdentifier(staleDrawable) {
+      drawableOwner = nil
+    }
+    setDrawable(nil)
+  }
+
+  func isCurrentDrawable(_ candidate: AnyObject) -> Bool {
+    guard let drawable else { return false }
+    return drawable === candidate
+  }
+
+  func isDrawableOwner(_ candidate: AnyObject) -> Bool {
+    drawableOwner == ObjectIdentifier(candidate)
+  }
+
+  private func applyDrawable(_ newDrawable: AnyObject?) {
     // Bind the outgoing reference to a local so it outlives the libVLC
     // call. After the ivar is reassigned, ARC would otherwise release
     // the previous view immediately; the vout thread could still be
@@ -412,12 +469,94 @@ public final class Player {
     // keeps the old view alive until this function returns, by which
     // point libVLC has atomically swapped the variable.
     let previous = drawable
+    if
+      let previous,
+      nativePlayerNeedsReplacementBeforePlayback,
+      newDrawable.map({ previous !== $0 }) ?? true
+    {
+      retainedDrawablesUntilNativePlayerRelease.append(previous)
+    }
     drawable = newDrawable
+    if newDrawable != nil {
+      nativePlayerHasHostedDrawable = true
+    }
     libvlc_media_player_set_nsobject(
       pointer,
       newDrawable.map { Unmanaged.passUnretained($0).toOpaque() }
     )
     _ = previous
+  }
+
+  func prepareDrawableForPlayback() {
+    if nativePlayerNeedsReplacementBeforePlayback {
+      replaceNativePlayerForDrawablePlayback(target: drawable)
+      return
+    }
+    guard let target = drawable else { return }
+    guard needsDrawableRebindForPlayback else { return }
+    let owner = drawableOwner
+    applyDrawable(nil)
+    drawableOwner = owner
+    applyDrawable(target)
+    needsDrawableRebindForPlayback = false
+  }
+
+  private func replaceNativePlayerForDrawablePlayback(target: AnyObject?) {
+    let oldPointer = pointer
+    let newPointer = Self.makeNativePlayer(instance: instance)
+    guard let newEventManager = libvlc_media_player_event_manager(newPointer) else {
+      libvlc_media_player_release(newPointer)
+      preconditionFailure("Failed to access libVLC media player event manager.")
+    }
+
+    let playbackRate = libvlc_media_player_get_rate(oldPointer)
+    let playerRole = libvlc_media_player_get_role(oldPointer)
+    let audioDelay = libvlc_audio_get_delay(oldPointer)
+    let subtitleDelay = libvlc_video_get_spu_delay(oldPointer)
+    let subtitleScale = libvlc_video_get_spu_text_scale(oldPointer)
+    let retainedDrawables = retainedDrawablesUntilNativePlayerRelease
+
+    if let currentMedia {
+      libvlc_media_player_set_media(newPointer, currentMedia.pointer)
+    }
+    _ = libvlc_audio_set_volume(newPointer, Int32(_volume * 100))
+    libvlc_audio_set_mute(newPointer, _isMuted ? 1 : 0)
+    _ = libvlc_media_player_set_rate(newPointer, playbackRate)
+    _ = libvlc_media_player_set_role(newPointer, UInt32(playerRole))
+    _ = libvlc_audio_set_delay(newPointer, audioDelay)
+    _ = libvlc_video_set_spu_delay(newPointer, subtitleDelay)
+    libvlc_video_set_spu_text_scale(newPointer, subtitleScale)
+    libvlc_media_player_set_equalizer(newPointer, _equalizer?.pointer)
+    libvlc_media_player_set_nsobject(
+      newPointer,
+      target.map { Unmanaged.passUnretained($0).toOpaque() }
+    )
+
+    eventBridge.reattach(to: newEventManager)
+    pointer = newPointer
+    applyAspectRatio()
+
+    retainedDrawablesUntilNativePlayerRelease.removeAll()
+    nativePlayerNeedsReplacementBeforePlayback = false
+    needsDrawableRebindForPlayback = false
+    nativePlayerHasHostedDrawable = target != nil
+
+    releaseNativePlayer(oldPointer, retaining: retainedDrawables)
+    notifyMediaDependentObservables()
+  }
+
+  private func releaseNativePlayer(
+    _ nativePlayer: OpaquePointer,
+    retaining drawables: [AnyObject] = []
+  ) {
+    nonisolated(unsafe) let nativePlayer = nativePlayer
+    nonisolated(unsafe) let drawables = drawables
+    DispatchQueue.global(qos: .utility).async {
+      libvlc_media_player_set_nsobject(nativePlayer, nil)
+      libvlc_media_player_stop_async(nativePlayer)
+      libvlc_media_player_release(nativePlayer)
+      _ = drawables
+    }
   }
 
   // MARK: - Media Loading
@@ -462,6 +601,7 @@ public final class Player {
   /// Starts playback.
   /// - Throws: `VLCError.playbackFailed` if playback cannot start.
   public func play() throws(VLCError) {
+    prepareDrawableForPlayback()
     if libvlc_media_player_play(pointer) == -1 {
       publishPlaybackIntent(false)
       let reason = libvlc_errmsg().map { String(cString: $0) } ?? "unknown"
@@ -608,6 +748,12 @@ public final class Player {
     pauseTransition = nil
     deferredPauseCommand = nil
     publishPlaybackIntent(false)
+    if nativePlayerHasHostedDrawable {
+      nativePlayerNeedsReplacementBeforePlayback = true
+      needsDrawableRebindForPlayback = true
+    } else {
+      needsDrawableRebindForPlayback = drawable != nil
+    }
     libvlc_media_player_stop_async(pointer)
   }
 
@@ -1322,13 +1468,13 @@ public final class Player {
 
   private func publishPlaybackState(_ newState: PlayerState) {
     state = newState
-    withMutation(keyPath: \.isPlaying) {}
     withMutation(keyPath: \.isActive) {}
   }
 
   private func publishPlaybackIntent(_ active: Bool) {
     guard isPlaybackRequestedActive != active else { return }
     isPlaybackRequestedActive = active
+    withMutation(keyPath: \.isPlaying) {}
     playbackIntentBridge.broadcast(active)
   }
 

--- a/Sources/SwiftVLC/Player/PlayerState.swift
+++ b/Sources/SwiftVLC/Player/PlayerState.swift
@@ -38,6 +38,15 @@ public enum PlayerState: Sendable, Hashable, CustomStringConvertible {
     }
   }
 
+  var isActive: Bool {
+    switch self {
+    case .playing, .opening, .buffering:
+      true
+    default:
+      false
+    }
+  }
+
   init(from cState: libvlc_state_t) {
     switch cState {
     case libvlc_NothingSpecial: self = .idle

--- a/Sources/SwiftVLC/SwiftVLC.docc/ComparisonWithVLCKit.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/ComparisonWithVLCKit.md
@@ -109,7 +109,7 @@ and re-publishing state yourself.
 
 SwiftVLC ships ``VideoView``, ``PiPVideoView``, and a ``PiPController``
 that handle the view bridge, the drawable attachment, and the
-sample-buffer pipeline for Picture-in-Picture. See
+platform PiP pipeline. See
 <doc:DisplayingVideo> and <doc:PictureInPicture>.
 
 ## Distribution

--- a/Sources/SwiftVLC/SwiftVLC.docc/ComparisonWithVLCKit.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/ComparisonWithVLCKit.md
@@ -8,15 +8,15 @@ to each.
 ## What they are
 
 **VLCKit** is VideoLAN's own wrapper around libVLC. It is written
-primarily in Objective-C and distributed for macOS, iOS, and tvOS,
-with the 4.0 line adding visionOS and watchOS. It has been the
-canonical answer for embedding VLC on Apple platforms for over a
-decade, and ships as three CocoaPods (`VLCKit`, `MobileVLCKit`,
-`TVVLCKit`) or as pre-built frameworks via Carthage.
+primarily in Objective-C and distributed for macOS, iOS, and tvOS. Its
+in-progress 4.0 line expands the platform surface to visionOS and
+watchOS. It has been the canonical answer for embedding VLC on Apple
+platforms for over a decade, and ships as three CocoaPods (`VLCKit`,
+`MobileVLCKit`, `TVVLCKit`) or as pre-built frameworks via Carthage.
 
 **SwiftVLC** is a Swift 6 binding to libVLC's C API, with no
 Objective-C layer in between. It targets only modern Apple platforms
-(iOS 18+, macOS 15+, tvOS 18+, macCatalyst 18+) and ships exclusively
+(iOS 18+, macOS 15+, tvOS 18+, visionOS 2+, macCatalyst 18+) and ships exclusively
 through Swift Package Manager.
 
 ## libVLC generation
@@ -125,12 +125,12 @@ sample-buffer pipeline for Picture-in-Picture. See
 
 | | VLCKit 3.x | VLCKit 4.0 (alpha) | SwiftVLC |
 |---|---|---|---|
-| iOS | 8.4+ | iOS (target not finalized) | 18+ |
-| macOS | 10.9+ | — | 15+ |
-| tvOS | 10.2+ | — | 18+ |
-| visionOS | — | Added | — |
-| watchOS | — | Added | — |
-| macCatalyst | — | — | 18+ |
+| iOS | 8.4+ | Supported in alpha | 18+ |
+| macOS | 10.9+ | Supported in alpha | 15+ |
+| tvOS | 10.2+ | Supported in alpha | 18+ |
+| visionOS | Not supported | Supported in alpha | 2+ |
+| watchOS | Not supported | Supported in alpha | Not supported |
+| macCatalyst | Not supported | Not supported | 18+ |
 
 ## License
 
@@ -157,7 +157,7 @@ requirements.
 
 **Pick SwiftVLC if:**
 
-- Your project targets iOS 18+ / macOS 15+ / tvOS 18+.
+- Your project targets iOS 18+ / macOS 15+ / tvOS 18+ / visionOS 2+.
 - You want `@Observable`, `AsyncStream`, typed throws, and strict
   concurrency without writing bridging code.
 - You're building on SwiftUI and want `VideoView(player)` to be the

--- a/Sources/SwiftVLC/SwiftVLC.docc/ConcurrencyModel.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/ConcurrencyModel.md
@@ -62,7 +62,9 @@ Every async API that waits on libVLC honors task cancellation:
 - ``Media/parse(timeout:instance:)``: canceling the enclosing task
   stops the parse.
 - ``Media/thumbnail(at:width:height:crop:timeout:instance:)``:
-  canceling destroys the in-flight thumbnail request.
+  canceling before libVLC accepts the request returns immediately. Once
+  accepted, SwiftVLC waits for the terminal thumbnail event so callback
+  and request teardown are complete before the task returns.
 - Streams finish when their owning type (`Player`, `VLCInstance`, or
   a discoverer) is released.
 

--- a/Sources/SwiftVLC/SwiftVLC.docc/DisplayingVideo.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/DisplayingVideo.md
@@ -37,9 +37,17 @@ player.aspectRatio = .fill              // cover the display; may crop
 ## When to use PiPVideoView instead
 
 For Picture-in-Picture on iOS or macOS, use ``PiPVideoView`` in place
-of ``VideoView``. The two cannot share a player: PiP routes frames
-through vmem callbacks into an `AVSampleBufferDisplayLayer`, which is
-incompatible with the `set_nsobject` drawable that ``VideoView`` uses.
+of ``VideoView``. The two should not share a player. iOS routes frames
+through SwiftVLC's sample-buffer pipeline; macOS hands libVLC a native
+drawable and moves that same view into the system PiP presenter, so PiP
+controls and timing stay attached to VLC's own video output without the
+AVKit sample-buffer mirror cropping path.
+
+On macOS, keep the default ``VLCInstance`` arguments for players that
+use PiP. The default keeps VLC's Apple sample-buffer display available
+for inline playback, while ``PiPVideoView`` moves the full native
+drawable container into the system PiP presenter so video and subtitles
+stay together.
 
 See <doc:PictureInPicture> for the complete setup.
 

--- a/Sources/SwiftVLC/SwiftVLC.docc/GettingStarted.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/GettingStarted.md
@@ -29,6 +29,31 @@ targets: [
 SwiftVLC requires Swift 6.3 and supports iOS 18, macOS 15, tvOS 18,
 visionOS 2, and macCatalyst 18.
 
+## Prepare libVLC at launch
+
+The first libVLC instance does one-time plugin and decoder setup. Start
+that work when your app launches so the first playback screen does not
+pay the cost while SwiftUI is pushing the view:
+
+```swift
+import SwiftUI
+import SwiftVLC
+
+@main
+struct MyApp: App {
+    init() {
+        VLCInstance.prewarmShared()
+    }
+
+    var body: some Scene {
+        WindowGroup { PlayerView() }
+    }
+}
+```
+
+If your app has an explicit loading phase, await
+``VLCInstance/prepareShared(priority:)`` before presenting playback UI.
+
 ## Play a URL
 
 ```swift
@@ -65,7 +90,7 @@ Most controls read a handful of observable properties directly:
 ```swift
 Text(player.state.description)
 ProgressView(value: player.position)
-Button(player.isPlaybackRequestedActive ? "Pause" : "Play") {
+Button(player.isPlaying ? "Pause" : "Play") {
     player.togglePlayPause()
 }
 ```

--- a/Sources/SwiftVLC/SwiftVLC.docc/GettingStarted.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/GettingStarted.md
@@ -65,8 +65,8 @@ Most controls read a handful of observable properties directly:
 ```swift
 Text(player.state.description)
 ProgressView(value: player.position)
-Button(player.isPlaying ? "Pause" : "Play") {
-    player.isPlaying ? player.pause() : try? player.play()
+Button(player.isPlaybackRequestedActive ? "Pause" : "Play") {
+    player.togglePlayPause()
 }
 ```
 

--- a/Sources/SwiftVLC/SwiftVLC.docc/GettingStarted.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/GettingStarted.md
@@ -27,7 +27,7 @@ targets: [
 ```
 
 SwiftVLC requires Swift 6.3 and supports iOS 18, macOS 15, tvOS 18,
-and macCatalyst 18.
+visionOS 2, and macCatalyst 18.
 
 ## Play a URL
 

--- a/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
@@ -5,8 +5,20 @@ PiP on macOS.
 
 ## Using PiPVideoView
 
-``PiPVideoView`` replaces ``VideoView`` and configures AVKit's PiP
-controller on your behalf.
+``PiPVideoView`` replaces ``VideoView`` and configures the platform PiP
+surface on your behalf. On iOS it uses SwiftVLC's AVKit sample-buffer
+path. On macOS it keeps libVLC's native drawable as the only video surface
+and moves that drawable into the system PiP presenter. That keeps video,
+audio, playback intent, and time on the same VLC timeline while avoiding
+macOS's broken AVKit sample-buffer mirror path.
+
+SwiftVLC's default macOS ``VLCInstance`` arguments leave VLC's Apple
+sample-buffer display enabled for normal inline playback. ``PiPVideoView``
+owns a native drawable container and moves that whole container into the
+system PiP presenter, so subtitle and video layers remain together during
+the transition. If you create a custom ``VLCInstance`` for a macOS player
+that will enter PiP, include ``VLCInstance/defaultArguments`` in your
+custom argument list.
 
 ```swift
 struct PlayerScreen: View {
@@ -27,7 +39,7 @@ struct PlayerScreen: View {
 
 The `controller` binding is populated during view construction and
 stays in sync with the view's lifetime. It's `nil` on platforms that
-don't support sample-buffer PiP (e.g. tvOS and visionOS).
+don't expose SwiftVLC's PiP APIs (e.g. tvOS and visionOS).
 
 ## Audio session (iOS only)
 
@@ -50,9 +62,9 @@ Your app must also declare background modes in its Info.plist:
 
 ## Using PiPController directly
 
-Instantiate ``PiPController`` yourself when placing the video into a
-non-SwiftUI view hierarchy, or when your layout needs more control
-than ``PiPVideoView`` offers:
+Instantiate ``PiPController`` yourself when placing SwiftVLC's
+sample-buffer video layer into a non-SwiftUI view hierarchy, or when
+your layout needs more control than ``PiPVideoView`` offers:
 
 ```swift
 let controller = PiPController(player: player)
@@ -61,23 +73,29 @@ controller.start()
 ```
 
 ``PiPController/layer`` uses `videoGravity = .resizeAspect`. Size the
-parent view to the aspect ratio you want.
+parent view to the aspect ratio you want. On macOS, prefer
+``PiPVideoView`` unless you are intentionally using the direct
+sample-buffer pipeline.
 
 ## Common pitfalls
 
-- **Never mix rendering paths.** A player attached to ``PiPController``
-  cannot also back a ``VideoView``. Frames flow through vmem callbacks
-  into an `AVSampleBufferDisplayLayer`; libVLC's `set_nsobject`
-  drawable is disabled on the same player.
-- **Add the layer to a view before calling `player.play()`.** PiP
-  recognizes the sample-buffer layer as a valid content source only
-  once it's on screen.
+- **Never mix rendering paths.** A player attached to direct
+  ``PiPController`` sample-buffer rendering cannot also back a
+  ``VideoView``. ``PiPVideoView`` owns the active video output for the
+  lifetime of the view.
+- **Put the PiP surface on screen before calling `player.play()`.**
+  AVKit recognizes the PiP source only once the surface is visible and
+  receiving frames.
+- **Keep the macOS PiP-safe VLC defaults.** Passing a completely custom
+  ``VLCInstance`` argument list on macOS can disable video output or force
+  an unsupported vout. Start from ``VLCInstance/defaultArguments`` and
+  append your own options instead.
 
 ## Platform availability
 
 Picture-in-Picture is available on iOS and macOS. tvOS has no PiP API
 (its system player UI handles background playback instead), and
-SwiftVLC does not compile the sample-buffer PiP wrapper on visionOS.
+SwiftVLC does not compile the PiP wrapper on visionOS.
 ``PiPController`` and ``PiPVideoView`` are not compiled on those
 platforms.
 

--- a/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
@@ -27,7 +27,7 @@ struct PlayerScreen: View {
 
 The `controller` binding is populated during view construction and
 stays in sync with the view's lifetime. It's `nil` on platforms that
-don't support sample-buffer PiP (e.g. tvOS).
+don't support sample-buffer PiP (e.g. tvOS and visionOS).
 
 ## Audio session (iOS only)
 
@@ -76,9 +76,10 @@ parent view to the aspect ratio you want.
 ## Platform availability
 
 Picture-in-Picture is available on iOS and macOS. tvOS has no PiP API
-(its system player UI handles background playback instead), so
-``PiPController`` and ``PiPVideoView`` are not compiled on that
-platform.
+(its system player UI handles background playback instead), and
+SwiftVLC does not compile the sample-buffer PiP wrapper on visionOS.
+``PiPController`` and ``PiPVideoView`` are not compiled on those
+platforms.
 
 ## Topics
 

--- a/Sources/SwiftVLC/SwiftVLC.docc/PlaybackEssentials.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/PlaybackEssentials.md
@@ -26,6 +26,7 @@ binds to them directly, without a publisher or Combine adapter.
 | Property | Type | Meaning |
 |---|---|---|
 | ``Player/state`` | ``PlayerState`` | `.idle`, `.opening`, `.buffering`, `.playing`, `.paused`, `.stopped`, `.stopping`, `.error` |
+| ``Player/isPlaybackRequestedActive`` | `Bool` | User-facing playback intent for transport controls while libVLC state transitions settle |
 | ``Player/bufferFill`` | `Float` | Continuously-updated cache level (`0.0…1.0`), independent of `state` |
 | ``Player/currentTime`` | `Duration` | Wall-clock position, millisecond resolution |
 | ``Player/duration`` | `Duration?` | `nil` until the container reports length |
@@ -39,6 +40,10 @@ binds to them directly, without a publisher or Combine adapter.
 - ``Player/isPlaying`` is `true` when `state == .playing`.
 - ``Player/isActive`` is `true` while the player is opening, buffering,
   or playing.
+- ``Player/isPlaybackRequestedActive`` is the best signal for a
+  Play/Pause button label because it updates synchronously when a pause
+  or resume request is accepted, before the native player finishes its
+  state transition.
 
 ## Bindable state
 
@@ -120,6 +125,7 @@ See <doc:ConcurrencyModel> for the full isolation story.
 - ``Player/duration``
 - ``Player/isPlaying``
 - ``Player/isActive``
+- ``Player/isPlaybackRequestedActive``
 - ``PlayerState``
 - ``PlayerEvent``
 

--- a/Sources/SwiftVLC/SwiftVLC.docc/PlaybackEssentials.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/PlaybackEssentials.md
@@ -18,6 +18,11 @@ Construction allocates the underlying libVLC resources. Release
 happens off the main actor in `deinit`, so tearing down a view never
 stalls the UI thread.
 
+For the default shared instance, call
+``VLCInstance/prewarmShared(priority:)`` during app launch when possible.
+That moves libVLC's one-time startup work out of the first SwiftUI
+player screen.
+
 ## Observable state
 
 Read-only properties refresh whenever libVLC reports new state. SwiftUI
@@ -26,7 +31,8 @@ binds to them directly, without a publisher or Combine adapter.
 | Property | Type | Meaning |
 |---|---|---|
 | ``Player/state`` | ``PlayerState`` | `.idle`, `.opening`, `.buffering`, `.playing`, `.paused`, `.stopped`, `.stopping`, `.error` |
-| ``Player/isPlaybackRequestedActive`` | `Bool` | User-facing playback intent for transport controls while libVLC state transitions settle |
+| ``Player/isPlaying`` | `Bool` | User-facing playback signal for Play/Pause controls while libVLC state transitions settle |
+| ``Player/isPlaybackRequestedActive`` | `Bool` | Lower-level playback intent mirrored by PiP and external transport controls |
 | ``Player/bufferFill`` | `Float` | Continuously-updated cache level (`0.0…1.0`), independent of `state` |
 | ``Player/currentTime`` | `Duration` | Wall-clock position, millisecond resolution |
 | ``Player/duration`` | `Duration?` | `nil` until the container reports length |
@@ -37,13 +43,13 @@ binds to them directly, without a publisher or Combine adapter.
 
 ### Convenience
 
-- ``Player/isPlaying`` is `true` when `state == .playing`.
+- ``Player/isPlaying`` is the best signal for a Play/Pause button label
+  because it updates synchronously when a play, pause, or resume request
+  is accepted, before the native player finishes its state transition.
 - ``Player/isActive`` is `true` while the player is opening, buffering,
   or playing.
-- ``Player/isPlaybackRequestedActive`` is the best signal for a
-  Play/Pause button label because it updates synchronously when a pause
-  or resume request is accepted, before the native player finishes its
-  state transition.
+- ``Player/state`` is the strict libVLC lifecycle state. It can lag
+  transport intent briefly during PiP and other asynchronous transitions.
 
 ## Bindable state
 

--- a/Sources/SwiftVLC/Video/VideoView.swift
+++ b/Sources/SwiftVLC/Video/VideoView.swift
@@ -55,44 +55,112 @@ public struct VideoView: UIViewRepresentable {
 @MainActor
 final class VideoSurface: UIView {
   private weak var attachedPlayer: Player?
-  private var lastBounds: CGRect = .zero
 
   func attach(to player: Player) {
-    guard attachedPlayer !== player else { return }
-    attachedPlayer?.setDrawable(nil)
-    attachedPlayer = player
-    player.setDrawable(self)
+    if attachedPlayer !== player {
+      attachedPlayer?.releaseDrawableOwnership(self)
+      attachedPlayer = player
+    }
+    player.claimDrawableOwnership(self)
+    publishDrawableIfReady()
   }
 
   func detach() {
     guard let player = attachedPlayer else { return }
-    player.setDrawable(nil)
+    player.releaseDrawableOwnership(self)
     attachedPlayer = nil
   }
 
   override func layoutSubviews() {
     super.layoutSubviews()
 
-    // First valid layout: re-assert the drawable so libVLC can attach
-    // its rendering subview once we have non-zero bounds. Both width
-    // and height must be non-zero; attaching at `(>0, 0)` creates the
-    // rendering subview at zero height and a later resize doesn't
-    // retroactively fix the initial parenting.
-    if let player = attachedPlayer, lastBounds == .zero, bounds.width > 0, bounds.height > 0 {
-      player.setDrawable(self)
-    }
+    guard hasDrawableBounds else { return }
 
-    // Keep VLC's rendering sublayer sized to our bounds
-    if bounds != lastBounds, bounds.width > 0, bounds.height > 0 {
-      lastBounds = bounds
-      layer.sublayers?.forEach { sublayer in
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
-        sublayer.frame = bounds
-        CATransaction.commit()
-      }
+    publishDrawableIfReady()
+    resizeRenderingChildren()
+  }
+
+  override func didAddSubview(_ subview: UIView) {
+    super.didAddSubview(subview)
+    resizeRenderingSubview(subview)
+  }
+
+  override func layoutSublayers(of layer: CALayer) {
+    super.layoutSublayers(of: layer)
+    guard layer === self.layer else { return }
+    resizeRenderingLayers()
+  }
+
+  override func didMoveToWindow() {
+    super.didMoveToWindow()
+    if window != nil {
+      publishDrawableIfReady()
+      setNeedsLayout()
+      layer.setNeedsLayout()
     }
   }
+
+  private var hasDrawableBounds: Bool {
+    bounds.width > 0 && bounds.height > 0
+  }
+
+  private func publishDrawableIfReady() {
+    guard let player = attachedPlayer, player.isDrawableOwner(self) else { return }
+    if !player.isCurrentDrawable(self) {
+      player.setDrawable(self, owner: self)
+      resizeRenderingChildren()
+    }
+  }
+
+  private func resizeRenderingChildren() {
+    guard hasDrawableBounds else { return }
+    subviews.forEach(resizeRenderingSubview)
+    resizeRenderingLayers()
+  }
+
+  private func resizeRenderingSubview(_ subview: UIView) {
+    guard hasDrawableBounds else { return }
+    subview.frame = bounds
+    subview.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    syncContentScale(to: subview)
+    subview.setNeedsLayout()
+    subview.layoutIfNeeded()
+    reshapeVLCSubviewIfNeeded(subview)
+  }
+
+  private func resizeRenderingLayers() {
+    guard hasDrawableBounds else { return }
+    layer.sublayers?.forEach { sublayer in
+      CATransaction.begin()
+      CATransaction.setDisableActions(true)
+      sublayer.frame = bounds
+      CATransaction.commit()
+    }
+  }
+
+  private func syncContentScale(to subview: UIView) {
+    #if os(visionOS)
+    let scale = layer.contentsScale
+    #else
+    let scale = window?.screen.scale
+      ?? subview.window?.screen.scale
+      ?? UIScreen.main.scale
+    #endif
+    subview.contentScaleFactor = scale
+    subview.layer.contentsScale = scale
+  }
+}
+
+private let vlcUIViewReshapeSelector = NSSelectorFromString("reshape")
+
+@MainActor
+private func reshapeVLCSubviewIfNeeded(_ subview: UIView) {
+  guard
+    subview.responds(to: vlcUIViewReshapeSelector),
+    subview.bounds.width > 0,
+    subview.bounds.height > 0
+  else { return }
+  _ = subview.perform(vlcUIViewReshapeSelector)
 }
 
 #elseif canImport(AppKit)
@@ -138,22 +206,23 @@ public struct VideoView: NSViewRepresentable {
 @MainActor
 final class VideoSurface: NSView {
   private weak var attachedPlayer: Player?
-  private var lastBounds: CGRect = .zero
 
   override var wantsDefaultClipping: Bool {
     true
   }
 
   func attach(to player: Player) {
-    guard attachedPlayer !== player else { return }
-    attachedPlayer?.setDrawable(nil)
-    attachedPlayer = player
-    player.setDrawable(self)
+    if attachedPlayer !== player {
+      attachedPlayer?.releaseDrawableOwnership(self)
+      attachedPlayer = player
+    }
+    player.claimDrawableOwnership(self)
+    publishDrawableIfReady()
   }
 
   func detach() {
     guard let player = attachedPlayer else { return }
-    player.setDrawable(nil)
+    player.releaseDrawableOwnership(self)
     attachedPlayer = nil
   }
 
@@ -167,23 +236,50 @@ final class VideoSurface: NSView {
   override func layout() {
     super.layout()
 
-    if let player = attachedPlayer, lastBounds == .zero, bounds.width > 0, bounds.height > 0 {
-      player.setDrawable(self)
-    }
+    guard hasDrawableBounds else { return }
 
-    if bounds != lastBounds, bounds.width > 0, bounds.height > 0 {
-      lastBounds = bounds
-      for subview in subviews {
-        subview.frame = bounds
-        reshapeVLCSubviewIfNeeded(subview)
-      }
-      layer?.sublayers?.forEach { sublayer in
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
-        sublayer.frame = bounds
-        CATransaction.commit()
-      }
+    publishDrawableIfReady()
+    resizeRenderingChildren()
+  }
+
+  override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    if window != nil {
+      publishDrawableIfReady()
+      needsLayout = true
+      layer?.setNeedsLayout()
     }
+  }
+
+  private var hasDrawableBounds: Bool {
+    bounds.width > 0 && bounds.height > 0
+  }
+
+  private func publishDrawableIfReady() {
+    guard let player = attachedPlayer, player.isDrawableOwner(self) else { return }
+    if !player.isCurrentDrawable(self) {
+      player.setDrawable(self, owner: self)
+      resizeRenderingChildren()
+    }
+  }
+
+  private func resizeRenderingChildren() {
+    guard hasDrawableBounds else { return }
+    for subview in subviews {
+      resizeRenderingSubview(subview)
+    }
+    layer?.sublayers?.forEach { sublayer in
+      CATransaction.begin()
+      CATransaction.setDisableActions(true)
+      sublayer.frame = bounds
+      CATransaction.commit()
+    }
+  }
+
+  private func resizeRenderingSubview(_ subview: NSView) {
+    guard hasDrawableBounds else { return }
+    subview.frame = bounds
+    reshapeVLCSubviewIfNeeded(subview)
   }
 }
 

--- a/Sources/SwiftVLC/Video/VideoView.swift
+++ b/Sources/SwiftVLC/Video/VideoView.swift
@@ -117,6 +117,8 @@ public struct VideoView: NSViewRepresentable {
     let surface = VideoSurface()
     surface.wantsLayer = true
     surface.layer?.backgroundColor = NSColor.black.cgColor
+    surface.layer?.masksToBounds = true
+    surface.autoresizesSubviews = true
     return surface
   }
 
@@ -138,6 +140,10 @@ final class VideoSurface: NSView {
   private weak var attachedPlayer: Player?
   private var lastBounds: CGRect = .zero
 
+  override var wantsDefaultClipping: Bool {
+    true
+  }
+
   func attach(to player: Player) {
     guard attachedPlayer !== player else { return }
     attachedPlayer?.setDrawable(nil)
@@ -151,11 +157,26 @@ final class VideoSurface: NSView {
     attachedPlayer = nil
   }
 
+  override func didAddSubview(_ subview: NSView) {
+    super.didAddSubview(subview)
+    subview.frame = bounds
+    subview.autoresizingMask = [.width, .height]
+    reshapeVLCSubviewIfNeeded(subview)
+  }
+
   override func layout() {
     super.layout()
 
+    if let player = attachedPlayer, lastBounds == .zero, bounds.width > 0, bounds.height > 0 {
+      player.setDrawable(self)
+    }
+
     if bounds != lastBounds, bounds.width > 0, bounds.height > 0 {
       lastBounds = bounds
+      for subview in subviews {
+        subview.frame = bounds
+        reshapeVLCSubviewIfNeeded(subview)
+      }
       layer?.sublayers?.forEach { sublayer in
         CATransaction.begin()
         CATransaction.setDisableActions(true)
@@ -164,6 +185,18 @@ final class VideoSurface: NSView {
       }
     }
   }
+}
+
+private let vlcOpenGLReshapeSelector = NSSelectorFromString("reshape")
+
+@MainActor
+private func reshapeVLCSubviewIfNeeded(_ subview: NSView) {
+  guard
+    subview.responds(to: vlcOpenGLReshapeSelector),
+    subview.bounds.width > 0,
+    subview.bounds.height > 0
+  else { return }
+  _ = subview.perform(vlcOpenGLReshapeSelector)
 }
 
 #endif

--- a/Tests/SwiftVLCTests/Core/VLCInstanceTests.swift
+++ b/Tests/SwiftVLCTests/Core/VLCInstanceTests.swift
@@ -60,12 +60,49 @@ extension Integration {
     func `Default arguments contains expected values`() {
       let args = VLCInstance.defaultArguments
       #expect(args.count == 2)
+      #expect(!args.contains("--force-darwin-legacy-display"))
+      #expect(!args.contains("--vout=macosx"))
       #expect(args.contains("--no-video-title-show"))
       #expect(args.contains("--no-snapshot-preview"))
+      #expect(!args.contains("--text-renderer=freetype"))
       // --no-stats is intentionally absent: it would zero every stats
       // counter every app ever reads. Opt in by passing it explicitly.
       #expect(!args.contains("--no-stats"))
     }
+
+    #if os(macOS)
+    @Test
+    func `Default instance uses PiP safe macOS display`() throws {
+      let instance = try VLCInstance()
+      #expect(instance.usesPiPSafeDarwinDisplay)
+      #expect(!instance.arguments.contains("--force-darwin-legacy-display"))
+      #expect(!instance.arguments.contains("--vout=macosx"))
+    }
+
+    @Test
+    func `Custom instance with legacy macOS vout is PiP safe on macOS`() throws {
+      let instance = try VLCInstance(arguments: ["--no-video-title-show", "--vout=macosx"])
+      #expect(instance.usesPiPSafeDarwinDisplay)
+    }
+
+    @Test
+    func `Custom instance with no video is not PiP safe on macOS`() throws {
+      let instance = try VLCInstance(arguments: ["--no-video-title-show", "--no-video"])
+      #expect(!instance.usesPiPSafeDarwinDisplay)
+    }
+
+    @Test
+    func `Custom instance with forced legacy display but no vout is not PiP safe on macOS`() throws {
+      let instance = try VLCInstance(arguments: ["--force-darwin-legacy-display"])
+      #expect(!instance.usesPiPSafeDarwinDisplay)
+    }
+
+    @Test
+    func `Custom instance with CAOpenGLLayer vout is not PiP safe on macOS`() throws {
+      let instance = try VLCInstance(arguments: ["--force-darwin-legacy-display", "--vout=caopengllayer"])
+      #expect(!instance.usesPiPSafeDarwinDisplay)
+    }
+    #endif
 
     @Test
     func `Audio outputs returns non-empty list`() {

--- a/Tests/SwiftVLCTests/Core/VLCInstanceTests.swift
+++ b/Tests/SwiftVLCTests/Core/VLCInstanceTests.swift
@@ -9,6 +9,12 @@ extension Integration {
     }
 
     @Test
+    func `Prewarm shared resolves the shared instance`() async {
+      let instance = await VLCInstance.prepareShared()
+      #expect(instance === VLCInstance.shared)
+    }
+
+    @Test
     func `Version string is non-empty and contains a dot`() {
       let version = VLCInstance.shared.version
       #expect(!version.isEmpty)

--- a/Tests/SwiftVLCTests/Media/MediaStatisticsTests.swift
+++ b/Tests/SwiftVLCTests/Media/MediaStatisticsTests.swift
@@ -12,7 +12,7 @@ extension Integration {
     @Test(.tags(.mainActor, .async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     @MainActor
     func `Available during playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       let media = try Media(url: TestMedia.testMP4URL)
       try player.play(media)
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
@@ -23,7 +23,7 @@ extension Integration {
     @Test(.tags(.mainActor, .async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     @MainActor
     func `Fields are reasonable`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       let media = try Media(url: TestMedia.twosecURL)
       try player.play(media)
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
@@ -48,7 +48,7 @@ extension Integration {
     @Test(.tags(.mainActor, .async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     @MainActor
     func `Statistics accessible during playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       let media = try Media(url: TestMedia.twosecURL)
       try player.play(media)
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")

--- a/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
@@ -18,12 +18,25 @@ extension Integration {
     final class PlaybackRecorder {
       var pauseCount = 0
       var resumeCount = 0
+      var cancelPendingPauseCount = 0
+      var shouldResume = false
+      var resumeResult = true
       var seekTargets: [Int64] = []
 
       var driver: PiPController.PlaybackDriver {
         .init(
-          pause: { self.pauseCount += 1 },
-          resume: { self.resumeCount += 1 },
+          pause: {
+            self.pauseCount += 1
+            return true
+          },
+          resume: {
+            self.resumeCount += 1
+            return self.resumeResult
+          },
+          cancelPendingPause: {
+            self.cancelPendingPauseCount += 1
+          },
+          shouldResume: { self.shouldResume },
           seek: { self.seekTargets.append($0.milliseconds) }
         )
       }
@@ -109,6 +122,49 @@ extension Integration {
       try? await Task.sleep(for: .milliseconds(20))
 
       #expect(recorder.resumeCount == 1, "resume must fire after a previously-issued pause")
+    }
+
+    @Test
+    func `setPlaying true resumes a native pause transition that is still in flight`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing)
+      let recorder = PlaybackRecorder()
+      recorder.shouldResume = true
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(250)
+      )
+
+      controller._setPlayingForTesting(true)
+
+      #expect(recorder.resumeCount == 1)
+      #expect(controller._pendingPiPPlaybackStateForTesting() == true)
+
+      controller._handleObservedPlaybackActivityForTesting(false)
+
+      #expect(controller._pipPlaybackActiveForTesting() == true)
+      #expect(controller._pendingPiPPlaybackStateForTesting() == true)
+    }
+
+    @Test
+    func `setPlaying true falls back to native state when resume is rejected`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .paused)
+      let recorder = PlaybackRecorder()
+      recorder.shouldResume = true
+      recorder.resumeResult = false
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(250)
+      )
+
+      controller._setPlayingForTesting(true)
+
+      #expect(recorder.resumeCount == 1)
+      #expect(controller._pipPlaybackActiveForTesting() == false)
+      #expect(controller._pendingPiPPlaybackStateForTesting() == nil)
     }
 
     /// While `.buffering`, the deferred pause loop keeps waiting for
@@ -197,6 +253,142 @@ extension Integration {
 
       controller._setPlayingForTesting(false)
       #expect(controller._isPlaybackPausedForTesting(pip) == true)
+    }
+
+    @Test
+    func `setPlaying updates player playback intent synchronously`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: PlaybackRecorder().driver,
+        pauseDebounce: .milliseconds(250)
+      )
+
+      controller._setPlayingForTesting(false)
+
+      #expect(player.isPlaybackRequestedActive == false)
+      #expect(controller._pipPlaybackActiveForTesting() == false)
+
+      controller._setPlayingForTesting(true)
+
+      #expect(player.isPlaybackRequestedActive == true)
+      #expect(controller._pipPlaybackActiveForTesting() == true)
+    }
+
+    @Test
+    func `external playback controls update PiP playback state`() async {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing, isPausable: false)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: PlaybackRecorder().driver,
+        pauseDebounce: .milliseconds(250)
+      )
+
+      #expect(controller._pipPlaybackActiveForTesting() == true)
+
+      player.pause()
+      try? await Task.sleep(for: .milliseconds(30))
+
+      #expect(player.isPlaybackRequestedActive == false)
+      #expect(controller._pipPlaybackActiveForTesting() == false)
+
+      player.resume()
+      try? await Task.sleep(for: .milliseconds(30))
+
+      #expect(player.isPlaybackRequestedActive == true)
+      #expect(controller._pipPlaybackActiveForTesting() == true)
+    }
+
+    @Test
+    func `external pause intent does not freeze video timebase before native pause`() async {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing, isPausable: false)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: PlaybackRecorder().driver,
+        pauseDebounce: .milliseconds(250)
+      )
+
+      #expect(controller._controlTimebaseRateForTesting() == 1)
+
+      player.pause()
+      try? await Task.sleep(for: .milliseconds(30))
+
+      #expect(player.isPlaybackRequestedActive == false)
+      #expect(controller._pipPlaybackActiveForTesting() == false)
+      #expect(controller._controlTimebaseRateForTesting() == 1)
+    }
+
+    @Test
+    func `PiP pause intent does not freeze video timebase before native pause`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: PlaybackRecorder().driver,
+        pauseDebounce: .milliseconds(250)
+      )
+
+      #expect(controller._controlTimebaseRateForTesting() == 1)
+
+      controller._setPlayingForTesting(false)
+
+      #expect(controller._pipPlaybackActiveForTesting() == false)
+      #expect(controller._controlTimebaseRateForTesting() == 1)
+    }
+
+    @Test
+    func `pending PiP pause is not overwritten by stale playing observation`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: PlaybackRecorder().driver,
+        pauseDebounce: .milliseconds(250)
+      )
+
+      controller._setPlayingForTesting(false)
+      controller._handleObservedPlaybackActivityForTesting(true)
+
+      #expect(controller._pipPlaybackActiveForTesting() == false)
+      #expect(controller._pendingPiPPlaybackStateForTesting() == false)
+    }
+
+    @Test
+    func `pending PiP pause clears when native playback reaches paused`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: PlaybackRecorder().driver,
+        pauseDebounce: .milliseconds(250)
+      )
+
+      controller._setPlayingForTesting(false)
+      player._setStateForTesting(state: .paused)
+      controller._handleObservedPlaybackActivityForTesting(false)
+
+      #expect(controller._pipPlaybackActiveForTesting() == false)
+      #expect(controller._pendingPiPPlaybackStateForTesting() == nil)
+    }
+
+    @Test
+    func `pending PiP play is not overwritten by stale paused observation`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .paused)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: PlaybackRecorder().driver,
+        pauseDebounce: .milliseconds(250)
+      )
+
+      controller._setPlayingForTesting(true)
+      controller._handleObservedPlaybackActivityForTesting(false)
+
+      #expect(controller._pipPlaybackActiveForTesting() == true)
+      #expect(controller._pendingPiPPlaybackStateForTesting() == true)
     }
 
     // MARK: - handleSkip boundary conditions
@@ -303,9 +495,9 @@ extension Integration {
 
     // MARK: - Delegate size transition hook
 
-    /// The size-transition hook is a no-op per Apple's sample-buffer PiP
-    /// pattern (the layer auto-resizes). Cover it so the method isn't
-    /// dead code.
+    /// AVKit reports PiP window-size changes through the playback delegate.
+    /// The forwarding path must remain safe even when the platform does not
+    /// need macOS's target-sized buffer rendering path.
     @Test
     func `didTransitionToRenderSize does not crash`() {
       let player = Player(instance: TestInstance.shared)
@@ -322,6 +514,28 @@ extension Integration {
         pip,
         size: CMVideoDimensions(width: 320, height: 240)
       )
+    }
+
+    @Test
+    func `didTransitionToRenderSize updates renderer target size`() {
+      let player = Player(instance: TestInstance.shared)
+      let controller = PiPController(player: player)
+      guard AVPictureInPictureController.isPictureInPictureSupported() else { return }
+
+      let contentSource = AVPictureInPictureController.ContentSource(
+        sampleBufferDisplayLayer: controller.layer,
+        playbackDelegate: controller._playbackDelegateForTesting
+      )
+      let pip = AVPictureInPictureController(contentSource: contentSource)
+
+      controller._didTransitionToRenderSizeForTesting(
+        pip,
+        size: CMVideoDimensions(width: 512, height: 288)
+      )
+
+      let renderSize = controller._renderSizeForTesting()
+      #expect(renderSize?.width == 512)
+      #expect(renderSize?.height == 288)
     }
 
     // MARK: - AVPictureInPictureControllerDelegate

--- a/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
@@ -517,7 +517,7 @@ extension Integration {
     }
 
     @Test
-    func `didTransitionToRenderSize updates renderer target size`() {
+    func `didTransitionToRenderSize updates renderer target size only on sample resizing platforms`() {
       let player = Player(instance: TestInstance.shared)
       let controller = PiPController(player: player)
       guard AVPictureInPictureController.isPictureInPictureSupported() else { return }
@@ -534,8 +534,12 @@ extension Integration {
       )
 
       let renderSize = controller._renderSizeForTesting()
+      #if os(macOS)
       #expect(renderSize?.width == 512)
       #expect(renderSize?.height == 288)
+      #else
+      #expect(renderSize == nil)
+      #endif
     }
 
     // MARK: - AVPictureInPictureControllerDelegate

--- a/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
@@ -14,12 +14,24 @@ extension Integration {
     final class PlaybackRecorder {
       var pauseCount = 0
       var resumeCount = 0
+      var cancelPendingPauseCount = 0
+      var shouldResume = false
       var seekTargets: [Int64] = []
 
       var driver: PiPController.PlaybackDriver {
         .init(
-          pause: { self.pauseCount += 1 },
-          resume: { self.resumeCount += 1 },
+          pause: {
+            self.pauseCount += 1
+            return true
+          },
+          resume: {
+            self.resumeCount += 1
+            return true
+          },
+          cancelPendingPause: {
+            self.cancelPendingPauseCount += 1
+          },
+          shouldResume: { self.shouldResume },
           seek: { self.seekTargets.append($0.milliseconds) }
         )
       }
@@ -211,6 +223,7 @@ extension Integration {
 
       #expect(recorder.pauseCount == 0)
       #expect(recorder.resumeCount == 0)
+      #expect(recorder.cancelPendingPauseCount == 1)
     }
 
     @Test
@@ -237,6 +250,7 @@ extension Integration {
 
       #expect(recorder.pauseCount == 0)
       #expect(recorder.resumeCount == 0)
+      #expect(recorder.cancelPendingPauseCount == 1)
       #expect(recorder.seekTargets.count == 1)
     }
   }

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
@@ -125,6 +125,27 @@ extension Integration {
     }
 
     @Test
+    func `macOS dismantle detaches native PiP drawable and clears controller`() {
+      let player = Player(instance: TestInstance.shared)
+      let host = MacNativePiPHostView()
+      let view = PiPVideoView(player)
+      let coordinator = view.makeCoordinator()
+      let controller = PiPController(player: player, nativeBackend: host.nativePiPBackend)
+
+      host.attach(to: player)
+      coordinator.player = player
+      coordinator.pipController = controller
+
+      PiPVideoView.dismantleNSView(host, coordinator: coordinator)
+
+      #expect(player.drawable == nil)
+      #expect(coordinator.pipController == nil)
+
+      host.detach()
+      #expect(player.drawable == nil)
+    }
+
+    @Test
     func `macOS native PiP drawable does not expose VLC AVKit PiP callbacks`() {
       let view = MacNativePiPDrawableView()
 

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
@@ -45,12 +45,14 @@ extension Integration {
       let coordinator = view.makeCoordinator()
       // Fresh coordinator has no references.
       #expect(coordinator.pipController == nil)
+      #if canImport(UIKit)
       #expect(coordinator.displayLayer == nil)
+      #endif
       #expect(coordinator.player == nil)
     }
 
-    /// Dismantle on an empty coordinator is a safe no-op — no
-    /// controller to stop, no layer to remove.
+    /// Dismantle on an empty coordinator is a safe no-op: no
+    /// controller to stop and no drawable attachment to clear.
     @Test
     func `dismantle on empty coordinator is a no-op`() {
       let player = Player(instance: TestInstance.shared)
@@ -61,13 +63,13 @@ extension Integration {
       let container = UIView()
       PiPVideoView.dismantleUIView(container, coordinator: coordinator)
       #elseif canImport(AppKit)
-      let container = NSView()
+      let container = MacNativePiPHostView()
       PiPVideoView.dismantleNSView(container, coordinator: coordinator)
       #endif
     }
 
     /// Dismantle with a controller attached must stop it and clear
-    /// all coordinator references.
+    /// coordinator-owned controller state.
     @Test
     func `dismantle with attached controller clears state`() {
       let player = Player(instance: TestInstance.shared)
@@ -78,20 +80,144 @@ extension Integration {
       // controller to the coordinator.
       let controller = PiPController(player: player)
       coordinator.pipController = controller
+      #if canImport(UIKit)
       coordinator.displayLayer = controller.layer
+      #endif
       coordinator.player = player
 
       #if canImport(UIKit)
       let container = UIView()
       PiPVideoView.dismantleUIView(container, coordinator: coordinator)
       #elseif canImport(AppKit)
-      let container = NSView()
+      let container = MacNativePiPHostView()
       PiPVideoView.dismantleNSView(container, coordinator: coordinator)
       #endif
 
       #expect(coordinator.pipController == nil)
+      #if canImport(UIKit)
       #expect(coordinator.displayLayer == nil)
+      #endif
     }
+
+    #if canImport(AppKit)
+    @Test
+    func `macOS native PiP host attaches drawable child`() {
+      let player = Player(instance: TestInstance.shared)
+      let host = MacNativePiPHostView()
+
+      host.attach(to: player)
+      #expect(player.drawable === host.drawableView)
+
+      host.detach()
+      #expect(player.drawable == nil)
+    }
+
+    @Test
+    func `macOS native PiP drawable attaches and detaches player drawable`() {
+      let player = Player(instance: TestInstance.shared)
+      let view = MacNativePiPDrawableView()
+
+      view.attach(to: player)
+      #expect(player.drawable === view)
+
+      view.detach()
+      #expect(player.drawable == nil)
+    }
+
+    @Test
+    func `macOS native PiP drawable does not expose VLC AVKit PiP callbacks`() {
+      let view = MacNativePiPDrawableView()
+
+      #expect(view.responds(to: NSSelectorFromString("pictureInPictureReady")) == false)
+      #expect(view.responds(to: NSSelectorFromString("mediaController")) == false)
+      #expect(view.responds(to: NSSelectorFromString("canStartPictureInPictureAutomaticallyFromInline")) == false)
+    }
+
+    @Test
+    func `macOS native PiP drawable exposes VLC embedding callbacks`() {
+      let view = MacNativePiPDrawableView()
+
+      #expect(view.responds(to: NSSelectorFromString("addVoutSubview:")))
+      #expect(view.responds(to: NSSelectorFromString("removeVoutSubview:")))
+    }
+
+    @Test
+    func `macOS native PiP drawable sizes VLC content to its bounds`() {
+      let view = MacNativePiPDrawableView()
+      view.frame = CGRect(x: 0, y: 0, width: 640, height: 360)
+      let vlcSubview = NSView()
+      view.addSubview(vlcSubview)
+      view.layoutSubtreeIfNeeded()
+
+      #expect(vlcSubview.frame.size == CGSize(width: 640, height: 360))
+      #expect(vlcSubview.autoresizingMask == [.width, .height])
+
+      view.frame = CGRect(x: 0, y: 0, width: 480, height: 270)
+      view.layoutSubtreeIfNeeded()
+
+      #expect(vlcSubview.frame.size == CGSize(width: 480, height: 270))
+      #expect(vlcSubview.autoresizingMask == [.width, .height])
+    }
+
+    @Test
+    func `macOS native PiP restore repeats full-size VLC content layout`() async {
+      let host = MacNativePiPHostView(frame: CGRect(x: 0, y: 0, width: 960, height: 540))
+      let drawable = host.drawableView
+      let vlcSubview = PiPReshapeProbeView()
+
+      drawable.addVoutSubview(vlcSubview)
+      host.layoutSubtreeIfNeeded()
+
+      func restoreFromPiPSize() {
+        drawable.removeFromSuperview()
+        drawable.frame = CGRect(x: 0, y: 0, width: 426, height: 240)
+        vlcSubview.frame = drawable.bounds
+
+        host.restoreDrawableView(drawable)
+      }
+
+      restoreFromPiPSize()
+      restoreFromPiPSize()
+
+      #expect(drawable.superview === host)
+      #expect(drawable.frame.size == host.bounds.size)
+      #expect(vlcSubview.frame.size == host.bounds.size)
+      #expect(vlcSubview.reshapeCount >= 2)
+
+      await Task.yield()
+
+      #expect(drawable.superview === host)
+      #expect(drawable.frame.size == host.bounds.size)
+      #expect(vlcSubview.frame.size == host.bounds.size)
+      #expect(vlcSubview.reshapeCount >= 3)
+    }
+
+    @Test
+    func `macOS native PiP rejects instances without video output`() throws {
+      let instance = try VLCInstance(arguments: ["--no-video-title-show", "--no-video", "--no-audio", "--quiet"])
+      let player = Player(instance: instance)
+      let backend = MacNativePiPBackend()
+
+      backend.attach(to: player)
+
+      #expect(backend.isPossible == false)
+    }
+
+    @Test
+    func `macOS native PiP media controller reports playback intent`() {
+      let player = Player(instance: TestInstance.shared)
+      let mediaController = MacNativePiPMediaController()
+      mediaController.player = player
+
+      #expect(mediaController.isMediaPlaying() == false)
+
+      player.setPlaybackIntentFromExternalControl(true)
+      #expect(mediaController.isMediaPlaying() == true)
+
+      player.setPlaybackIntentFromExternalControl(false)
+      #expect(mediaController.isMediaPlaying() == false)
+    }
+    #endif
   }
 }
 
@@ -103,4 +229,16 @@ private final class Box<T> {
     value = initial
   }
 }
+
+#if canImport(AppKit)
+@MainActor
+private final class PiPReshapeProbeView: NSView {
+  var reshapeCount = 0
+
+  @objc(reshape)
+  func reshapeForTesting() {
+    reshapeCount += 1
+  }
+}
+#endif
 #endif

--- a/Tests/SwiftVLCTests/PiP/PixelBufferRendererCallbackTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferRendererCallbackTests.swift
@@ -3,6 +3,7 @@
 import AVFoundation
 import CoreMedia
 import CoreVideo
+import CustomDump
 import Synchronization
 import Testing
 
@@ -25,12 +26,83 @@ extension Integration {
       var lines: UInt32 = 0
     }
 
+    private func makeRetainedContext(
+      renderer: PixelBufferRenderer
+    ) -> Unmanaged<PixelBufferRendererCallbackContext> {
+      Unmanaged.passRetained(PixelBufferRendererCallbackContext(renderer: renderer))
+    }
+
+    private func makeBGRAImageBuffer(
+      width: Int,
+      height: Int,
+      alpha: UInt8 = .max
+    )
+      throws -> CVPixelBuffer {
+      var pixelBuffer: CVPixelBuffer?
+      let attrs: [String: Any] = [
+        kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+        kCVPixelBufferWidthKey as String: width,
+        kCVPixelBufferHeightKey as String: height,
+        kCVPixelBufferIOSurfacePropertiesKey as String: [:] as [String: Any]
+      ]
+      let status = CVPixelBufferCreate(
+        kCFAllocatorDefault,
+        width,
+        height,
+        kCVPixelFormatType_32BGRA,
+        attrs as CFDictionary,
+        &pixelBuffer
+      )
+      #expect(status == kCVReturnSuccess)
+      let buffer = try #require(pixelBuffer)
+
+      #expect(CVPixelBufferLockBaseAddress(buffer, []) == kCVReturnSuccess)
+      defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+      let base = try #require(CVPixelBufferGetBaseAddress(buffer))
+        .assumingMemoryBound(to: UInt8.self)
+      let bytesPerRow = CVPixelBufferGetBytesPerRow(buffer)
+      for row in 0..<height {
+        var pixel = base.advanced(by: row * bytesPerRow)
+        for column in 0..<width {
+          pixel[0] = UInt8((column * 47) & 0xFF)
+          pixel[1] = UInt8((row * 83) & 0xFF)
+          pixel[2] = 0xCC
+          pixel[3] = alpha
+          pixel = pixel.advanced(by: 4)
+        }
+      }
+
+      return buffer
+    }
+
+    private func alphaBytes(in buffer: CVPixelBuffer) throws -> [UInt8] {
+      #expect(CVPixelBufferLockBaseAddress(buffer, .readOnly) == kCVReturnSuccess)
+      defer { CVPixelBufferUnlockBaseAddress(buffer, .readOnly) }
+
+      let width = CVPixelBufferGetWidth(buffer)
+      let height = CVPixelBufferGetHeight(buffer)
+      let bytesPerRow = CVPixelBufferGetBytesPerRow(buffer)
+      let base = try #require(CVPixelBufferGetBaseAddress(buffer))
+        .assumingMemoryBound(to: UInt8.self)
+
+      var result: [UInt8] = []
+      result.reserveCapacity(width * height)
+      for row in 0..<height {
+        var alpha = base.advanced(by: row * bytesPerRow + 3)
+        for _ in 0..<width {
+          result.append(alpha.pointee)
+          alpha = alpha.advanced(by: 4)
+        }
+      }
+      return result
+    }
+
     // MARK: - Format callback
 
     @Test
     func `Format callback creates pool and updates state`() {
       let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
-      let retained = Unmanaged.passRetained(renderer)
+      let retained = makeRetainedContext(renderer: renderer)
       defer { retained.release() }
 
       var opaqueSlot: UnsafeMutableRawPointer? = retained.toOpaque()
@@ -57,7 +129,7 @@ extension Integration {
         }
       }
 
-      #expect(result == 1) // single BGRA plane
+      #expect(result == 3)
 
       // Chroma should be forced to BGRA.
       let chromaString = String(
@@ -117,7 +189,7 @@ extension Integration {
     @Test
     func `Lock callback returns nil before pool is initialized`() {
       let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
-      let retained = Unmanaged.passRetained(renderer)
+      let retained = makeRetainedContext(renderer: renderer)
       defer { retained.release() }
 
       var plane: UnsafeMutableRawPointer?
@@ -140,7 +212,7 @@ extension Integration {
     @Test
     func `Lock then unlock round trip after format`() {
       let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
-      let retained = Unmanaged.passRetained(renderer)
+      let retained = makeRetainedContext(renderer: renderer)
       defer { retained.release() }
 
       // Prime the pool via format callback.
@@ -200,6 +272,146 @@ extension Integration {
       pixelBufferCleanupCallback(opaque: nil)
     }
 
+    @Test
+    func `Retiring callback context without opened vout releases opaque retain`() {
+      weak var weakContext: PixelBufferRendererCallbackContext?
+      weak var weakRenderer: PixelBufferRenderer?
+
+      do {
+        var renderer: PixelBufferRenderer? = PixelBufferRenderer(
+          displayLayer: AVSampleBufferDisplayLayer()
+        )
+        let context = try! PixelBufferRendererCallbackContext(renderer: #require(renderer))
+        weakContext = context
+        weakRenderer = renderer
+        let retained = Unmanaged.passRetained(context)
+        renderer = nil
+
+        context.requestRetirement(
+          opaque: retained.toOpaque(),
+          deferIfVoutMayBeOpening: false
+        )
+      }
+
+      #expect(weakContext == nil)
+      #expect(weakRenderer == nil)
+    }
+
+    @Test
+    func `Retirement keeps renderer alive for a callback already in flight`() throws {
+      weak var weakContext: PixelBufferRendererCallbackContext?
+      weak var weakRenderer: PixelBufferRenderer?
+
+      do {
+        var renderer: PixelBufferRenderer? = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+        let context = try PixelBufferRendererCallbackContext(renderer: #require(renderer))
+        weakContext = context
+        weakRenderer = renderer
+        renderer = nil
+        let retained = Unmanaged.passRetained(context)
+
+        let result = context.withRenderer(opaque: retained.toOpaque()) { callbackRenderer in
+          context.requestRetirement(
+            opaque: retained.toOpaque(),
+            deferIfVoutMayBeOpening: false
+          )
+          #expect(weakRenderer != nil)
+          _ = callbackRenderer
+          return true
+        }
+
+        #expect(result == true)
+      }
+
+      #expect(weakContext == nil)
+      #expect(weakRenderer == nil)
+    }
+
+    @Test
+    func `Retired callback context balances no-op callback entry`() throws {
+      weak var weakContext: PixelBufferRendererCallbackContext?
+      weak var weakRenderer: PixelBufferRenderer?
+
+      do {
+        var renderer: PixelBufferRenderer? = PixelBufferRenderer(
+          displayLayer: AVSampleBufferDisplayLayer()
+        )
+        let context = PixelBufferRendererCallbackContext(renderer: try #require(renderer))
+        weakContext = context
+        weakRenderer = renderer
+        let retained = Unmanaged.passRetained(context)
+        renderer = nil
+
+        context.requestRetirement(
+          opaque: retained.toOpaque(),
+          deferIfVoutMayBeOpening: true
+        )
+
+        #expect(weakContext != nil)
+        #expect(weakRenderer == nil)
+        let result = context.withRenderer(opaque: retained.toOpaque()) { _ in true }
+        #expect(result == nil)
+        #expect(context.releaseRetiredOpaqueRetainIfNoOpenVout(opaque: retained.toOpaque()))
+      }
+
+      #expect(weakContext == nil)
+      #expect(weakRenderer == nil)
+    }
+
+    @Test
+    func `Retired callback context keeps opaque alive until vout cleanup`() {
+      weak var weakContext: PixelBufferRendererCallbackContext?
+      weak var weakRenderer: PixelBufferRenderer?
+      var contextOpaque: UnsafeMutableRawPointer?
+
+      do {
+        let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+        let context = PixelBufferRendererCallbackContext(renderer: renderer)
+        weakContext = context
+        weakRenderer = renderer
+        let retained = Unmanaged.passRetained(context)
+        contextOpaque = retained.toOpaque()
+
+        var opaqueSlot: UnsafeMutableRawPointer? = contextOpaque
+        var buffers = FormatBuffers()
+        let result = withUnsafeMutablePointer(to: &opaqueSlot) { opaquePtr in
+          buffers.chroma.withUnsafeMutableBufferPointer { chromaBuf in
+            withUnsafeMutablePointer(to: &buffers.width) { widthPtr in
+              withUnsafeMutablePointer(to: &buffers.height) { heightPtr in
+                withUnsafeMutablePointer(to: &buffers.pitches) { pitchPtr in
+                  withUnsafeMutablePointer(to: &buffers.lines) { linesPtr in
+                    pixelBufferFormatCallback(
+                      opaque: opaquePtr,
+                      chroma: chromaBuf.baseAddress,
+                      width: widthPtr,
+                      height: heightPtr,
+                      pitches: pitchPtr,
+                      lines: linesPtr
+                    )
+                  }
+                }
+              }
+            }
+          }
+        }
+        #expect(result == 3)
+        #expect(context.hasOpenVoutForTesting)
+
+        context.requestRetirement(
+          opaque: retained.toOpaque(),
+          deferIfVoutMayBeOpening: false
+        )
+      }
+
+      #expect(weakContext != nil)
+      #expect(weakRenderer == nil)
+
+      pixelBufferCleanupCallback(opaque: contextOpaque)
+
+      #expect(weakContext == nil)
+      #expect(weakRenderer == nil)
+    }
+
     // MARK: - Display callback
 
     /// Synthesize a BGRA `CVPixelBuffer`, hand it to the display callback,
@@ -209,32 +421,16 @@ extension Integration {
     /// Runs on `@MainActor` because `AVSampleBufferDisplayLayer` is not
     /// `Sendable` — the layer and the renderer must be allocated on the
     /// same actor. The callback itself is invoked synchronously; the
-    /// `DispatchQueue.main.async` enqueue inside is awaited via a
-    /// `Task.sleep` afterwards.
+    /// renderer's async enqueue is awaited via a short `Task.sleep`.
     @MainActor
     @Test
-    func `Display callback enqueues a sample onto the display layer`() async {
+    func `Display callback enqueues a sample onto the display layer`() async throws {
       let displayLayer = AVSampleBufferDisplayLayer()
       let renderer = PixelBufferRenderer(displayLayer: displayLayer)
-      let retained = Unmanaged.passRetained(renderer)
+      let retained = makeRetainedContext(renderer: renderer)
       defer { retained.release() }
 
-      // Build a 2x2 BGRA pixel buffer.
-      var pixelBuffer: CVPixelBuffer?
-      let attrs: [String: Any] = [
-        kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
-        kCVPixelBufferWidthKey as String: 2,
-        kCVPixelBufferHeightKey as String: 2,
-        kCVPixelBufferIOSurfacePropertiesKey as String: [:] as [String: Any]
-      ]
-      let status = CVPixelBufferCreate(
-        kCFAllocatorDefault, 2, 2,
-        kCVPixelFormatType_32BGRA,
-        attrs as CFDictionary,
-        &pixelBuffer
-      )
-      #expect(status == kCVReturnSuccess)
-      guard let pb = pixelBuffer else { return }
+      let pb = try makeBGRAImageBuffer(width: 2, height: 2)
 
       // The display callback expects a retained `AnyObject` pointer —
       // matches the `passRetained(pb as AnyObject)` on the lock path.
@@ -242,8 +438,25 @@ extension Integration {
 
       pixelBufferDisplayCallback(opaque: retained.toOpaque(), picture: pictureHandle)
 
-      // Give the main-queue async enqueue a moment to settle.
+      // Give the renderer's async enqueue queue a moment to settle.
       try? await Task.sleep(for: .milliseconds(20))
+    }
+
+    @MainActor
+    @Test
+    func `Display callback does not mutate source frame bytes`() throws {
+      let displayLayer = AVSampleBufferDisplayLayer()
+      let renderer = PixelBufferRenderer(displayLayer: displayLayer)
+      let retained = makeRetainedContext(renderer: renderer)
+      defer { retained.release() }
+
+      let pb = try makeBGRAImageBuffer(width: 3, height: 2, alpha: 37)
+      let expectedAlphaBytes = try alphaBytes(in: pb)
+
+      let pictureHandle = Unmanaged.passRetained(pb as AnyObject).toOpaque()
+      pixelBufferDisplayCallback(opaque: retained.toOpaque(), picture: pictureHandle)
+
+      try expectNoDifference(alphaBytes(in: pb), expectedAlphaBytes)
     }
 
     /// A nil `opaque` guards-out early.
@@ -258,7 +471,7 @@ extension Integration {
     @Test
     func `Display callback with nil picture is a no-op`() {
       let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
-      let retained = Unmanaged.passRetained(renderer)
+      let retained = makeRetainedContext(renderer: renderer)
       defer { retained.release() }
 
       pixelBufferDisplayCallback(opaque: retained.toOpaque(), picture: nil)

--- a/Tests/SwiftVLCTests/PiP/PixelBufferRendererTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferRendererTests.swift
@@ -2,6 +2,7 @@
 @testable import SwiftVLC
 import AVFoundation
 import CoreMedia
+import CoreVideo
 import Synchronization
 import Testing
 
@@ -135,11 +136,9 @@ extension Integration {
         timebaseOut: &timebase
       )
       renderer.setTimebase(timebase)
-      // Verify it was set
       let before = renderer.state.withLock { $0.timebase }
       #expect(before != nil)
 
-      // Clear it
       renderer.setTimebase(nil)
       let after = renderer.state.withLock { $0.timebase }
       #expect(after == nil)
@@ -159,7 +158,6 @@ extension Integration {
       renderer.setDisplayLayer(nil)
       renderer.setDisplayLayer(AVSampleBufferDisplayLayer())
       renderer.setDisplayLayer(nil)
-      // If we reach here without crashing, the test passes
       let current = renderer.state.withLock { $0.displayLayer.layer }
       #expect(current == nil)
     }
@@ -180,9 +178,50 @@ extension Integration {
       }
       renderer.setTimebase(nil)
       renderer.setTimebase(nil)
-      // If we reach here without crashing, the test passes
       let current = renderer.state.withLock { $0.timebase }
       #expect(current == nil)
+    }
+
+    @Test
+    func `outputPixelBuffer scales to active render size`() throws {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      renderer.setRenderSize(CMVideoDimensions(width: 320, height: 180))
+
+      let sourceBuffer = try makeBGRAImageBuffer(width: 1280, height: 720)
+      let output = try #require(renderer.outputPixelBuffer(from: sourceBuffer)?.buffer)
+
+      #expect(CVPixelBufferGetWidth(output) == 320)
+      #expect(CVPixelBufferGetHeight(output) == 180)
+    }
+
+    @Test
+    func `clearing render size returns original pixel buffer`() throws {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+
+      renderer.setRenderSize(CMVideoDimensions(width: 8, height: 8))
+      renderer.setRenderSize(nil)
+
+      let sourceBuffer = try makeBGRAImageBuffer(width: 16, height: 16)
+      let output = try #require(renderer.outputPixelBuffer(from: sourceBuffer)?.buffer)
+      #expect(output === sourceBuffer)
+    }
+
+    @Test
+    func `render size changes invalidate pending frames`() throws {
+      let layer = AVSampleBufferDisplayLayer()
+      let renderer = PixelBufferRenderer(displayLayer: layer)
+
+      let sourceBuffer = try makeBGRAImageBuffer(width: 16, height: 16)
+
+      renderer.setRenderSize(CMVideoDimensions(width: 8, height: 8))
+      let firstFrame = try #require(renderer.outputPixelBuffer(from: sourceBuffer))
+      #expect(renderer.canEnqueueFrame(generation: firstFrame.generation, on: layer))
+
+      renderer.setRenderSize(CMVideoDimensions(width: 10, height: 10))
+
+      #expect(!renderer.canEnqueueFrame(generation: firstFrame.generation, on: layer))
+      let secondFrame = try #require(renderer.outputPixelBuffer(from: sourceBuffer))
+      #expect(renderer.canEnqueueFrame(generation: secondFrame.generation, on: layer))
     }
 
     @Test
@@ -199,5 +238,25 @@ extension Integration {
       #expect(stored === layer)
     }
   }
+}
+
+private func makeBGRAImageBuffer(width: Int, height: Int) throws -> CVPixelBuffer {
+  var buffer: CVPixelBuffer?
+  let attrs: [String: Any] = [
+    kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+    kCVPixelBufferWidthKey as String: width,
+    kCVPixelBufferHeightKey as String: height,
+    kCVPixelBufferIOSurfacePropertiesKey as String: [:] as [String: Any]
+  ]
+  let status = CVPixelBufferCreate(
+    kCFAllocatorDefault,
+    width,
+    height,
+    kCVPixelFormatType_32BGRA,
+    attrs as CFDictionary,
+    &buffer
+  )
+  #expect(status == kCVReturnSuccess)
+  return try #require(buffer)
 }
 #endif

--- a/Tests/SwiftVLCTests/Player/ObservationTests.swift
+++ b/Tests/SwiftVLCTests/Player/ObservationTests.swift
@@ -102,7 +102,7 @@ extension Integration {
     }
 
     @Test
-    func `state events invalidate isPlaying and isActive`() {
+    func `state events reconcile playback intent and invalidate active observations`() {
       let player = Player(instance: TestInstance.makeAudioOnly())
       let isPlayingFired = Mutex(false)
       let isActiveFired = Mutex(false)
@@ -122,6 +122,23 @@ extension Integration {
       player._handleEventForTesting(.stateChanged(.playing))
       #expect(isPlayingFired.withLock { $0 })
       #expect(isActiveFired.withLock { $0 })
+    }
+
+    @Test
+    func `playback intent invalidates isPlaying`() {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let fired = Mutex(false)
+
+      withObservationTracking {
+        _ = player.isPlaying
+      } onChange: {
+        fired.withLock { $0 = true }
+      }
+
+      player.setPlaybackIntentFromExternalControl(true)
+
+      #expect(player.isPlaying == true)
+      #expect(fired.withLock { $0 })
     }
 
     @Test

--- a/Tests/SwiftVLCTests/Player/PlayerBranchCoverageTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerBranchCoverageTests.swift
@@ -22,6 +22,54 @@ extension Integration {
     }
 
     @Test
+    func `togglePlayPause follows pending playback intent while native state catches up`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing, isPausable: false)
+
+      player.togglePlayPause()
+
+      #expect(player.isPlaybackRequestedActive == false)
+      #expect(player._hasDeferredPauseForTesting())
+
+      player.togglePlayPause()
+
+      #expect(player.isPlaybackRequestedActive == true)
+      #expect(!player._hasDeferredPauseForTesting())
+    }
+
+    @Test
+    func `togglePlayPause can cancel a pending resume while native state is still paused`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .paused, isPlaybackRequestedActive: true)
+
+      player.togglePlayPause()
+
+      #expect(player.isPlaybackRequestedActive == false)
+    }
+
+    @Test
+    func `togglePlayPause from early playing queues pause until VLC is pausable`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing, isPausable: false)
+
+      player.togglePlayPause()
+
+      #expect(player._hasDeferredPauseForTesting())
+    }
+
+    @Test
+    func `resume cancels queued early pause`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing, isPausable: false)
+
+      player.pause()
+      player.resume()
+
+      #expect(player.isPlaybackRequestedActive)
+      #expect(!player._hasDeferredPauseForTesting())
+    }
+
+    @Test
     func `togglePlayPause from paused calls resume`() {
       let player = Player(instance: TestInstance.shared)
       player._setStateForTesting(state: .paused)
@@ -41,17 +89,39 @@ extension Integration {
       player.togglePlayPause()
     }
 
-    /// Transient states must not issue any libVLC command — a pause
-    /// toggle during `.opening`/`.buffering` can corrupt libVLC's
-    /// `timing.pause_date` and trip an assertion in `dec.c`.
+    /// Active transient states must not issue an immediate libVLC
+    /// pause-toggle, but they should remember the user's pause intent
+    /// and apply it once playback reaches a stable pausable state.
     @Test
-    func `togglePlayPause from transient states is a no-op`() {
-      let player = Player(instance: TestInstance.shared)
-      for state in [PlayerState.opening, .buffering, .stopping, .error] {
+    func `togglePlayPause from active transient states queues pause`() {
+      for state in [PlayerState.opening, .buffering] {
+        let player = Player(instance: TestInstance.shared)
+        player._setStateForTesting(state: state)
+        player.togglePlayPause()
+        #expect(player._hasDeferredPauseForTesting(), "togglePlayPause on .\(state) must queue pause")
+      }
+    }
+
+    @Test
+    func `togglePlayPause from inactive transient states is a no-op`() {
+      for state in [PlayerState.stopping, .error] {
+        let player = Player(instance: TestInstance.shared)
         player._setStateForTesting(state: state)
         player.togglePlayPause()
         #expect(player.state == state, "togglePlayPause on .\(state) must not mutate state")
+        #expect(!player._hasDeferredPauseForTesting(), "togglePlayPause on .\(state) must not queue pause")
       }
+    }
+
+    @Test
+    func `encountered error clears playback intent`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing)
+
+      player._handleEventForTesting(.encounteredError)
+
+      #expect(player.state == .error)
+      #expect(player.isPlaybackRequestedActive == false)
     }
 
     // MARK: - seek(by:) clamp

--- a/Tests/SwiftVLCTests/Player/PlayerBranchCoverageTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerBranchCoverageTests.swift
@@ -38,6 +38,23 @@ extension Integration {
     }
 
     @Test
+    func `isPlaying follows playback intent while native state catches up`() {
+      let player = Player(instance: TestInstance.shared)
+
+      player._setStateForTesting(state: .opening, isPlaybackRequestedActive: true)
+      #expect(player.state == .opening)
+      #expect(player.isPlaying)
+
+      player._setStateForTesting(state: .paused, isPlaybackRequestedActive: true)
+      #expect(player.state == .paused)
+      #expect(player.isPlaying)
+
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: false)
+      #expect(player.state == .playing)
+      #expect(player.isPlaying == false)
+    }
+
+    @Test
     func `togglePlayPause can cancel a pending resume while native state is still paused`() {
       let player = Player(instance: TestInstance.shared)
       player._setStateForTesting(state: .paused, isPlaybackRequestedActive: true)

--- a/Tests/SwiftVLCTests/Player/PlayerDeepCoverageTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerDeepCoverageTests.swift
@@ -27,7 +27,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Track selection and external subtitle during playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       try #require(await poll(until: { !player.audioTracks.isEmpty }), "Waiting for: !player.audioTracks.isEmpty")
@@ -61,7 +61,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Aspect ratio seek rate volume during playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       // Aspect ratio all cases
@@ -104,7 +104,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Statistics recording snapshot equalizer during playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       try await Task.sleep(for: .milliseconds(300))
@@ -133,7 +133,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Pause resume delay role scale nextFrame during playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       // Pause/resume
@@ -169,7 +169,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Titles chapters programs ABloop mediaSwitch during playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       // Titles & chapters
@@ -200,7 +200,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Load play seekable duration time stop reset`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       let media = try Media(url: TestMedia.twosecURL)
       player.load(media)
       #expect(player.currentMedia != nil)
@@ -232,7 +232,7 @@ extension Integration {
 
       // Deinit during playback (nested scope)
       do {
-        let p2 = Player(instance: TestInstance.shared)
+        let p2 = Player(instance: TestInstance.makePlayback())
         try p2.play(Media(url: TestMedia.twosecURL))
         _ = try await poll(until: { p2.state == .playing })
       }
@@ -243,7 +243,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Buffering state observed during opening`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       var sawBuffering = false
       for _ in 0..<40 {

--- a/Tests/SwiftVLCTests/Player/PlayerEventHandlerTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerEventHandlerTests.swift
@@ -56,6 +56,7 @@ extension Integration {
       player._handleEventForTesting(.bufferingProgress(0.1))
 
       #expect(player.state == .buffering)
+      #expect(player.isPlaying)
       #expect(player.bufferFill == 0.1)
     }
 

--- a/Tests/SwiftVLCTests/Player/PlayerExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerExtendedTests.swift
@@ -187,7 +187,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `isPlaying true during playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       // State was .playing at poll time; exercise the properties
@@ -198,7 +198,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `isPlaying false after stop`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       player.stop()
@@ -208,7 +208,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `isActive false after stop`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       player.stop()
@@ -357,7 +357,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Toggle play pause during playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       player.togglePlayPause()
@@ -470,8 +470,8 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Multiple players simultaneous playback`() async throws {
-      let player1 = Player(instance: TestInstance.shared)
-      let player2 = Player(instance: TestInstance.shared)
+      let player1 = Player(instance: TestInstance.makePlayback())
+      let player2 = Player(instance: TestInstance.makePlayback())
 
       try player1.play(Media(url: TestMedia.twosecURL))
       try player2.play(Media(url: TestMedia.silenceURL))

--- a/Tests/SwiftVLCTests/Player/PlayerFinalCoverageTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerFinalCoverageTests.swift
@@ -48,7 +48,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `All observable properties and mutations during playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       try #require(await poll(until: { player.duration != nil }), "Waiting for: player.duration != nil")
@@ -94,7 +94,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Track selection and audio devices during playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       try #require(await poll(until: { !player.audioTracks.isEmpty }), "Waiting for: !player.audioTracks.isEmpty")
@@ -133,7 +133,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Pause resume isActive and event consumer during playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
 
       // Event consumer (line 814) - state changes prove it's running
@@ -164,7 +164,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `AB loop titles chapters programs and snapshot during playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       // Titles (lines 452-460)
@@ -210,7 +210,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `isActive during opening state`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       // Rapidly poll for opening/buffering
       for _ in 0..<100 {

--- a/Tests/SwiftVLCTests/Player/PlayerSubtitleTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerSubtitleTests.swift
@@ -1,0 +1,42 @@
+@testable import SwiftVLC
+import Foundation
+import Testing
+
+extension Integration {
+  @Suite(.tags(.mainActor))
+  @MainActor struct PlayerSubtitleTests {
+    @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
+    func `external subtitle selection remains selected after aspect ratio changes`() async throws {
+      let player = Player(instance: TestInstance.makePlayback())
+      try player.play(Media(url: TestMedia.twosecURL))
+      try #require(
+        await poll(timeout: .seconds(10), until: { player.state == .playing }),
+        "Waiting for playback"
+      )
+      try player.addExternalTrack(from: TestMedia.subtitleURL, type: .subtitle, select: true)
+      try #require(
+        await poll(timeout: .seconds(10), until: { !player.subtitleTracks.isEmpty }),
+        "Waiting for subtitle tracks"
+      )
+
+      let subtitle = try #require(player.subtitleTracks.first)
+      player.selectedSubtitleTrack = subtitle
+
+      try #require(
+        await poll(timeout: .seconds(10), until: { player.selectedSubtitleTrack?.id == subtitle.id }),
+        "Waiting for selected subtitle track"
+      )
+
+      for ratio: AspectRatio in [.ratio(4, 3), .fill, .ratio(16, 9), .default] {
+        player.aspectRatio = ratio
+        try await Task.sleep(for: .milliseconds(100))
+        try #require(
+          player.selectedSubtitleTrack?.id == subtitle.id,
+          "Subtitle selection should survive aspect ratio change to \(ratio)"
+        )
+      }
+
+      player.stop()
+    }
+  }
+}

--- a/Tests/SwiftVLCTests/Player/PlayerTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerTests.swift
@@ -244,8 +244,14 @@ extension Integration {
     }
 
     @Test
-    func `isPlaying reflects state`() {
+    func `isPlaying reflects playback intent`() {
       let player = Player(instance: TestInstance.shared)
+      #expect(player.isPlaying == false)
+
+      player.setPlaybackIntentFromExternalControl(true)
+      #expect(player.isPlaying == true)
+
+      player.setPlaybackIntentFromExternalControl(false)
       #expect(player.isPlaying == false)
     }
 

--- a/Tests/SwiftVLCTests/Player/PlayerTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerTests.swift
@@ -114,7 +114,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Play starts playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.testMP4URL))
       try #require(await poll(until: { player.state != .idle }), "Waiting for: player.state != .idle")
       #expect(player.state != .idle)
@@ -123,7 +123,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Pause pauses playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       player.pause()
@@ -134,7 +134,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Resume after pause`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       player.pause()
@@ -147,7 +147,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Stop stops playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.testMP4URL))
       try #require(await poll(until: { player.state != .idle }), "Waiting for: player.state != .idle")
       player.stop()
@@ -157,7 +157,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Seek to time`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       player.seek(to: .seconds(1))
@@ -167,7 +167,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Seek by offset`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       player.seek(by: .milliseconds(500))
@@ -305,7 +305,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Play URL convenience`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(url: TestMedia.testMP4URL)
       try #require(await poll(until: { player.state != .idle }), "Waiting for: player.state != .idle")
       #expect(player.state != .idle)
@@ -340,7 +340,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Stop resets position`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       player.stop()
@@ -487,7 +487,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Add external subtitle track`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       do {
@@ -574,7 +574,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Tracks refresh during playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       _ = player.audioTracks
@@ -585,7 +585,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Duration available during playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
 
       // libVLC's `MediaPlayerLengthChanged` event is not guaranteed to fire
@@ -640,7 +640,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Duration set via event during playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.duration != nil }), "Waiting for: player.duration != nil")
       if let dur = player.duration {
@@ -651,7 +651,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Position updates during playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       _ = player.position
@@ -660,7 +660,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Seekable and pausable update during playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       _ = player.isSeekable
@@ -670,7 +670,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `isActive true during playback`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       if player.state == .playing || player.state == .opening {
@@ -681,7 +681,7 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Stop sets state to stopped`() async throws {
-      let player = Player(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.makePlayback())
       try player.play(Media(url: TestMedia.twosecURL))
       try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
       player.stop()

--- a/Tests/SwiftVLCTests/Playlist/MediaListPlayerTests.swift
+++ b/Tests/SwiftVLCTests/Playlist/MediaListPlayerTests.swift
@@ -109,8 +109,9 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Play at valid index`() async throws {
-      let listPlayer = MediaListPlayer(instance: TestInstance.shared)
-      let player = Player(instance: TestInstance.shared)
+      let instance = TestInstance.makePlayback()
+      let listPlayer = MediaListPlayer(instance: instance)
+      let player = Player(instance: instance)
       listPlayer.mediaPlayer = player
       let list = MediaList()
       try list.append(Media(url: TestMedia.testMP4URL))
@@ -153,8 +154,9 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Play and stop lifecycle`() async throws {
-      let listPlayer = MediaListPlayer(instance: TestInstance.shared)
-      let player = Player(instance: TestInstance.shared)
+      let instance = TestInstance.makePlayback()
+      let listPlayer = MediaListPlayer(instance: instance)
+      let player = Player(instance: instance)
       listPlayer.mediaPlayer = player
       let list = MediaList()
       try list.append(Media(url: TestMedia.twosecURL))
@@ -167,8 +169,9 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Pause and resume lifecycle`() async throws {
-      let listPlayer = MediaListPlayer(instance: TestInstance.shared)
-      let player = Player(instance: TestInstance.shared)
+      let instance = TestInstance.makePlayback()
+      let listPlayer = MediaListPlayer(instance: instance)
+      let player = Player(instance: instance)
       listPlayer.mediaPlayer = player
       let list = MediaList()
       try list.append(Media(url: TestMedia.twosecURL))
@@ -184,8 +187,9 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `State during playback`() async throws {
-      let listPlayer = MediaListPlayer(instance: TestInstance.shared)
-      let player = Player(instance: TestInstance.shared)
+      let instance = TestInstance.makePlayback()
+      let listPlayer = MediaListPlayer(instance: instance)
+      let player = Player(instance: instance)
       listPlayer.mediaPlayer = player
       let list = MediaList()
       try list.append(Media(url: TestMedia.twosecURL))
@@ -226,8 +230,9 @@ extension Integration {
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Clearing media list removes stale native playback state`() async throws {
-      let listPlayer = MediaListPlayer(instance: TestInstance.shared)
-      let player = Player(instance: TestInstance.shared)
+      let instance = TestInstance.makePlayback()
+      let listPlayer = MediaListPlayer(instance: instance)
+      let player = Player(instance: instance)
       listPlayer.mediaPlayer = player
 
       let list = MediaList()

--- a/Tests/SwiftVLCTests/Video/VideoSurfaceTests.swift
+++ b/Tests/SwiftVLCTests/Video/VideoSurfaceTests.swift
@@ -106,6 +106,33 @@ extension Integration {
       #endif
     }
 
+    @Test
+    func `AppKit surface pins and reshapes VLC subviews to local bounds`() {
+      #if canImport(AppKit)
+      let surface = VideoSurface(frame: NSRect(x: 120, y: 80, width: 320, height: 180))
+      surface.wantsLayer = true
+      surface.layer?.masksToBounds = true
+
+      let vlcSubview = AppKitReshapeProbeView(frame: surface.frame)
+      surface.addSubview(vlcSubview)
+
+      #expect(vlcSubview.frame == surface.bounds)
+      #expect(vlcSubview.autoresizingMask.contains(.width))
+      #expect(vlcSubview.autoresizingMask.contains(.height))
+      #expect(vlcSubview.reshapeCount == 1)
+      #expect(surface.wantsDefaultClipping)
+      #expect(surface.layer?.masksToBounds == true)
+
+      surface.setFrameSize(NSSize(width: 640, height: 360))
+      surface.layoutSubtreeIfNeeded()
+
+      #expect(vlcSubview.frame == surface.bounds)
+      #expect(vlcSubview.reshapeCount >= 2)
+      #else
+      #expect(Bool(true))
+      #endif
+    }
+
     /// Layout with zero-width or zero-height bounds must be a no-op
     /// so we don't race with libVLC's own initial sizing.
     @Test
@@ -130,3 +157,15 @@ extension Integration {
     }
   }
 }
+
+#if canImport(AppKit)
+@MainActor
+private final class AppKitReshapeProbeView: NSView {
+  var reshapeCount = 0
+
+  @objc(reshape)
+  func reshapeForTesting() {
+    reshapeCount += 1
+  }
+}
+#endif

--- a/Tests/SwiftVLCTests/Video/VideoSurfaceTests.swift
+++ b/Tests/SwiftVLCTests/Video/VideoSurfaceTests.swift
@@ -49,7 +49,7 @@ extension Integration {
     func `re-attaching to a different player switches surfaces cleanly`() {
       let playerA = Player(instance: TestInstance.shared)
       let playerB = Player(instance: TestInstance.shared)
-      let surface = VideoSurface()
+      let surface = sizedSurface()
 
       surface.attach(to: playerA)
       surface.attach(to: playerB)
@@ -74,7 +74,7 @@ extension Integration {
     func `Dropping a still-attached surface leaves the player usable`() {
       let player = Player(instance: TestInstance.shared)
       do {
-        let surface = VideoSurface()
+        let surface = sizedSurface()
         surface.attach(to: player)
       }
       #expect(player.state == .idle)
@@ -90,7 +90,7 @@ extension Integration {
       let sublayer = CALayer()
       sublayer.frame = .zero
       surface.layer.addSublayer(sublayer)
-      // Force a new bounds so the `bounds != lastBounds` branch hits.
+      // Force a new bounds before layout so the sublayer frame sync path runs.
       surface.bounds = CGRect(x: 0, y: 0, width: 640, height: 480)
       surface.layoutSubviews()
       #expect(sublayer.frame == surface.bounds)
@@ -103,6 +103,75 @@ extension Integration {
       surface.bounds = CGRect(x: 0, y: 0, width: 640, height: 480)
       surface.layout()
       #expect(sublayer.frame == surface.bounds)
+      #endif
+    }
+
+    /// libVLC can create its renderer after SwiftUI has already laid out
+    /// the hosting view. A late layer still has to be pinned immediately,
+    /// otherwise playback continues behind a black placeholder.
+    @Test
+    func `Late-added renderer layer is pinned without a bounds change`() {
+      let sublayer = CALayer()
+      sublayer.frame = .zero
+
+      #if canImport(UIKit)
+      let surface = VideoSurface(frame: CGRect(x: 0, y: 0, width: 320, height: 180))
+      surface.layoutSubviews()
+      surface.layer.addSublayer(sublayer)
+      surface.layoutSublayers(of: surface.layer)
+      #expect(sublayer.frame == surface.bounds)
+      #elseif canImport(AppKit)
+      let surface = VideoSurface(frame: CGRect(x: 0, y: 0, width: 320, height: 180))
+      surface.wantsLayer = true
+      surface.layout()
+      surface.layer?.addSublayer(sublayer)
+      surface.layout()
+      #expect(sublayer.frame == surface.bounds)
+      #endif
+    }
+
+    /// Some libVLC display modules add a native child view instead of a
+    /// raw sublayer. That child view must be pinned as soon as it appears.
+    @Test
+    func `Late-added renderer view is pinned to local bounds`() {
+      #if canImport(UIKit)
+      let surface = VideoSurface(frame: CGRect(x: 20, y: 40, width: 320, height: 180))
+      surface.layoutSubviews()
+      let renderer = UIKitLayoutProbeView(frame: .zero)
+      surface.addSubview(renderer)
+
+      #expect(renderer.frame == surface.bounds)
+      #expect(renderer.autoresizingMask.contains(.flexibleWidth))
+      #expect(renderer.autoresizingMask.contains(.flexibleHeight))
+      #expect(renderer.layoutCount == 1)
+      #elseif canImport(AppKit)
+      let surface = VideoSurface(frame: NSRect(x: 20, y: 40, width: 320, height: 180))
+      surface.layout()
+      let renderer = NSView(frame: .zero)
+      surface.addSubview(renderer)
+
+      #expect(renderer.frame == surface.bounds)
+      #expect(renderer.autoresizingMask.contains(.width))
+      #expect(renderer.autoresizingMask.contains(.height))
+      #endif
+    }
+
+    @Test
+    func `UIKit surface applies display scale before reshaping VLC subviews`() {
+      #if canImport(UIKit) && !os(visionOS)
+      let surface = VideoSurface(frame: CGRect(x: 20, y: 40, width: 320, height: 180))
+      surface.layoutSubviews()
+
+      let renderer = UIKitReshapeProbeView(frame: .zero)
+      surface.addSubview(renderer)
+
+      #expect(renderer.frame == surface.bounds)
+      #expect(renderer.contentScaleFactor == UIScreen.main.scale)
+      #expect(renderer.layer.contentsScale == UIScreen.main.scale)
+      #expect(renderer.reshapeCount == 1)
+      #expect(renderer.scaleAtReshape == UIScreen.main.scale)
+      #else
+      #expect(Bool(true))
       #endif
     }
 
@@ -155,6 +224,14 @@ extension Integration {
       #expect(sublayer.frame == CGRect(x: 0, y: 0, width: 100, height: 100))
       #endif
     }
+
+    private func sizedSurface() -> VideoSurface {
+      #if canImport(UIKit)
+      VideoSurface(frame: CGRect(x: 0, y: 0, width: 320, height: 180))
+      #elseif canImport(AppKit)
+      VideoSurface(frame: NSRect(x: 0, y: 0, width: 320, height: 180))
+      #endif
+    }
   }
 }
 
@@ -166,6 +243,30 @@ private final class AppKitReshapeProbeView: NSView {
   @objc(reshape)
   func reshapeForTesting() {
     reshapeCount += 1
+  }
+}
+#endif
+
+#if canImport(UIKit)
+@MainActor
+private final class UIKitLayoutProbeView: UIView {
+  var layoutCount = 0
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    layoutCount += 1
+  }
+}
+
+@MainActor
+private final class UIKitReshapeProbeView: UIView {
+  var reshapeCount = 0
+  var scaleAtReshape: CGFloat = 0
+
+  @objc(reshape)
+  func reshapeForTesting() {
+    reshapeCount += 1
+    scaleAtReshape = contentScaleFactor
   }
 }
 #endif

--- a/Tests/SwiftVLCTests/Video/VideoViewFinalTests.swift
+++ b/Tests/SwiftVLCTests/Video/VideoViewFinalTests.swift
@@ -33,6 +33,7 @@ extension Integration {
       let player = Player(instance: TestInstance.shared)
       let surface = VideoSurface()
       let surfacePtr = Unmanaged.passUnretained(surface).toOpaque()
+
       surface.attach(to: player)
       #expect(drawable(of: player) == surfacePtr)
       surface.detach()
@@ -41,7 +42,7 @@ extension Integration {
     @Test
     func `detach clears nsobject`() {
       let player = Player(instance: TestInstance.shared)
-      let surface = VideoSurface()
+      let surface = sizedSurface()
       surface.attach(to: player)
       surface.detach()
       #expect(drawable(of: player) == nil)
@@ -52,14 +53,14 @@ extension Integration {
     @Test
     func `layout with non-zero bounds updates sublayers`() {
       let player = Player(instance: TestInstance.shared)
-      let surface = VideoSurface()
+      let surface = sizedSurface()
       surface.attach(to: player)
 
       #if canImport(AppKit)
       surface.wantsLayer = true
       surface.frame = NSRect(x: 0, y: 0, width: 640, height: 480)
       surface.layout()
-      // Call layout again with the same bounds — lastBounds guard should skip update
+      // Call layout again with the same bounds to verify the repeated pass is safe.
       surface.layout()
       // Change bounds to trigger the sublayer update path again
       surface.frame = NSRect(x: 0, y: 0, width: 800, height: 600)
@@ -76,7 +77,7 @@ extension Integration {
     @Test
     func `attach same player twice is no-op`() {
       let player = Player(instance: TestInstance.shared)
-      let surface = VideoSurface()
+      let surface = sizedSurface()
       surface.attach(to: player)
       // Second attach with same player should hit the guard and return early
       surface.attach(to: player)
@@ -86,7 +87,7 @@ extension Integration {
     @Test
     func `multiple attach detach cycles`() {
       let player = Player(instance: TestInstance.shared)
-      let surface = VideoSurface()
+      let surface = sizedSurface()
 
       for _ in 0..<5 {
         surface.attach(to: player)
@@ -105,7 +106,7 @@ extension Integration {
     func `attach different players replaces previous`() {
       let player1 = Player(instance: TestInstance.shared)
       let player2 = Player(instance: TestInstance.shared)
-      let surface = VideoSurface()
+      let surface = sizedSurface()
       let surfacePtr = Unmanaged.passUnretained(surface).toOpaque()
 
       surface.attach(to: player1)
@@ -113,6 +114,90 @@ extension Integration {
       surface.attach(to: player2)
       #expect(drawable(of: player1) == nil)
       #expect(drawable(of: player2) == surfacePtr)
+      surface.detach()
+    }
+
+    @Test
+    func `stale surface detach does not clear current drawable`() {
+      let player = Player(instance: TestInstance.shared)
+      let firstSurface = sizedSurface()
+      let secondSurface = sizedSurface()
+      let secondPtr = Unmanaged.passUnretained(secondSurface).toOpaque()
+
+      firstSurface.attach(to: player)
+      secondSurface.attach(to: player)
+      #expect(drawable(of: player) == secondPtr)
+
+      firstSurface.detach()
+      #expect(drawable(of: player) == secondPtr)
+
+      secondSurface.detach()
+      #expect(drawable(of: player) == nil)
+    }
+
+    @Test
+    func `playback after stop rebinds a retained drawable`() {
+      let player = Player(instance: TestInstance.shared)
+      let surface = sizedSurface()
+      let surfacePtr = Unmanaged.passUnretained(surface).toOpaque()
+
+      surface.attach(to: player)
+      player.stop()
+      #expect(player.needsDrawableRebindForPlayback)
+
+      let stoppedNativePlayer = player.pointer
+      player.prepareDrawableForPlayback()
+      #expect(player.pointer != stoppedNativePlayer)
+      #expect(drawable(of: player) == surfacePtr)
+      #expect(!player.needsDrawableRebindForPlayback)
+
+      surface.detach()
+    }
+
+    @Test
+    func `stop requires drawable rebind across surface detach and reattach`() {
+      let player = Player(instance: TestInstance.shared)
+      let surface = sizedSurface()
+      let surfacePtr = Unmanaged.passUnretained(surface).toOpaque()
+
+      surface.attach(to: player)
+      player.stop()
+      surface.detach()
+      #expect(drawable(of: player) == nil)
+      #expect(player.needsDrawableRebindForPlayback)
+
+      surface.attach(to: player)
+      #expect(drawable(of: player) == surfacePtr)
+      #expect(player.needsDrawableRebindForPlayback)
+
+      let stoppedNativePlayer = player.pointer
+      player.prepareDrawableForPlayback()
+      #expect(player.pointer != stoppedNativePlayer)
+      #expect(drawable(of: player) == surfacePtr)
+      #expect(!player.needsDrawableRebindForPlayback)
+
+      surface.detach()
+    }
+
+    @Test
+    func `playback after stop replaces native player even before surface reattaches`() {
+      let player = Player(instance: TestInstance.shared)
+      let surface = sizedSurface()
+      let surfacePtr = Unmanaged.passUnretained(surface).toOpaque()
+
+      surface.attach(to: player)
+      player.stop()
+      surface.detach()
+
+      let stoppedNativePlayer = player.pointer
+      player.prepareDrawableForPlayback()
+      #expect(player.pointer != stoppedNativePlayer)
+      #expect(drawable(of: player) == nil)
+      #expect(!player.needsDrawableRebindForPlayback)
+
+      surface.attach(to: player)
+      #expect(drawable(of: player) == surfacePtr)
+
       surface.detach()
     }
 
@@ -133,7 +218,7 @@ extension Integration {
     @Test
     func `layout after detach does not crash`() {
       let player = Player(instance: TestInstance.shared)
-      let surface = VideoSurface()
+      let surface = sizedSurface()
       surface.attach(to: player)
       surface.detach()
 
@@ -144,6 +229,14 @@ extension Integration {
       #elseif canImport(UIKit)
       surface.frame = CGRect(x: 0, y: 0, width: 320, height: 240)
       surface.layoutSubviews()
+      #endif
+    }
+
+    private func sizedSurface() -> VideoSurface {
+      #if canImport(AppKit)
+      VideoSurface(frame: NSRect(x: 0, y: 0, width: 320, height: 180))
+      #elseif canImport(UIKit)
+      VideoSurface(frame: CGRect(x: 0, y: 0, width: 320, height: 180))
       #endif
     }
   }

--- a/Tests/SwiftVLCTests/VideoSurfaceRaceTests.swift
+++ b/Tests/SwiftVLCTests/VideoSurfaceRaceTests.swift
@@ -47,7 +47,7 @@ extension Integration {
       let instance = try VLCInstance(arguments: ["--quiet"])
       for _ in 0..<20 {
         let player = Player(instance: instance)
-        let surface = VideoSurface()
+        let surface = sizedSurface()
         surface.attach(to: player)
         try player.play(url: TestMedia.twosecURL)
         // Brief yield so the vout thread has a chance to pick up the
@@ -81,7 +81,7 @@ extension Integration {
         // reference, but `player.drawable` is still holding it, so the
         // view outlives this block.
         do {
-          let surface = VideoSurface()
+          let surface = sizedSurface()
           surface.attach(to: player)
           try player.play(url: TestMedia.twosecURL)
           try await Task.sleep(for: .milliseconds(5))
@@ -110,10 +110,10 @@ extension Integration {
       let player = Player(instance: instance)
       try player.play(url: TestMedia.twosecURL)
       for _ in 0..<20 {
-        let surfaceA = VideoSurface()
+        let surfaceA = sizedSurface()
         surfaceA.attach(to: player)
         try await Task.sleep(for: .milliseconds(2))
-        let surfaceB = VideoSurface()
+        let surfaceB = sizedSurface()
         surfaceB.attach(to: player)
         // Drop both locals. `player.drawable` retains B; A was already
         // released when B was attached.
@@ -133,7 +133,7 @@ extension Integration {
       let instance = try VLCInstance(arguments: ["--quiet"])
       for _ in 0..<10 {
         let player = Player(instance: instance)
-        let surfaces = (0..<4).map { _ in VideoSurface() }
+        let surfaces = (0..<4).map { _ in sizedSurface() }
         for surface in surfaces {
           surface.attach(to: player)
         }
@@ -161,7 +161,7 @@ extension Integration {
       let player = Player(instance: instance)
       let reached = subscribeAndAwait(.playing, on: player, timeout: .seconds(3))
       do {
-        let surface = VideoSurface()
+        let surface = sizedSurface()
         surface.attach(to: player)
         try player.play(url: TestMedia.twosecURL)
         _ = await reached.value
@@ -214,5 +214,13 @@ extension Integration {
       }
     }
     #endif
+
+    private func sizedSurface() -> VideoSurface {
+      #if canImport(UIKit)
+      VideoSurface(frame: CGRect(x: 0, y: 0, width: 320, height: 180))
+      #elseif canImport(AppKit)
+      VideoSurface(frame: NSRect(x: 0, y: 0, width: 320, height: 180))
+      #endif
+    }
   }
 }

--- a/scripts/build-libvlc.sh
+++ b/scripts/build-libvlc.sh
@@ -642,12 +642,69 @@ if [ -n "${PATCHES_DIR}" ] && [ -d "${PATCHES_DIR}" ]; then
     cd "${BUILD_DIR}"
 fi
 
-# --- Step 1c: Patch VLC for Mac Catalyst support ---
+# --- Step 1c: Patch VLC snapshot conversion owner ---
+# VLC's snapshot path can convert a hardware/opaque picture to RGBA in order
+# to blend a rendered subpicture into the saved PNG. At the pinned libVLC
+# revision, that conversion filter chain is created with a video owner whose
+# buffer allocator is NULL, but filter_chain_NewVideo() asserts that a parent
+# video owner must provide one. This trips when snapshots are taken while SPU
+# overlays/subtitles are active. Give the snapshot-only conversion chain a
+# plain software picture allocator so the assertion and the conversion both
+# have a valid output buffer.
+patch_vlc_snapshot_filter_owner() {
+    local VIDEO_OUTPUT_C="${VLC_SRC}/src/video_output/video_output.c"
+
+    if grep -q 'VoutSnapshotFilterNewPicture' "$VIDEO_OUTPUT_C"; then
+        info "VLC snapshot filter owner already patched"
+        return 0
+    fi
+
+    info "Patching VLC snapshot filter owner buffer allocator..."
+
+    python3 - "$VIDEO_OUTPUT_C" << 'PYEOF'
+import sys
+
+path = sys.argv[1]
+with open(path, 'r') as f:
+    content = f.read()
+
+needle = '''static const struct filter_video_callbacks vout_video_cbs = {
+    NULL, VoutHoldDecoderDevice,
+};
+'''
+
+replacement = '''static picture_t *VoutSnapshotFilterNewPicture(filter_t *filter)
+{
+    return picture_NewFromFormat(&filter->fmt_out.video);
+}
+
+static const struct filter_video_callbacks vout_video_cbs = {
+    VoutSnapshotFilterNewPicture, VoutHoldDecoderDevice,
+};
+'''
+
+if needle not in content:
+    raise SystemExit('snapshot filter callback block not found - VLC video_output.c shape changed')
+
+content = content.replace(needle, replacement, 1)
+
+with open(path, 'w') as f:
+    f.write(content)
+
+print('Snapshot filter owner patched successfully')
+PYEOF
+
+    info "VLC snapshot filter owner patched"
+}
+
+patch_vlc_snapshot_filter_owner
+
+# --- Step 1d: Patch VLC for Mac Catalyst support ---
 if [ "$BUILD_CATALYST" = "yes" ]; then
     patch_vlc_for_catalyst
 fi
 
-# --- Step 1d: Patch LDFLAGS to include -isysroot ---
+# --- Step 1e: Patch LDFLAGS to include -isysroot ---
 # On newer Xcode versions (26+), the linker requires an explicit -isysroot
 # to find system libraries (libSystem, etc.). VLC's build.sh omits this from
 # LDFLAGS, causing FFmpeg's configure (and others) to fail with:
@@ -867,7 +924,7 @@ PYEOF
 
 patch_vlc_deployment_targets
 
-# --- Step 1e: Force libtool --tag=CC for Objective-C convenience library ---
+# --- Step 1f: Force libtool --tag=CC for Objective-C convenience library ---
 # VLC's src/Makefile.am builds libvlccore_objc.la from .m files, but doesn't
 # tell libtool which tag to use. On libtool 2.5+ (current Homebrew), libtool
 # can't infer the tag from the compile command and fails with:
@@ -965,7 +1022,7 @@ PYEOF
 
 patch_vlc_objc_libtool
 
-# --- Step 1f: Disable Rust-based contribs ---
+# --- Step 1g: Disable Rust-based contribs ---
 # VLC contribs pin cargo-c 0.9.29, which transitively pulls time 0.3.31 — a
 # crate that no longer compiles on recent Rust (type inference for Box<_>).
 # The only Rust contrib we'd get on Apple is rav1e (AV1 *encoder*); we already

--- a/scripts/build-libvlc.sh
+++ b/scripts/build-libvlc.sh
@@ -10,7 +10,7 @@
 #
 # Usage:
 #   ./build-libvlc.sh              # Build for iOS device + simulator
-#   ./build-libvlc.sh --all        # Build for iOS, tvOS, macOS, Catalyst
+#   ./build-libvlc.sh --all        # Build for iOS, tvOS, visionOS, macOS, Catalyst
 #   ./build-libvlc.sh --ios-only   # iOS device + simulator only
 #   ./build-libvlc.sh --macos-only # macOS only (fastest for dev)
 #   ./build-libvlc.sh --catalyst   # Add Mac Catalyst (arm64 + x86_64)
@@ -37,12 +37,14 @@ PATCHES_DIR=""
 
 BUILD_IOS=yes
 BUILD_TVOS=no
+BUILD_VISIONOS=no
 BUILD_MACOS=no
 BUILD_CATALYST=no
 
 # Keep these deployment targets in sync with Package.swift.
 SWIFTVLC_MIN_IOS="18.0"
 SWIFTVLC_MIN_TVOS="18.0"
+SWIFTVLC_MIN_VISIONOS="2.0"
 SWIFTVLC_MIN_MACOS="15.0"
 SWIFTVLC_MIN_CATALYST="18.0"
 
@@ -173,16 +175,22 @@ for arg in "$@"; do
         --all)
             BUILD_IOS=yes
             BUILD_TVOS=yes
+            BUILD_VISIONOS=yes
             BUILD_MACOS=yes
             BUILD_CATALYST=yes
             ;;
         --ios-only)
             BUILD_IOS=yes
             BUILD_TVOS=no
+            BUILD_VISIONOS=no
             BUILD_MACOS=no
+            BUILD_CATALYST=no
             ;;
         --tvos)
             BUILD_TVOS=yes
+            ;;
+        --visionos)
+            BUILD_VISIONOS=yes
             ;;
         --macos)
             BUILD_MACOS=yes
@@ -190,12 +198,23 @@ for arg in "$@"; do
         --macos-only)
             BUILD_IOS=no
             BUILD_TVOS=no
+            BUILD_VISIONOS=no
             BUILD_MACOS=yes
+            BUILD_CATALYST=no
             ;;
         --tvos-only)
             BUILD_IOS=no
             BUILD_TVOS=yes
+            BUILD_VISIONOS=no
             BUILD_MACOS=no
+            BUILD_CATALYST=no
+            ;;
+        --visionos-only)
+            BUILD_IOS=no
+            BUILD_TVOS=no
+            BUILD_VISIONOS=yes
+            BUILD_MACOS=no
+            BUILD_CATALYST=no
             ;;
         --catalyst)
             BUILD_CATALYST=yes
@@ -203,6 +222,7 @@ for arg in "$@"; do
         --catalyst-only)
             BUILD_IOS=no
             BUILD_TVOS=no
+            BUILD_VISIONOS=no
             BUILD_MACOS=no
             BUILD_CATALYST=yes
             ;;
@@ -236,12 +256,14 @@ for arg in "$@"; do
 Usage: $0 [OPTIONS]
 
 Platform selection:
-  --all              Build for iOS, tvOS, macOS, and Mac Catalyst
+  --all              Build for iOS, tvOS, visionOS, macOS, and Mac Catalyst
   --ios-only         iOS device + simulator only (default)
   --macos-only       macOS only (fastest for development)
   --tvos-only        tvOS device + simulator only
+  --visionos-only    visionOS device + simulator only
   --catalyst-only    Mac Catalyst only
   --tvos             Add tvOS to the build
+  --visionos         Add visionOS to the build
   --macos            Add macOS to the build
   --catalyst         Add Mac Catalyst to the build
 
@@ -737,6 +759,64 @@ PYEOF
 
 patch_vlc_cppflags_version_min
 
+patch_vlc_xros_deployment_target() {
+    local BUILD_SH="${VLC_SRC}/extras/package/apple/build.sh"
+
+    if grep -q 'SWIFTVLC_XROS_TARGET_TRIPLE' "$BUILD_SH"; then
+        info "VLC build.sh already patched for visionOS deployment target"
+        return 0
+    fi
+
+    info "Patching VLC build.sh to set visionOS deployment targets..."
+
+    python3 - "$BUILD_SH" << 'PYEOF'
+import sys
+
+build_sh_path = sys.argv[1]
+
+with open(build_sh_path, 'r') as f:
+    content = f.read()
+
+needle = (
+    '# Validate architecture argument\n'
+    'validate_architecture "$VLC_HOST_ARCH"\n'
+    '\n'
+    '# Set triplet (needs to be called after validating the arch)\n'
+)
+replacement = (
+    '# Validate architecture argument\n'
+    'validate_architecture "$VLC_HOST_ARCH"\n'
+    '\n'
+    '# SWIFTVLC_XROS_TARGET_TRIPLE: the pinned VLC build script leaves xrOS\n'
+    '# min-version flags empty, which makes clang stamp objects with the SDK\n'
+    '# version. Use a target triple so visionOS objects keep SwiftVLC's minimum.\n'
+    'if [ "$VLC_HOST_OS" = "xros" ]; then\n'
+    '    xros_simulator_suffix=""\n'
+    '    if [ -n "$VLC_HOST_PLATFORM_SIMULATOR" ]; then\n'
+    '        xros_simulator_suffix="-simulator"\n'
+    '    fi\n'
+    '    VLC_DEPLOYMENT_TARGET_CFLAG="--target=${VLC_HOST_ARCH}-apple-xros${VLC_DEPLOYMENT_TARGET}${xros_simulator_suffix}"\n'
+    '    VLC_DEPLOYMENT_TARGET_LDFLAG="${VLC_DEPLOYMENT_TARGET_CFLAG}"\n'
+    'fi\n'
+    '\n'
+    '# Set triplet (needs to be called after validating the arch)\n'
+)
+if needle not in content:
+    raise SystemExit('architecture validation block not found — VLC build.sh shape changed')
+
+content = content.replace(needle, replacement, 1)
+
+with open(build_sh_path, 'w') as f:
+    f.write(content)
+
+print('visionOS deployment target patch applied successfully')
+PYEOF
+
+    info "VLC build.sh visionOS deployment target patched"
+}
+
+patch_vlc_xros_deployment_target
+
 patch_vlc_deployment_targets() {
     local BUILD_CONF="${VLC_SRC}/extras/package/apple/build.conf"
 
@@ -746,11 +826,12 @@ patch_vlc_deployment_targets() {
         "$SWIFTVLC_MIN_MACOS" \
         "$SWIFTVLC_MIN_IOS" \
         "$SWIFTVLC_MIN_TVOS" \
-        "$SWIFTVLC_MIN_CATALYST" << 'PYEOF'
+        "$SWIFTVLC_MIN_CATALYST" \
+        "$SWIFTVLC_MIN_VISIONOS" << 'PYEOF'
 import re
 import sys
 
-build_conf_path, macos, ios, tvos, catalyst = sys.argv[1:]
+build_conf_path, macos, ios, tvos, catalyst, visionos = sys.argv[1:]
 
 with open(build_conf_path, 'r') as f:
     content = f.read()
@@ -761,6 +842,7 @@ replacements = {
     r'^export VLC_DEPLOYMENT_TARGET_IOS_SIMULATOR=.*$': f'export VLC_DEPLOYMENT_TARGET_IOS_SIMULATOR="{ios}"',
     r'^export VLC_DEPLOYMENT_TARGET_TVOS=.*$': f'export VLC_DEPLOYMENT_TARGET_TVOS="{tvos}"',
     r'^export VLC_DEPLOYMENT_TARGET_TVOS_SIMULATOR=.*$': f'export VLC_DEPLOYMENT_TARGET_TVOS_SIMULATOR="{tvos}"',
+    r'^export VLC_DEPLOYMENT_TARGET_XROS=.*$': f'export VLC_DEPLOYMENT_TARGET_XROS="{visionos}"',
 }
 
 for pattern, replacement in replacements.items():
@@ -873,6 +955,8 @@ PYEOF
            "${VLC_SRC}"/build-iphonesimulator-* \
            "${VLC_SRC}"/build-appletvos-* \
            "${VLC_SRC}"/build-appletvsimulator-* \
+           "${VLC_SRC}"/build-xros-* \
+           "${VLC_SRC}"/build-xrsimulator-* \
            "${VLC_SRC}"/build-macosx-* \
            "${VLC_SRC}"/build-maccatalyst-*
 
@@ -1044,6 +1128,25 @@ if [ "$BUILD_TVOS" = "yes" ]; then
     XCFRAMEWORK_ARGS+=(-library "${BUILD_DIR}/libs/tvos-simulator/libvlc.a" -headers "${REPO_ROOT}/Sources/CLibVLC/include")
 fi
 
+if [ "$BUILD_VISIONOS" = "yes" ]; then
+    compile_libvlc aarch64 xros
+    compile_libvlc aarch64 xrsimulator
+    compile_libvlc x86_64 xrsimulator
+
+    mkdir -p "${BUILD_DIR}/libs/visionos-simulator"
+    lipo \
+        "${VLC_SRC}/build-xrsimulator-arm64/static-lib/libvlc-full-static.a" \
+        "${VLC_SRC}/build-xrsimulator-x86_64/static-lib/libvlc-full-static.a" \
+        -create -output "${BUILD_DIR}/libs/visionos-simulator/libvlc.a"
+
+    mkdir -p "${BUILD_DIR}/libs/visionos-device"
+    cp "${VLC_SRC}/build-xros-arm64/static-lib/libvlc-full-static.a" \
+       "${BUILD_DIR}/libs/visionos-device/libvlc.a"
+
+    XCFRAMEWORK_ARGS+=(-library "${BUILD_DIR}/libs/visionos-device/libvlc.a" -headers "${REPO_ROOT}/Sources/CLibVLC/include")
+    XCFRAMEWORK_ARGS+=(-library "${BUILD_DIR}/libs/visionos-simulator/libvlc.a" -headers "${REPO_ROOT}/Sources/CLibVLC/include")
+fi
+
 if [ "$BUILD_MACOS" = "yes" ]; then
     compile_libvlc aarch64 macosx
     compile_libvlc x86_64 macosx
@@ -1075,7 +1178,7 @@ fi
 
 # --- Step 4: Create XCFramework ---
 if [ ${#XCFRAMEWORK_ARGS[@]} -eq 0 ]; then
-    error "No platforms were built. Use --macos, --ios-only, --tvos-only, --catalyst-only, --tvos, --macos, --catalyst, or --all"
+    error "No platforms were built. Use --macos, --ios-only, --tvos-only, --visionos-only, --catalyst-only, --tvos, --visionos, --macos, --catalyst, or --all"
 fi
 
 info "Creating libvlc.xcframework..."
@@ -1120,6 +1223,8 @@ verify_deployment_targets() {
         "ios-arm64_x86_64-simulator:${SWIFTVLC_MIN_IOS}"
         "tvos-arm64:${SWIFTVLC_MIN_TVOS}"
         "tvos-arm64_x86_64-simulator:${SWIFTVLC_MIN_TVOS}"
+        "xros-arm64:${SWIFTVLC_MIN_VISIONOS}"
+        "xros-arm64_x86_64-simulator:${SWIFTVLC_MIN_VISIONOS}"
         "macos-arm64_x86_64:${SWIFTVLC_MIN_MACOS}"
         "ios-arm64_x86_64-maccatalyst:${SWIFTVLC_MIN_CATALYST}"
     )

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -19,13 +19,15 @@ SHOWCASE_PROJECT="Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj"
 ZIP_NAME="libvlc.xcframework.zip"
 MAX_SIZE=$((2 * 1024 * 1024 * 1024))  # 2 GB (GitHub release asset limit)
 
-# All 6 slices the xcframework must contain. If a slice is missing, the
-# release would ship a partial artifact that fails on one of iOS/tvOS/macOS/Catalyst.
+# All 8 slices the xcframework must contain. If a slice is missing, the release
+# would ship a partial artifact that fails on one of SwiftVLC's Apple platforms.
 EXPECTED_SLICES=(
   "ios-arm64"
   "ios-arm64_x86_64-simulator"
   "tvos-arm64"
   "tvos-arm64_x86_64-simulator"
+  "xros-arm64"
+  "xros-arm64_x86_64-simulator"
   "macos-arm64_x86_64"
   "ios-arm64_x86_64-maccatalyst"
 )
@@ -405,7 +407,7 @@ gh release create "$TAG" "$ZIP_PATH" \
 
 Pre-built static xcframework for libVLC 4.0.
 
-**Platforms:** iOS 18+, macOS 15+, tvOS 18+, Mac Catalyst
+**Platforms:** iOS 18+, macOS 15+, tvOS 18+, visionOS 2+, Mac Catalyst
 **Size:** ${ZIP_SIZE_MB} MB (stripped)
 **Checksum:** \`$CHECKSUM\`
 


### PR DESCRIPTION
## Summary

- Add visionOS showcase support and update release/package documentation.
- Harden libVLC playback lifecycles around pause/audio-output races, thumbnail cancellation, repeated snapshots, drawable replacement, and event cleanup.
- Rework iOS and macOS PiP/video rendering teardown so callback lifetimes, player state, and native PiP presentation stay synchronized.
- Add regression coverage for PiP, playback lifecycle, drawable teardown, subtitle handling, and showcase/UI flows.

Fixes #20.

## Branch commits

- 40f91e8 Add visionOS support
- 4eb0f7c Fix libVLC pause audio-output race (#12)
- 6c1e069 Fix thumbnail cancellation lifetime (#19)
- fd940a4 Stabilize GitHub Actions playback tests
- 746e2ca Fix macOS subtitles and PiP playback
- 532d779 Fix repeated snapshot crash in libVLC
- b265c0a Fix iOS playback and PiP lifecycle races
- 67f2eab Fix macOS PiP teardown crash

## Verification

- `swift test --filter PiPVideoViewTests` passed: 14 tests.
- `swift test` passed: 1153 tests in 94 suites.
- `xcodebuild build -project Showcase/SwiftVLCShowcase.xcodeproj -scheme macOS -destination 'platform=macOS,arch=arm64'` succeeded.
- `git diff --check` clean.

Note: the local macOS UI test runner could not execute because XCTest timed out enabling automation mode before launching the app.
