### PR TITLE
Increase CI-safe test coverage

### DIFF
--- a/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
+++ b/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
@@ -135,7 +135,8 @@ public final class MediaListPlayer {
   }
 
   /// Plays the item at the specified index.
-  /// - Throws: ``VLCError/invalidInput(_:)`` if the index is out of range for the
+  /// - Throws: ``VLCError/invalidState(_:)`` if no media list is attached,
+  ///   ``VLCError/invalidInput(_:)`` if the index is out of range for the
   ///   attached list, or ``VLCError/operationFailed(_:)`` if libVLC rejects it.
   public func play(at requestedIndex: Int) throws(VLCError) {
     let index = try checkedNonnegativeInt32(requestedIndex, parameter: "index")
@@ -151,7 +152,8 @@ public final class MediaListPlayer {
   }
 
   /// Plays a specific media item from the list.
-  /// - Throws: `VLCError.operationFailed` if the item is not in the list.
+  /// - Throws: ``VLCError/invalidState(_:)`` if no media list is attached,
+  ///   or ``VLCError/operationFailed(_:)`` if the item is not in the list.
   public func play(_ media: borrowing Media) throws(VLCError) {
     guard _mediaList != nil else {
       throw .invalidState("mediaList must be set before playing an item")

--- a/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
+++ b/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
@@ -137,16 +137,16 @@ public final class MediaListPlayer {
   /// Plays the item at the specified index.
   /// - Throws: ``VLCError/invalidInput(_:)`` if the index is out of range for the
   ///   attached list, or ``VLCError/operationFailed(_:)`` if libVLC rejects it.
-  public func play(at index: Int) throws(VLCError) {
-    let checkedIndex = try checkedNonnegativeInt32(index, parameter: "index")
+  public func play(at requestedIndex: Int) throws(VLCError) {
+    let index = try checkedNonnegativeInt32(requestedIndex, parameter: "index")
     guard let count = _mediaList?.count else {
       throw .invalidState("mediaList must be set before playing by index")
     }
-    if !(0..<count).contains(index) {
+    if !(0..<count).contains(requestedIndex) {
       throw .invalidInput("index must be in 0..<\(count)")
     }
-    guard libvlc_media_list_player_play_item_at_index(pointer, checkedIndex) == 0 else {
-      throw .operationFailed("Play item at index \(checkedIndex)")
+    guard libvlc_media_list_player_play_item_at_index(pointer, index) == 0 else {
+      throw .operationFailed("Play item at index \(index)")
     }
   }
 

--- a/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
+++ b/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
@@ -138,19 +138,24 @@ public final class MediaListPlayer {
   /// - Throws: ``VLCError/invalidInput(_:)`` if the index is out of range for the
   ///   attached list, or ``VLCError/operationFailed(_:)`` if libVLC rejects it.
   public func play(at index: Int) throws(VLCError) {
-    let count = _mediaList?.count
-    if let count, !(0..<count).contains(index) {
+    let checkedIndex = try checkedNonnegativeInt32(index, parameter: "index")
+    guard let count = _mediaList?.count else {
+      throw .invalidState("mediaList must be set before playing by index")
+    }
+    if !(0..<count).contains(index) {
       throw .invalidInput("index must be in 0..<\(count)")
     }
-    let index = try checkedNonnegativeInt32(index, parameter: "index")
-    guard libvlc_media_list_player_play_item_at_index(pointer, index) == 0 else {
-      throw .operationFailed("Play item at index \(index)")
+    guard libvlc_media_list_player_play_item_at_index(pointer, checkedIndex) == 0 else {
+      throw .operationFailed("Play item at index \(checkedIndex)")
     }
   }
 
   /// Plays a specific media item from the list.
   /// - Throws: `VLCError.operationFailed` if the item is not in the list.
   public func play(_ media: borrowing Media) throws(VLCError) {
+    guard _mediaList != nil else {
+      throw .invalidState("mediaList must be set before playing an item")
+    }
     guard libvlc_media_list_player_play_item(pointer, media.pointer) == 0 else {
       throw .operationFailed("Play media item")
     }

--- a/Tests/SwiftVLCTests/Audio/EqualizerBandsTests.swift
+++ b/Tests/SwiftVLCTests/Audio/EqualizerBandsTests.swift
@@ -106,6 +106,15 @@ extension Integration {
       #expect(changeCount == 1)
     }
 
+    @Test
+    func `setAmplification rejects NaN values`() {
+      let eq = Equalizer()
+
+      #expect(throws: VLCError.self) {
+        try eq.setAmplification(.nan, forBand: 0)
+      }
+    }
+
     // MARK: - Presets
 
     /// Every preset must construct a valid equalizer. If libVLC drops a

--- a/Tests/SwiftVLCTests/Core/DialogHandlerExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Core/DialogHandlerExtendedTests.swift
@@ -164,6 +164,25 @@ extension Integration {
     }
 
     @Test
+    func `QuestionRequest rejects unrepresentable action without consuming dialog`() {
+      let (ptr, raw) = Self.makeDummyPointer()
+      defer { raw.deallocate() }
+
+      let request = QuestionRequest(
+        dialogId: DialogID(pointer: ptr),
+        title: "Question",
+        text: "Choose an action",
+        type: .normal,
+        cancelText: "Cancel",
+        action1Text: "OK",
+        action2Text: nil
+      )
+
+      #expect(request.post(action: Int.max) == false)
+      #expect(request.dialogId.pointer == ptr)
+    }
+
+    @Test
     func `QuestionRequest is Sendable`() {
       let _: any Sendable.Type = QuestionRequest.self
       let (ptr, raw) = Self.makeDummyPointer()

--- a/Tests/SwiftVLCTests/Core/DialogHandlerNetworkTests.swift
+++ b/Tests/SwiftVLCTests/Core/DialogHandlerNetworkTests.swift
@@ -1,0 +1,259 @@
+@testable import SwiftVLC
+import Darwin
+import Foundation
+import Synchronization
+import Testing
+
+extension Integration {
+  struct DialogHandlerNetworkTests {
+    @Test(.tags(.async, .media), .timeLimit(.minutes(1)))
+    @MainActor
+    func `HTTP auth emits login dialog`() async throws {
+      let server = try BasicAuthProbeServer()
+      defer { server.stop() }
+
+      let instance = TestInstance.shared
+      let handler = DialogHandler(instance: instance)
+      let media = try Media(url: server.url)
+      let player = Player(instance: instance)
+      defer { player.stop() }
+
+      do {
+        try player.play(media)
+      } catch {
+        // The zero-byte response is not meaningful media; this test is
+        // about the auth dialog surfaced before playback fails.
+      }
+
+      let event = try #require(
+        await firstDialog(from: handler.dialogs, timeout: .seconds(8)),
+        "Expected libVLC to emit a login dialog for the HTTP auth challenge"
+      )
+
+      guard case .login(let request) = event else {
+        Issue.record("Expected login dialog, got \(event)")
+        return
+      }
+
+      #expect(request.title.isEmpty == false)
+      #expect(request.defaultUsername.isEmpty)
+      #expect(request.post(username: "swift", password: "vlc"))
+
+      try #require(await poll(every: .milliseconds(10), timeout: .seconds(3)) {
+        server.sawAuthorizedRequest
+      }, "Expected libVLC to retry the request with posted credentials")
+    }
+
+    @Test(.tags(.async, .media), .timeLimit(.minutes(1)))
+    @MainActor
+    func `HTTP auth login dialog can be dismissed`() async throws {
+      let server = try BasicAuthProbeServer()
+      defer { server.stop() }
+
+      let instance = TestInstance.shared
+      let handler = DialogHandler(instance: instance)
+      let media = try Media(url: server.url)
+      let player = Player(instance: instance)
+      defer { player.stop() }
+
+      do {
+        try player.play(media)
+      } catch {
+        // The challenge should be delivered before playback ultimately fails.
+      }
+
+      let event = try #require(
+        await firstDialog(from: handler.dialogs, timeout: .seconds(8)),
+        "Expected libVLC to emit a login dialog for the HTTP auth challenge"
+      )
+
+      guard case .login(let request) = event else {
+        Issue.record("Expected login dialog, got \(event)")
+        return
+      }
+
+      #expect(request.dismiss())
+    }
+  }
+}
+
+private func firstDialog(
+  from stream: AsyncStream<DialogEvent>,
+  timeout: Duration
+)
+  async -> DialogEvent? {
+  await withTaskGroup(of: DialogEvent?.self) { group in
+    group.addTask {
+      var iterator = stream.makeAsyncIterator()
+      return await iterator.next()
+    }
+    group.addTask {
+      try? await Task.sleep(for: timeout)
+      return nil
+    }
+
+    let result = await group.next() ?? nil
+    group.cancelAll()
+    return result
+  }
+}
+
+private final class BasicAuthProbeServer: @unchecked Sendable {
+  private static let expectedAuthorization = "Authorization: Basic c3dpZnQ6dmxj"
+
+  private let socketFD: Int32
+  private let queue = DispatchQueue(label: "swiftvlc.basic-auth-probe")
+  private let state = StateBox()
+
+  let url: URL
+
+  var sawAuthorizedRequest: Bool {
+    state.sawAuthorizedRequest
+  }
+
+  init() throws {
+    let fd = socket(AF_INET, SOCK_STREAM, 0)
+    guard fd >= 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
+
+    var reuse: Int32 = 1
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size))
+
+    var address = sockaddr_in()
+    address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+    address.sin_family = sa_family_t(AF_INET)
+    address.sin_port = 0
+    address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+    let bindResult = withUnsafePointer(to: &address) { pointer in
+      pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+        Darwin.bind(fd, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_in>.size))
+      }
+    }
+    guard bindResult == 0 else {
+      let error = POSIXError(.init(rawValue: errno) ?? .EIO)
+      close(fd)
+      throw error
+    }
+
+    guard listen(fd, 4) == 0 else {
+      let error = POSIXError(.init(rawValue: errno) ?? .EIO)
+      close(fd)
+      throw error
+    }
+
+    var boundAddress = sockaddr_in()
+    var boundLength = socklen_t(MemoryLayout<sockaddr_in>.size)
+    let nameResult = withUnsafeMutablePointer(to: &boundAddress) { pointer in
+      pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+        getsockname(fd, sockaddrPointer, &boundLength)
+      }
+    }
+    guard nameResult == 0 else {
+      let error = POSIXError(.init(rawValue: errno) ?? .EIO)
+      close(fd)
+      throw error
+    }
+
+    let port = UInt16(bigEndian: boundAddress.sin_port)
+    socketFD = fd
+    url = URL(string: "http://127.0.0.1:\(port)/protected.mp4")!
+
+    queue.async { [fd, state] in
+      Self.acceptLoop(socketFD: fd, state: state)
+    }
+  }
+
+  deinit {
+    stop()
+  }
+
+  func stop() {
+    state.mutex.withLock { state in
+      guard !state.isStopped else { return }
+      state.isStopped = true
+      shutdown(socketFD, SHUT_RDWR)
+      close(socketFD)
+    }
+  }
+
+  private static func acceptLoop(socketFD: Int32, state: StateBox) {
+    while true {
+      let client = accept(socketFD, nil, nil)
+      if client < 0 { return }
+      handle(client: client, state: state)
+      close(client)
+    }
+  }
+
+  private static func handle(client: Int32, state: StateBox) {
+    let request = readRequest(from: client)
+    let authorized = request.localizedCaseInsensitiveContains(expectedAuthorization)
+    if authorized {
+      state.mutex.withLock { $0.sawAuthorizedRequest = true }
+    }
+
+    let response = authorized
+      ? httpResponse(
+        status: "HTTP/1.1 200 OK",
+        headers: [
+          "Content-Type: video/mp4",
+          "Content-Length: 0",
+          "Connection: close"
+        ]
+      )
+      : httpResponse(
+        status: "HTTP/1.1 401 Unauthorized",
+        headers: [
+          "WWW-Authenticate: Basic realm=\"SwiftVLC\"",
+          "Content-Length: 0",
+          "Connection: close"
+        ]
+      )
+    response.withCString { pointer in
+      _ = write(client, pointer, strlen(pointer))
+    }
+  }
+
+  private static func httpResponse(status: String, headers: [String]) -> String {
+    ([status] + headers).joined(separator: "\r\n") + "\r\n\r\n"
+  }
+
+  private static func readRequest(from client: Int32) -> String {
+    var bytes: [UInt8] = []
+    var buffer = [UInt8](repeating: 0, count: 1024)
+
+    while bytes.count < 16 * 1024 {
+      let count = recv(client, &buffer, buffer.count, 0)
+      guard count > 0 else { break }
+      bytes.append(contentsOf: buffer.prefix(count))
+      if bytes.containsCRLFCRLF { break }
+    }
+
+    return String(bytes: bytes, encoding: .utf8) ?? ""
+  }
+
+  private struct State: @unchecked Sendable {
+    var isStopped = false
+    var sawAuthorizedRequest = false
+  }
+
+  private final class StateBox: @unchecked Sendable {
+    let mutex = Mutex(State())
+
+    var sawAuthorizedRequest: Bool {
+      mutex.withLock { $0.sawAuthorizedRequest }
+    }
+  }
+}
+
+extension [UInt8] {
+  fileprivate var containsCRLFCRLF: Bool {
+    guard count >= 4 else { return false }
+    return indices.dropFirst(3).contains { index in
+      self[index - 3] == 13
+        && self[index - 2] == 10
+        && self[index - 1] == 13
+        && self[index] == 10
+    }
+  }
+}

--- a/Tests/SwiftVLCTests/Core/InputValidationTests.swift
+++ b/Tests/SwiftVLCTests/Core/InputValidationTests.swift
@@ -17,6 +17,12 @@ extension Logic {
     }
 
     @Test
+    func `checkedNonnegativeInt32 accepts zero and positive values`() throws {
+      #expect(try checkedNonnegativeInt32(0, parameter: "index") == 0)
+      #expect(try checkedNonnegativeInt32(42, parameter: "index") == 42)
+    }
+
+    @Test
     func `checkedUInt32 accepts unsigned range endpoints`() throws {
       #expect(try checkedUInt32(0, parameter: "width") == 0)
       #expect(try checkedUInt32(Int(UInt32.max), parameter: "width") == UInt32.max)

--- a/Tests/SwiftVLCTests/Core/VLCInstanceTests.swift
+++ b/Tests/SwiftVLCTests/Core/VLCInstanceTests.swift
@@ -1,4 +1,5 @@
 @testable import SwiftVLC
+import Foundation
 import Testing
 
 extension Integration {
@@ -52,6 +53,60 @@ extension Integration {
     func `Init with empty arguments succeeds`() throws {
       let instance = try VLCInstance(arguments: [])
       #expect(!instance.version.isEmpty)
+    }
+
+    @Test
+    func `Dialog registration claims exactly one slot until released`() throws {
+      let instance = try VLCInstance(arguments: ["--quiet"])
+      let firstBox = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
+      let secondBox = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
+      defer {
+        firstBox.deallocate()
+        secondBox.deallocate()
+      }
+
+      var installCount = 0
+      var clearCount = 0
+      let token = try #require(instance.claimDialogRegistration(box: firstBox) { _, box in
+        installCount += 1
+        #expect(box == firstBox)
+      })
+
+      let rejected = instance.claimDialogRegistration(box: secondBox) { _, _ in
+        Issue.record("Second dialog registration must not install callbacks")
+      }
+      #expect(rejected == nil)
+
+      let wrongRelease = instance.releaseDialogRegistration(token: UUID()) { _ in
+        Issue.record("Wrong token must not clear callbacks")
+      }
+      #expect(wrongRelease == nil)
+
+      let released = instance.releaseDialogRegistration(token: token) { _ in
+        clearCount += 1
+      }
+
+      #expect(released == firstBox)
+      #expect(installCount == 1)
+      #expect(clearCount == 1)
+    }
+
+    @Test
+    func `VLCInstance deinit clears an unreleased dialog registration`() throws {
+      let leakedBox = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
+      defer { leakedBox.deallocate() }
+      weak var weakInstance: VLCInstance?
+
+      do {
+        let instance = try VLCInstance(arguments: ["--quiet"])
+        weakInstance = instance
+        let token = instance.claimDialogRegistration(box: leakedBox) { _, box in
+          #expect(box == leakedBox)
+        }
+        #expect(token != nil)
+      }
+
+      #expect(weakInstance == nil)
     }
 
     @Test

--- a/Tests/SwiftVLCTests/Discovery/MediaDiscovererTests.swift
+++ b/Tests/SwiftVLCTests/Discovery/MediaDiscovererTests.swift
@@ -81,6 +81,19 @@ extension Integration {
     }
 
     @Test
+    func `Init with empty name may throw VLCError`() {
+      do {
+        let discoverer = try MediaDiscoverer(name: "")
+        _ = discoverer
+      } catch {
+        guard case .instanceCreationFailed = error else {
+          Issue.record("Expected .instanceCreationFailed, got \(error)")
+          return
+        }
+      }
+    }
+
+    @Test
     func `Start and stop`() {
       let services = MediaDiscoverer.availableServices(category: .localDirectories)
       guard let service = services.first else { return }

--- a/Tests/SwiftVLCTests/Discovery/RendererDiscovererTests.swift
+++ b/Tests/SwiftVLCTests/Discovery/RendererDiscovererTests.swift
@@ -52,6 +52,19 @@ extension Integration {
     }
 
     @Test
+    func `Init with empty name may throw VLCError`() {
+      do {
+        let discoverer = try RendererDiscoverer(name: "")
+        _ = discoverer
+      } catch {
+        guard case .instanceCreationFailed = error else {
+          Issue.record("Expected .instanceCreationFailed, got \(error)")
+          return
+        }
+      }
+    }
+
+    @Test
     func `Events stream accessible`() {
       let services = RendererDiscoverer.availableServices()
       guard let service = services.first else { return }

--- a/Tests/SwiftVLCTests/Media/MediaErrorPathsTests.swift
+++ b/Tests/SwiftVLCTests/Media/MediaErrorPathsTests.swift
@@ -122,6 +122,29 @@ extension Integration {
       }
     }
 
+    @Test(.tags(.async, .media))
+    func `parse from an already cancelled task returns cancelled failure`() async throws {
+      let media = try Media(url: TestMedia.testMP4URL)
+
+      let task = Task {
+        withUnsafeCurrentTask { task in
+          task?.cancel()
+        }
+
+        do {
+          _ = try await media.parse(timeout: .seconds(5), instance: TestInstance.shared)
+          return false
+        } catch let error as VLCError {
+          guard case .parseFailed(let reason) = error else { return false }
+          return reason.contains("cancelled")
+        } catch {
+          return false
+        }
+      }
+
+      #expect(await task.value)
+    }
+
     @Test
     func `thumbnail rejects invalid public input before starting request`() async throws {
       let media = try Media(url: URL(fileURLWithPath: "/tmp/swiftvlc-test.mp4"))

--- a/Tests/SwiftVLCTests/Media/ThumbnailCancellationTests.swift
+++ b/Tests/SwiftVLCTests/Media/ThumbnailCancellationTests.swift
@@ -83,5 +83,86 @@ extension Integration {
         _ = await task.result
       }
     }
+
+    /// Audio-only media has no video frame to extract, but the request
+    /// should still run through libVLC's thumbnailer and return a typed
+    /// failure instead of hanging or requiring real video output.
+    @Test(.timeLimit(.minutes(1)))
+    func `Audio-only thumbnail request reports failure without video output`() async throws {
+      let media = try Media(url: TestMedia.silenceURL)
+
+      do {
+        _ = try await media.thumbnail(
+          at: .zero,
+          width: 64,
+          timeout: .milliseconds(500),
+          instance: TestInstance.shared
+        )
+        Issue.record("Expected audio-only media to fail thumbnail generation")
+      } catch .operationFailed(let reason) {
+        #expect(reason.contains("Generate thumbnail"))
+      } catch {
+        Issue.record("Expected operationFailed, got \(error)")
+      }
+    }
+
+    /// A video thumbnail request should always complete promptly even
+    /// on the no-video CI instance. Depending on libVLC's thumbnailer
+    /// availability it may produce a PNG or report an operation failure;
+    /// both outcomes are valid, but hanging is not.
+    @Test(.timeLimit(.minutes(1)))
+    func `Video thumbnail request completes without real video output`() async throws {
+      let media = try Media(url: TestMedia.testMP4URL)
+
+      do {
+        let data = try await media.thumbnail(
+          at: .zero,
+          width: 32,
+          timeout: .milliseconds(500),
+          instance: TestInstance.shared
+        )
+        #expect(!data.isEmpty)
+      } catch .operationFailed(let reason) {
+        #expect(reason.contains("Generate thumbnail"))
+      } catch {
+        Issue.record("Expected success or operationFailed, got \(error)")
+      }
+    }
+
+    @Test(.tags(.async, .media), .timeLimit(.minutes(1)))
+    func `Already cancelled thumbnail request returns promptly and releases its slot`() async throws {
+      let media = try Media(url: TestMedia.testMP4URL)
+
+      let task = Task {
+        withUnsafeCurrentTask { task in
+          task?.cancel()
+        }
+
+        return try await media.thumbnail(
+          at: .zero,
+          width: 64,
+          timeout: .seconds(5),
+          instance: TestInstance.shared
+        )
+      }
+
+      switch await task.result {
+      case .success:
+        Issue.record("Expected cancellation error")
+      case .failure(let error):
+        #expect(String(describing: error).contains("cancelled"))
+      }
+
+      do {
+        _ = try await media.thumbnail(
+          at: .zero,
+          width: 64,
+          timeout: .milliseconds(500),
+          instance: TestInstance.shared
+        )
+      } catch {
+        #expect(String(describing: error).contains("Generate thumbnail"))
+      }
+    }
   }
 }

--- a/Tests/SwiftVLCTests/Media/ThumbnailCoordinatorTests.swift
+++ b/Tests/SwiftVLCTests/Media/ThumbnailCoordinatorTests.swift
@@ -1,0 +1,89 @@
+@testable import SwiftVLC
+import Testing
+
+extension Logic {
+  @Suite(.tags(.async))
+  struct ThumbnailCoordinatorTests {
+    @Test
+    func `queued acquire resumes when active request releases`() async throws {
+      let coordinator = ThumbnailCoordinator()
+      try await coordinator.acquire()
+
+      let waiter = Task {
+        try await coordinator.acquire()
+        await coordinator.release()
+        return true
+      }
+
+      await allowQueuedAcquireToSuspend()
+      await coordinator.release()
+
+      #expect(try await waiter.value)
+
+      try await coordinator.acquire()
+      await coordinator.release()
+    }
+
+    @Test
+    func `queued acquire throws cancellation error when cancelled while waiting`() async throws {
+      let coordinator = ThumbnailCoordinator()
+      try await coordinator.acquire()
+
+      let waiter = Task {
+        do {
+          try await coordinator.acquire()
+          await coordinator.release()
+          Issue.record("Expected queued acquire to throw after cancellation")
+          return false
+        } catch let error as VLCError {
+          guard case .operationFailed(let reason) = error else {
+            Issue.record("Expected operationFailed cancellation, got \(error)")
+            return false
+          }
+          return reason.contains("cancelled")
+        } catch {
+          Issue.record("Expected operationFailed cancellation, got \(error)")
+          return false
+        }
+      }
+
+      await allowQueuedAcquireToSuspend()
+      waiter.cancel()
+
+      #expect(await waiter.value)
+      await coordinator.release()
+    }
+
+    @Test
+    func `release skips cancelled waiters and opens the next waiter`() async throws {
+      let coordinator = ThumbnailCoordinator()
+      try await coordinator.acquire()
+
+      let cancelledWaiter = Task {
+        try await coordinator.acquire()
+        await coordinator.release()
+      }
+      await allowQueuedAcquireToSuspend()
+      cancelledWaiter.cancel()
+      _ = await cancelledWaiter.result
+
+      let nextWaiter = Task {
+        try await coordinator.acquire()
+        await coordinator.release()
+        return true
+      }
+      await allowQueuedAcquireToSuspend()
+
+      await coordinator.release()
+
+      #expect(try await nextWaiter.value)
+    }
+
+    private func allowQueuedAcquireToSuspend() async {
+      for _ in 0..<10 {
+        await Task.yield()
+      }
+      try? await Task.sleep(for: .milliseconds(10))
+    }
+  }
+}

--- a/Tests/SwiftVLCTests/Media/TrackExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Media/TrackExtendedTests.swift
@@ -187,6 +187,33 @@ extension Integration {
     }
 
     @Test
+    func `C subtitle track maps encoding and clears audio video fields`() {
+      var subtitle = libvlc_subtitle_track_t()
+
+      let track = "UTF-8".withCString { encoding in
+        subtitle.psz_encoding = UnsafeMutablePointer(mutating: encoding)
+        var cTrack = libvlc_media_track_t()
+        cTrack.i_id = 7
+        cTrack.i_type = libvlc_track_text
+        cTrack.i_codec = 0x7372_7420
+
+        return withUnsafeMutablePointer(to: &subtitle) { subtitlePointer in
+          cTrack.subtitle = subtitlePointer
+          return withUnsafePointer(to: cTrack) { Track(from: $0) }
+        }
+      }
+
+      #expect(track.id == "7")
+      #expect(track.type == .subtitle)
+      #expect(track.encoding == "UTF-8")
+      #expect(track.channels == nil)
+      #expect(track.sampleRate == nil)
+      #expect(track.width == nil)
+      #expect(track.height == nil)
+      #expect(track.frameRate == nil)
+    }
+
+    @Test
     func `Track with nil language and description`() {
       let track = makeTrack(id: "x-0", type: .audio)
       #expect(track.language == nil)

--- a/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
@@ -20,6 +20,7 @@ extension Integration {
       var pauseCount = 0
       var resumeCount = 0
       var cancelPendingPauseCount = 0
+      var pauseResult = true
       var shouldResume = false
       var resumeResult = true
       var seekTargets: [Int64] = []
@@ -28,7 +29,7 @@ extension Integration {
         .init(
           pause: {
             self.pauseCount += 1
-            return true
+            return self.pauseResult
           },
           resume: {
             self.resumeCount += 1
@@ -200,6 +201,78 @@ extension Integration {
       #expect(recorder.pauseCount == 0, "Buffering must not trigger a native pause")
     }
 
+    @Test
+    func `deferred PiP pause retries while native pause is rejected`() async throws {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing)
+      let recorder = PlaybackRecorder()
+      recorder.pauseResult = false
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(10)
+      )
+
+      try? await Task.sleep(for: .milliseconds(20))
+      controller._setPlayingForTesting(false)
+
+      #expect(try await poll(every: .milliseconds(10), timeout: .milliseconds(250)) {
+        recorder.pauseCount >= 2
+      })
+
+      controller._setPlayingForTesting(true)
+    }
+
+    @Test
+    func `external play intent clears previously issued PiP pause`() async throws {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing)
+      let recorder = PlaybackRecorder()
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(10)
+      )
+
+      try? await Task.sleep(for: .milliseconds(20))
+      controller._setPlayingForTesting(false)
+
+      #expect(try await poll(every: .milliseconds(10), timeout: .milliseconds(250)) {
+        recorder.pauseCount == 1
+      })
+
+      player.setPlaybackIntentFromExternalControl(true)
+
+      #expect(try await poll(every: .milliseconds(10), timeout: .milliseconds(250)) {
+        controller._pipPlaybackActiveForTesting()
+      })
+
+      controller._setPlayingForTesting(true)
+
+      #expect(recorder.resumeCount == 0)
+    }
+
+    @Test
+    func `external pause intent supersedes pending PiP play request`() async throws {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .paused)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: PlaybackRecorder().driver,
+        pauseDebounce: .milliseconds(250)
+      )
+
+      controller._setPlayingForTesting(true)
+      #expect(controller._pendingPiPPlaybackStateForTesting() == true)
+
+      player.setPlaybackIntentFromExternalControl(false)
+
+      #expect(try await poll(every: .milliseconds(10), timeout: .milliseconds(250)) {
+        controller._pendingPiPPlaybackStateForTesting() == false
+      })
+      #expect(controller._pipPlaybackActiveForTesting() == false)
+    }
+
     // MARK: - toggle branches
 
     /// `toggle()` while PiP is active dispatches to `stop()`. Real
