### PR TITLE
Polish developer documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,7 +105,7 @@ Foundation types shared across all modules.
 | `VLCError.swift` | `enum VLCError: Error, Sendable, Equatable, Hashable, LocalizedError, CustomStringConvertible` | Typed errors with hand-rolled per-case accessors (`error.parseTimeout`, `error.mediaCreationFailed`, …). Auto-synthesized `Equatable`/`Hashable` over `String` payloads. |
 | `Broadcaster.swift` | `final class Broadcaster<Element: Sendable>` | Internal multi-consumer fan-out used by the dialog, renderer, log, player-event, and playback-intent streams. Exposes `subscribe`, `broadcast`, `finishAll` (allows resubscribe) and `terminate` (permanent — future `subscribe` calls return immediately-finished streams) inside the module. Lifecycle reconciliation runs on a private serial queue. |
 | `DialogHandler.swift` | `final class DialogHandler: Sendable` | Bridges libVLC's dialog callbacks (`login`, `question`, `progress`, `error`) onto a `Broadcaster<DialogEvent>`. `DialogID` carries the dialog handle through `DialogIDStorage` for safe `dismiss()` + post calls. |
-| `Logging.swift` | `AsyncStream<LogEntry>` via `LogBridge` | Filterable log stream backed by `Broadcaster<LogEntry>`. C shim formats `va_list` before Swift callback. `LogNoiseFilter` demotes known-noisy libVLC errors to warnings. |
+| `Logging.swift` | `AsyncStream<LogEntry>` via `LogBroadcaster` | Filterable log stream backed by `Broadcaster<LogEntry>`. C shim formats `va_list` before Swift callback. `LogNoiseFilter` demotes known-noisy libVLC errors to warnings. |
 | `Signposts.swift` | `enum Signposts` | Process-wide `OSSignposter` for `org.swiftvlc` subsystem. Hot paths (`Broadcaster.broadcast`, `Player.handleEvent`, `EventBridge.callback`, `PixelBufferRenderer.outputPixelBuffer`) emit signposts visible in Instruments. Zero cost when no profiler is attached. |
 | `Duration+Extensions.swift` | Extensions on `Duration` | `milliseconds`, `microseconds` properties and `formatted` display string |
 
@@ -117,7 +117,7 @@ The central observable type that drives all playback.
 
 | File | Type | Purpose |
 |---|---|---|
-| `Player.swift` | `@Observable @MainActor class` | Wraps `libvlc_media_player_t*`. Lifecycle, drawable management, media loading, and core playback control. The class body is split across 8 extensions in sibling files; the file itself contains no `swiftlint:disable` directives. |
+| `Player.swift` | `@Observable @MainActor class` | Wraps `libvlc_media_player_t*`. Lifecycle, drawable management, media loading, and core playback control. Extension files group audio, chapters, events, overlays, programs, recording, typed values, and native-lifecycle helpers. |
 | `Player+Events.swift` | `extension Player` | The libVLC event-consumer task and `handleEvent(_:)` dispatch — pause-transition state machine, deferred-pause command, native-state probing, media-derived state reset. |
 | `Player+Audio.swift` | `extension Player` | Audio-output device selection, role, mix mode, stereo mode. |
 | `Player+Chapters.swift` | `extension Player` | Title/chapter navigation, DVD menu actions. |
@@ -163,7 +163,7 @@ player.selectedAudioTrack // Track?
 player.selectedSubtitleTrack // Track?
 player.aspectRatio        // AspectRatio
 
-// Checked mutations for formerly writable playback observations
+// Checked mutations for read-only playback observations
 try player.seek(to: PlaybackPosition(0.5))
 try player.setAudioVolume(0.8)
 try player.setPlaybackRate(1.5)
@@ -258,7 +258,7 @@ Network service and renderer discovery.
 | File | Type | Purpose |
 |---|---|---|
 | `MediaDiscoverer.swift` | `final class MediaDiscoverer: Sendable` | Discovers media on LAN/SMB/UPnP/SAP. Returns `MediaList` of found items. |
-| `RendererDiscoverer.swift` | `final class RendererDiscoverer: Sendable` | Discovers Chromecast/AirPlay renderers. `AsyncStream<RendererEvent>` for add/remove. |
+| `RendererDiscoverer.swift` | `final class RendererDiscoverer: Sendable` | Discovers renderer devices exposed by libVLC plugins. `AsyncStream<RendererEvent>` for add/remove. |
 
 ### PiP (iOS/macOS only)
 
@@ -266,8 +266,7 @@ Picture-in-Picture uses the platform path that best matches libVLC's
 video output. iOS uses public AVKit sample-buffer PiP. macOS has a
 native-drawable backend behind `PrivateMacOSPiP` SPI because the public
 sample-buffer mirror crops incorrectly on supported macOS releases. The
-module is split into 5 focused files; none carries a `swiftlint:disable`
-directive.
+module is split into 5 focused files.
 
 | File | Type | Purpose |
 |---|---|---|
@@ -292,7 +291,7 @@ Sources/CLibVLC/
 │   ├── libvlc_media_player.h  # Player, tracks, events
 │   ├── libvlc_media_list.h    # Playlist
 │   ├── libvlc_media_discoverer.h  # Network discovery
-│   ├── libvlc_renderer_discoverer.h  # Chromecast/AirPlay
+│   ├── libvlc_renderer_discoverer.h  # Renderer discovery
 │   ├── libvlc_picture.h  # Thumbnail generation
 │   └── libvlc_events.h   # Event types
 └── shim.c                # C shim for va_list formatting
