### PR TITLE
fix(showcase): subscribe to player.events before calling play()

### DIFF
--- a/Showcase/iOS/CaseStudies/10-Diagnostics-Events.swift
+++ b/Showcase/iOS/CaseStudies/10-Diagnostics-Events.swift
@@ -47,8 +47,9 @@ struct EventsCase: View {
   }
 
   private func task() async {
+    let events = player.events
     try? player.play(url: TestMedia.demo)
-    for await event in player.events {
+    for await event in events {
       if let text = describe(event) {
         log.insert(LogLine(text: text), at: 0)
         if log.count > 50 { log.removeLast() }

--- a/Showcase/iOS/CaseStudies/10-Diagnostics-MultiConsumer.swift
+++ b/Showcase/iOS/CaseStudies/10-Diagnostics-MultiConsumer.swift
@@ -61,15 +61,23 @@ struct MultiConsumerEventsCase: View {
     }
     .showcaseFormStyle()
     .navigationTitle("Multi-consumer events")
-    .task { await consumerA() }
-    .task { await consumerB() }
+    .task { await run() }
     .onDisappear { player.stop() }
   }
 
-  /// Independent stream #1: only lifecycle transitions.
-  private func consumerA() async {
+  /// Bootstrap: subscribe both consumers before starting playback.
+  private func run() async {
+    let events = player.events
     try? player.play(url: TestMedia.demo)
-    for await event in player.events {
+    await withTaskGroup(of: Void.self) { group in
+      group.addTask { await self.consumerA(events: events) }
+      group.addTask { await self.consumerB(events: events) }
+    }
+  }
+
+  /// Independent stream #1: only lifecycle transitions.
+  private func consumerA(events: AsyncStream<PlayerEvent>) async {
+    for await event in events {
       let text: String? = switch event {
       case .stateChanged(let state): "state → \(state)"
       case .seekableChanged(let ok): "seekable → \(ok)"
@@ -85,8 +93,8 @@ struct MultiConsumerEventsCase: View {
   }
 
   /// Independent stream #2: only media / track events.
-  private func consumerB() async {
-    for await event in player.events {
+  private func consumerB(events: AsyncStream<PlayerEvent>) async {
+    for await event in events {
       let text: String? = switch event {
       case .mediaChanged: "media changed"
       case .tracksChanged: "tracks changed (\(player.audioTracks.count) audio)"


### PR DESCRIPTION
## Summary

Subscribe to `player.events` BEFORE calling `play()` in the EventsCase and MultiConsumerEventsCase showcase cases. The `AsyncStream` has no replay buffer — events fired before `subscribe()` runs are silently dropped.

## Changes

### 10-Diagnostics-Events.swift
Capture the events stream before playback starts:
```swift
let events = player.events       // ← capture first
try? player.play(url: TestMedia.demo)
for await event in events { ... }
```

### 10-Diagnostics-MultiConsumer.swift
Add a `run()` bootstrap that both consumers subscribe before `play()`:
```swift
private func run() async {
    let events = player.events
    try? player.play(url: TestMedia.demo)
    await withTaskGroup(of: Void.self) { group in
      group.addTask { await self.consumerA(events: events) }
      group.addTask { await self.consumerB(events: events) }
    }
}
```

## Root cause

`player.events` returns a fresh stream that only broadcasts to current subscribers. `libvlc_media_player_play` starts playback and returns immediately — libVLC then dispatches `Opening`/`Playing` state events asynchronously. If the `for await` hasn't registered its continuation yet, those early events are lost.

Fixes #50.