@@ -238,6 +311,19 @@ extension Integration {
       // a dangling callback pointer, a subsequent operation would
       // crash here.
       #expect(player.state == .idle)
+    }
+
+    @Test
+    func `PiPController deinit defers renderer cleanup for an active cached player`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+
+      do {
+        let controller = PiPController(player: player)
+        _ = controller.layer
+      }
+
+      #expect(player.state == .playing)
     }
 
     /// `pictureInPictureControllerIsPlaybackPaused` must read from the
@@ -664,6 +750,22 @@ extension Integration {
 
       #expect(controller._pipPlaybackActiveForTesting() == false)
       #expect(controller._pendingPiPPlaybackStateForTesting() == nil)
+    }
+
+    @Test
+    func `observed playback activity mirrors external active changes without pending PiP state`() {
+      let player = Player(instance: TestInstance.shared)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: PlaybackRecorder().driver,
+        pauseDebounce: .milliseconds(250)
+      )
+
+      controller._handleObservedPlaybackActivityForTesting(true)
+      #expect(controller._pipPlaybackActiveForTesting() == true)
+
+      controller._handleObservedPlaybackActivityForTesting(false)
+      #expect(controller._pipPlaybackActiveForTesting() == false)
     }
   }
 }

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
@@ -335,6 +335,38 @@ extension Integration {
     }
 
     @Test
