### PR TITLE
Increase SwiftVLC test coverage

### DIFF
--- a/Tests/SwiftVLCTests/Core/BroadcasterTests.swift
+++ b/Tests/SwiftVLCTests/Core/BroadcasterTests.swift
@@ -1,4 +1,5 @@
 @testable import SwiftVLC
+import Dispatch
 import Synchronization
 import Testing
 
@@ -249,6 +250,45 @@ extension Logic {
       try? await Task.sleep(for: .milliseconds(100))
 
       #expect(firstCount.withLock { $0 } == 2)
+    }
+
+    @Test func `subscriber reattach while teardown runs schedules first callback again`() async {
+      let firstCount = Mutex(0)
+      let lastCount = Mutex(0)
+      let lastEntered = DispatchSemaphore(value: 0)
+      let allowLastToFinish = DispatchSemaphore(value: 0)
+      let broadcaster = Broadcaster<Int>(
+        onFirstSubscriber: {
+          firstCount.withLock { $0 += 1 }
+        },
+        onLastUnsubscribed: {
+          lastCount.withLock { $0 += 1 }
+          lastEntered.signal()
+          _ = allowLastToFinish.wait(timeout: .now() + .seconds(2))
+        }
+      )
+
+      var stream: AsyncStream<Int>? = broadcaster.subscribe()
+      try? await Task.sleep(for: .milliseconds(100))
+      #expect(firstCount.withLock { $0 } == 1)
+
+      stream = nil
+      let teardownStarted = await withCheckedContinuation { continuation in
+        DispatchQueue.global(qos: .utility).async {
+          continuation.resume(
+            returning: lastEntered.wait(timeout: .now() + .seconds(2)) == .success
+          )
+        }
+      }
+      #expect(teardownStarted)
+
+      let reattachedStream = broadcaster.subscribe()
+      allowLastToFinish.signal()
+      try? await Task.sleep(for: .milliseconds(200))
+
+      #expect(lastCount.withLock { $0 } == 1)
+      #expect(firstCount.withLock { $0 } == 2)
+      _ = (stream, reattachedStream)
     }
 
     // MARK: - Concurrency stress

--- a/Tests/SwiftVLCTests/Core/DialogEventAccessorTests.swift
+++ b/Tests/SwiftVLCTests/Core/DialogEventAccessorTests.swift
@@ -14,7 +14,7 @@ extension Logic {
         defaultUsername: "guest",
         askStore: true
       )
