### PR TITLE
Fix chapter/title range mutation guards

### DIFF
--- a/Sources/SwiftVLC/Player/Player+Chapters.swift
+++ b/Sources/SwiftVLC/Player/Player+Chapters.swift
@@ -27,8 +27,8 @@ extension Player {
       return Int(libvlc_media_player_get_chapter(pointer))
     }
     set {
+      guard let chapter = Int32(exactly: newValue) else { return }
       withMutation(keyPath: \.currentChapter) {
-        guard let chapter = Int32(exactly: newValue) else { return }
         libvlc_media_player_set_chapter(pointer, chapter)
       }
     }
@@ -63,8 +63,8 @@ extension Player {
       return Int(libvlc_media_player_get_title(pointer))
     }
     set {
+      guard let title = Int32(exactly: newValue) else { return }
       withMutation(keyPath: \.currentTitle) {
-        guard let title = Int32(exactly: newValue) else { return }
         libvlc_media_player_set_title(pointer, title)
       }
     }

--- a/Tests/SwiftVLCTests/Player/ObservationTests.swift
+++ b/Tests/SwiftVLCTests/Player/ObservationTests.swift
@@ -281,5 +281,32 @@ extension Integration {
       }
       #expect(!chapterFired.withLock { $0 })
     }
+
+    @Test
+    func `out of range chapter and title setters do not invalidate observation`() {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let chapterFired = Mutex(false)
+      let titleFired = Mutex(false)
+
+      withObservationTracking {
+        _ = player.currentChapter
+      } onChange: {
+        chapterFired.withLock { $0 = true }
+      }
+
+      withObservationTracking {
+        _ = player.currentTitle
+      } onChange: {
+        titleFired.withLock { $0 = true }
+      }
+
+      for value in [Int(Int32.max) + 1, Int(Int32.min) - 1] {
+        player.currentChapter = value
+        player.currentTitle = value
+      }
+
+      #expect(!chapterFired.withLock { $0 })
+      #expect(!titleFired.withLock { $0 })
+    }
   }
 }


### PR DESCRIPTION
## Summary

Hoists the `Int32(exactly:)` conversions for `currentChapter` and `currentTitle` before their `withMutation` calls. Values outside the libVLC `Int32` range now return before publishing an Observation mutation, while valid values still enter `withMutation` and call the existing libVLC setters.

Also adds an Observation regression test that assigns values just beyond both ends of the `Int32` range and asserts neither `currentChapter` nor `currentTitle` observers fire.

Closes harflabs/SwiftVLC#42.

## Verification

- `git diff --check`
- Blocked: `swift test --filter ObservationTests` could not run locally because this host does not have `swift` installed (`swift: command not found`). `swiftformat` / `swift-format` are also unavailable locally.