+    func `macOS native PiP backend remains unavailable for no-video instances even when private API is enabled`() throws {
+      let initialAllowsPrivateAPI = PiPController.allowsPrivateMacOSAPI
+      defer { PiPController.allowsPrivateMacOSAPI = initialAllowsPrivateAPI }
+      PiPController.allowsPrivateMacOSAPI = true
+
+      let instance = try VLCInstance(arguments: ["--no-video-title-show", "--no-video", "--no-audio", "--quiet"])
+      let player = Player(instance: instance)
+      let backend = MacNativePiPBackend()
+
+      backend.attach(to: player)
+
+      #expect(backend.isPossible == false)
+    }
+
+    @Test
+    func `macOS native PiP backend start with media but unavailable host is a no-op`() throws {
+      let initialAllowsPrivateAPI = PiPController.allowsPrivateMacOSAPI
+      defer { PiPController.allowsPrivateMacOSAPI = initialAllowsPrivateAPI }
+      PiPController.allowsPrivateMacOSAPI = false
+
+      let player = Player(instance: TestInstance.shared)
+      try player.load(Media(url: TestMedia.twosecURL))
+      let backend = MacNativePiPBackend()
+
+      backend.attach(to: player)
+      backend.start()
+
+      #expect(backend.isPossible == false)
+      #expect(backend.isActive == false)
+    }
+
+    @Test
     func `macOS PiP controller delegates to native backend`() {
       let initialAllowsPrivateAPI = PiPController.allowsPrivateMacOSAPI
       defer { PiPController.allowsPrivateMacOSAPI = initialAllowsPrivateAPI }
@@ -404,6 +436,20 @@ extension Integration {
       #expect(mediaController.mediaTime() >= 0)
       _ = mediaController.isMediaSeekable()
       #expect(mediaController.isMediaPlaying() == false)
+    }
+
+    @Test
+    func `macOS native PiP media controller resumes active player state`() async {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: false)
+
+      let mediaController = MacNativePiPMediaController()
+      mediaController.player = player
+
+      mediaController.play()
+      await Task.yield()
+
+      #expect(player.isPlaybackRequestedActive)
     }
 
     @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))