@@ -350,7 +349,7 @@ flowchart LR
 
 1. **`@MainActor` types** own mutable state that SwiftUI observes. All property access and mutation happens on the main actor.
 2. **`Sendable` types** are either immutable value types or use internal synchronization (`Mutex<T>`, libVLC's own locks).
-3. **C callbacks** fire on libVLC's internal threads. They yield values into `AsyncStream` continuations (which are thread-safe) or dispatch to main via `DispatchQueue.main.async`.
+3. **C callbacks** fire on libVLC's internal threads. They yield values into `AsyncStream` continuations (which are thread-safe) or hop to the main actor where UI-adjacent state must change.
 4. **`nonisolated(unsafe)`** is used for `OpaquePointer` fields that are only valid during the object's lifetime and accessed on the correct actor.
 
 ### Capturing C Pointers in `@Sendable` Closures
@@ -388,7 +387,7 @@ flowchart TB
     end
 
     subgraph L2["AsyncStream Broadcasting — any thread"]
-        Store["EventBridge · Mutex-protected continuation store<br/>Each makeStream() creates an independent consumer"]
+        Store["EventBridge · Broadcaster<PlayerEvent><br/>Each makeStream() creates an independent consumer"]
     end
 
     subgraph L3["Observable Properties — @MainActor"]
@@ -405,12 +404,12 @@ libVLC's player event types are attached to the event manager and mapped to type
 
 | Category | Swift Cases |
 |---|---|
-| **State** | `stateChanged(PlayerState)`, `encounteredError` |
+| **State** | `stateChanged(PlayerState)`, `mediaStopping`, `encounteredError` |
 | **Time** | `timeChanged(Duration)`, `positionChanged(Double)`, `lengthChanged(Duration)` |
 | **Capability** | `seekableChanged(Bool)`, `pausableChanged(Bool)` |
 | **Tracks** | `tracksChanged`, `mediaChanged` |
 | **Buffering** | `bufferingProgress(Float)` |
-| **Audio** | `volumeChanged(Float)`, `muted`, `unmuted` |
+| **Audio** | `volumeChanged(Float)`, `muted`, `unmuted`, `corked`, `uncorked`, `audioDeviceChanged(String?)` |
 | **Video** | `voutChanged(Int)`, `snapshotTaken(String)` |
 | **Chapters** | `chapterChanged(Int)`, `titleListChanged`, `titleSelectionChanged(Int)` |
 | **Recording** | `recordingChanged(isRecording:filePath:)` |
@@ -418,7 +417,7 @@ libVLC's player event types are attached to the event manager and mapped to type
 
 ### Multi-Consumer Broadcasting
 
-`Broadcaster<Element: Sendable>` (in [`Sources/SwiftVLC/Core/Broadcaster.swift`](Sources/SwiftVLC/Core/Broadcaster.swift)) consolidates this pattern across the 5 places that needed it: player events, log entries, dialog callbacks, renderer discovery events, and playback intent. Per-subscriber state (continuation, optional filter, lifecycle phase) lives under a single `Mutex<State>`, so registration is one lock acquisition. `broadcast` snapshots the matching subscribers under the lock and yields outside it. Yielding resumes a consumer task and acquires its status-record lock; a concurrent task cancellation holds that same lock and calls `onTermination → unsubscribe → acquire Mutex`, so yielding while holding the `Mutex` would produce an AB-BA deadlock.
+`Broadcaster<Element: Sendable>` (in [`Sources/SwiftVLC/Core/Broadcaster.swift`](Sources/SwiftVLC/Core/Broadcaster.swift)) consolidates this pattern for player events, log entries, dialog callbacks, renderer discovery events, and playback intent. Per-subscriber state (continuation, optional filter, lifecycle phase) lives under a single `Mutex<State>`, so registration is one lock acquisition. `broadcast` snapshots the matching subscribers under the lock and yields outside it. Yielding resumes a consumer task and acquires its status-record lock; a concurrent task cancellation holds that same lock and calls `onTermination → unsubscribe → acquire Mutex`, so yielding while holding the `Mutex` would produce an AB-BA deadlock.
 
 ```swift
 final class Broadcaster<Element: Sendable>: Sendable {
@@ -465,7 +464,7 @@ For C callback contexts that need to bridge to Swift objects:
 
 | Pattern | Use Case | Lifetime |
 |---|---|---|
-| `Unmanaged.passRetained` | Long-lived callback context (EventBridge store, LogContext, DialogHandler) | Explicitly released in cleanup/deinit |
+| `Unmanaged.passRetained` | Long-lived callback context or broadcaster box (EventBridge, logging, dialogs, renderer discovery) | Explicitly released in cleanup/deinit |
 | `Unmanaged.passUnretained` | Short-lived reference (VideoSurface in `set_nsobject`) | Object must outlive the call |
 
 ### Deinit Ordering
@@ -474,7 +473,7 @@ Ordering in `Player.deinit` is load-bearing: detaching the listeners **before** 
 
 1. Cancel event consumer task
 2. `EventBridge.invalidate()`
-   - Detach all 31 C event listeners
+   - Detach the C event listeners
    - Finish all `AsyncStream` continuations
    - Release retained store
 3. `libvlc_media_player_stop_async()`
@@ -650,7 +649,15 @@ func playAndWaitForState() async throws {
 }
 ```
 
-**CI execution.** GitHub Actions runs on `macos-latest` with Xcode pinned to `latest-stable` (currently 26.x) plus the Swift 6.3 open-source toolchain from swift.org, invoked via `xcrun --toolchain`. The test step is wrapped by `scripts/ci-run-with-timeouts.py`, which enforces a 10-minute wall clock and a 3-minute idle watchdog and sends SIGKILL to the process group when either fires. Three layered caches keep cold-start cost down: the libvlc xcframework (keyed on its SHA-256), compiled build products (keyed on `hashFiles` of sources and the manifest), and SPM dependency checkouts.
+**CI execution.** GitHub Actions runs package tests on `macos-latest`
+with Xcode `latest-stable` plus the Swift 6.3.1 open-source toolchain
+from swift.org, invoked via `xcrun --toolchain`. Showcase builds run on
+`macos-26` with Xcode 26.4 because Xcode's built-in SwiftPM must parse
+the Swift 6.3 manifest. The package test step is wrapped by
+`scripts/ci-run-with-timeouts.py`, which enforces a 10-minute wall
+clock and a 3-minute idle watchdog and sends SIGKILL to the process
+group when either fires. Caches cover the libvlc xcframework, compiled
+build products, and SPM dependency checkouts.
 
 ---
 
@@ -721,7 +728,8 @@ Preflight refuses releases from non-`main` branches, uncommitted changes in `Pac
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `test.yml` | Push / PR | Runs full test suite against the last-released xcframework on `macos-latest` + Swift 6.3 toolchain. Xcframework cached by SHA-256. |
+| `test.yml` | Push to `main` / PR | Lints sources, builds all Showcase schemes, runs package tests with coverage, and checks public API doc coverage. |
+| `sanitize.yml` | Push to `main`, selected PR paths, weekly schedule | Runs race, stress, memory, and lifecycle tests under Thread Sanitizer and Address Sanitizer. |
 | `claude.yml` | Issue comment / PR mention | Claude Code bot integration. |
 
 ---
@@ -756,8 +764,8 @@ SwiftVLC/
 │   ├── tvOS/                       # Native tvOS target/scheme with TV-tailored showcases
 │   ├── visionOS/                   # Native visionOS target/scheme with focused playback coverage
 │   └── UITests/
-│       ├── iOS/                    # Existing UI tests for the iOS/Catalyst showcase
-│       ├── macOS/                  # Empty native macOS UI-test target shell
+│       ├── iOS/                    # UI tests for the iOS/Catalyst showcase
+│       ├── macOS/                  # Native macOS UI tests
 │       └── tvOS/                   # Empty tvOS UI-test target shell
 │
 ├── Vendor/                         # libvlc.xcframework (multi-GB unstripped; release zip a few hundred MB)
@@ -772,6 +780,7 @@ SwiftVLC/
 │
 ├── .github/workflows/
 │   ├── test.yml                   # CI test runner
+│   ├── sanitize.yml               # Sanitizer test runner
 │   └── claude.yml                 # Claude Code bot integration
 │
 ├── Package.swift                  # SPM manifest (Swift 6.3+)

--- a/Package.swift
+++ b/Package.swift
@@ -77,9 +77,9 @@ let package = Package(
     ),
     .testTarget(
       name: "SwiftVLCTests",
-      // CLibVLC is available transitively through SwiftVLC — re-linking it
-      // here causes "Class X is implemented in both A and B" runtime warnings
-      // when a test binary ends up with two copies of the same symbol graph.
+      // CLibVLC is available transitively through SwiftVLC. Re-linking it
+      // here can load duplicate Objective-C runtime classes from libVLC's
+      // static dependencies.
       dependencies: [
         "SwiftVLC",
         .product(name: "CustomDump", package: "swift-custom-dump")

--- a/README.md
+++ b/README.md
@@ -13,11 +13,14 @@ A Swift wrapper around [libVLC](https://www.videolan.org/vlc/libvlc.html) for iO
 
 ## Why?
 
-Apple's AVFoundation covers a narrow slice of the media landscape. It cannot play MKV, FLAC, or most subtitle formats, and it does not support network protocols like RTSP, SMB, or UPnP. Codec support is limited to what Apple ships. Any app that needs to reach beyond MP4 and HLS eventually runs out of runway.
+AVFoundation is excellent for Apple's native media stack, but its
+container, codec, subtitle, and network-protocol support is limited to
+what Apple ships. Apps that need MKV, SSA/ASS subtitles, RTSP, SMB,
+UPnP, or other VLC-backed formats and protocols need a broader engine.
 
-[VLC](https://www.videolan.org/) plays virtually everything, and its engine, **libVLC**, is available as a C library you can embed in any app.
+[VLC](https://www.videolan.org/)'s engine, **libVLC**, supports a broad set of codecs, containers, subtitles, and network protocols through embeddable C APIs.
 
-The existing iOS wrapper, [VLCKit](https://code.videolan.org/videolan/VLCKit), is written in Objective-C. It uses delegates, KVO, `NSNotificationCenter`, and manual thread management, which is a faithful reflection of the era it was designed in.
+VideoLAN's Apple wrapper, [VLCKit](https://code.videolan.org/videolan/VLCKit), is written primarily in Objective-C. It uses delegates, KVO, `NSNotificationCenter`, and manual thread management, which is a faithful reflection of the era it was designed in.
 
 **SwiftVLC** wraps libVLC 4.0 directly in Swift, with no Objective-C layer in between. It is built for `@Observable`, `async/await`, and `VideoView(player)`.
 
@@ -29,11 +32,11 @@ The existing iOS wrapper, [VLCKit](https://code.videolan.org/videolan/VLCKit), i
 | **Bindings** | Direct C → Swift | C → Objective-C → Swift bridging |
 | **State management** | `@Observable`, drives SwiftUI directly | KVO, `NSNotificationCenter`, and delegates |
 | **Concurrency** | `@MainActor`, `Sendable`, `async/await` | Manual thread dispatch, no isolation |
-| **Video rendering** | `VideoView(player)` | Manual `UIView` setup plus drawable configuration |
+| **Video rendering** | `VideoView(player)` | App-supplied view setup plus drawable configuration |
 | **Errors** | `throws(VLCError)`, typed and exhaustive | `NSError` codes |
 | **Events** | `AsyncStream<PlayerEvent>` with multiple consumers | `NSNotificationCenter` |
-| **libVLC version** | 4.0 | 3.x |
-| **PiP** | iOS via public AVKit sample buffers; macOS private backend is SPI opt-in | Not included |
+| **libVLC generation** | 4.0 | 3.x stable line; 4.0 alpha packages exist |
+| **SwiftUI PiP** | iOS via public AVKit sample buffers; macOS private backend is SPI opt-in | App-supplied integration |
 | **Swift 6 safe** | Yes, with strict concurrency | No |
 
 ## Features
@@ -45,7 +48,7 @@ The existing iOS wrapper, [VLCKit](https://code.videolan.org/videolan/VLCKit), i
 - 10-band equalizer with libVLC's built-in presets.
 - A-B looping, playback rate control, and subtitle and audio delay.
 - Picture-in-Picture on iOS with full playback controls; macOS native PiP is available only through an explicit private-API SPI opt-in.
-- Network discovery for LAN, SMB, UPnP media sources, and Chromecast and AirPlay renderers.
+- Media discovery and renderer discovery through services exposed by the bundled libVLC plugins.
 - 360° video with full viewpoint control over yaw, pitch, roll, and field of view.
 - Asynchronous thumbnail generation at arbitrary timestamps.
 - `MediaListPlayer` for playlist playback with loop and repeat modes.
@@ -139,12 +142,15 @@ Full API reference is hosted on Swift Package Index:
 
 The `Showcase/` directory contains separate folders, targets, and schemes for each showcase lane:
 
-- **iOS.** The existing full-featured app target, also enabled for Mac Catalyst.
+- **iOS.** Full-featured app target, also enabled for Mac Catalyst.
 - **macOS.** Native macOS app target with the same showcase coverage, adapted into sidebar-driven Mac UI.
 - **tvOS.** Native tvOS showcase app target with TV-focused focus navigation and Siri Remote controls.
 - **visionOS.** Native visionOS app target with a focused simple playback showcase.
 
-Showcase UI tests live under `Showcase/UITests/`. `iOSUITests` covers the broad showcase flows, and `macOSUITests` now covers the release-critical PiP, deinterlacing, and music-player regressions. `tvOSUITests` is still an empty target shell, and the visionOS showcase does not have a UI-test target yet.
+Showcase UI tests live under `Showcase/UITests/`. `iOSUITests` covers
+the broad showcase flows, `macOSUITests` covers native macOS PiP, and
+`tvOSUITests` is a placeholder target. The visionOS showcase does not
+have a UI-test target.
 
 ## Testing
 
@@ -152,8 +158,8 @@ The core package uses a comprehensive
 [Swift Testing](https://developer.apple.com/xcode/swift-testing/) suite
 against the real libVLC binary, so regressions in the C bridge surface
 immediately rather than hiding behind a fake. Showcase UI tests use
-XCTest separately. CI runs the full suite on every push and every pull
-request.
+XCTest separately. CI runs package tests, lint, doc coverage, and
+Showcase builds on pull requests and on `main`.
 
 ```bash
 swift test
@@ -212,7 +218,7 @@ VLC master requires a few local patches for SwiftVLC's supported Apple toolchain
 2. **visionOS deployment target.** Adds the `xros` target triple so object files are stamped with visionOS 2.0 instead of the installed SDK version.
 3. **Xcode 26 LDFLAGS.** Adds `-isysroot` to linker invocations so libSystem resolves.
 4. **libtool 2.5 OBJC tag.** Adds `_LIBTOOLFLAGS = --tag=CC` to the `Makefile.am` files that contain `.m` sources. Older libtool versions inferred the tag; 2.5 refuses.
-5. **Rust contribs disabled.** `cargo-c 0.9.29` no longer compiles on recent Rust. The only Rust contrib on Apple is `rav1e` (AV1 *encoder*); `dav1d` handles decoding.
+5. **Rust contribs disabled.** VLC's contribs pin `cargo-c 0.9.29`, which pulls `time 0.3.31` and fails type inference under the supported Rust toolchain. The only Rust contrib on Apple is `rav1e` (AV1 *encoder*); `dav1d` handles decoding.
 6. **`dup3` / `pipe2`.** Forced unavailable via autoconf cache vars. iOS Simulator SDK 26 exports these Linux-only syscalls from libSystem, fooling configure into using them.
 
 `git reset --hard` only runs when HEAD is not at `VLC_HASH`, so the patches and per-platform build dirs survive repeated runs.
@@ -252,6 +258,6 @@ libVLC is licensed under [LGPLv2.1](https://www.gnu.org/licenses/old-licenses/lg
 
 ## Acknowledgments
 
-SwiftVLC stands on the work of the [VideoLAN](https://www.videolan.org/) community. The VLC media player and libVLC are among the most important open-source projects in media, representing decades of work by hundreds of contributors that made it possible to play virtually anything, anywhere.
+SwiftVLC stands on the work of the [VideoLAN](https://www.videolan.org/) community. VLC and libVLC represent decades of media playback work by hundreds of contributors.
 
-Thanks also to [VLCKit](https://code.videolan.org/videolan/VLCKit) for paving the way for libVLC on Apple platforms. VLCKit proved that embedding VLC in iOS and macOS apps was not only possible but practical, and it has powered countless apps over the years. SwiftVLC would not exist without the foundation VLCKit laid.
+Thanks also to [VLCKit](https://code.videolan.org/videolan/VLCKit) for establishing libVLC on Apple platforms.

--- a/Sources/SwiftVLC/Core/Broadcaster.swift
+++ b/Sources/SwiftVLC/Core/Broadcaster.swift
@@ -207,8 +207,8 @@ final class Broadcaster<Element: Sendable>: Sendable {
   /// fires on the reconciliation queue if there were active subscribers.
   ///
   /// Use when the broadcaster's underlying source is gone for good
-  /// (handler deinit, registration loss). For temporary teardown where
-  /// new subscribers might re-attach, use ``finishAll()`` instead.
+  /// (handler deinit, registration loss). If subscribers may re-attach,
+  /// use ``finishAll()`` instead.
   func terminate() {
     let (snapshot, becameEmpty) = state.withLock { state -> ([Subscriber], Bool) in
       state.terminated = true

--- a/Sources/SwiftVLC/Core/LogNoiseFilter.swift
+++ b/Sources/SwiftVLC/Core/LogNoiseFilter.swift
@@ -35,15 +35,12 @@
 /// `scripts/build-libvlc.sh`, re-verify that those locations and message
 /// strings still apply; the unit tests catch wording drift.
 ///
-/// The right long-term home for these severity corrections is upstream VLC.
-/// Until those land, this filter is how SwiftVLC consumers get a clean
-/// error level.
 enum LogNoiseFilter {
   /// Returns the highest severity this filter can emit for a raw libVLC
   /// level, before the message string has been allocated.
   ///
-  /// The current rules only demote `.error` entries to `.warning`; they
-  /// never promote lower-severity entries. That invariant lets the log
+  /// Rules only demote `.error` entries to `.warning`; they never
+  /// promote lower-severity entries. That invariant lets the log
   /// callback skip String allocation when no subscriber is interested in
   /// the raw level.
   static func mostSeverePossibleResult(for level: LogLevel) -> LogLevel {

--- a/Sources/SwiftVLC/Core/Logging.swift
+++ b/Sources/SwiftVLC/Core/Logging.swift
@@ -128,9 +128,9 @@ final class LogBroadcaster: Sendable {
     // The install closure needs to retain the broadcaster as the
     // userData pointer it passes to libVLC. We can't capture
     // `self.broadcaster` here because it isn't initialized yet, and
-    // capturing a `var` local by value only sees its initial nil. The
-    // workaround is a tiny `Box` reference that the closure captures
-    // by reference; we populate it after the broadcaster is built.
+    // capturing a `var` local by value only sees its initial nil. Use a
+    // tiny `Box` reference that the closure captures by reference; we
+    // populate it after the broadcaster is built.
     let broadcasterBox = BroadcasterBox()
     broadcaster = Broadcaster<LogEntry>(
       defaultBufferSize: 128,

--- a/Sources/SwiftVLC/Core/VLCInstance.swift
+++ b/Sources/SwiftVLC/Core/VLCInstance.swift
@@ -38,7 +38,7 @@ public final class VLCInstance: Sendable {
 
   /// Initializes and returns ``shared`` from a background task.
   ///
-  /// Use this when an app has an explicit loading phase and wants to guarantee
+  /// Use this when an app has an explicit loading phase and wants to ensure
   /// the shared libVLC instance is ready before constructing a default
   /// ``Player``.
   public static func prepareShared(priority: TaskPriority = .utility) async -> VLCInstance {

--- a/Sources/SwiftVLC/Discovery/RendererDiscoverer.swift
+++ b/Sources/SwiftVLC/Discovery/RendererDiscoverer.swift
@@ -1,7 +1,7 @@
 import CLibVLC
 import Dispatch
 
-/// Discovers available renderers (Chromecast, AirPlay, etc.) on the local network.
+/// Discovers renderer devices exposed by libVLC renderer-discovery plugins.
 ///
 /// Start the discoverer, then observe ``events`` to be notified as renderers
 /// come and go. Cast to a discovered renderer by passing its
@@ -107,7 +107,7 @@ public final class RendererDiscoverer: Sendable {
 
 // MARK: - Renderer Item
 
-/// A discovered renderer (e.g. Chromecast).
+/// A discovered renderer device.
 ///
 /// Holds a reference to the underlying `libvlc_renderer_item_t`.
 /// Pass to ``Player/setRenderer(_:)`` to start casting.

--- a/Sources/SwiftVLC/Media/Media.swift
+++ b/Sources/SwiftVLC/Media/Media.swift
@@ -226,8 +226,7 @@ public final class Media: Sendable {
   ///
   /// Useful for tailoring UI: show a network indicator for `.stream`,
   /// a disc icon for `.disc`, and so on. Reports `.unknown` until
-  /// libVLC has enough context to determine the type — immediately
-  /// after creation for local paths, after parse for network URLs.
+  /// libVLC has enough context to determine the type.
   public var mediaType: MediaType {
     MediaType(from: libvlc_media_get_type(pointer))
   }
@@ -243,10 +242,8 @@ public final class Media: Sendable {
   ///   - url: URL of the slave file (must be a valid URI, e.g. `file://`).
   ///   - type: Subtitle or audio.
   ///   - priority: Higher priorities are preferred when multiple slaves of
-  ///     the same type are present. Must be non-negative and fit in a
-  ///     `UInt32`. libVLC clamps the value to its user-slave ceiling
-  ///     internally, so values above ~4 are normalized. Defaults to `4`
-  ///     which matches libVLC's priority for user-added files.
+  ///     the same type are present. libVLC documents `0` as low priority
+  ///     and `4` as high priority. Defaults to `4`.
   /// - Throws: ``VLCError/invalidInput(_:)`` if `priority` is negative or too large,
   ///   or ``VLCError/operationFailed(_:)`` if the slave cannot be attached.
   public func addSlave(

--- a/Sources/SwiftVLC/Media/Metadata.swift
+++ b/Sources/SwiftVLC/Media/Metadata.swift
@@ -3,8 +3,8 @@ import Foundation
 
 /// Immutable metadata parsed from a ``Media`` source.
 ///
-/// All metadata keys from libVLC are exposed as typed properties.
-/// Access any key programmatically via subscript:
+/// Common metadata keys are exposed as typed properties. Access any
+/// libVLC metadata key programmatically via subscript:
 /// ```swift
 /// let title = metadata[.title]
 /// ```

--- a/Sources/SwiftVLC/Media/ThumbnailRequest.swift
+++ b/Sources/SwiftVLC/Media/ThumbnailRequest.swift
@@ -5,9 +5,9 @@ import Synchronization
 /// How libVLC should locate the source frame when generating a thumbnail.
 public enum ThumbnailSeekMode: Sendable, Hashable {
   /// Snap to the nearest keyframe. Fast but imprecise: videos with
-  /// sparse keyframes (Big Buck Bunny is one example) can return the
-  /// same frame for every offset. Use for library cover art where the
-  /// exact frame doesn't matter.
+  /// sparse keyframes can return the same frame for nearby offsets.
+  /// Use for library cover art where exact frame selection does not
+  /// matter.
   case fast
 
   /// Decode intervening frames until the exact requested offset is
@@ -67,13 +67,8 @@ extension Media {
     let height = try checkedUInt32(height, parameter: "height")
 
     try await thumbnailCoordinator.acquire()
-    // Structured release: bind the coordinator into a local actor
-    // reference so we can release synchronously at the end of this
-    // function. The old `defer { Task { await release() } }` form
-    // deferred the release into an unstructured task; a second
-    // thumbnail on the same Media could then see the coordinator still
-    // "busy" and block even though the first caller had already
-    // returned, which looked like "thumbnails queue up."
+    // Hold a local actor reference so the media-wide thumbnail gate is
+    // released synchronously before this method returns.
     let coordinator = thumbnailCoordinator
 
     if Task.isCancelled {

--- a/Sources/SwiftVLC/Media/Track.swift
+++ b/Sources/SwiftVLC/Media/Track.swift
@@ -20,7 +20,7 @@ public struct Track: Sendable, Identifiable, Hashable {
   /// Human-readable track name.
   public let name: String
 
-  /// Codec identifier as a FourCC integer (e.g. `0x34363248` for "H264").
+  /// Codec identifier as libVLC's raw FourCC integer.
   public let codec: Int
 
   /// ISO 639 language code (e.g. `"eng"`, `"fra"`, `"ja"`) as declared

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -132,7 +132,7 @@ public final class PiPController: NSObject {
   var pipPlaybackActive: Bool = false
   /// Desired playback state from the PiP controls while libVLC is still
   /// catching up. During this window player events can still report the
-  /// old state, so the event observer must not overwrite
+  /// previous state, so the event observer must not overwrite
   /// `pipPlaybackActive` until native playback reaches the requested
   /// state or exits playback entirely.
   @ObservationIgnored
@@ -515,11 +515,8 @@ public final class PiPController: NSObject {
           return
         }
 
-        // `guard let self` is placed *after* the suspension so the
-        // strong binding is scoped to this iteration body only. The
-        // prior shape pulled the guard above the while loop, which
-        // extends the binding across every `await`, pinning `self`
-        // for the full debounce window and delaying deinit.
+        // Bind `self` after the suspension so the observer only keeps the
+        // controller alive while it is deciding whether to issue the pause.
         guard let self else { return }
         guard !Task.isCancelled, currentDeferredPauseGeneration == generation, !pipPlaybackActive else { return }
 
@@ -872,10 +869,9 @@ public final class PiPController: NSObject {
     playbackDelegateProxy.pictureInPictureController(controller, didTransitionToRenderSize: size)
   }
 
-  /// Hands back the internal playback-delegate proxy so tests that need
-  /// to build an `AVPictureInPictureController.ContentSource` can pass
-  /// the proxy directly (the public type no longer conforms to
-  /// `AVPictureInPictureSampleBufferPlaybackDelegate`).
+  /// Hands back the internal playback-delegate proxy so tests that build
+  /// an `AVPictureInPictureController.ContentSource` can pass the object
+  /// that implements `AVPictureInPictureSampleBufferPlaybackDelegate`.
   nonisolated var _playbackDelegateForTesting: AVPictureInPictureSampleBufferPlaybackDelegate {
     playbackDelegateProxy
   }

--- a/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
@@ -2,8 +2,7 @@
 // mirrors video through a `CALayerHost` that, on the macOS releases
 // SwiftVLC supports, crops to 1:1 instead of scaling into the PiP
 // panel. The private `PIPViewController` (loaded dynamically from
-// `PIP.framework`) reparents the real VLC drawable instead, which
-// matches the approach used by native macOS players such as IINA.
+// `PIP.framework`) reparents the real VLC drawable instead.
 
 #if os(macOS)
 import AppKit

--- a/Sources/SwiftVLC/Player/EventBridge.swift
+++ b/Sources/SwiftVLC/Player/EventBridge.swift
@@ -52,8 +52,8 @@ final class EventBridge: Sendable {
   ///
   /// `Player` recreates its libVLC handle after a stopped drawable-backed
   /// playback because libVLC keeps a "free vout" whose iOS window provider
-  /// still points at the old UIView. The Swift `Player.events` stream must
-  /// survive that native-handle swap, so this detaches callbacks from the old
+  /// still points at the previous UIView. The Swift `Player.events` stream must
+  /// survive that native-handle swap, so this detaches callbacks from the previous
   /// event manager and attaches the same broadcaster to the new one.
   func reattach(to newEventManager: OpaquePointer) {
     let isInvalidated = invalidated.withLock { $0 }

--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -140,8 +140,8 @@ extension Player {
 
     // Computed properties read fresh state from libVLC in their getter.
     // An empty `withMutation` is what re-triggers SwiftUI when the
-    // underlying C state changes externally (hardware keys, AirPlay,
-    // CarPlay, renderer-initiated chapter/title moves). Without this
+    // underlying C state changes externally (hardware keys, system controls,
+    // renderer-initiated chapter/title moves). Without this
     // the observers stay pinned to their last read.
     case .volumeChanged:
       withMutation(keyPath: \.volume) {}

--- a/Sources/SwiftVLC/Player/Player+Programs.swift
+++ b/Sources/SwiftVLC/Player/Player+Programs.swift
@@ -1,7 +1,7 @@
 import CLibVLC
 
-/// DVB/MPEG-TS program selection, renderer (Chromecast/AirPlay)
-/// targeting, and the deinterlace filter.
+/// DVB/MPEG-TS program selection, renderer targeting, and the
+/// deinterlace filter.
 extension Player {
   // MARK: - Programs (DVB/MPEG-TS)
 
@@ -37,9 +37,9 @@ extension Player {
     return libvlc_media_player_program_scrambled(pointer)
   }
 
-  // MARK: - Renderer (Chromecast / AirPlay)
+  // MARK: - Renderer
 
-  /// Sets a renderer for output (e.g. Chromecast).
+  /// Sets a renderer for output.
   ///
   /// Pass `nil` to revert to local playback. libVLC only applies renderer
   /// selection before the first `play()` call on a native media player.

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -335,7 +335,7 @@ public final class Player {
   /// Shadow of the string last passed to `Marquee.setText`. libVLC's text
   /// renderer keys its glyph-bitmap cache on the text string, so a style-
   /// only write (color/opacity/fontSize) hits the cached entry and draws
-  /// with the old style. The `Marquee` setters briefly write a different
+  /// with the previous style. The `Marquee` setters briefly write a different
   /// text to bust the cache, then restore this value.
   var _marqueeText: String = ""
   /// In-flight task that restores `_marqueeText` after a cache-bust write.
@@ -481,8 +481,8 @@ public final class Player {
     // Bind the outgoing reference to a local so it outlives the libVLC
     // call. After the ivar is reassigned, ARC would otherwise release
     // the previous view immediately; the vout thread could still be
-    // mid-deref of the old `drawable-nsobject` pointer. `previous`
-    // keeps the old view alive until this function returns, by which
+    // mid-deref of that `drawable-nsobject` pointer. `previous`
+    // keeps the previous view alive until this function returns, by which
     // point libVLC has atomically swapped the variable.
     let previous = drawable
     if
@@ -580,7 +580,7 @@ public final class Player {
   /// `media` is declared `sending`, so callers can construct a ``Media``
   /// on any actor or task and hand it off to this main-actor method
   /// without a copy. The compiler enforces the transfer: the caller
-  /// cannot retain the original reference after the call.
+  /// cannot keep using the transferred reference after the call.
   public func load(_ media: sending Media) {
     currentMedia = media
     resetMediaDerivedState()
@@ -749,12 +749,12 @@ public final class Player {
   /// Dispatches through explicit pause/resume requests using the
   /// observed ``state`` and the current playback intent, rather than
   /// calling `libvlc_media_player_pause` (which is itself a toggle). The
-  /// naked toggle is unsafe mid-transition: interleaving a pause-toggle
+  /// raw toggle is unsafe mid-transition: interleaving a pause-toggle
   /// with the audio output's opening path corrupts
   /// `stream->timing.pause_date` and trips the upstream assertion
   /// `stream->timing.pause_date == VLC_TICK_INVALID` in
-  /// `src/audio_output/dec.c:876`, killing the process. The usual repro
-  /// is a user tapping Play/Pause immediately after a
+  /// `src/audio_output/dec.c:876`, killing the process. This can happen
+  /// when a user taps Play/Pause immediately after a
   /// `.task { try? player.play(url:) }` begins.
   public func togglePlayPause() {
     switch state {

--- a/Sources/SwiftVLC/Player/PlayerEvent.swift
+++ b/Sources/SwiftVLC/Player/PlayerEvent.swift
@@ -27,11 +27,10 @@ public enum PlayerEvent: Sendable, CustomStringConvertible {
   case muted
   /// Audio was unmuted.
   case unmuted
-  /// Audio playback was suspended by the system (e.g. phone call, headphones
-  /// unplugged with mix-with-others disabled). The player is paused until
-  /// ``uncorked-enum.case`` fires.
+  /// Audio playback was suspended by the audio backend. The paired
+  /// ``uncorked-enum.case`` event reports that output resumed.
   case corked
-  /// Audio playback resumed after a cork (e.g. call ended).
+  /// Audio playback resumed after a cork.
   case uncorked
   /// The active audio output device changed. Value is the new device
   /// identifier, or `nil` if unknown.

--- a/Sources/SwiftVLC/Player/PlayerRole.swift
+++ b/Sources/SwiftVLC/Player/PlayerRole.swift
@@ -1,9 +1,10 @@
 import CLibVLC
 
-/// The role of a media player, used to hint the system about audio behavior.
+/// The media player's audio role hint.
 ///
-/// For example, setting `.music` may prevent system sounds from interrupting,
-/// while `.communication` enables voice call processing.
+/// libVLC forwards this to the active audio backend when supported, so
+/// the platform can choose routing, mixing, or ducking behavior that
+/// matches the playback use case.
 public enum PlayerRole: Sendable, Hashable, CustomStringConvertible {
   /// No specific role (system default behavior).
   case none

--- a/Sources/SwiftVLC/Playlist/MediaList.swift
+++ b/Sources/SwiftVLC/Playlist/MediaList.swift
@@ -100,7 +100,7 @@ public final class MediaList: Sendable {
     media(at: index)
   }
 
-  /// Accesses a media item at the given index within a locked scope.
+  /// Accesses a media item at the given index.
   ///
   /// The returned `Media` is retained, and is safe to use after this
   /// call returns.

--- a/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
+++ b/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
@@ -95,7 +95,7 @@ public final class MediaListPlayer {
   ///
   /// Dispatches on the observed ``state`` rather than calling the raw
   /// `libvlc_media_list_player_pause` (which is itself a toggle). The
-  /// naked toggle is unsafe mid-transition: interleaving a pause-toggle
+  /// raw toggle is unsafe mid-transition: interleaving a pause-toggle
   /// with the audio output's opening path corrupts
   /// `stream->timing.pause_date` and trips the upstream assertion
   /// `stream->timing.pause_date == VLC_TICK_INVALID` in

--- a/Sources/SwiftVLC/SwiftVLC.docc/AudioFeatures.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/AudioFeatures.md
@@ -39,8 +39,8 @@ system-initiated device changes (e.g. headphones connecting).
 
 ## Equalizer
 
-``Equalizer`` is a 10-band parametric EQ with a preamp and preset
-support. Build one, tune it, and attach it to a player:
+``Equalizer`` is a 10-band graphic EQ with preamp and preset support.
+Build one, tune it, and attach it to a player:
 
 ```swift
 let eq = Equalizer()
@@ -49,9 +49,8 @@ try eq.setAmplification(5.0, forBand: 0)     // bass lift
 player.equalizer = eq
 ```
 
-For new code, prefer the typed accessors that wrap raw `Float` gains
-in ``EqualizerGain`` — each value is clamped to libVLC's
-`-20.0 ... +20.0` dB range at the type level:
+Typed gain accessors wrap raw `Float` values in ``EqualizerGain``.
+Each value is clamped to libVLC's `-20.0 ... +20.0` dB range:
 
 ```swift
 eq.preampGain = .flat
@@ -86,12 +85,12 @@ player.mixMode = .binaural       // spatialize for headphones
 
 ## Role hints
 
-Tell the system what kind of audio you're playing so it can route and
-duck appropriately:
+Pass libVLC an audio-role hint. The effect depends on the platform and
+active output module:
 
 ```swift
 player.role = .music         // long-form listening
-player.role = .communication // voice chat; enables VoIP-style processing
+player.role = .communication // voice/video calls
 ```
 
 See ``PlayerRole`` for the full set.

--- a/Sources/SwiftVLC/SwiftVLC.docc/ComparisonWithVLCKit.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/ComparisonWithVLCKit.md
@@ -8,36 +8,33 @@ to each.
 ## What they are
 
 **VLCKit** is VideoLAN's own wrapper around libVLC. It is written
-primarily in Objective-C and distributed for macOS, iOS, and tvOS. Its
-in-progress 4.0 line expands the platform surface to visionOS and
-watchOS. It has been the canonical answer for embedding VLC on Apple
-platforms for over a decade, and ships as three CocoaPods (`VLCKit`,
-`MobileVLCKit`, `TVVLCKit`) or as pre-built frameworks via Carthage.
+primarily in Objective-C and distributed for macOS, iOS, and tvOS. It
+has long been the established answer for embedding VLC on Apple
+platforms, and its README documents CocoaPods (`VLCKit`,
+`MobileVLCKit`, `TVVLCKit`) and pre-built Carthage frameworks.
 
 **SwiftVLC** is a Swift 6 binding to libVLC's C API, with no
-Objective-C layer in between. It targets only modern Apple platforms
-(iOS 18+, macOS 15+, tvOS 18+, visionOS 2+, macCatalyst 18+) and ships exclusively
+Objective-C layer in between. It targets modern Apple platforms (iOS
+18+, macOS 15+, tvOS 18+, visionOS 2+, macCatalyst 18+) and ships
 through Swift Package Manager.
 
 ## libVLC generation
 
 | | VLCKit | SwiftVLC |
 |---|---|---|
-| Stable line | libVLC 3.x | libVLC 4.0 |
-| libVLC 4.0 port | Still in alpha | Shipping as the stable line |
+| README installation examples | 3.3 CocoaPods/Carthage line | Swift Package Manager binary target |
+| libVLC 4.0 | Published as alpha CocoaPods packages | Used by published releases |
 
-VLCKit's stable 3.x branch tracks libVLC 3.0 and is actively
-maintained. Its 4.0 line has been in alpha since early 2025 and
-continues to iterate. SwiftVLC is already built against libVLC 4.0 on
-its stable line, which makes the newer libVLC features available on a
-non-prerelease today. Those features include subsecond seek precision,
-the new track-selection API, two simultaneous subtitle tracks, and a
-richer metadata surface.
+VLCKit's README examples target its 3.3 CocoaPods/Carthage line, while
+CocoaPods also lists 4.0 alpha packages. SwiftVLC's published releases
+are built against libVLC 4.0, which provides APIs SwiftVLC exposes for
+subsecond seek precision, track selection, thumbnail requests, and richer
+metadata.
 
 ## Language and integration surface
 
-VLCKit is Objective-C (roughly 85% by SLOC). Calling it from Swift
-routes through the C → Objective-C → Swift bridge: types are
+VLCKit is primarily Objective-C. Calling it from Swift routes through
+the C → Objective-C → Swift bridge: types are
 `NSObject` subclasses, events arrive via delegate protocols and
 `NSNotificationCenter`, and errors are `NSError` instances.
 
@@ -117,21 +114,20 @@ SPI opt-in rather than stable public API. See
 
 | | VLCKit | SwiftVLC |
 |---|---|---|
-| Swift Package Manager | Not officially supported (open since 2022) | Yes, and the only supported method |
-| CocoaPods | `VLCKit` / `MobileVLCKit` / `TVVLCKit` | No |
-| Carthage binaries | Yes | No |
-| Pre-built framework | Yes | xcframework distributed via the SPM `.binaryTarget` |
+| Swift Package Manager | Not documented in the VLCKit README | Yes |
+| CocoaPods | Documented: `VLCKit` / `MobileVLCKit` / `TVVLCKit` | No |
+| Carthage binaries | Documented in the VLCKit README | No |
+| Pre-built framework | Documented by VLCKit | xcframework distributed via the SPM `.binaryTarget` |
 
 ## Platforms and deployment targets
 
-| | VLCKit 3.x | VLCKit 4.0 (alpha) | SwiftVLC |
-|---|---|---|---|
-| iOS | 8.4+ | Supported in alpha | 18+ |
-| macOS | 10.9+ | Supported in alpha | 15+ |
-| tvOS | 10.2+ | Supported in alpha | 18+ |
-| visionOS | Not supported | Supported in alpha | 2+ |
-| watchOS | Not supported | Supported in alpha | Not supported |
-| macCatalyst | Not supported | Not supported | 18+ |
+| | VLCKit README | SwiftVLC |
+|---|---|---|
+| iOS | 8.4+ | 18+ |
+| macOS | 10.9+ | 15+ |
+| tvOS | 10.2+ | 18+ |
+| visionOS | Not listed | 2+ |
+| macCatalyst | Not listed | 18+ |
 
 ## License
 
@@ -150,11 +146,10 @@ requirements.
 **Pick VLCKit if:**
 
 - You need to support older OS versions (iOS 8.4+, macOS 10.9+).
-- You need watchOS today (via VLCKit 4.0 alpha).
 - You have an existing Objective-C codebase where the delegate /
   notification idioms fit naturally.
 - You prefer a long-established library with many years of production
-  use, even if the 4.0 port is still in alpha.
+  use and can stay on its stable 3.x line.
 
 **Pick SwiftVLC if:**
 
@@ -163,9 +158,9 @@ requirements.
   concurrency without writing bridging code.
 - You're building on SwiftUI and want `VideoView(player)` to be the
   whole video setup.
-- You want libVLC 4.0 features today on a stable release line.
-- You're integrating via Swift Package Manager only.
+- You want libVLC 4.0 APIs from a Swift package.
+- You're integrating through Swift Package Manager.
 
-Both libraries are actively maintained, and they coexist. SwiftVLC is
-not a fork of VLCKit or a replacement for it; it's a different set of
-trade-offs aimed at a different generation of Swift.
+The libraries coexist. SwiftVLC is not a fork of VLCKit or a replacement
+for it; it's a different set of trade-offs aimed at a different
+generation of Swift.

--- a/Sources/SwiftVLC/SwiftVLC.docc/ConcurrencyModel.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/ConcurrencyModel.md
@@ -27,9 +27,9 @@ public func load(_ media: sending Media)
 ```
 
 `sending` asks the compiler to transfer ownership of `media` across
-the isolation boundary. Because the caller cannot retain a reference
-after the call, there can never be a race between a background task
-still holding `media` and the main-actor player using it.
+the isolation boundary. After the call, the caller cannot keep using
+the transferred reference, which prevents a background task from racing
+the main-actor player through the same `Media` object.
 
 ```swift
 Task.detached {

--- a/Sources/SwiftVLC/SwiftVLC.docc/DiscoveryAndCasting.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/DiscoveryAndCasting.md
@@ -1,13 +1,13 @@
 # Discovery and casting
 
-Find media on the local network, and cast to Chromecast or AirPlay
-receivers.
+Find media and renderer devices through libVLC discovery services.
 
 ## Discovering media sources
 
-``MediaDiscoverer`` wraps a named libVLC service, such as UPnP, SMB,
-local directories, or podcasts. List the available services, then
-start one:
+``MediaDiscoverer`` wraps a named libVLC service. Depending on the
+bundled plugins and host platform, services may include UPnP, SMB,
+local directories, or podcasts. List the available services, then start
+one:
 
 ```swift
 let services = MediaDiscoverer.availableServices(category: .lan)
@@ -29,15 +29,15 @@ Categories:
 | ``DiscoveryCategory`` | What it finds |
 |---|---|
 | `.devices` | Physical devices (portable music players, disc drives) |
-| `.lan` | UPnP, SMB, SAP, Bonjour |
+| `.lan` | LAN discoverers such as UPnP, SMB, SAP, or Bonjour when available |
 | `.podcasts` | Podcast directories |
 | `.localDirectories` | System Music/Video/Pictures folders |
 
 ## Casting to a renderer
 
-``RendererDiscoverer`` discovers Chromecast, AirPlay, and UPnP/DLNA
-renderers. It emits events through an `AsyncStream`, so apps can react
-as soon as a renderer appears or disappears:
+``RendererDiscoverer`` discovers renderer devices exposed by libVLC's
+renderer-discovery plugins. It emits events through an `AsyncStream`, so
+apps can react as soon as a renderer appears or disappears:
 
 ```swift
 let services = RendererDiscoverer.availableServices()

--- a/Sources/SwiftVLC/SwiftVLC.docc/PlaybackEssentials.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/PlaybackEssentials.md
@@ -14,9 +14,9 @@ decorate its output.
 @State private var player = Player()
 ```
 
-Construction allocates the underlying libVLC resources. Release
-happens off the main actor in `deinit`, so tearing down a view never
-stalls the UI thread.
+Construction allocates the underlying libVLC resources. `deinit` moves
+blocking native release calls off the main actor, so view teardown does
+not perform that work on the UI thread.
 
 For the default shared instance, call
 ``VLCInstance/prewarmShared(priority:)`` during app launch when possible.

--- a/Sources/SwiftVLC/SwiftVLC.docc/SwiftVLC.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/SwiftVLC.md
@@ -15,7 +15,7 @@ model does.
   track lists without manual bridging.
 - **Typed errors.** Every throwing API uses `throws(VLCError)`, so
   the compiler sees the full error surface and a general `catch` is
-  never needed.
+  not required for exhaustive handling.
 - **Structured events.** Playback, discovery, logging, and dialog
   prompts all surface through `AsyncStream`. Multiple consumers can
   subscribe concurrently.
@@ -24,8 +24,8 @@ model does.
   the player's lifetime, so the compiler rejects any code that would
   store a dangling pointer.
 - **Tested against real libVLC.** A comprehensive Swift Testing suite
-  exercises the full C bridge with no mocks or fakes, and CI runs it
-  on every push.
+  exercises the full C bridge with no mocks or fakes; CI runs it on
+  pull requests and on `main`.
 
 ### First play
 

--- a/Sources/SwiftVLC/SwiftVLC.docc/WorkingWithMedia.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/WorkingWithMedia.md
@@ -35,8 +35,8 @@ print(metadata.duration ?? "—")
 print(metadata.artworkURL?.absoluteString ?? "no artwork")
 ```
 
-Every libVLC metadata key is typed on ``Metadata``. Access less-common
-keys through the subscript:
+Common metadata keys are exposed as typed properties on ``Metadata``.
+Access every libVLC metadata key through the subscript:
 
 ```swift
 let now = metadata[.nowPlaying]

--- a/Sources/SwiftVLC/Video/Marquee.swift
+++ b/Sources/SwiftVLC/Video/Marquee.swift
@@ -177,7 +177,7 @@ public struct Marquee: ~Copyable, ~Escapable {
   /// libVLC's `freetype` module caches rasterized text bitmaps keyed on the
   /// *text string*; a style-only write (color, opacity, or font size) updates
   /// the filter's internal state but still hits the cached bitmap, so the
-  /// overlay keeps the old look until the text itself changes. We bust the
+  /// overlay keeps the previous style until the text itself changes. We bust the
   /// cache by briefly writing a padded variant of the current text, then
   /// restoring the original after one render cycle. The intermediate write
   /// produces a cache miss that re-renders with the new style, and the

--- a/scripts/build-libvlc.sh
+++ b/scripts/build-libvlc.sh
@@ -705,7 +705,7 @@ if [ "$BUILD_CATALYST" = "yes" ]; then
 fi
 
 # --- Step 1e: Patch LDFLAGS to include -isysroot ---
-# On newer Xcode versions (26+), the linker requires an explicit -isysroot
+# On Xcode 26+, the linker requires an explicit -isysroot
 # to find system libraries (libSystem, etc.). VLC's build.sh omits this from
 # LDFLAGS, causing FFmpeg's configure (and others) to fail with:
 #   ld: library 'System' not found
@@ -1023,8 +1023,8 @@ PYEOF
 patch_vlc_objc_libtool
 
 # --- Step 1g: Disable Rust-based contribs ---
-# VLC contribs pin cargo-c 0.9.29, which transitively pulls time 0.3.31 — a
-# crate that no longer compiles on recent Rust (type inference for Box<_>).
+# VLC contribs pin cargo-c 0.9.29, which transitively pulls time 0.3.31 and
+# fails type inference for Box<_> under the supported Rust toolchain.
 # The only Rust contrib we'd get on Apple is rav1e (AV1 *encoder*); we already
 # have dav1d for AV1 *decoding*, which is what matters for playback. iOS and
 # tvOS already skip Rust (Tier 3 targets); this unifies macOS + Catalyst.
@@ -1045,8 +1045,9 @@ with open(path, 'r') as f:
     content = f.read()
 content = content.replace(
     'BUILD_RUST="1"',
-    '# SWIFTVLC_DISABLE_RUST: cargo-c 0.9.29 fails on recent Rust; rav1e is\n'
-    '# an encoder (dav1d handles AV1 decoding). Never set BUILD_RUST.\n'
+    '# SWIFTVLC_DISABLE_RUST: cargo-c 0.9.29 pulls time 0.3.31, which fails\n'
+    '# type inference for Box<_>; rav1e is an encoder and dav1d handles\n'
+    '# AV1 decoding. Never set BUILD_RUST.\n'
     '# BUILD_RUST="1"'
 )
 with open(path, 'w') as f:
@@ -1072,8 +1073,8 @@ cd "${BUILD_DIR}"
 # SDK 26+ exports dup3/pipe2 from libSystem (so autoconf's link test says
 # "yes"), but the iOS headers don't declare them — leading to
 # "use of undeclared identifier 'dup3'" during src/posix/filesystem.c.
-# Device builds correctly detect "no"; simulator (and newer Apple SDKs
-# generally) get confused. VLC's code has proper #else fallbacks.
+# Device builds correctly detect "no"; simulator SDKs that expose those
+# symbols get confused. VLC's code has proper #else fallbacks.
 export ac_cv_func_dup3=no
 export ac_cv_func_pipe2=no
 


### PR DESCRIPTION
## Summary
- Tighten README, architecture, and DocC wording around VLCKit comparison, discovery/renderers, PiP, CI, release, and build claims.
- Remove stale or transitional source comments while preserving behavior.
- Validate relative Markdown links and DocC generation after the cleanup.

## Validation
- git diff --check
- swiftformat Sources/SwiftVLC Package.swift --lint --strict
- ./scripts/doc-coverage.sh --json
- swift package --disable-sandbox generate-documentation --target SwiftVLC
- relative Markdown link check across README, ARCHITECTURE, and DocC files