### PR TITLE
Add PiPController.onRestoreUserInterface hook to distinguish restore from close

### DIFF
--- a/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
@@ -40,6 +40,29 @@ extension PiPController: AVPictureInPictureControllerDelegate {
     }
   }
 
+  /// Called when the user taps the PiP window's restore ("return to app")
+  /// control. Forwards to ``PiPController/onRestoreUserInterface`` so the
+  /// host app can bring its player UI back, then completes the AVKit
+  /// transition. If no hook is set, completes immediately.
+  ///
+  /// The close (X) button does **not** route through here — it only fires
+  /// ``pictureInPictureControllerDidStopPictureInPicture(_:)`` — which is
+  /// how callers distinguish "restore" from "close".
+  public nonisolated func pictureInPictureController(
+    _: AVPictureInPictureController,
+    restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler: @escaping @Sendable (Bool) -> Void
+  ) {
+    pipMainActorSync {
+      guard let onRestoreUserInterface else {
+        completionHandler(true)
+        return
+      }
+      onRestoreUserInterface {
+        completionHandler(true)
+      }
+    }
+  }
+
   /// `AVPictureInPictureControllerDelegate` hook. SwiftVLC does not
   /// propagate PiP start failures; we still resync the observed flags so
   /// the UI doesn't stay stuck in a stale "starting" state.

--- a/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
@@ -57,8 +57,8 @@ extension PiPController: AVPictureInPictureControllerDelegate {
         completionHandler(true)
         return
       }