--- a/Tests/SwiftVLCTests/PiP/PixelBufferRendererCallbackTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferRendererCallbackTests.swift
@@ -459,6 +459,32 @@ extension Integration {
       try expectNoDifference(alphaBytes(in: pb), expectedAlphaBytes)
     }
 
+    @MainActor
+    @Test
+    func `Display callback uses configured timebase for presentation time`() throws {
+      let displayLayer = AVSampleBufferDisplayLayer()
+      let renderer = PixelBufferRenderer(displayLayer: displayLayer)
+      let retained = makeRetainedContext(renderer: renderer)
+      defer { retained.release() }
+
+      let clock = CMClockGetHostTimeClock()
+      var timebase: CMTimebase?
+      let status = CMTimebaseCreateWithSourceClock(
+        allocator: kCFAllocatorDefault,
+        sourceClock: clock,
+        timebaseOut: &timebase
+      )
+      #expect(status == noErr)
+      let tb = try #require(timebase)
+      CMTimebaseSetTime(tb, time: CMTime(seconds: 3, preferredTimescale: 1000))
+      renderer.setTimebase(tb)
+
+      let pb = try makeBGRAImageBuffer(width: 2, height: 2)
+      let pictureHandle = Unmanaged.passRetained(pb as AnyObject).toOpaque()
+
+      pixelBufferDisplayCallback(opaque: retained.toOpaque(), picture: pictureHandle)
+    }
+
     /// A nil `opaque` guards-out early.
     @Test
     func `Display callback with nil opaque is a no-op`() {

--- a/Tests/SwiftVLCTests/PiP/PixelBufferRendererTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferRendererTests.swift
@@ -225,6 +225,56 @@ extension Integration {
     }
 
     @Test
+    func `setting the same render size keeps the current generation`() {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+
+      renderer.setRenderSize(CMVideoDimensions(width: 8, height: 8))
+      let firstGeneration = renderer.state.withLock { $0.renderGeneration }
+
+      renderer.setRenderSize(CMVideoDimensions(width: 8, height: 8))
+      let secondGeneration = renderer.state.withLock { $0.renderGeneration }
+
+      #expect(secondGeneration == firstGeneration)
+    }
+
+    @Test
+    func `matching render size returns original pixel buffer`() throws {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      renderer.setRenderSize(CMVideoDimensions(width: 16, height: 16))
+
+      let sourceBuffer = try makeBGRAImageBuffer(width: 16, height: 16)
+      let output = try #require(renderer.outputPixelBuffer(from: sourceBuffer)?.buffer)
+
+      #expect(output === sourceBuffer)
+    }
+
+    @Test
+    func `repeated scaling reuses the render pool for unchanged dimensions`() throws {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      renderer.setRenderSize(CMVideoDimensions(width: 8, height: 8))
+
+      let sourceBuffer = try makeBGRAImageBuffer(width: 16, height: 16)
+      _ = try #require(renderer.outputPixelBuffer(from: sourceBuffer))
+      let firstPool = renderer.state.withLock { $0.renderPool }
+
+      _ = try #require(renderer.outputPixelBuffer(from: sourceBuffer))
+      let secondPool = renderer.state.withLock { $0.renderPool }
+
+      #expect(firstPool != nil)
+      #expect(firstPool === secondPool)
+    }
+
+    @Test
+    func `unallocatable render size returns nil instead of enqueuing a frame`() throws {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      renderer.setRenderSize(CMVideoDimensions(width: 1_000_000, height: 1_000_000))
+
+      let sourceBuffer = try makeBGRAImageBuffer(width: 2, height: 2)
+
+      #expect(renderer.outputPixelBuffer(from: sourceBuffer) == nil)
+    }
+
+    @Test
     func `Initial state has all fields at default values`() {
       let layer = AVSampleBufferDisplayLayer()
       let renderer = PixelBufferRenderer(displayLayer: layer)

--- a/Tests/SwiftVLCTests/Player/MapEventTests.swift
+++ b/Tests/SwiftVLCTests/Player/MapEventTests.swift
@@ -379,6 +379,64 @@ extension Logic {
       #expect(device == nil)
     }
 
+    @Test
+    func `AudioDevice with device maps string payload`() {
+      "coreaudio-default".withCString { cDevice in
+        let e = event(type: libvlc_MediaPlayerAudioDevice.rawValue) { e in
+          e.u.media_player_audio_device.device = cDevice
+        }
+        guard case .audioDeviceChanged(let device) = mapEvent(e) else {
+          Issue.record("Expected .audioDeviceChanged")
+          return
+        }
+        #expect(device == "coreaudio-default")
+      }
+    }
+
+    @Test
+    func `RecordChanged maps recording flag and output path`() {
+      "/tmp/swiftvlc-record.ts".withCString { cPath in
+        let e = event(type: libvlc_MediaPlayerRecordChanged.rawValue) { e in
+          e.u.media_player_record_changed.recording = true
+          e.u.media_player_record_changed.recorded_file_path = cPath
+        }
+        guard case .recordingChanged(let isRecording, let filePath) = mapEvent(e) else {
+          Issue.record("Expected .recordingChanged")
+          return
+        }
+        #expect(isRecording)
+        #expect(filePath == "/tmp/swiftvlc-record.ts")
+      }
+    }
+
+    @Test
+    func `RecordChanged maps nil output path`() {
+      let e = event(type: libvlc_MediaPlayerRecordChanged.rawValue) { e in
+        e.u.media_player_record_changed.recording = false
+        e.u.media_player_record_changed.recorded_file_path = nil
+      }
+      guard case .recordingChanged(let isRecording, let filePath) = mapEvent(e) else {
+        Issue.record("Expected .recordingChanged")
+        return
+      }
+      #expect(isRecording == false)
+      #expect(filePath == nil)
+    }
+
+    @Test
+    func `SnapshotTaken maps file path`() {
+      "/tmp/swiftvlc-snapshot.png".withCString { cPath in
+        let e = event(type: libvlc_MediaPlayerSnapshotTaken.rawValue) { e in
+          e.u.media_player_snapshot_taken.psz_filename = UnsafeMutablePointer(mutating: cPath)
+        }
+        guard case .snapshotTaken(let path) = mapEvent(e) else {
+          Issue.record("Expected .snapshotTaken")
+          return
+        }
+        #expect(path == "/tmp/swiftvlc-snapshot.png")
+      }
+    }
+
     // MARK: - Unknown / default
 
     @Test

--- a/Tests/SwiftVLCTests/Player/PlayerBranchCoverageTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerBranchCoverageTests.swift
@@ -537,6 +537,7 @@ extension Integration {
     func `selectProgram with unknown id does not crash`() {
       let player = Player(instance: TestInstance.shared)
       player.selectProgram(id: 999)
+      player.selectProgram(id: Int.max)
     }
 
     /// `isProgramScrambled` on a player without active programs must

--- a/Tests/SwiftVLCTests/Player/PlayerEventHandlerTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerEventHandlerTests.swift
@@ -1,4 +1,5 @@
 @testable import SwiftVLC
+import CLibVLC
 import Observation
 import Synchronization
 import Testing
@@ -107,6 +108,15 @@ extension Integration {
     }
 
     @Test
+    func `positionChanged updates observed position`() {
+      let player = Player(instance: TestInstance.shared)
+
+      player._handleEventForTesting(.positionChanged(0.25))
+
+      #expect(player.position == 0.25)
+    }
+
+    @Test
     func `lengthChanged updates duration`() {
       let player = Player(instance: TestInstance.shared)
 
@@ -144,6 +154,68 @@ extension Integration {
       #expect(player.state == .stopped)
       #expect(player.currentTime == .zero)
       #expect(player.bufferFill == 0)
+    }
+
+    @Test
+    func `stateChanged to paused clears playback intent when no resume is pending`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing)
+
+      player._handleEventForTesting(.stateChanged(.paused))
+
+      #expect(player.state == .paused)
+      #expect(player.isPlaying == false)
+    }
+
+    @Test
+    func `matching pause transition clears transition state`() {
+      let player = Player(instance: TestInstance.shared)
+      player.pauseTransition = .pausing
+
+      player.updatePauseTransition(for: .paused)
+
+      #expect(player.pauseTransition == nil)
+    }
+
+    @Test
+    func `canIssueNativePause is false before native playback has advanced`() {
+      let player = Player(instance: TestInstance.shared)
+
+      #expect(libvlc_media_player_get_time(player.pointer) <= 0)
+      #expect(player.canIssueNativePause == false)
+    }
+
+    @Test
+    func `issuePause defers when native player is not yet pausable`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing, isPausable: true)
+
+      #expect(player.issuePause() == false)
+      #expect(player._hasDeferredPauseForTesting())
+      #expect(player.isPlaying == false)
+      #expect(player.pauseTransition == nil)
+    }
+
+    @Test
+    func `stop clears in-flight pause transition`() {
+      let player = Player(instance: TestInstance.shared)
+      player.pauseTransition = .pausing
+
+      player.stop()
+
+      #expect(player.pauseTransition == nil)
+    }
+
+    @Test
+    func `refreshNativeState syncs native mute shadow when available`() {
+      let player = Player(instance: TestInstance.shared)
+      libvlc_audio_set_mute(player.pointer, 1)
+      guard libvlc_audio_get_mute(player.pointer) >= 0 else { return }
+      player._isMuted = false
+
+      player.refreshNativeStateIfNeeded()
+
+      #expect(player.isMuted == true)
     }
 
     // MARK: - Observation invalidation for external state changes