-      expectNoDifference(try #require(DialogEvent.login(login).login).title, "Login")
+      try expectNoDifference(#require(DialogEvent.login(login).login).title, "Login")
 
       let question = QuestionRequest(
         dialogId: DialogID(pointer: SyntheticDialogPointer.next()),
@@ -25,7 +25,7 @@ extension Logic {
         action1Text: "Allow",
         action2Text: "Deny"
       )
-      expectNoDifference(try #require(DialogEvent.question(question).question).type, .critical)
+      try expectNoDifference(#require(DialogEvent.question(question).question).type, .critical)
 
       let progress = ProgressInfo(
         dialogId: DialogID(pointer: SyntheticDialogPointer.next()),
@@ -35,14 +35,14 @@ extension Logic {
         position: 0.25,
         cancelText: "Stop"
       )
-      expectNoDifference(try #require(DialogEvent.progress(progress).progress).position, 0.25)
+      try expectNoDifference(#require(DialogEvent.progress(progress).progress).position, 0.25)
 
       let update = ProgressUpdate(
         dialogId: DialogID(pointer: SyntheticDialogPointer.next()),
         position: 0.5,
         text: "Halfway"
       )
-      expectNoDifference(try #require(DialogEvent.progressUpdated(update).progressUpdated).text, "Halfway")
+      try expectNoDifference(#require(DialogEvent.progressUpdated(update).progressUpdated).text, "Halfway")
 
       let cancel = DialogID(pointer: SyntheticDialogPointer.next())
       #expect(try #require(DialogEvent.cancel(cancel).cancel)._isValidForTesting)

--- a/Tests/SwiftVLCTests/Core/DialogEventAccessorTests.swift
+++ b/Tests/SwiftVLCTests/Core/DialogEventAccessorTests.swift
@@ -1,0 +1,124 @@
+@testable import SwiftVLC
+import CustomDump
+import Synchronization
+import Testing
+
+extension Logic {
+  struct DialogEventAccessorTests {
+    @Test
+    func `Per-case accessors return associated payloads`() throws {
+      let login = LoginRequest(
+        dialogId: DialogID(pointer: SyntheticDialogPointer.next()),
+        title: "Login",
+        text: "Credentials required",
+        defaultUsername: "guest",
+        askStore: true
+      )
+      expectNoDifference(try #require(DialogEvent.login(login).login).title, "Login")
+
+      let question = QuestionRequest(
+        dialogId: DialogID(pointer: SyntheticDialogPointer.next()),
+        title: "Trust",
+        text: "Continue?",
+        type: .critical,
+        cancelText: "Cancel",
+        action1Text: "Allow",
+        action2Text: "Deny"
+      )
+      expectNoDifference(try #require(DialogEvent.question(question).question).type, .critical)
+
+      let progress = ProgressInfo(
+        dialogId: DialogID(pointer: SyntheticDialogPointer.next()),
+        title: "Download",
+        text: "Fetching",
+        isIndeterminate: false,
+        position: 0.25,
+        cancelText: "Stop"
+      )
+      expectNoDifference(try #require(DialogEvent.progress(progress).progress).position, 0.25)
+
+      let update = ProgressUpdate(
+        dialogId: DialogID(pointer: SyntheticDialogPointer.next()),
+        position: 0.5,
+        text: "Halfway"
+      )
+      expectNoDifference(try #require(DialogEvent.progressUpdated(update).progressUpdated).text, "Halfway")
+
+      let cancel = DialogID(pointer: SyntheticDialogPointer.next())
+      #expect(try #require(DialogEvent.cancel(cancel).cancel)._isValidForTesting)
+
+      let error = try #require(DialogEvent.error(title: "Network", message: "Denied").error)
+      expectNoDifference(error.title, "Network")
+      expectNoDifference(error.message, "Denied")
+    }
+
+    @Test
+    func `Per-case accessors return nil for non-matching events`() {
+      let event = DialogEvent.error(title: "Title", message: "Message")
+      let nilResults = [
+        event.login == nil,
+        event.question == nil,
+        event.progress == nil,
+        event.progressUpdated == nil,
+        event.cancel == nil,
+        DialogEvent.cancel(DialogID(pointer: SyntheticDialogPointer.next())).error == nil
+      ]
+
+      expectNoDifference(nilResults, Array(repeating: true, count: nilResults.count))
+    }
+
+    @Test
+    func `Request response helpers are one-shot safe`() {
+      let loginId = DialogID(pointer: SyntheticDialogPointer.next())
+      _ = loginId._consumeForTesting()
+      let login = LoginRequest(
+        dialogId: loginId,
+        title: "Login",
+        text: "Credentials required",
+        defaultUsername: "",
+        askStore: false
+      )
+      #expect(!login.post(username: "user", password: "pass"))
+      #expect(!login.dismiss())
+
+      let questionId = DialogID(pointer: SyntheticDialogPointer.next())
+      let question = QuestionRequest(
+        dialogId: questionId,
+        title: "Question",
+        text: "Pick one",
+        type: .normal,
+        cancelText: "Cancel",
+        action1Text: "One",
+        action2Text: nil
+      )
+      #expect(!question.post(action: Int.max))
+      #expect(questionId._isValidForTesting, "Out-of-range action must not consume the dialog id")
+      _ = questionId._consumeForTesting()
+      #expect(!question.dismiss())
+
+      let progressId = DialogID(pointer: SyntheticDialogPointer.next())
+      _ = progressId._consumeForTesting()
+      let progress = ProgressInfo(
+        dialogId: progressId,
+        title: "Progress",
+        text: "Working",
+        isIndeterminate: true,
+        position: 0,
+        cancelText: nil
+      )
+      #expect(!progress.dismiss())
+    }
+  }
+}
+
+private enum SyntheticDialogPointer {
+  private static let counter = Mutex(0xC0FF_EE00)
+
+  static func next() -> OpaquePointer {
+    let address = counter.withLock { value -> Int in
+      value += 16
+      return value
+    }
+    return OpaquePointer(bitPattern: address)!
+  }
+}

--- a/Tests/SwiftVLCTests/Core/DurationExtensionsTests.swift
+++ b/Tests/SwiftVLCTests/Core/DurationExtensionsTests.swift
@@ -100,5 +100,22 @@ extension Logic {
           .checkedNonnegativeInt32Milliseconds(parameter: "timeout")
       }
     }
+
+    @Test
+    func `Checked microsecond conversion rejects overflow`() {
+      #expect(throws: VLCError.self) {
+        _ = try Duration.seconds(Int64.max).checkedMicroseconds(parameter: "audioDelay")
+      }
+    }
+
+    @Test
+    func `Subsecond addition overflow saturates instead of trapping`() {
+      let nearLimit = Duration(
+        secondsComponent: Int64.max / 1000,
+        attosecondsComponent: 999_000_000_000_000_000
+      )
+
+      #expect(nearLimit.milliseconds == Int64.max)
+    }
   }
 }

--- a/Tests/SwiftVLCTests/Core/InputValidationTests.swift
+++ b/Tests/SwiftVLCTests/Core/InputValidationTests.swift
@@ -1,0 +1,25 @@
+@testable import SwiftVLC
+import Testing
+
+extension Logic {
+  struct InputValidationTests {
+    @Test
+    func `checkedInt32 accepts exact Int32 range values`() throws {
+      #expect(try checkedInt32(Int(Int32.min), parameter: "value") == Int32.min)
+      #expect(try checkedInt32(Int(Int32.max), parameter: "value") == Int32.max)
+    }
+
+    @Test
+    func `checkedNonnegativeInt32 rejects negative values`() {
+      #expect(throws: VLCError.self) {
+        _ = try checkedNonnegativeInt32(-1, parameter: "index")
+      }
+    }
+
+    @Test
+    func `checkedUInt32 accepts unsigned range endpoints`() throws {
+      #expect(try checkedUInt32(0, parameter: "width") == 0)
+      #expect(try checkedUInt32(Int(UInt32.max), parameter: "width") == UInt32.max)
+    }
+  }
+}

--- a/Tests/SwiftVLCTests/Core/LoggingExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Core/LoggingExtendedTests.swift
@@ -150,6 +150,18 @@ extension Integration {
       _ = stream
     }
 
+    @Test
+    func `LogBroadcaster exposes the instance pointer it was created with`() {
+      let broadcaster = LogBroadcaster(
+        instancePointer: VLCInstance.shared.pointer,
+        installBridge: { _, _ in nil },
+        uninstallBridge: { _, _ in }
+      )
+      defer { broadcaster.invalidate() }
+
+      #expect(broadcaster.instancePointer == VLCInstance.shared.pointer)
+    }
+
     @Test(.tags(.async))
     func `Failed log install retries only on later reconciles`() async {
       let attempts = Mutex(0)

--- a/Tests/SwiftVLCTests/Core/VLCErrorAccessorTests.swift
+++ b/Tests/SwiftVLCTests/Core/VLCErrorAccessorTests.swift
@@ -1,0 +1,37 @@
+@testable import SwiftVLC
+import CustomDump
+import Testing
+
+extension Logic {
+  struct VLCErrorAccessorTests {
+    @Test
+    func `Per-case accessors return associated payloads`() {
+      #expect(VLCError.instanceCreationFailed.instanceCreationFailed != nil)
+      expectNoDifference(VLCError.mediaCreationFailed(source: "file.mp4").mediaCreationFailed, "file.mp4")
+      expectNoDifference(VLCError.playbackFailed(reason: "codec").playbackFailed, "codec")
+      expectNoDifference(VLCError.parseFailed(reason: "bad input").parseFailed, "bad input")
+      #expect(VLCError.parseTimeout.parseTimeout != nil)
+      expectNoDifference(VLCError.trackNotFound(id: "audio-1").trackNotFound, "audio-1")
+      expectNoDifference(VLCError.invalidState("not loaded").invalidState, "not loaded")
+      expectNoDifference(VLCError.invalidInput("width").invalidInput, "width")
+      expectNoDifference(VLCError.operationFailed("Snapshot").operationFailed, "Snapshot")
+    }
+
+    @Test
+    func `Per-case accessors return nil for non-matching errors`() {
+      let nilResults = [
+        VLCError.parseTimeout.instanceCreationFailed == nil,
+        VLCError.parseTimeout.mediaCreationFailed == nil,
+        VLCError.parseTimeout.playbackFailed == nil,
+        VLCError.parseTimeout.parseFailed == nil,
+        VLCError.instanceCreationFailed.parseTimeout == nil,
+        VLCError.parseTimeout.trackNotFound == nil,
+        VLCError.parseTimeout.invalidState == nil,
+        VLCError.parseTimeout.invalidInput == nil,
+        VLCError.parseTimeout.operationFailed == nil
+      ]
+
+      expectNoDifference(nilResults, Array(repeating: true, count: nilResults.count))
+    }
+  }
+}

--- a/Tests/SwiftVLCTests/Core/VLCInstanceTests.swift
+++ b/Tests/SwiftVLCTests/Core/VLCInstanceTests.swift
@@ -92,6 +92,12 @@ extension Integration {
     }
 
     @Test
+    func `Custom instance accepts separated macOS vout option`() throws {
+      let instance = try VLCInstance(arguments: ["--force-darwin-legacy-display", "--vout", "macosx"])
+      #expect(instance.usesPiPSafeDarwinDisplay)
+    }
+
+    @Test
     func `Custom instance with no video is not PiP safe on macOS`() throws {
       let instance = try VLCInstance(arguments: ["--no-video-title-show", "--no-video"])
       #expect(!instance.usesPiPSafeDarwinDisplay)
@@ -123,6 +129,17 @@ extension Integration {
         ]
       )
       #expect(instance.supportsDynamicDeinterlaceChanges)
+    }
+
+    @Test
+    func `VideoToolbox in separated codec list disables dynamic deinterlace changes`() throws {
+      let instance = try VLCInstance(
+        arguments: VLCInstance.defaultArguments + [
+          "--codec",
+          " avcodec, videotoolbox, "
+        ]
+      )
+      #expect(!instance.supportsDynamicDeinterlaceChanges)
     }
 
     @Test

--- a/Tests/SwiftVLCTests/Media/ThumbnailRequestTests.swift
+++ b/Tests/SwiftVLCTests/Media/ThumbnailRequestTests.swift
@@ -105,6 +105,28 @@ extension Integration {
       #expect(completed, "Queued acquire should stop waiting as soon as it is cancelled")
     }
 
+    @Test(.tags(.async))
+    func `Queued thumbnail coordinator acquire resumes on release`() async throws {
+      let coordinator = ThumbnailCoordinator()
+      try await coordinator.acquire()
+
+      let acquired = Task {
+        try await coordinator.acquire()
+        await coordinator.release()
+        return true
+      }
+
+      await Task.yield()
+      await coordinator.release()
+
+      #expect(try await acquired.value)
+
+      // The second task releases its slot, so a later acquire should
+      // not remain stuck behind stale waiter state.
+      try await coordinator.acquire()
+      await coordinator.release()
+    }
+
     @Test
     func `Audio-only returns error`() async {
       do {

--- a/Tests/SwiftVLCTests/Media/TrackExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Media/TrackExtendedTests.swift
@@ -168,6 +168,25 @@ extension Integration {
     }
 
     @Test
+    func `Unknown C track maps through default type-specific branch`() {
+      var cTrack = libvlc_media_track_t()
+      cTrack.i_id = 42
+      cTrack.i_type = libvlc_track_unknown
+
+      let track = withUnsafePointer(to: cTrack) { Track(from: $0) }
+
+      #expect(track.id == "42")
+      #expect(track.type == .unknown)
+      #expect(track.name == "Track 42")
+      #expect(track.channels == nil)
+      #expect(track.sampleRate == nil)
+      #expect(track.width == nil)
+      #expect(track.height == nil)
+      #expect(track.frameRate == nil)
+      #expect(track.encoding == nil)
+    }
+
+    @Test
     func `Track with nil language and description`() {
       let track = makeTrack(id: "x-0", type: .audio)
       #expect(track.language == nil)

--- a/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
@@ -4,6 +4,7 @@ import AVFoundation
 import AVKit
 import CoreMedia
 import CustomDump
+import Synchronization
 import Testing
 
 /// Complements `PiPControllerTests` by exercising the delegate /
@@ -40,6 +41,17 @@ extension Integration {
           seek: { self.seekTargets.append($0.milliseconds) }
         )
       }
+    }
+
+    private func makePictureInPictureController(
+      for controller: PiPController
+    ) -> AVPictureInPictureController? {
+      guard AVPictureInPictureController.isPictureInPictureSupported() else { return nil }
+      let contentSource = AVPictureInPictureController.ContentSource(
+        sampleBufferDisplayLayer: controller.layer,
+        playbackDelegate: controller._playbackDelegateForTesting
+      )
+      return AVPictureInPictureController(contentSource: contentSource)
     }
 
     // MARK: - handleSetPlaying
@@ -451,6 +463,69 @@ extension Integration {
       expectNoDifference(recorder.seekTargets, [8000])
     }
 
+    @Test
+    func `playback delegate proxy forwards setPlaying to owner`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: PlaybackRecorder().driver,
+        pauseDebounce: .milliseconds(250)
+      )
+      guard let pip = makePictureInPictureController(for: controller) else { return }
+
+      controller._playbackDelegateForTesting.pictureInPictureController(pip, setPlaying: false)
+
+      #expect(controller._pipPlaybackActiveForTesting() == false)
+      #expect(controller._pendingPiPPlaybackStateForTesting() == false)
+    }
+
+    @Test
+    func `playback delegate proxy forwards skip to owner`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(currentTime: .seconds(5), duration: .seconds(20))
+      let recorder = PlaybackRecorder()
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(250)
+      )
+      guard let pip = makePictureInPictureController(for: controller) else { return }
+      let didComplete = Mutex(false)
+
+      controller._playbackDelegateForTesting.pictureInPictureController(
+        pip,
+        skipByInterval: CMTime(seconds: 2, preferredTimescale: 1000)
+      ) {
+        didComplete.withLock { $0 = true }
+      }
+
+      expectNoDifference(recorder.seekTargets, [7000])
+      #expect(didComplete.withLock { $0 })
+    }
+
+    @Test
+    func `playback delegate proxy completes skip when owner is gone`() {
+      let proxy = PiPPlaybackDelegateProxy()
+      let layer = AVSampleBufferDisplayLayer()
+      guard AVPictureInPictureController.isPictureInPictureSupported() else { return }
+      let contentSource = AVPictureInPictureController.ContentSource(
+        sampleBufferDisplayLayer: layer,
+        playbackDelegate: proxy
+      )
+      let pip = AVPictureInPictureController(contentSource: contentSource)
+      let didComplete = Mutex(false)
+
+      proxy.pictureInPictureController(
+        pip,
+        skipByInterval: CMTime(seconds: 10, preferredTimescale: 1000)
+      ) {
+        didComplete.withLock { $0 = true }
+      }
+
+      #expect(didComplete.withLock { $0 })
+    }
+
     // MARK: - Delegate TimeRangeForPlayback
 
     /// Without a known duration, the delegate must report a 24-hour
@@ -459,13 +534,7 @@ extension Integration {
     func `timeRangeForPlayback reports sentinel when duration is unknown`() {
       let player = Player(instance: TestInstance.shared)
       let controller = PiPController(player: player)
-      guard AVPictureInPictureController.isPictureInPictureSupported() else { return }
-
-      let contentSource = AVPictureInPictureController.ContentSource(
-        sampleBufferDisplayLayer: controller.layer,
-        playbackDelegate: controller._playbackDelegateForTesting
-      )
-      let pip = AVPictureInPictureController(contentSource: contentSource)
+      guard let pip = makePictureInPictureController(for: controller) else { return }
 
       let range = controller._timeRangeForPlaybackForTesting(pip)
 
@@ -479,13 +548,7 @@ extension Integration {
       let player = Player(instance: TestInstance.shared)
       player._setStateForTesting(duration: .seconds(120))
       let controller = PiPController(player: player)
-      guard AVPictureInPictureController.isPictureInPictureSupported() else { return }
-
-      let contentSource = AVPictureInPictureController.ContentSource(
-        sampleBufferDisplayLayer: controller.layer,
-        playbackDelegate: controller._playbackDelegateForTesting
-      )
-      let pip = AVPictureInPictureController(contentSource: contentSource)
+      guard let pip = makePictureInPictureController(for: controller) else { return }
 
       let range = controller._timeRangeForPlaybackForTesting(pip)
 
@@ -502,13 +565,7 @@ extension Integration {
     func `didTransitionToRenderSize does not crash`() {
       let player = Player(instance: TestInstance.shared)
       let controller = PiPController(player: player)
-      guard AVPictureInPictureController.isPictureInPictureSupported() else { return }
-
-      let contentSource = AVPictureInPictureController.ContentSource(
-        sampleBufferDisplayLayer: controller.layer,
-        playbackDelegate: controller._playbackDelegateForTesting
-      )
-      let pip = AVPictureInPictureController(contentSource: contentSource)
+      guard let pip = makePictureInPictureController(for: controller) else { return }
 
       controller._didTransitionToRenderSizeForTesting(
         pip,
@@ -520,13 +577,7 @@ extension Integration {
     func `didTransitionToRenderSize updates renderer target size only on sample resizing platforms`() {
       let player = Player(instance: TestInstance.shared)
       let controller = PiPController(player: player)
-      guard AVPictureInPictureController.isPictureInPictureSupported() else { return }
-
-      let contentSource = AVPictureInPictureController.ContentSource(
-        sampleBufferDisplayLayer: controller.layer,
-        playbackDelegate: controller._playbackDelegateForTesting
-      )
-      let pip = AVPictureInPictureController(contentSource: contentSource)
+      guard let pip = makePictureInPictureController(for: controller) else { return }
 
       controller._didTransitionToRenderSizeForTesting(
         pip,
@@ -552,13 +603,7 @@ extension Integration {
     func `didStartPictureInPicture sets isActive`() {
       let player = Player(instance: TestInstance.shared)
       let controller = PiPController(player: player)
-      guard AVPictureInPictureController.isPictureInPictureSupported() else { return }
-
-      let contentSource = AVPictureInPictureController.ContentSource(
-        sampleBufferDisplayLayer: controller.layer,
-        playbackDelegate: controller._playbackDelegateForTesting
-      )
-      let pip = AVPictureInPictureController(contentSource: contentSource)
+      guard let pip = makePictureInPictureController(for: controller) else { return }
 
       #expect(controller.isActive == false)
       controller.pictureInPictureControllerDidStartPictureInPicture(pip)
@@ -566,17 +611,23 @@ extension Integration {
     }
 
     @Test
+    func `willStartPictureInPicture syncs playback state`() {
+      let player = Player(instance: TestInstance.shared)
+      let controller = PiPController(player: player)
+      guard let pip = makePictureInPictureController(for: controller) else { return }
+
+      player._setStateForTesting(isPlaybackRequestedActive: true)
+      controller.pictureInPictureControllerWillStartPictureInPicture(pip)
+
+      #expect(controller._pipPlaybackActiveForTesting() == true)
+    }
+
+    @Test
     func `didStopPictureInPicture clears isActive`() {
       let player = Player(instance: TestInstance.shared)
       let controller = PiPController(player: player)
       controller._setStateForTesting(isActive: true)
-      guard AVPictureInPictureController.isPictureInPictureSupported() else { return }
-
-      let contentSource = AVPictureInPictureController.ContentSource(
-        sampleBufferDisplayLayer: controller.layer,
-        playbackDelegate: controller._playbackDelegateForTesting
-      )
-      let pip = AVPictureInPictureController(contentSource: contentSource)
+      guard let pip = makePictureInPictureController(for: controller) else { return }
 
       #expect(controller.isActive == true)
       controller.pictureInPictureControllerDidStopPictureInPicture(pip)
@@ -590,17 +641,29 @@ extension Integration {
       let player = Player(instance: TestInstance.shared)
       let controller = PiPController(player: player)
       controller._setStateForTesting(isActive: true)
-      guard AVPictureInPictureController.isPictureInPictureSupported() else { return }
-
-      let contentSource = AVPictureInPictureController.ContentSource(
-        sampleBufferDisplayLayer: controller.layer,
-        playbackDelegate: controller._playbackDelegateForTesting
-      )
-      let pip = AVPictureInPictureController(contentSource: contentSource)
+      guard let pip = makePictureInPictureController(for: controller) else { return }
 
       let fakeError = NSError(domain: "swiftvlc.test", code: 42)
       controller.pictureInPictureController(pip, failedToStartPictureInPictureWithError: fakeError)
       #expect(controller.isActive == false)
+    }
+
+    @Test
+    func `terminal observed state clears stale pending PiP play request`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .paused)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: PlaybackRecorder().driver,
+        pauseDebounce: .milliseconds(250)
+      )
+
+      controller._setPlayingForTesting(true)
+      player._setStateForTesting(state: .error)
+      controller._handleObservedPlaybackActivityForTesting(false)
+
+      #expect(controller._pipPlaybackActiveForTesting() == false)
+      #expect(controller._pendingPiPPlaybackStateForTesting() == nil)
     }
   }
 }

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
@@ -406,6 +406,24 @@ extension Integration {
       #expect(mediaController.isMediaPlaying() == false)
     }
 
+    @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
+    func `macOS native PiP media controller play resumes paused playback`() async throws {
+      let player = Player(instance: TestInstance.makePlayback())
+      let mediaController = MacNativePiPMediaController()
+      mediaController.player = player
+
+      try player.play(Media(url: TestMedia.twosecURL))
+      try #require(await poll(until: { player.state == .playing }), "Waiting for: player.state == .playing")
+
+      player.pause()
+      try #require(await poll(until: { player.state == .paused }), "Waiting for: player.state == .paused")
+
+      mediaController.play()
+      try #require(await poll(until: { mediaController.isMediaPlaying() }), "Waiting for: PiP media controller playback")
+
+      player.stop()
+    }
+
     @Test
     func `SwiftUI host creates and updates native PiP view`() async throws {
       let firstPlayer = Player(instance: TestInstance.shared)

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
@@ -181,6 +181,32 @@ extension Integration {
     }
 
     @Test
+    func `macOS native PiP drawable removes VLC subviews only when owned`() {
+      let view = MacNativePiPDrawableView()
+      let ownedSubview = NSView()
+      let externalSubview = NSView()
+
+      view.addVoutSubview(ownedSubview)
+      view.removeVoutSubview(externalSubview)
+      #expect(ownedSubview.superview === view)
+
+      view.removeVoutSubview(ownedSubview)
+      #expect(ownedSubview.superview == nil)
+    }
+
+    @Test
+    func `macOS native PiP drawable lays out direct sublayers`() {
+      let view = MacNativePiPDrawableView()
+      view.frame = CGRect(x: 0, y: 0, width: 320, height: 180)
+      let sublayer = CALayer()
+
+      view.layer?.addSublayer(sublayer)
+      view.restoreVLCContentLayout()
+
+      #expect(sublayer.frame.size == CGSize(width: 320, height: 180))
+    }
+
+    @Test
     func `macOS native PiP restore repeats full-size VLC content layout`() async {
       let host = MacNativePiPHostView(frame: CGRect(x: 0, y: 0, width: 960, height: 540))
       let drawable = host.drawableView

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
@@ -1,5 +1,5 @@
 #if os(iOS) || os(macOS)
-@testable import SwiftVLC
+@_spi(PrivateMacOSPiP) @testable import SwiftVLC
 import AVFoundation
 import SwiftUI
 import Testing
@@ -236,6 +236,79 @@ extension Integration {
       #expect(mediaController.isMediaPlaying() == true)
 
       player.setPlaybackIntentFromExternalControl(false)
+      #expect(mediaController.isMediaPlaying() == false)
+    }
+
+    @Test
+    func `macOS native PiP backend start stop without media are safe no-ops`() {
+      let initialAllowsPrivateAPI = PiPController.allowsPrivateMacOSAPI
+      defer { PiPController.allowsPrivateMacOSAPI = initialAllowsPrivateAPI }
+      PiPController.allowsPrivateMacOSAPI = false
+
+      let player = Player(instance: TestInstance.shared)
+      let backend = MacNativePiPBackend()
+
+      backend.attach(to: player)
+      backend.start()
+      backend.invalidatePlaybackState()
+      backend.stop()
+
+      #expect(backend.isPossible == false)
+      #expect(backend.isActive == false)
+
+      backend.detach()
+
+      #expect(backend.isPossible == false)
+      #expect(backend.isActive == false)
+    }
+
+    @Test
+    func `macOS native PiP media controller defaults without player`() async {
+      let mediaController = MacNativePiPMediaController()
+      let didComplete = Box(false)
+
+      mediaController.play()
+      mediaController.pause()
+      mediaController.seek(by: 250) {
+        didComplete.value = true
+      }
+
+      await Task.yield()
+
+      #expect(didComplete.value)
+      #expect(mediaController.mediaLength() == 0)
+      #expect(mediaController.mediaTime() == 0)
+      #expect(mediaController.isMediaSeekable() == false)
+      #expect(mediaController.isMediaPlaying() == false)
+    }
+
+    @Test
+    func `macOS native PiP media controller reads player defaults and completes seek`() async {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(
+        currentTime: .seconds(5),
+        duration: .seconds(10),
+        isSeekable: true
+      )
+
+      let mediaController = MacNativePiPMediaController()
+      mediaController.player = player
+      let didComplete = Box(false)
+
+      mediaController.play()
+      mediaController.pause()
+      mediaController.seek(by: -10_000) {
+        didComplete.value = true
+      }
+
+      await Task.yield()
+      player.setPlaybackIntentFromExternalControl(false)
+
+      #expect(didComplete.value)
+      #expect(player.currentTime == .zero)
+      #expect(mediaController.mediaLength() >= 0)
+      #expect(mediaController.mediaTime() >= 0)
+      _ = mediaController.isMediaSeekable()
       #expect(mediaController.isMediaPlaying() == false)
     }
     #endif

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
@@ -359,6 +359,35 @@ extension Integration {
       _ = mediaController.isMediaSeekable()
       #expect(mediaController.isMediaPlaying() == false)
     }
+
+    @Test
+    func `SwiftUI host creates and updates native PiP view`() async throws {
+      let firstPlayer = Player(instance: TestInstance.shared)
+      let secondPlayer = Player(instance: TestInstance.shared)
+      let storage = Box<PiPController?>(nil)
+      let binding = Binding<PiPController?>(
+        get: { storage.value },
+        set: { storage.value = $0 }
+      )
+      let host = NSHostingView(rootView: PiPVideoView(firstPlayer, controller: binding))
+
+      host.frame = NSRect(x: 0, y: 0, width: 320, height: 180)
+      host.layoutSubtreeIfNeeded()
+      await Task.yield()
+
+      let initialContainer = try #require(host.firstDescendant(ofType: MacNativePiPHostView.self))
+      #expect(firstPlayer.drawable === initialContainer.drawableView)
+      #expect(storage.value != nil)
+
+      host.rootView = PiPVideoView(secondPlayer, controller: binding)
+      host.layoutSubtreeIfNeeded()
+      await Task.yield()
+
+      let updatedContainer = try #require(host.firstDescendant(ofType: MacNativePiPHostView.self))
+      #expect(firstPlayer.drawable == nil)
+      #expect(secondPlayer.drawable === updatedContainer.drawableView)
+      #expect(storage.value != nil)
+    }
     #endif
   }
 }
@@ -373,6 +402,20 @@ private final class Box<T> {
 }
 
 #if canImport(AppKit)
+private extension NSView {
+  func firstDescendant<T: NSView>(ofType type: T.Type) -> T? {
+    if let match = self as? T {
+      return match
+    }
+    for subview in subviews {
+      if let match = subview.firstDescendant(ofType: type) {
+        return match
+      }
+    }
+    return nil
+  }
+}
+
 @MainActor
 private final class PiPReshapeProbeView: NSView {
   var reshapeCount = 0

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
@@ -289,6 +289,28 @@ extension Integration {
     }
 
     @Test
+    func `macOS PiP controller delegates to native backend`() {
+      let initialAllowsPrivateAPI = PiPController.allowsPrivateMacOSAPI
+      defer { PiPController.allowsPrivateMacOSAPI = initialAllowsPrivateAPI }
+      PiPController.allowsPrivateMacOSAPI = false
+
+      let player = Player(instance: TestInstance.shared)
+      let backend = MacNativePiPBackend()
+      let controller = PiPController(player: player, nativeBackend: backend)
+
+      controller.start()
+      controller.invalidatePictureInPicturePlaybackState()
+      controller.stop()
+      controller.handleNativePictureInPictureReady()
+      controller.handleNativePictureInPictureActiveChanged(true)
+      #expect(controller.isActive == true)
+      controller.handleNativePictureInPictureActiveChanged(false)
+      #expect(controller.isActive == false)
+      controller.handleNativePictureInPictureSetPlaying(true)
+      #expect(controller._pipPlaybackActiveForTesting() == true)
+    }
+
+    @Test
     func `macOS native PiP media controller defaults without player`() async {
       let mediaController = MacNativePiPMediaController()
       let didComplete = Box(false)

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
@@ -447,21 +447,6 @@ private final class Box<T> {
   }
 }
 
-#if canImport(AppKit)
-extension NSView {
-  fileprivate func firstDescendant<T: NSView>(ofType type: T.Type) -> T? {
-    if let match = self as? T {
-      return match
-    }
-    for subview in subviews {
-      if let match = subview.firstDescendant(ofType: type) {
-        return match
-      }
-    }
-    return nil
-  }
-}
-
 @MainActor
 private final class PiPReshapeProbeView: NSView {
   var reshapeCount = 0
@@ -471,5 +456,4 @@ private final class PiPReshapeProbeView: NSView {
     reshapeCount += 1
   }
 }
-#endif
 #endif

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
@@ -99,6 +99,34 @@ extension Integration {
       #endif
     }
 
+    @Test
+    func `dismantle fallback stops controller and clears binding`() async {
+      #if canImport(AppKit)
+      let player = Player(instance: TestInstance.shared)
+      let storage = Box<PiPController?>(nil)
+      let binding = Binding<PiPController?>(
+        get: { storage.value },
+        set: { storage.value = $0 }
+      )
+      let view = PiPVideoView(player, controller: binding)
+      let coordinator = view.makeCoordinator()
+      let controller = PiPController(player: player)
+
+      storage.value = controller
+      coordinator.pipController = controller
+      coordinator.controllerBinding = binding
+
+      PiPVideoView.dismantleNSView(NSView(), coordinator: coordinator)
+      await Task.yield()
+
+      #expect(coordinator.pipController == nil)
+      #expect(coordinator.controllerBinding == nil)
+      #expect(storage.value == nil)
+      #else
+      #expect(Bool(true))
+      #endif
+    }
+
     #if canImport(AppKit)
     @Test
     func `macOS native PiP host attaches drawable child`() {
@@ -204,6 +232,24 @@ extension Integration {
       view.restoreVLCContentLayout()
 
       #expect(sublayer.frame.size == CGSize(width: 320, height: 180))
+    }
+
+    @Test
+    func `macOS native PiP drawable rebinds stale drawable on first nonzero layout`() {
+      let player = Player(instance: TestInstance.shared)
+      let view = MacNativePiPDrawableView()
+      let staleDrawable = NSView()
+
+      view.attach(to: player)
+      player.setDrawable(staleDrawable, owner: view)
+      #expect(player.drawable === staleDrawable)
+
+      view.frame = NSRect(x: 0, y: 0, width: 320, height: 180)
+      view.layout()
+
+      #expect(player.drawable === view)
+
+      view.detach()
     }
 
     @Test
@@ -345,7 +391,7 @@ extension Integration {
 
       mediaController.play()
       mediaController.pause()
-      mediaController.seek(by: -10_000) {
+      mediaController.seek(by: -10000) {
         didComplete.value = true
       }
 
@@ -402,8 +448,8 @@ private final class Box<T> {
 }
 
 #if canImport(AppKit)
-private extension NSView {
-  func firstDescendant<T: NSView>(ofType type: T.Type) -> T? {
+extension NSView {
+  fileprivate func firstDescendant<T: NSView>(ofType type: T.Type) -> T? {
     if let match = self as? T {
       return match
     }

--- a/Tests/SwiftVLCTests/Player/PlaybackValuesTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlaybackValuesTests.swift
@@ -63,6 +63,11 @@ extension Logic {
       #expect(v.rawValue == 0.8)
     }
 
+    @Test func `Volume is Comparable`() {
+      #expect(Volume.muted < Volume.unity)
+      #expect(Volume.unity < Volume.max)
+    }
+
     // MARK: - PlaybackRate
 
     @Test func `PlaybackRate clamps below 0.25`() {
@@ -111,6 +116,11 @@ extension Logic {
       #expect(SubtitleScale(.nan) == .normal)
     }
 
+    @Test func `SubtitleScale is Comparable`() {
+      #expect(SubtitleScale.halfSize < SubtitleScale.normal)
+      #expect(SubtitleScale.normal < SubtitleScale.doubleSize)
+    }
+
     // MARK: - EqualizerGain
 
     @Test func `EqualizerGain clamps below -20`() {
@@ -135,6 +145,11 @@ extension Logic {
       let g: EqualizerGain = 6.0
       #expect(g.rawValue == 6.0)
     }
+
+    @Test func `EqualizerGain is Comparable`() {
+      #expect(EqualizerGain.minimum < EqualizerGain.flat)
+      #expect(EqualizerGain.flat < EqualizerGain.maximum)
+    }
   }
 }
 
@@ -150,8 +165,10 @@ extension Integration {
       let player = Player(instance: TestInstance.shared)
       try player.setAudioVolume(.unity)
       #expect(player.volume == 1.0)
+      #expect(player.audioVolume == .unity)
       try player.setAudioVolume(Volume(2.0)) // clamps to 1.25
       #expect(player.volume == 1.25)
+      #expect(player.audioVolume == .max)
     }
 
     @Test func `setPlaybackRate typed accessor passes through to libVLC`() throws {

--- a/Tests/SwiftVLCTests/Player/PlayerBranchCoverageTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerBranchCoverageTests.swift
@@ -87,6 +87,52 @@ extension Integration {
     }
 
     @Test
+    func `pause while resume transition is in flight defers pause request`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      player.pauseTransition = .resuming
+
+      #expect(player.issuePause() == false)
+
+      #expect(player.deferredPauseCommand == .pause)
+      #expect(player.isPlaybackRequestedActive == false)
+    }
+
+    @Test
+    func `resume while pause transition is in flight defers resume request`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .paused, isPlaybackRequestedActive: false)
+      player.pauseTransition = .pausing
+
+      #expect(player.issueResume())
+
+      #expect(player.deferredPauseCommand == .resume)
+      #expect(player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `resume while cached state remains active republishes play intent`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: false)
+
+      #expect(player.issueResume())
+
+      #expect(player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `cancelPendingPause clears queued pause and restores play intent`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: false)
+      player.deferredPauseCommand = .pause
+
+      player.cancelPendingPause()
+
+      #expect(player.deferredPauseCommand == nil)
+      #expect(player.isPlaybackRequestedActive)
+    }
+
+    @Test
     func `togglePlayPause from paused calls resume`() {
       let player = Player(instance: TestInstance.shared)
       player._setStateForTesting(state: .paused)
@@ -188,6 +234,33 @@ extension Integration {
       try player.seek(by: .seconds(5))
 
       #expect(player.currentTime == .seconds(15))
+    }
+
+    @Test
+    func `seek by offset rejects millisecond overflow`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(
+        currentTime: .milliseconds(Int64.max),
+        duration: nil,
+        isSeekable: true
+      )
+
+      #expect(throws: VLCError.self) {
+        try player.seek(by: .milliseconds(1))
+      }
+    }
+
+    @Test
+    func `absolute seek rejects times beyond known duration`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(
+        duration: .seconds(5),
+        isSeekable: true
+      )
+
+      #expect(throws: VLCError.self) {
+        try player.seek(to: .seconds(6))
+      }
     }
 
     // MARK: - checked position seek
@@ -467,6 +540,15 @@ extension Integration {
     func `recording toggle without media does not crash`() {
       let player = Player(instance: TestInstance.shared)
       player.startRecording(to: "/tmp/swiftvlc-test-recording")
+      player.stopRecording()
+    }
+
+    @Test
+    func `recording toggle with loaded media reaches libVLC record path`() throws {
+      let player = Player(instance: TestInstance.shared)
+      try player.load(Media(url: TestMedia.twosecURL))
+
+      player.startRecording(to: "/tmp")
       player.stopRecording()
     }
 

--- a/Tests/SwiftVLCTests/Player/PlayerBranchCoverageTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerBranchCoverageTests.swift
@@ -351,6 +351,31 @@ extension Integration {
       player.selectedSubtitleTrack = nil
     }
 
+    @Test
+    func `selectedAudioTrack ignores a stale track id`() {
+      let player = Player(instance: TestInstance.shared)
+      let staleTrack = Track(
+        id: "swiftvlc-stale-audio-track",
+        type: .audio,
+        name: "Stale audio",
+        codec: 0,
+        language: nil,
+        trackDescription: nil,
+        isSelected: false,
+        bitrate: 0,
+        channels: 2,
+        sampleRate: 44100,
+        width: nil,
+        height: nil,
+        frameRate: nil,
+        encoding: nil
+      )
+
+      player.selectedAudioTrack = staleTrack
+
+      #expect(player.selectedAudioTrack == nil)
+    }
+
     // MARK: - isActive across states
 
     /// `isActive` is true for `.playing`, `.opening`, `.buffering` and

--- a/Tests/SwiftVLCTests/Player/PlayerEventAccessorTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerEventAccessorTests.swift
@@ -1,0 +1,100 @@
+@testable import SwiftVLC
+import CustomDump
+import Testing
+
+extension Logic {
+  struct PlayerEventAccessorTests {
+    @Test
+    func `Per-case accessors return associated payloads`() throws {
+      expectNoDifference(PlayerEvent.stateChanged(.playing).stateChanged, .playing)
+      expectNoDifference(PlayerEvent.timeChanged(.seconds(5)).timeChanged, .seconds(5))
+      expectNoDifference(PlayerEvent.positionChanged(0.25).positionChanged, 0.25)
+      expectNoDifference(PlayerEvent.lengthChanged(.seconds(90)).lengthChanged, .seconds(90))
+      expectNoDifference(PlayerEvent.seekableChanged(true).seekableChanged, true)
+      expectNoDifference(PlayerEvent.pausableChanged(false).pausableChanged, false)
+      expectNoDifference(PlayerEvent.volumeChanged(0.75).volumeChanged, 0.75)
+      expectNoDifference(PlayerEvent.voutChanged(2).voutChanged, 2)
+      expectNoDifference(PlayerEvent.bufferingProgress(0.5).bufferingProgress, 0.5)
+      expectNoDifference(PlayerEvent.chapterChanged(4).chapterChanged, 4)
+      expectNoDifference(PlayerEvent.titleSelectionChanged(3).titleSelectionChanged, 3)
+      expectNoDifference(PlayerEvent.snapshotTaken("/tmp/snapshot.png").snapshotTaken, "/tmp/snapshot.png")
+      expectNoDifference(PlayerEvent.programAdded(7).programAdded, 7)
+      expectNoDifference(PlayerEvent.programDeleted(8).programDeleted, 8)
+      expectNoDifference(PlayerEvent.programUpdated(9).programUpdated, 9)
+
+      #expect(PlayerEvent.tracksChanged.tracksChanged != nil)
+      #expect(PlayerEvent.mediaChanged.mediaChanged != nil)
+      #expect(PlayerEvent.encounteredError.encounteredError != nil)
+      #expect(PlayerEvent.muted.muted != nil)
+      #expect(PlayerEvent.unmuted.unmuted != nil)
+      #expect(PlayerEvent.corked.corked != nil)
+      #expect(PlayerEvent.uncorked.uncorked != nil)
+      #expect(PlayerEvent.mediaStopping.mediaStopping != nil)
+      #expect(PlayerEvent.titleListChanged.titleListChanged != nil)
+
+      if case .some(.some(let device)) = PlayerEvent.audioDeviceChanged("built-in").audioDeviceChanged {
+        expectNoDifference(device, "built-in")
+      } else {
+        Issue.record("Expected a wrapped non-nil audio device id")
+      }
+
+      if case .some(.none) = PlayerEvent.audioDeviceChanged(nil).audioDeviceChanged {
+      } else {
+        Issue.record("Expected a wrapped nil audio device id")
+      }
+
+      let recording = try #require(
+        PlayerEvent.recordingChanged(isRecording: true, filePath: "/tmp/out.ts").recordingChanged
+      )
+      #expect(recording.isRecording)
+      expectNoDifference(recording.filePath, "/tmp/out.ts")
+
+      let stoppedRecording = try #require(
+        PlayerEvent.recordingChanged(isRecording: false, filePath: nil).recordingChanged
+      )
+      #expect(!stoppedRecording.isRecording)
+      expectNoDifference(stoppedRecording.filePath, nil)
+
+      let selection = try #require(
+        PlayerEvent.programSelected(unselectedId: 11, selectedId: 12).programSelected
+      )
+      expectNoDifference(selection.unselectedId, 11)
+      expectNoDifference(selection.selectedId, 12)
+    }
+
+    @Test
+    func `Per-case accessors return nil for non-matching events`() {
+      let nilResults = [
+        PlayerEvent.muted.stateChanged == nil,
+        PlayerEvent.muted.timeChanged == nil,
+        PlayerEvent.muted.positionChanged == nil,
+        PlayerEvent.muted.lengthChanged == nil,
+        PlayerEvent.muted.seekableChanged == nil,
+        PlayerEvent.muted.pausableChanged == nil,
+        PlayerEvent.muted.tracksChanged == nil,
+        PlayerEvent.muted.mediaChanged == nil,
+        PlayerEvent.muted.encounteredError == nil,
+        PlayerEvent.muted.volumeChanged == nil,
+        PlayerEvent.unmuted.muted == nil,
+        PlayerEvent.muted.unmuted == nil,
+        PlayerEvent.muted.corked == nil,
+        PlayerEvent.muted.uncorked == nil,
+        PlayerEvent.muted.audioDeviceChanged == nil,
+        PlayerEvent.muted.mediaStopping == nil,
+        PlayerEvent.muted.voutChanged == nil,
+        PlayerEvent.muted.bufferingProgress == nil,
+        PlayerEvent.muted.chapterChanged == nil,
+        PlayerEvent.muted.recordingChanged == nil,
+        PlayerEvent.muted.titleListChanged == nil,
+        PlayerEvent.muted.titleSelectionChanged == nil,
+        PlayerEvent.muted.snapshotTaken == nil,
+        PlayerEvent.muted.programAdded == nil,
+        PlayerEvent.muted.programDeleted == nil,
+        PlayerEvent.muted.programSelected == nil,
+        PlayerEvent.muted.programUpdated == nil
+      ]
+
+      expectNoDifference(nilResults, Array(repeating: true, count: nilResults.count))
+    }
+  }
+}

--- a/Tests/SwiftVLCTests/Player/PlayerNativeLifecycleTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerNativeLifecycleTests.swift
@@ -1,0 +1,58 @@
+@testable import SwiftVLC
+import Testing
+
+extension Integration {
+  @Suite(.tags(.mainActor))
+  @MainActor struct PlayerNativeLifecycleTests {
+    @Test
+    func `shouldReplaceNativePlayerBeforePlaybackLoad is false without current media`() {
+      let player = Player(instance: TestInstance.shared)
+
+      player._setStateForTesting(state: .playing)
+
+      #expect(player.shouldReplaceNativePlayerBeforePlaybackLoad == false)
+    }
+
+    @Test(
+      arguments: [
+        PlayerState.opening,
+        .buffering,
+        .playing,
+        .paused,
+        .stopping,
+        .error
+      ]
+    )
+    func `shouldReplaceNativePlayerBeforePlaybackLoad is true for active observed states`(
+      state: PlayerState
+    ) throws {
+      let player = Player(instance: TestInstance.shared)
+      player.load(try Media(url: TestMedia.twosecURL))
+
+      player._setStateForTesting(state: state)
+
+      #expect(player.shouldReplaceNativePlayerBeforePlaybackLoad)
+    }
+
+    @Test(arguments: [PlayerState.idle, .stopped])
+    func `shouldReplaceNativePlayerBeforePlaybackLoad is false for inactive observed and native states`(
+      state: PlayerState
+    ) throws {
+      let player = Player(instance: TestInstance.shared)
+      player.load(try Media(url: TestMedia.twosecURL))
+
+      player._setStateForTesting(state: state)
+
+      #expect(player.shouldReplaceNativePlayerBeforePlaybackLoad == false)
+    }
+
+    @Test
+    func `stopNativePlayerBeforeRelease resumes before stopping when requested`() {
+      let player = Player(instance: TestInstance.shared)
+
+      Player.stopNativePlayerBeforeRelease(player.pointer, resumeBeforeStop: true)
+
+      #expect(player.state == .idle)
+    }
+  }
+}

--- a/Tests/SwiftVLCTests/Player/PlayerNativeLifecycleTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerNativeLifecycleTests.swift
@@ -27,9 +27,10 @@ extension Integration {
     )
     func `shouldReplaceNativePlayerBeforePlaybackLoad is true for active observed states`(
       state: PlayerState
-    ) throws {
+    )
+      throws {
       let player = Player(instance: TestInstance.shared)
-      player.load(try Media(url: TestMedia.twosecURL))
+      try player.load(Media(url: TestMedia.twosecURL))
 
       player._setStateForTesting(state: state)
 
@@ -39,9 +40,10 @@ extension Integration {
     @Test(arguments: [PlayerState.idle, .stopped])
     func `shouldReplaceNativePlayerBeforePlaybackLoad is false for inactive observed and native states`(
       state: PlayerState
-    ) throws {
+    )
+      throws {
       let player = Player(instance: TestInstance.shared)
-      player.load(try Media(url: TestMedia.twosecURL))
+      try player.load(Media(url: TestMedia.twosecURL))
 
       player._setStateForTesting(state: state)
 
@@ -112,9 +114,20 @@ extension Integration {
     }
 
     @Test
+    func `deferred resume commands are consumed when performed`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .paused)
+      player.deferredPauseCommand = .resume
+
+      player.performDeferredPauseCommandIfNeeded()
+
+      #expect(player.deferredPauseCommand == nil)
+    }
+
+    @Test
     func `syncCurrentMediaFromNative clears stale current media when native player has none`() throws {
       let player = Player(instance: TestInstance.shared)
-      player.load(try Media(url: TestMedia.twosecURL))
+      try player.load(Media(url: TestMedia.twosecURL))
       libvlc_media_player_set_media(player.pointer, nil)
 
       player.syncCurrentMediaFromNative()

--- a/Tests/SwiftVLCTests/Player/PlayerNativeLifecycleTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerNativeLifecycleTests.swift
@@ -1,4 +1,6 @@
 @testable import SwiftVLC
+import CLibVLC
+import Foundation
 import Testing
 
 extension Integration {
@@ -53,6 +55,71 @@ extension Integration {
       Player.stopNativePlayerBeforeRelease(player.pointer, resumeBeforeStop: true)
 
       #expect(player.state == .idle)
+    }
+
+    @Test
+    func `direct drawable attachment and clearing maintain ownership`() {
+      let player = Player(instance: TestInstance.shared)
+      let drawable = NSObject()
+      let unrelated = NSObject()
+
+      player.setDrawable(drawable)
+      #expect(player.isCurrentDrawable(drawable))
+      #expect(player.isDrawableOwner(drawable))
+
+      player.clearDrawable(ifCurrent: unrelated)
+      #expect(player.isCurrentDrawable(drawable))
+
+      player.clearDrawable(ifCurrent: drawable)
+      #expect(player.drawable == nil)
+      #expect(!player.isDrawableOwner(drawable))
+    }
+
+    @Test
+    func `prepareDrawableForPlayback rebinds drawable when requested`() throws {
+      let player = Player(instance: TestInstance.shared)
+      let drawable = NSObject()
+
+      player.setDrawable(drawable)
+      player.needsDrawableRebindForPlayback = true
+
+      try player.prepareDrawableForPlayback()
+
+      #expect(player.isCurrentDrawable(drawable))
+      #expect(player.needsDrawableRebindForPlayback == false)
+    }
+
+    @Test
+    func `stop marks hosted drawable for rebind before later playback`() {
+      let player = Player(instance: TestInstance.shared)
+      let drawable = NSObject()
+
+      player.setDrawable(drawable)
+      player.stop()
+
+      #expect(player.needsDrawableRebindForPlayback)
+    }
+
+    @Test
+    func `deferred pause commands are consumed when performed`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .paused)
+      player.deferredPauseCommand = .pause
+
+      player.performDeferredPauseCommandIfNeeded()
+
+      #expect(player.deferredPauseCommand == nil)
+    }
+
+    @Test
+    func `syncCurrentMediaFromNative clears stale current media when native player has none`() throws {
+      let player = Player(instance: TestInstance.shared)
+      player.load(try Media(url: TestMedia.twosecURL))
+      libvlc_media_player_set_media(player.pointer, nil)
+
+      player.syncCurrentMediaFromNative()
+
+      #expect(player.currentMedia == nil)
     }
   }
 }

--- a/Tests/SwiftVLCTests/Player/PlayerThrowsTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerThrowsTests.swift
@@ -209,8 +209,9 @@ extension Integration {
 
     @Test
     func `setAudioOutput accepts an available module`() {
-      let player = Player(instance: TestInstance.shared)
-      let outputs = TestInstance.shared.audioOutputs()
+      let instance = TestInstance.makePlayback()
+      let player = Player(instance: instance)
+      let outputs = instance.audioOutputs()
       var didSetOutput = false
 
       for output in outputs where (try? player.setAudioOutput(output.name)) != nil {

--- a/Tests/SwiftVLCTests/Player/PlayerThrowsTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerThrowsTests.swift
@@ -207,6 +207,20 @@ extension Integration {
       }
     }
 
+    @Test
+    func `setAudioOutput accepts an available module`() throws {
+      let player = Player(instance: TestInstance.shared)
+      let outputs = TestInstance.shared.audioOutputs()
+      var didSetOutput = false
+
+      for output in outputs where (try? player.setAudioOutput(output.name)) != nil {
+        didSetOutput = true
+        break
+      }
+
+      #expect(didSetOutput || outputs.isEmpty)
+    }
+
     // MARK: - A-B loop error paths
 
     /// A-B loop requires the player to have a loaded media with a known
@@ -225,6 +239,22 @@ extension Integration {
       let player = Player(instance: TestInstance.shared)
       #expect(throws: VLCError.self) {
         try player.setABLoop(aPosition: 0.1, bPosition: 0.2)
+      }
+    }
+
+    @Test
+    func `setABLoop by time rejects non-increasing bounds before libVLC`() {
+      let player = Player(instance: TestInstance.shared)
+      #expect(throws: VLCError.invalidInput("A-B loop requires a < b")) {
+        try player.setABLoop(a: .seconds(2), b: .seconds(2))
+      }
+    }
+
+    @Test
+    func `setABLoop by position rejects non-increasing bounds before libVLC`() {
+      let player = Player(instance: TestInstance.shared)
+      #expect(throws: VLCError.invalidInput("A-B loop requires aPosition < bPosition")) {
+        try player.setABLoop(aPosition: 0.5, bPosition: 0.5)
       }
     }
 

--- a/Tests/SwiftVLCTests/Player/PlayerThrowsTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerThrowsTests.swift
@@ -208,7 +208,7 @@ extension Integration {
     }
 
     @Test
-    func `setAudioOutput accepts an available module`() throws {
+    func `setAudioOutput accepts an available module`() {
       let player = Player(instance: TestInstance.shared)
       let outputs = TestInstance.shared.audioOutputs()
       var didSetOutput = false

--- a/Tests/SwiftVLCTests/Playlist/MediaListPlayerTests.swift
+++ b/Tests/SwiftVLCTests/Playlist/MediaListPlayerTests.swift
@@ -228,6 +228,49 @@ extension Integration {
       #expect(listPlayer.mediaList == nil)
     }
 
+    @Test
+    func `Clearing media player rebuilds native list player without dropping media list`() throws {
+      let listPlayer = MediaListPlayer(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.shared)
+      let list = MediaList()
+      try list.append(Media(url: TestMedia.testMP4URL))
+
+      listPlayer.mediaPlayer = player
+      listPlayer.mediaList = list
+      listPlayer.mediaPlayer = nil
+
+      #expect(listPlayer.mediaPlayer == nil)
+      #expect(listPlayer.mediaList === list)
+      let nativePlayer = libvlc_media_list_player_get_media_player(listPlayer.pointer)
+      defer {
+        if let nativePlayer {
+          libvlc_media_player_release(nativePlayer)
+        }
+      }
+      #expect(nativePlayer != player.pointer)
+    }
+
+    @Test
+    func `Clearing media list rebuilds native list player without dropping media player`() {
+      let listPlayer = MediaListPlayer(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.shared)
+      let list = MediaList()
+
+      listPlayer.mediaPlayer = player
+      listPlayer.mediaList = list
+      listPlayer.mediaList = nil
+
+      #expect(listPlayer.mediaPlayer === player)
+      #expect(listPlayer.mediaList == nil)
+      let nativePlayer = libvlc_media_list_player_get_media_player(listPlayer.pointer)
+      defer {
+        if let nativePlayer {
+          libvlc_media_player_release(nativePlayer)
+        }
+      }
+      #expect(nativePlayer == player.pointer)
+    }
+
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `Clearing media list removes stale native playback state`() async throws {
       let instance = TestInstance.makePlayback()

--- a/Tests/SwiftVLCTests/Playlist/MediaListPlayerTests.swift
+++ b/Tests/SwiftVLCTests/Playlist/MediaListPlayerTests.swift
@@ -186,6 +186,28 @@ extension Integration {
     }
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
+    func `Toggle pause dispatches from active list player states`() async throws {
+      let instance = TestInstance.makePlayback()
+      let listPlayer = MediaListPlayer(instance: instance)
+      let player = Player(instance: instance)
+      listPlayer.mediaPlayer = player
+      let list = MediaList()
+      try list.append(Media(url: TestMedia.twosecURL))
+      listPlayer.mediaList = list
+
+      listPlayer.play()
+      try #require(await poll(until: { listPlayer.isPlaying }), "Waiting for: listPlayer.isPlaying")
+
+      listPlayer.togglePause()
+      if try await poll(timeout: .seconds(3), until: { listPlayer.state == .paused }) {
+        listPlayer.togglePause()
+        _ = try await poll(timeout: .seconds(3), until: { listPlayer.isPlaying })
+      }
+
+      listPlayer.stop()
+    }
+
+    @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `State during playback`() async throws {
       let instance = TestInstance.makePlayback()
       let listPlayer = MediaListPlayer(instance: instance)

--- a/Tests/SwiftVLCTests/Playlist/MediaListTests.swift
+++ b/Tests/SwiftVLCTests/Playlist/MediaListTests.swift
@@ -131,5 +131,50 @@ extension Integration {
       try list.remove(at: 0) // Remove remaining
       #expect(list.isEmpty)
     }
+
+    @Test
+    func `Retaining existing pointer exposes the same underlying list`() throws {
+      let original = MediaList()
+      try original.append(Media(url: TestMedia.testMP4URL))
+
+      let retained = MediaList(retaining: original.pointer)
+      #expect(retained.count == 1)
+
+      try retained.append(Media(url: TestMedia.twosecURL))
+
+      #expect(original.count == 2)
+      #expect(retained.count == 2)
+    }
+
+    @Test
+    func `Media lookup returns nil outside list bounds`() throws {
+      let list = MediaList()
+      try list.append(Media(url: TestMedia.testMP4URL))
+
+      #expect(list.media(at: -1) == nil)
+      #expect(list.media(at: 1) == nil)
+      #expect(list[Int.max] == nil)
+    }
+
+    @Test
+    func `Locked view exposes a consistent snapshot`() throws {
+      let list = MediaList()
+      try list.append(Media(url: TestMedia.testMP4URL))
+      try list.append(Media(url: TestMedia.twosecURL))
+
+      let mrls = list.withLocked { view in
+        #expect(view.count == 2)
+        #expect(view.isEmpty == false)
+        #expect(view.media(at: -1) == nil)
+        #expect(view[2] == nil)
+        return [
+          view[0]?.mrl,
+          view.media(at: 1)?.mrl
+        ]
+      }
+
+      #expect(mrls[0]?.contains("test.mp4") == true)
+      #expect(mrls[1]?.contains("twosec.mp4") == true)
+    }
   }
 }

--- a/Tests/SwiftVLCTests/Support/NSViewTestHelpers.swift
+++ b/Tests/SwiftVLCTests/Support/NSViewTestHelpers.swift
@@ -1,0 +1,17 @@
+#if canImport(AppKit)
+import AppKit
+
+extension NSView {
+  func firstDescendant<T: NSView>(ofType type: T.Type) -> T? {
+    if let match = self as? T {
+      return match
+    }
+    for subview in subviews {
+      if let match = subview.firstDescendant(ofType: type) {
+        return match
+      }
+    }
+    return nil
+  }
+}
+#endif

--- a/Tests/SwiftVLCTests/Video/VideoSurfaceTests.swift
+++ b/Tests/SwiftVLCTests/Video/VideoSurfaceTests.swift
@@ -202,6 +202,31 @@ extension Integration {
       #endif
     }
 
+    @Test
+    func `AppKit surface republishes drawable when moved into a window`() {
+      #if canImport(AppKit)
+      let player = Player(instance: TestInstance.shared)
+      let surface = VideoSurface(frame: NSRect(x: 0, y: 0, width: 320, height: 180))
+      let window = NSWindow(
+        contentRect: NSRect(x: 0, y: 0, width: 320, height: 180),
+        styleMask: [],
+        backing: .buffered,
+        defer: false
+      )
+
+      surface.wantsLayer = true
+      surface.attach(to: player)
+      window.contentView?.addSubview(surface)
+
+      #expect(player.drawable === surface)
+      #expect(surface.needsLayout)
+
+      surface.detach()
+      #else
+      #expect(Bool(true))
+      #endif
+    }
+
     /// Layout with zero-width or zero-height bounds must be a no-op
     /// so we don't race with libVLC's own initial sizing.
     @Test

--- a/Tests/SwiftVLCTests/Video/VideoViewRepresentableTests.swift
+++ b/Tests/SwiftVLCTests/Video/VideoViewRepresentableTests.swift
@@ -94,8 +94,8 @@ extension Integration {
 }
 
 #if canImport(AppKit)
-private extension NSView {
-  func firstDescendant<T: NSView>(ofType type: T.Type) -> T? {
+extension NSView {
+  fileprivate func firstDescendant<T: NSView>(ofType type: T.Type) -> T? {
     if let match = self as? T {
       return match
     }

--- a/Tests/SwiftVLCTests/Video/VideoViewRepresentableTests.swift
+++ b/Tests/SwiftVLCTests/Video/VideoViewRepresentableTests.swift
@@ -87,24 +87,8 @@ extension Integration {
       #expect(firstPlayer.drawable == nil)
       #expect(secondPlayer.drawable === surface)
       #else
-      #expect(Bool(true))
+      #expect(true)
       #endif
     }
   }
 }
-
-#if canImport(AppKit)
-extension NSView {
-  fileprivate func firstDescendant<T: NSView>(ofType type: T.Type) -> T? {
-    if let match = self as? T {
-      return match
-    }
-    for subview in subviews {
-      if let match = subview.firstDescendant(ofType: type) {
-        return match
-      }
-    }
-    return nil
-  }
-}
-#endif

--- a/Tests/SwiftVLCTests/Video/VideoViewRepresentableTests.swift
+++ b/Tests/SwiftVLCTests/Video/VideoViewRepresentableTests.swift
@@ -1,4 +1,5 @@
 @testable import SwiftVLC
+import SwiftUI
 import Testing
 
 #if canImport(UIKit)
@@ -60,5 +61,50 @@ extension Integration {
       VideoView.dismantleNSView(wrong, coordinator: ())
       #endif
     }
+
+    @Test
+    func `SwiftUI host creates and updates AppKit video surface`() async throws {
+      #if canImport(AppKit)
+      let firstPlayer = Player(instance: TestInstance.shared)
+      let secondPlayer = Player(instance: TestInstance.shared)
+      let host = NSHostingView(rootView: VideoView(firstPlayer))
+
+      host.frame = NSRect(x: 0, y: 0, width: 320, height: 180)
+      host.layoutSubtreeIfNeeded()
+      await Task.yield()
+
+      let surface = try #require(host.firstDescendant(ofType: VideoSurface.self))
+      #expect(surface.wantsLayer == true)
+      #expect(surface.layer?.backgroundColor == NSColor.black.cgColor)
+      #expect(surface.layer?.masksToBounds == true)
+      #expect(surface.autoresizesSubviews == true)
+      #expect(firstPlayer.drawable === surface)
+
+      host.rootView = VideoView(secondPlayer)
+      host.layoutSubtreeIfNeeded()
+      await Task.yield()
+
+      #expect(firstPlayer.drawable == nil)
+      #expect(secondPlayer.drawable === surface)
+      #else
+      #expect(Bool(true))
+      #endif
+    }
   }
 }
+
+#if canImport(AppKit)
+private extension NSView {
+  func firstDescendant<T: NSView>(ofType type: T.Type) -> T? {
+    if let match = self as? T {
+      return match
+    }
+    for subview in subviews {
+      if let match = subview.firstDescendant(ofType: type) {
+        return match
+      }
+    }
+    return nil
+  }
+}
+#endif


### PR DESCRIPTION
## Summary
- Adds focused accessor coverage for player events, VLC errors, dialog events, and one-shot dialog request helpers.
- Expands lifecycle coverage around native player replacement, drawable rebinding, media lists, playlist rebuilds, input validation, stale track selection, and typed playback values.
- Adds deeper PiP coverage for delegate proxies, native macOS backend delegation, hosted SwiftUI/AppKit video surfaces, PiP drawable layout behavior, playback state-machine edges, and native PiP media-controller resume behavior.
- Keeps changes test-only; no production source files were modified.

## Verification
- `swiftformat Sources Tests Showcase`
- `swiftlint lint --strict --quiet Sources Tests Showcase`
- `swiftformat Sources Tests Showcase --lint --strict`
- `swift test --filter 'PlayerBranchCoverageTests|PlayerThrowsTests|MediaListPlayerTests'`\n- `swift test --filter 'PlayerThrowsTests|VideoViewRepresentableTests|PiPVideoViewTests'`\n- `swift test --filter 'TrackExtendedTests|PiPVideoViewTests'`\n- `swift test --enable-code-coverage` (1,345 tests)\n- `scripts/export-lcov.sh`\n- Source line coverage improved from 83.28% (5071/6089) to 89.44% (5446/6089) on the final local full run.\n\n## Remaining hard-to-cover areas\n- Private macOS PiP framework integration paths, real libVLC dialog callbacks, renderer discovery callbacks, and rare parse/thumbnail cancellation races still account for most remaining uncovered lines. I avoided fake native callbacks or invalid pointers because those would make the tests brittle or unsafe.