-      onRestoreUserInterface {
-        completionHandler(true)
+      onRestoreUserInterface { restored in
+        completionHandler(restored)
       }
     }
   }

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -202,7 +202,9 @@ public final class PiPController: NSObject {
   /// Use this to bring your full-screen player UI back on screen when the
   /// user wants to keep watching in the app. The closure receives a
   /// completion handler that you **must** call once your interface has
-  /// finished restoring, so AVKit can dismiss the PiP window cleanly.
+  /// finished restoring, so AVKit can dismiss the PiP window cleanly. Pass
+  /// `true` if the UI was restored successfully, or `false` if you could
+  /// not bring it back; the value is forwarded to AVKit.
   ///
   /// This is *not* called when PiP stops via the close button, an
   /// end-of-media stop, or a programmatic ``stop()`` — those paths only
@@ -214,7 +216,7 @@ public final class PiPController: NSObject {
   ///
   /// - Note: iOS sample-buffer PiP only. On platforms/backends without a
   ///   restore affordance this is never called.
-  public var onRestoreUserInterface: (@MainActor (@escaping @MainActor () -> Void) -> Void)?
+  public var onRestoreUserInterface: (@MainActor (@escaping @MainActor (Bool) -> Void) -> Void)?
 
   /// The layer that renders video frames for both the inline and PiP
   /// presentations.

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -195,6 +195,27 @@ public final class PiPController: NSObject {
   /// Whether a PiP window is currently visible.
   public private(set) var isActive: Bool = false
 
+  /// Invoked when the user taps the PiP window's **restore** affordance
+  /// (the "return to app" control), as opposed to the **close** (X)
+  /// button.
+  ///
+  /// Use this to bring your full-screen player UI back on screen when the
+  /// user wants to keep watching in the app. The closure receives a
+  /// completion handler that you **must** call once your interface has
+  /// finished restoring, so AVKit can dismiss the PiP window cleanly.
+  ///
+  /// This is *not* called when PiP stops via the close button, an
+  /// end-of-media stop, or a programmatic ``stop()`` — those paths only
+  /// flip ``isActive`` to `false`. That distinction is the whole point:
+  /// observe ``isActive`` for "PiP ended", and use this hook for "PiP
+  /// ended *and the user asked to come back*".
+  ///
+  /// If this is `nil`, restoration completes immediately.
+  ///
+  /// - Note: iOS sample-buffer PiP only. On platforms/backends without a
+  ///   restore affordance this is never called.
+  public var onRestoreUserInterface: (@MainActor (@escaping @MainActor () -> Void) -> Void)?
+
   /// The layer that renders video frames for both the inline and PiP
   /// presentations.
   ///

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -216,6 +216,7 @@ public final class PiPController: NSObject {
   ///
   /// - Note: iOS sample-buffer PiP only. On platforms/backends without a
   ///   restore affordance this is never called.
+  @ObservationIgnored
   public var onRestoreUserInterface: (@MainActor (@escaping @MainActor (Bool) -> Void) -> Void)?
 
   /// The layer that renders video frames for both the inline and PiP

--- a/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
@@ -734,6 +734,69 @@ extension Integration {
       #expect(controller.isActive == false)
     }
 
+    /// With no `onRestoreUserInterface` hook, AVKit's completion handler
+    /// must still fire — with `true` — so PiP tears down instead of
+    /// hanging.
+    @Test
+    func `restoreUserInterface completes with true when no hook is set`() {
+      let player = Player(instance: TestInstance.shared)
+      let controller = PiPController(player: player)
+      guard let pip = makePictureInPictureController(for: controller) else { return }
+
+      let restored = Mutex<Bool?>(nil)
+      controller.pictureInPictureController(
+        pip,
+        restoreUserInterfaceForPictureInPictureStopWithCompletionHandler: { value in restored.withLock { $0 = value } }
+      )
+
+      #expect(restored.withLock { $0 } == true)
+    }
+
+    /// The host's restore hook is invoked, and the success value it passes
+    /// to its completion is forwarded verbatim to AVKit.
+    @Test
+    func `restoreUserInterface forwards host success to AVKit`() {
+      let player = Player(instance: TestInstance.shared)
+      let controller = PiPController(player: player)
+      guard let pip = makePictureInPictureController(for: controller) else { return }
+
+      let hookCalled = Mutex(false)
+      controller.onRestoreUserInterface = { done in
+        hookCalled.withLock { $0 = true }
+        done(true)
+      }
+
+      let restored = Mutex<Bool?>(nil)
+      controller.pictureInPictureController(
+        pip,
+        restoreUserInterfaceForPictureInPictureStopWithCompletionHandler: { value in restored.withLock { $0 = value } }
+      )
+
+      #expect(hookCalled.withLock { $0 })
+      #expect(restored.withLock { $0 } == true)
+    }
+
+    /// A host that fails to restore its UI passes `false`, which must reach
+    /// AVKit so the system can react accordingly.
+    @Test
+    func `restoreUserInterface forwards host failure to AVKit`() {
+      let player = Player(instance: TestInstance.shared)
+      let controller = PiPController(player: player)
+      guard let pip = makePictureInPictureController(for: controller) else { return }
+
+      controller.onRestoreUserInterface = { done in
+        done(false)
+      }
+
+      let restored = Mutex<Bool?>(nil)
+      controller.pictureInPictureController(
+        pip,
+        restoreUserInterfaceForPictureInPictureStopWithCompletionHandler: { value in restored.withLock { $0 = value } }
+      )
+
+      #expect(restored.withLock { $0 } == false)
+    }
+
     @Test
     func `terminal observed state clears stale pending PiP play request`() {
       let player = Player(instance: TestInstance.shared)


### PR DESCRIPTION
## Summary

`PiPController` already mirrors AVKit's PiP lifecycle into Observation, but it collapses **both** ways a PiP window can end — the user tapping the **restore** ("return to app") control and tapping the **close** (X) button — into a single `isActive → false` transition. Hosts therefore can't tell the two apart: restoring should bring the full player UI back, while closing should stop playback.

AVKit *does* distinguish them via `pictureInPictureController(_:restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:)`, which fires **only** for the restore control. SwiftVLC sets itself as the controller's delegate (and keeps the `AVPictureInPictureController` private), so apps have no way to observe that callback today.

This PR forwards that delegate method to a new public closure.

## Changes

- **`PiPController.onRestoreUserInterface`** — a public, `@ObservationIgnored` `(@MainActor (@escaping @MainActor (Bool) -> Void) -> Void)?` hook. It's called only when the user taps the restore control; the host brings its UI back and invokes the provided completion, passing `true` if the UI was restored successfully or `false` if it couldn't be. That value is forwarded to AVKit's completion handler so the system knows whether restoration succeeded. `nil` (the default) completes with `true` immediately, preserving current behavior. It's marked `@ObservationIgnored` because it's a configuration hook, not UI state, so assigning it shouldn't trigger view invalidation.
- **`PiPController+Delegate.swift`** — implements `restoreUserInterfaceForPictureInPictureStopWithCompletionHandler`, forwarding to the hook on the main actor (matching the existing `pipMainActorSync` + `@Sendable` completion-handler pattern used by the skip delegate).

The close (X) button still routes only through `pictureInPictureControllerDidStopPictureInPicture` → `isActive = false`, so the contract is: **observe `isActive` for "PiP ended"; use `onRestoreUserInterface` for "PiP ended and the user asked to come back."**

## Notes

- Purely additive; no behavior change when the hook is unset.
- iOS sample-buffer PiP path. Not invoked on backends/platforms without a restore affordance.
- Covered by tests for the no-hook, success, and failure paths.
- `swift build` passes.