@@ -239,6 +311,17 @@ extension Integration {
       player._handleEventForTesting(.audioDeviceChanged("core-audio"))
 
       #expect(fired.withLock { $0 })
+    }
+
+    @Test
+    func `refreshTracks without media publishes empty track lists`() {
+      let player = Player(instance: TestInstance.shared)
+
+      player.refreshTracks()
+
+      #expect(player.audioTracks.isEmpty)
+      #expect(player.videoTracks.isEmpty)
+      #expect(player.subtitleTracks.isEmpty)
     }
 
     /// Program-related events fan out to `programs`, `selectedProgram`,

--- a/Tests/SwiftVLCTests/Player/PlayerThrowsTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerThrowsTests.swift
@@ -93,6 +93,14 @@ extension Integration {
     }
 
     @Test
+    func `setDeinterlace with unknown mode throws operation failed`() throws {
+      let player = Player(instance: TestInstance.shared)
+      #expect(throws: VLCError.self) {
+        try player.setDeinterlace(state: 1, mode: "__swiftvlc_unknown_deinterlace_mode__")
+      }
+    }
+
+    @Test
     func `setDeinterlace rejects unrepresentable state instead of trapping`() throws {
       let player = Player(instance: TestInstance.shared)
       #expect(throws: VLCError.self) {

--- a/Tests/SwiftVLCTests/Player/PlayerThrowsTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerThrowsTests.swift
@@ -4,9 +4,9 @@ import Testing
 
 /// Covers the error paths on `Player`'s `throws(VLCError)` API.
 ///
-/// Each test forces libVLC into a state where the underlying call is
-/// guaranteed to fail, then asserts the typed-throw shape. Pairs with
-/// `PlayerTests` which covers the success paths.
+/// Tests force SwiftVLC or libVLC into documented success/failure
+/// boundaries and assert the typed wrapper behavior. Pairs with
+/// `PlayerTests` which covers the broad success paths.
 extension Integration {
   @Suite(.tags(.mainActor))
   @MainActor struct PlayerThrowsTests {
@@ -93,10 +93,16 @@ extension Integration {
     }
 
     @Test
-    func `setDeinterlace with unknown mode throws operation failed`() throws {
+    func `setDeinterlace with unknown mode follows libVLC result`() throws {
       let player = Player(instance: TestInstance.shared)
-      #expect(throws: VLCError.self) {
+
+      do {
         try player.setDeinterlace(state: 1, mode: "__swiftvlc_unknown_deinterlace_mode__")
+      } catch {
+        guard case .operationFailed("Set deinterlace") = error else {
+          Issue.record("Expected operationFailed Set deinterlace, got \(error)")
+          return
+        }
       }
     }
 

--- a/Tests/SwiftVLCTests/Player/PlayerWithMediaBranchTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerWithMediaBranchTests.swift
@@ -78,6 +78,21 @@ extension Integration {
       #expect(player.currentMedia === second)
     }
 
+    @Test
+    func `play replacement path preserves media handoff when cached state is active`() throws {
+      let player = Player(instance: TestInstance.shared)
+      let first = try Media(url: TestMedia.testMP4URL)
+      player.load(first)
+      player._setStateForTesting(state: .playing)
+
+      let second = try Media(url: TestMedia.twosecURL)
+      try player.play(second)
+      defer { player.stop() }
+
+      #expect(player.currentMedia === second)
+      #expect(player.isPlaybackRequestedActive)
+    }
+
     /// Setting audioDelay on a player with media round-trips through
     /// libVLC and reflects on the next read.
     @Test

--- a/Tests/SwiftVLCTests/Playlist/MediaListPlayerRebuildTests.swift
+++ b/Tests/SwiftVLCTests/Playlist/MediaListPlayerRebuildTests.swift
@@ -76,6 +76,38 @@ extension Integration {
       }
     }
 
+    @Test
+    func `play at negative index rejects before reaching libVLC`() {
+      let listPlayer = MediaListPlayer(instance: TestInstance.shared)
+
+      #expect(throws: VLCError.invalidInput("index must be non-negative")) {
+        try listPlayer.play(at: -1)
+      }
+    }
+
+    @Test
+    func `play at valid attached index reaches libVLC and can be stopped`() throws {
+      let listPlayer = MediaListPlayer(instance: TestInstance.shared)
+      let list = MediaList()
+      try list.append(Media(url: TestMedia.twosecURL))
+      listPlayer.mediaList = list
+      defer { listPlayer.stop() }
+
+      try listPlayer.play(at: 0)
+    }
+
+    @Test
+    func `play attached media item reaches libVLC and can be stopped`() throws {
+      let listPlayer = MediaListPlayer(instance: TestInstance.shared)
+      let list = MediaList()
+      let media = try Media(url: TestMedia.twosecURL)
+      try list.append(media)
+      listPlayer.mediaList = list
+      defer { listPlayer.stop() }
+
+      try listPlayer.play(media)
+    }
+
     /// `togglePause` / `pause` / `resume` / `stop` are all safe no-ops
     /// on an empty list player.
     @Test

--- a/Tests/SwiftVLCTests/Playlist/MediaListPlayerTests.swift
+++ b/Tests/SwiftVLCTests/Playlist/MediaListPlayerTests.swift
@@ -74,6 +74,14 @@ extension Integration {
     }
 
     @Test
+    func `Play at index without attached list throws before reaching libVLC`() throws {
+      let listPlayer = MediaListPlayer(instance: TestInstance.shared)
+      #expect(throws: VLCError.invalidState("mediaList must be set before playing by index")) {
+        try listPlayer.play(at: 0)
+      }
+    }
+
+    @Test
     func `Next without items throws`() throws {
       let listPlayer = MediaListPlayer(instance: TestInstance.shared)
       #expect(throws: VLCError.self) {
@@ -128,6 +136,15 @@ extension Integration {
       listPlayer.mediaList = list
       let media = try Media(url: TestMedia.testMP4URL)
       #expect(throws: VLCError.self) {
+        try listPlayer.play(media)
+      }
+    }
+
+    @Test
+    func `Play media item without attached list throws before reaching libVLC`() throws {
+      let listPlayer = MediaListPlayer(instance: TestInstance.shared)
+      let media = try Media(url: TestMedia.testMP4URL)
+      #expect(throws: VLCError.invalidState("mediaList must be set before playing an item")) {
         try listPlayer.play(media)
       }
     }


### PR DESCRIPTION
## Summary
- Add CI-safe coverage across thumbnail coordination/cancellation, PiP playback state handling, pixel-buffer rendering, player event handling, libVLC event mapping, dialog/VLC instance registration, media/discovery edge cases, playlist validation, and equalizer error handling.
- Include a small production guard fix for `MediaListPlayer` so index/item playback fails with `invalidState` when no media list is attached instead of forwarding the invalid state to libVLC.
- Push local CI-mode source coverage to 89.19% in the exported lcov report.

## Verification
- /opt/homebrew/bin/swiftformat Sources Tests Showcase --lint --strict
- /opt/homebrew/bin/swiftlint lint --strict --quiet Sources Tests Showcase
- CI=1 xcrun swift test --no-parallel --enable-code-coverage (1394 tests in 109 suites)
- scripts/export-lcov.sh

## Remaining coverage constraints
The largest remaining uncovered areas are private macOS PiP integration, libVLC callback-only dialog/thumbnail/renderer paths, renderer items that require real libVLC-owned pointers, and live playback / structured-media paths that are intentionally skipped in CI to avoid audio/video-output instability.
