### PR TITLE
Native iOS Picture in Picture, per-handle callback lifetime, and aspect fixes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -48,7 +48,7 @@ flowchart TB
         subgraph Bottom["Supporting Modules"]
             Playlist["Playlist<br/>MediaList · ListPlayer"]
             Discovery["Discovery<br/>LAN/UPnP · Renderer"]
-            PiP["PiP<br/>iOS public sample buffers · macOS SPI native drawable"]
+            PiP["PiP<br/>iOS native drawable or direct vmem · macOS SPI drawable"]
             EventBridge["EventBridge<br/>C → AsyncStream"]
         end
     end
@@ -86,7 +86,7 @@ flowchart TB
 | **State** | `@Observable` / `@MainActor` | Automatic SwiftUI integration, thread safety |
 | **Events** | `AsyncStream<PlayerEvent>` | Native structured concurrency, multi-consumer |
 | **Video** | `UIView` / `NSView` via `set_nsobject` | Platform-native rendering, zero-copy |
-| **PiP** | iOS: vmem → `AVSampleBufferDisplayLayer`; macOS: native drawable backend behind SPI | Public iOS PiP plus explicit private-API macOS opt-in |
+| **PiP** | iOS `PiPVideoView`: native drawable; direct controller: vmem → `AVSampleBufferDisplayLayer`; macOS view: native drawable behind SPI | Public iOS PiP, a public direct sample-buffer route, plus explicit private-API macOS opt-in |
 | **Thread Safety** | `Mutex<T>`, `Sendable`, `nonisolated(unsafe)` | Compile-time data race prevention |
 | **Testing** | Swift Testing framework | Modern `@Test`, `#expect`, tags, traits |
 | **Platforms** | iOS 18+, macOS 15+, tvOS 18+, visionOS 2+, Mac Catalyst | Unified SwiftUI minimum |
@@ -263,18 +263,23 @@ Network service and renderer discovery.
 ### PiP (iOS/macOS only)
 
 Picture-in-Picture uses the platform path that best matches libVLC's
-video output. iOS uses public AVKit sample-buffer PiP. macOS has a
+video output. `PiPVideoView` uses libVLC's native drawable integration on
+iOS. Instantiating `PiPController` directly instead installs public vmem
+callbacks and exposes an `AVSampleBufferDisplayLayer`. macOS has a
 native-drawable backend behind `PrivateMacOSPiP` SPI because the public
-sample-buffer mirror crops incorrectly on supported macOS releases. The
-module is split into 5 focused files.
+sample-buffer mirror crops incorrectly on supported macOS releases.
 
 | File | Type | Purpose |
 |---|---|---|
 | `PiPController.swift` | `@MainActor class PiPController` | PiP lifecycle, timebase sync, deferred-pause state machine, native-state observer task. |
 | `PiPController+Delegate.swift` | extension + private `PiPPlaybackDelegateProxy` | `AVPictureInPictureControllerDelegate` conformance plus the sample-buffer playback delegate proxy that breaks AVKit's strong-retain cycle (AVKit captures the playback delegate strongly even though the header declares it `weak`). Also hosts the `pipMainActorSync` helper for non-main AVKit callbacks that need synchronous main-actor answers. |
-| `PiPVideoView.swift` | SwiftUI representable | `PiPVideoView(player, controller: $binding)` — iOS hosts an `AVSampleBufferDisplayLayer`; macOS hosts native drawable containers whose PiP start path is unavailable unless the SPI opt-in is enabled. |
+| `PiPController+AudioSession.swift` | extension | Configures the iOS playback category at construction, defers activation until playback/PiP intent, and retries after transient activation failure. |
+| `PiPController+PlaybackState.swift` | extension | Payload-driven AVKit range invalidation and seekability-to-linear-playback policy that is independent of `Player` subscriber ordering. |
+| `PiPControllerBindingPublication.swift` | `@MainActor` helper | Defers representable binding writes, rejects stale generations, and clears only the controller identity published by that view lifecycle. |
+| `PiPVideoView.swift` | SwiftUI representable | Owns `PiPVideoView(player, controller: $binding)` construction, player swaps, coordinator lifetime, and platform host attachment without embedding backend implementation details. |
+| `PiPVideoView+iOSNative.swift` | iOS native drawable plumbing | Drawable proxy and layout, generation-gated off-main callbacks, libVLC media controls, and the backend that wraps libVLC's system PiP controller for state and control. |
 | `PiPVideoView+MacPrivate.swift` | macOS-only private API plumbing | `MacNativePiPBackend` orchestrates `MacPrivatePiPPresenter` (dynamic loader for `PIPViewController` from `PIP.framework`), `MacPrivatePiPDelegate`, and `MacNativePiPMediaController`. All private-framework symbol references live in this one file for security/audit review. Gated by `PiPController.allowsPrivateMacOSAPI` SPI. |
-| `PixelBufferRenderer.swift` | `class PixelBufferRenderer: Sendable` | iOS/direct sample-buffer path: format → lock → unlock → display. `CVPixelBufferPool` → `CMSampleBuffer` → layer. |
+| `PixelBufferRenderer.swift` | `class PixelBufferRenderer: Sendable` | Direct sample-buffer path: format → lock → unlock → display. `CVPixelBufferPool` → `CMSampleBuffer` → layer. |
 
 ---
 
@@ -514,10 +519,21 @@ PiP rendering depends on the platform:
 | Path | Pipeline |
 |---|---|
 | **VideoView** | `set_nsobject` → VLC renders directly into the view |
-| **PiP on iOS** | vmem callbacks → `CVPixelBuffer` → `CMSampleBuffer` → `AVSampleBufferDisplayLayer` → PiP |
-| **PiP on macOS** | SPI opt-in: `set_nsobject` drawable → same VLC-owned `NSView` is moved into the system PiP presenter |
+| **PiPVideoView on iOS** | `set_nsobject` drawable proxy → libVLC's iOS sample-buffer video output → libVLC-owned `AVPictureInPictureController` |
+| **Direct PiPController** | vmem callbacks → `CVPixelBuffer` → `CMSampleBuffer` → SwiftVLC-owned `AVSampleBufferDisplayLayer` → AVKit PiP |
+| **PiPVideoView on macOS** | SPI opt-in: `set_nsobject` drawable → same VLC-owned `NSView` is moved into the system PiP presenter |
 
-### iOS/Direct vmem Callback Pipeline
+### iOS Native-drawable Path
+
+`PiPVideoView` attaches a drawable proxy to the player. The proxy hosts
+libVLC's inline rendering children and implements the Picture in Picture
+selectors expected by VLC's bundled iOS video output. That output creates
+and owns the `AVPictureInPictureController`, then passes its native window
+controller back to SwiftVLC for start/stop, possibility, activity, playback
+invalidation, and linear-playback policy. The view never hosts
+`PiPController.layer`; that layer belongs exclusively to the direct path.
+
+### Direct vmem Callback Pipeline
 
 ```mermaid
 flowchart TB
@@ -537,17 +553,76 @@ flowchart TB
         Layer --> Controller
     end
 
-    D -->|"enqueues on main queue"| Layer
+    D -->|"enqueues on dedicated serial queue"| Layer
 ```
+
+The direct renderer requests 8-bit BGRA frames. Its optional resize pass
+uses a device-RGB Core Image target, so this path is SDR and does not
+preserve HDR or wide-color metadata.
+
+### Direct Callback Ownership
+
+libVLC copies vmem function pointers and their opaque value when a video
+output opens. Clearing the media-player callback variables therefore does
+not revoke a copy already held by that output. SwiftVLC ties each retained
+opaque to one exact `libvlc_media_player_t` through
+`NativePlayerHandleLifetime`:
+
+- Sequential direct controllers on the same native handle reuse one stable
+  handle slot. During format negotiation, each vout replaces its copied
+  handle opaque with a separately retained vout context and decode pool. An
+  overlapping output therefore cannot change another output's dimensions,
+  pitch, pool, pending picture, or cleanup state. Each vout still resolves
+  its display target through the handle slot, so a successor controller can
+  atomically take over an already-open output.
+- Replacing the native media-player handle creates a fresh slot for the new
+  handle and permanently retires the old slot.
+- Every successful lock pins exactly one buffer until matching display, a
+  superseding successful lock, or that vout's cleanup. This balances the
+  retain even when pinned vmem suppresses display after native picture
+  construction fails. Cleanup drains only its own vout and releases that
+  vout context exactly once.
+- Each `MediaListPlayer` native binding is a counted owner because pinned
+  libVLC retains the same `libvlc_media_player_t`. A rebuild synchronously
+  rebinds the retiring list player to an independent neutral player before
+  offloading its release, so it cannot advance or stop a successor's shared
+  handle. Final shutdown waits for the initial owner and every counted list
+  owner to release.
+- Retirement suppresses new display work, but releases the handle opaque
+  only after the final counted native release returns for that exact handle
+  and every handle callback already in flight has drained. No timeout or
+  transient `vout` observation is treated as proof of safety.
+
+This per-handle rule prevents both use-after-free during teardown and stale
+controller teardown from clearing a successor's callbacks.
+
+### Playback Range and Invalidation Policy
+
+The direct AVKit playback delegate synchronously snapshots the current
+native handle and maps media state as follows:
+
+| Native state | AVKit range |
+|---|---|
+| No media | Invalid |
+| Loaded media with length `<= 0` | Start zero, positive-infinite duration |
+| Loaded media with positive length | Start zero, finite native duration |
+
+An unknown duration is therefore valid live/indefinite content; rendering
+does not wait for a finite length. Media, length, and seekability events
+drive invalidation from their payloads. That is load-bearing because
+`Player` and `PiPController` subscribe independently and either consumer
+may observe the event first. Playback-state changes conservatively
+invalidate as a payload-free fallback. Seekability payloads also synchronize
+`requiresLinearPlayback` on the direct controller and iOS native backend.
 
 ### PiPController Responsibilities
 
 1. **Timebase sync.** Creates a `CMTimebase` and keeps it aligned with the player's state (playing, paused, or rate-shifted).
-2. **Duration reporting.** Invalidates the PiP controller once the duration becomes known, which is required before the controls can render.
-3. **Playback delegation.** Owns a `PiPPlaybackDelegateProxy` that implements `AVPictureInPictureSampleBufferPlaybackDelegate`, breaking AVKit's strong-retain cycle while routing PiP play, pause, and seek commands into the ``Player``.
-4. **State observation.** An observer task distinguishes VLC-initiated state changes from PiP-initiated ones.
-5. **Render-size tracking.** The iOS/direct sample-buffer path follows AVKit's render-size callbacks and emits target-sized buffers so live PiP resizing cannot display stale-size frames.
-6. **Deferred pause.** Skip-without-blink by deferring the pause via task cancellation.
+2. **Playback delegation.** Owns a `PiPPlaybackDelegateProxy` that implements `AVPictureInPictureSampleBufferPlaybackDelegate`, breaking AVKit's strong-retain cycle while routing PiP play, pause, and seek commands into the `Player`.
+3. **Range policy.** Reports no-content, live/indefinite, and finite media distinctly, and invalidates from event payloads rather than stale observable mirrors.
+4. **State observation.** Distinguishes VLC-initiated state changes from pending PiP-initiated play/pause intent and keeps AVKit's linear-playback policy aligned with seekability.
+5. **Deferred pause.** Debounces transient AVKit pause signals so skips and PiP transitions do not issue an unsafe short-lived native pause.
+6. **Audio policy.** Configures the iOS playback category at construction but defers `setActive(true)` until PiP start or active playback intent. Direct and inactive native construction do not take audio focus; native adoption of an already-active Player activates before publishing backend ownership so automatic PiP cannot outrun session setup. A failed attempt remains retryable at observed native did-start.
 
 On macOS, the SPI native backend intentionally bypasses SwiftVLC's vmem
 renderer. It gives libVLC a normal `NSView` drawable and deliberately does
@@ -561,10 +636,21 @@ into the PiP panel.
 
 ### Mutually Exclusive
 
-`VideoView` and `PiPVideoView` are mutually exclusive for a given player.
-On iOS, `set_nsobject` and vmem callbacks cannot coexist on the same
-`libvlc_media_player_t`. On macOS, both views use `set_nsobject`, and
-the most recently attached drawable owns VLC's native video output.
+Only one rendering path may own a player at a time. On iOS,
+`PiPVideoView` and `VideoView` both use `set_nsobject`, while a direct
+`PiPController` replaces drawable rendering with vmem callbacks. A stable
+same-handle callback slot makes sequential direct-controller handoff safe;
+it does not make simultaneous drawable and vmem outputs supported. On
+macOS, both SwiftUI views use `set_nsobject`, and the most recently attached
+drawable owns VLC's native video output.
+
+### Physical-device Validation
+
+The iOS native backend deliberately reports PiP unavailable in Simulator.
+Simulator AVKit can report an active sample-buffer PiP controller while the
+system window remains black, so state-only simulator tests cannot validate
+video delivery. End-to-end PiP rendering must be exercised on a physical
+iOS device with the `audio` background mode enabled.
 
 ---
 

--- a/Showcase/Shared/AccessibilityID.swift
+++ b/Showcase/Shared/AccessibilityID.swift
@@ -151,6 +151,17 @@ enum AccessibilityID {
     static let preparingLabel = "pip.preparing"
   }
 
+  enum PiPLiveValidation {
+    static let videoView = "pipLive.videoView"
+    static let stateLabel = "pipLive.state"
+    static let durationLabel = "pipLive.duration"
+    static let displayedPicturesLabel = "pipLive.displayedPictures"
+    static let possibleLabel = "pipLive.possible"
+    static let activeLabel = "pipLive.active"
+    static let toggleButton = "pipLive.toggle"
+    static let errorLabel = "pipLive.error"
+  }
+
   enum AudioOutputs {
     static let videoView = "audioout.videoView"
     static let playPauseButton = "audioout.playPause"

--- a/Showcase/Shared/LaunchArguments.swift
+++ b/Showcase/Shared/LaunchArguments.swift
@@ -23,6 +23,16 @@ enum LaunchArguments {
   /// streams.
   static let musicFixtureURLs = "-UITestMusicFixtureURLs"
 
+  /// Indefinite MPEG-TS stream used by the physical-device PiP validation
+  /// lane. This remains operator-supplied so the repository never embeds a
+  /// private or short-lived stream URL.
+  static let pipLiveURL = "-UITestPiPLiveURL"
+
+  /// Selects the PiP implementation exercised by the physical-device
+  /// validation surface: `native` for `PiPVideoView`, `direct` for a hosted
+  /// `PiPController.layer`.
+  static let pipRenderingPath = "-UITestPiPRenderingPath"
+
   /// Name of a showcase to deep-link to on launch (e.g. `"SimplePlayback"`).
   /// When unset, the showcase opens its normal navigation tree.
   static let route = "-UITestRoute"
@@ -44,6 +54,14 @@ enum LaunchArguments {
       .split(separator: "|")
       .map { URL(fileURLWithPath: String($0)) }
       ?? []
+  }
+
+  static var pipLiveURLValue: URL? {
+    UserDefaults.standard.string(forKey: key(pipLiveURL)).flatMap(URL.init(string:))
+  }
+
+  static var pipRenderingPathValue: String? {
+    UserDefaults.standard.string(forKey: key(pipRenderingPath))
   }
 
   static var routeValue: String? {
@@ -102,6 +120,7 @@ enum UITestRoute: String, CaseIterable {
   case multiTrackSelection = "MultiTrackSelection"
   case multiConsumer = "MultiConsumer"
   case harnessHome = "HarnessHome"
+  case pipLiveValidation = "PiPLiveValidation"
 
   static var current: UITestRoute? {
     LaunchArguments.routeValue.flatMap(UITestRoute.init(rawValue:))

--- a/Showcase/UITests/iOS/Support/PiPMotionRegionAnalyzer.swift
+++ b/Showcase/UITests/iOS/Support/PiPMotionRegionAnalyzer.swift
@@ -1,0 +1,608 @@
+/// One RGB sample in a downsampled screen capture.
+///
+/// This type and the analyzer below deliberately have no UIKit, Core Graphics,
+/// or XCTest dependency. The physical-device UI test is only an adapter from
+/// `UIImage` to this deterministic, platform-neutral input.
+struct PiPMotionPixel: Equatable {
+  let red: UInt8
+  let green: UInt8
+  let blue: UInt8
+
+  static let black = Self(red: 0, green: 0, blue: 0)
+
+  func differs(from other: Self, threshold: Int) -> Bool {
+    max(
+      abs(Int(red) - Int(other.red)),
+      abs(Int(green) - Int(other.green)),
+      abs(Int(blue) - Int(other.blue))
+    ) >= threshold
+  }
+
+  func isNonBlack(threshold: UInt8) -> Bool {
+    max(red, green, blue) > threshold
+  }
+}
+
+/// A row-major RGB frame consumed by `PiPMotionRegionAnalyzer`.
+struct PiPMotionFrame: Equatable {
+  let width: Int
+  let height: Int
+  let pixels: [PiPMotionPixel]
+
+  init(width: Int, height: Int, pixels: [PiPMotionPixel]) {
+    precondition(width > 0 && height > 0)
+    precondition(pixels.count == width * height)
+    self.width = width
+    self.height = height
+    self.pixels = pixels
+  }
+}
+
+/// Integer coordinates in the analyzer's downsampled frame.
+struct PiPMotionRegion: Equatable {
+  let x: Int
+  let y: Int
+  let width: Int
+  let height: Int
+
+  var maxX: Int {
+    x + width
+  }
+
+  var maxY: Int {
+    y + height
+  }
+
+  var area: Int {
+    width * height
+  }
+
+  var centerX: Double {
+    Double(x) + Double(width) / 2
+  }
+
+  var centerY: Double {
+    Double(y) + Double(height) / 2
+  }
+
+  func intersectionArea(with other: Self) -> Int {
+    let overlapWidth = max(0, min(maxX, other.maxX) - max(x, other.x))
+    let overlapHeight = max(0, min(maxY, other.maxY) - max(y, other.y))
+    return overlapWidth * overlapHeight
+  }
+}
+
+struct PiPMotionRegionAnalysis: Equatable {
+  enum Failure: String, Equatable {
+    case insufficientFrames = "fewer than five frames"
+    case mismatchedFrameDimensions = "frame dimensions changed"
+    case noStablePiPSizedComponent = "no contiguous, persistent PiP-sized motion component"
+    case ambiguousMotionRegions = "multiple similarly sized persistent motion components"
+    case unstableRegion = "motion component position drifted"
+    case insufficientSustainedMotion = "motion was not sustained in the detected region"
+    case insufficientNonBlackContent = "detected region did not contain sustained non-black pixels"
+  }
+
+  let frameWidth: Int
+  let frameHeight: Int
+  let region: PiPMotionRegion?
+  let failure: Failure?
+  let pairMotionRatios: [Double]
+  let frameNonBlackRatios: [Double]
+  let requiredPairCount: Int
+  let requiredNonBlackFrameCount: Int
+  let matchingPairCount: Int
+  let sustainedMotionPairCount: Int
+  let nonBlackFrameCount: Int
+  let persistentComponentCount: Int
+  let regionAreaRatio: Double
+  let regionAspectRatio: Double
+  let persistentFillRatio: Double
+  let horizontalCenterDriftRatio: Double
+  let verticalCenterDriftRatio: Double
+  let largestPersistentComponentAreaRatio: Double
+
+  var passed: Bool {
+    failure == nil
+  }
+}
+
+/// Finds one bounded, persistent motion component with the geometry and pixel
+/// evidence expected of a landscape system PiP window.
+///
+/// The oracle intentionally does not use a whole-screen changed-pixel ratio:
+/// every accepted pair must support the same connected component, its center
+/// must remain stable, and the same bounded region must contain both sustained
+/// motion and non-black pixels.
+struct PiPMotionRegionAnalyzer {
+  struct Configuration: Equatable {
+    var minimumFrames = 5
+    var pixelDeltaThreshold = 28
+    var nonBlackThreshold: UInt8 = 40
+    var tileSize = 3
+    var activeTileChangedRatio = 0.10
+    var minimumRegionAreaRatio = 0.012
+    var maximumRegionAreaRatio = 0.18
+    var minimumRegionAspectRatio = 1.45
+    var maximumRegionAspectRatio = 2.05
+    var minimumPersistentFillRatio = 0.30
+    var minimumPairComponentSupportRatio = 0.35
+    var minimumPairRegionAreaScale = 0.25
+    var maximumPairRegionAreaScale = 2.0
+    var minimumPairMotionRatio = 0.06
+    var minimumFrameNonBlackRatio = 0.20
+    var maximumCenterDriftRatio = 0.15
+    var ambiguitySizeRatio = 0.65
+
+    static let physicalPiP = Self()
+  }
+
+  var configuration: Configuration = .physicalPiP
+
+  func analyze(_ frames: [PiPMotionFrame]) -> PiPMotionRegionAnalysis {
+    guard frames.count >= configuration.minimumFrames else {
+      return emptyAnalysis(
+        frames: frames,
+        failure: .insufficientFrames
+      )
+    }
+
+    let width = frames[0].width
+    let height = frames[0].height
+    guard frames.allSatisfy({ $0.width == width && $0.height == height }) else {
+      return emptyAnalysis(
+        frames: frames,
+        failure: .mismatchedFrameDimensions
+      )
+    }
+
+    let pairCount = frames.count - 1
+    let requiredPairCount = max(2, pairCount - 1)
+    let tileColumns = divideRoundingUp(width, by: configuration.tileSize)
+    let tileRows = divideRoundingUp(height, by: configuration.tileSize)
+    let pairData = zip(frames, frames.dropFirst()).map {
+      makePairData(
+        first: $0,
+        second: $1,
+        tileColumns: tileColumns,
+        tileRows: tileRows
+      )
+    }
+
+    var persistentCounts = [Int](repeating: 0, count: tileColumns * tileRows)
+    for data in pairData {
+      for (index, active) in data.activeTiles.enumerated() where active {
+        persistentCounts[index] += 1
+      }
+    }
+
+    let persistentTiles = persistentCounts.map { $0 >= requiredPairCount }
+    let persistentComponents = connectedComponents(
+      in: persistentTiles,
+      columns: tileColumns,
+      rows: tileRows
+    )
+    let evaluatedComponents = persistentComponents.map {
+      evaluate(
+        component: $0,
+        frameWidth: width,
+        frameHeight: height,
+        tileColumns: tileColumns
+      )
+    }
+    let largestAreaRatio = evaluatedComponents.map(\.areaRatio).max() ?? 0
+    let candidates = evaluatedComponents
+      .filter(\.isPiPSized)
+      .sorted {
+        if $0.component.indices.count == $1.component.indices.count {
+          return $0.region.area > $1.region.area
+        }
+        return $0.component.indices.count > $1.component.indices.count
+      }
+
+    guard let candidate = candidates.first else {
+      return analysis(
+        width: width,
+        height: height,
+        region: nil,
+        failure: .noStablePiPSizedComponent,
+        requiredPairCount: requiredPairCount,
+        persistentComponentCount: persistentComponents.count,
+        largestAreaRatio: largestAreaRatio
+      )
+    }
+
+    if
+      candidates.count > 1,
+      Double(candidates[1].component.indices.count)
+      >= Double(candidate.component.indices.count) * configuration.ambiguitySizeRatio {
+      return analysis(
+        width: width,
+        height: height,
+        region: candidate.region,
+        failure: .ambiguousMotionRegions,
+        requiredPairCount: requiredPairCount,
+        persistentComponentCount: persistentComponents.count,
+        regionAreaRatio: candidate.areaRatio,
+        regionAspectRatio: candidate.aspectRatio,
+        persistentFillRatio: candidate.fillRatio,
+        largestAreaRatio: largestAreaRatio
+      )
+    }
+
+    let persistentIndices = Set(candidate.component.indices)
+    var matchingRegions: [PiPMotionRegion] = []
+    var matchingPairCount = 0
+    var pairMotionRatios: [Double] = []
+    var sustainedMotionPairCount = 0
+
+    for data in pairData {
+      let components = connectedComponents(
+        in: data.activeTiles,
+        columns: tileColumns,
+        rows: tileRows
+      )
+      let match = components
+        .map { component in
+          let overlap = component.indices.count { persistentIndices.contains($0) }
+          return (component: component, overlap: overlap)
+        }
+        .max {
+          if $0.overlap == $1.overlap {
+            return $0.component.indices.count < $1.component.indices.count
+          }
+          return $0.overlap < $1.overlap
+        }
+      let supportRatio = match.map {
+        Double($0.overlap) / Double(max(1, candidate.component.indices.count))
+      } ?? 0
+      let motionRatio = changedRatio(
+        in: candidate.region,
+        changedPixels: data.changedPixels,
+        frameWidth: width
+      )
+      pairMotionRatios.append(motionRatio)
+
+      if let match {
+        let matchedRegion = region(
+          for: match.component,
+          frameWidth: width,
+          frameHeight: height,
+          tileColumns: tileColumns
+        )
+        let areaScale = Double(matchedRegion.area) / Double(candidate.region.area)
+        guard
+          supportRatio >= configuration.minimumPairComponentSupportRatio,
+          areaScale >= configuration.minimumPairRegionAreaScale,
+          areaScale <= configuration.maximumPairRegionAreaScale
+        else { continue }
+
+        matchingPairCount += 1
+        matchingRegions.append(matchedRegion)
+        if motionRatio >= configuration.minimumPairMotionRatio {
+          sustainedMotionPairCount += 1
+        }
+      }
+    }
+
+    let horizontalDrift = centerDrift(
+      matchingRegions.map(\.centerX),
+      relativeTo: candidate.region.width
+    )
+    let verticalDrift = centerDrift(
+      matchingRegions.map(\.centerY),
+      relativeTo: candidate.region.height
+    )
+    let nonBlackRatios = frames.map {
+      nonBlackRatio(in: candidate.region, frame: $0)
+    }
+    let nonBlackFrameCount = nonBlackRatios.count {
+      $0 >= configuration.minimumFrameNonBlackRatio
+    }
+    let requiredNonBlackFrameCount = max(2, frames.count - 1)
+
+    let failure: PiPMotionRegionAnalysis.Failure? = if
+      matchingPairCount < requiredPairCount
+      || horizontalDrift > configuration.maximumCenterDriftRatio
+      || verticalDrift > configuration.maximumCenterDriftRatio {
+      .unstableRegion
+    } else if sustainedMotionPairCount < requiredPairCount {
+      .insufficientSustainedMotion
+    } else if nonBlackFrameCount < requiredNonBlackFrameCount {
+      .insufficientNonBlackContent
+    } else {
+      nil
+    }
+
+    return PiPMotionRegionAnalysis(
+      frameWidth: width,
+      frameHeight: height,
+      region: candidate.region,
+      failure: failure,
+      pairMotionRatios: pairMotionRatios,
+      frameNonBlackRatios: nonBlackRatios,
+      requiredPairCount: requiredPairCount,
+      requiredNonBlackFrameCount: requiredNonBlackFrameCount,
+      matchingPairCount: matchingPairCount,
+      sustainedMotionPairCount: sustainedMotionPairCount,
+      nonBlackFrameCount: nonBlackFrameCount,
+      persistentComponentCount: persistentComponents.count,
+      regionAreaRatio: candidate.areaRatio,
+      regionAspectRatio: candidate.aspectRatio,
+      persistentFillRatio: candidate.fillRatio,
+      horizontalCenterDriftRatio: horizontalDrift,
+      verticalCenterDriftRatio: verticalDrift,
+      largestPersistentComponentAreaRatio: largestAreaRatio
+    )
+  }
+}
+
+extension PiPMotionRegionAnalyzer {
+  fileprivate struct PairData {
+    let changedPixels: [Bool]
+    let activeTiles: [Bool]
+  }
+
+  fileprivate struct TileComponent {
+    let indices: [Int]
+    let minimumColumn: Int
+    let maximumColumn: Int
+    let minimumRow: Int
+    let maximumRow: Int
+  }
+
+  fileprivate struct EvaluatedComponent {
+    let component: TileComponent
+    let region: PiPMotionRegion
+    let areaRatio: Double
+    let aspectRatio: Double
+    let fillRatio: Double
+    let isPiPSized: Bool
+  }
+
+  private func makePairData(
+    first: PiPMotionFrame,
+    second: PiPMotionFrame,
+    tileColumns: Int,
+    tileRows: Int
+  ) -> PairData {
+    let changedPixels = zip(first.pixels, second.pixels).map {
+      $0.differs(from: $1, threshold: configuration.pixelDeltaThreshold)
+    }
+    var activeTiles = [Bool](repeating: false, count: tileColumns * tileRows)
+
+    for row in 0..<tileRows {
+      for column in 0..<tileColumns {
+        let minimumX = column * configuration.tileSize
+        let minimumY = row * configuration.tileSize
+        let maximumX = min(first.width, minimumX + configuration.tileSize)
+        let maximumY = min(first.height, minimumY + configuration.tileSize)
+        var changedCount = 0
+        var sampleCount = 0
+
+        for y in minimumY..<maximumY {
+          for x in minimumX..<maximumX {
+            sampleCount += 1
+            if changedPixels[y * first.width + x] {
+              changedCount += 1
+            }
+          }
+        }
+
+        let changedRatio = Double(changedCount) / Double(max(1, sampleCount))
+        activeTiles[row * tileColumns + column] =
+          changedRatio >= configuration.activeTileChangedRatio
+      }
+    }
+
+    return PairData(changedPixels: changedPixels, activeTiles: activeTiles)
+  }
+
+  private func connectedComponents(
+    in mask: [Bool],
+    columns: Int,
+    rows: Int
+  ) -> [TileComponent] {
+    var visited = [Bool](repeating: false, count: mask.count)
+    var result: [TileComponent] = []
+
+    for start in mask.indices where mask[start] && !visited[start] {
+      visited[start] = true
+      var queue = [start]
+      var nextQueueIndex = 0
+      var indices: [Int] = []
+      var minimumColumn = columns
+      var maximumColumn = 0
+      var minimumRow = rows
+      var maximumRow = 0
+
+      while nextQueueIndex < queue.count {
+        let index = queue[nextQueueIndex]
+        nextQueueIndex += 1
+        indices.append(index)
+        let column = index % columns
+        let row = index / columns
+        minimumColumn = min(minimumColumn, column)
+        maximumColumn = max(maximumColumn, column)
+        minimumRow = min(minimumRow, row)
+        maximumRow = max(maximumRow, row)
+
+        for rowOffset in -1...1 {
+          for columnOffset in -1...1 where rowOffset != 0 || columnOffset != 0 {
+            let neighborColumn = column + columnOffset
+            let neighborRow = row + rowOffset
+            guard
+              neighborColumn >= 0,
+              neighborColumn < columns,
+              neighborRow >= 0,
+              neighborRow < rows
+            else { continue }
+
+            let neighbor = neighborRow * columns + neighborColumn
+            guard mask[neighbor], !visited[neighbor] else { continue }
+            visited[neighbor] = true
+            queue.append(neighbor)
+          }
+        }
+      }
+
+      result.append(
+        TileComponent(
+          indices: indices,
+          minimumColumn: minimumColumn,
+          maximumColumn: maximumColumn,
+          minimumRow: minimumRow,
+          maximumRow: maximumRow
+        )
+      )
+    }
+
+    return result
+  }
+
+  private func evaluate(
+    component: TileComponent,
+    frameWidth: Int,
+    frameHeight: Int,
+    tileColumns: Int
+  ) -> EvaluatedComponent {
+    let componentRegion = region(
+      for: component,
+      frameWidth: frameWidth,
+      frameHeight: frameHeight,
+      tileColumns: tileColumns
+    )
+    let areaRatio = Double(componentRegion.area) / Double(frameWidth * frameHeight)
+    let aspectRatio = Double(componentRegion.width) / Double(componentRegion.height)
+    let tileBoundsArea = (component.maximumColumn - component.minimumColumn + 1)
+      * (component.maximumRow - component.minimumRow + 1)
+    let fillRatio = Double(component.indices.count) / Double(tileBoundsArea)
+    let isPiPSized = areaRatio >= configuration.minimumRegionAreaRatio
+      && areaRatio <= configuration.maximumRegionAreaRatio
+      && aspectRatio >= configuration.minimumRegionAspectRatio
+      && aspectRatio <= configuration.maximumRegionAspectRatio
+      && fillRatio >= configuration.minimumPersistentFillRatio
+
+    return EvaluatedComponent(
+      component: component,
+      region: componentRegion,
+      areaRatio: areaRatio,
+      aspectRatio: aspectRatio,
+      fillRatio: fillRatio,
+      isPiPSized: isPiPSized
+    )
+  }
+
+  fileprivate func region(
+    for component: TileComponent,
+    frameWidth: Int,
+    frameHeight: Int,
+    tileColumns _: Int
+  ) -> PiPMotionRegion {
+    let minimumX = component.minimumColumn * configuration.tileSize
+    let minimumY = component.minimumRow * configuration.tileSize
+    let maximumX = min(
+      frameWidth,
+      (component.maximumColumn + 1) * configuration.tileSize
+    )
+    let maximumY = min(
+      frameHeight,
+      (component.maximumRow + 1) * configuration.tileSize
+    )
+    return PiPMotionRegion(
+      x: minimumX,
+      y: minimumY,
+      width: maximumX - minimumX,
+      height: maximumY - minimumY
+    )
+  }
+
+  private func changedRatio(
+    in region: PiPMotionRegion,
+    changedPixels: [Bool],
+    frameWidth: Int
+  ) -> Double {
+    var changedCount = 0
+    for y in region.y..<region.maxY {
+      for x in region.x..<region.maxX where changedPixels[y * frameWidth + x] {
+        changedCount += 1
+      }
+    }
+    return Double(changedCount) / Double(max(1, region.area))
+  }
+
+  private func nonBlackRatio(
+    in region: PiPMotionRegion,
+    frame: PiPMotionFrame
+  ) -> Double {
+    var nonBlackCount = 0
+    for y in region.y..<region.maxY {
+      for x in region.x..<region.maxX
+        where frame.pixels[y * frame.width + x]
+        .isNonBlack(threshold: configuration.nonBlackThreshold) {
+        nonBlackCount += 1
+      }
+    }
+    return Double(nonBlackCount) / Double(max(1, region.area))
+  }
+
+  private func centerDrift(_ centers: [Double], relativeTo extent: Int) -> Double {
+    guard let minimum = centers.min(), let maximum = centers.max() else {
+      return .infinity
+    }
+    return (maximum - minimum) / Double(max(1, extent))
+  }
+
+  private func divideRoundingUp(_ value: Int, by divisor: Int) -> Int {
+    (value + divisor - 1) / divisor
+  }
+
+  private func emptyAnalysis(
+    frames: [PiPMotionFrame],
+    failure: PiPMotionRegionAnalysis.Failure
+  ) -> PiPMotionRegionAnalysis {
+    analysis(
+      width: frames.first?.width ?? 0,
+      height: frames.first?.height ?? 0,
+      region: nil,
+      failure: failure,
+      requiredPairCount: max(2, frames.count - 2),
+      persistentComponentCount: 0,
+      largestAreaRatio: 0
+    )
+  }
+
+  private func analysis(
+    width: Int,
+    height: Int,
+    region: PiPMotionRegion?,
+    failure: PiPMotionRegionAnalysis.Failure,
+    requiredPairCount: Int,
+    persistentComponentCount: Int,
+    regionAreaRatio: Double = 0,
+    regionAspectRatio: Double = 0,
+    persistentFillRatio: Double = 0,
+    largestAreaRatio: Double
+  ) -> PiPMotionRegionAnalysis {
+    PiPMotionRegionAnalysis(
+      frameWidth: width,
+      frameHeight: height,
+      region: region,
+      failure: failure,
+      pairMotionRatios: [],
+      frameNonBlackRatios: [],
+      requiredPairCount: requiredPairCount,
+      requiredNonBlackFrameCount: requiredPairCount + 1,
+      matchingPairCount: 0,
+      sustainedMotionPairCount: 0,
+      nonBlackFrameCount: 0,
+      persistentComponentCount: persistentComponentCount,
+      regionAreaRatio: regionAreaRatio,
+      regionAspectRatio: regionAspectRatio,
+      persistentFillRatio: persistentFillRatio,
+      horizontalCenterDriftRatio: 0,
+      verticalCenterDriftRatio: 0,
+      largestPersistentComponentAreaRatio: largestAreaRatio
+    )
+  }
+}

--- a/Showcase/UITests/iOS/Support/ShowcaseIOSTestCase.swift
+++ b/Showcase/UITests/iOS/Support/ShowcaseIOSTestCase.swift
@@ -145,6 +145,30 @@ class ShowcaseIOSTestCase: XCTestCase {
     }
   }
 
+  /// Spins until an accessibility label parses as an integer above the
+  /// supplied lower bound, then returns the observed value.
+  @discardableResult
+  func waitForIntegerLabel(
+    _ element: XCUIElement,
+    greaterThan lowerBound: Int,
+    timeout: TimeInterval,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) -> Int {
+    let predicate = NSPredicate { _, _ in
+      Int(element.label).map { $0 > lowerBound } == true
+    }
+    let exp = expectation(for: predicate, evaluatedWith: NSObject())
+    if XCTWaiter.wait(for: [exp], timeout: timeout) != .completed {
+      XCTFail(
+        "Expected an integer label above \(lowerBound), but found '\(element.label)' after \(timeout)s",
+        file: file,
+        line: line
+      )
+    }
+    return Int(element.label) ?? Int.min
+  }
+
   /// Waits until the element's visible screen region contains real video
   /// pixels instead of the all-black drawable placeholder.
   func assertRendersNonBlackFrame(
@@ -194,6 +218,82 @@ class ShowcaseIOSTestCase: XCTestCase {
     }
     XCTFail(
       "Expected video pixels, but sampled only \(Int(lastNonBlackRatio * 100))% non-black pixels after \(timeout)s",
+      file: file,
+      line: line
+    )
+  }
+
+  /// Samples the display after backgrounding and finds one stable, contiguous
+  /// PiP-sized motion component. The same bounded region must contain
+  /// sustained motion and non-black pixels; whole-screen animation, clocks,
+  /// widgets, spinners, scattered changes, and position drift are rejected.
+  func assertSystemPictureInPictureRendersMotion(
+    samples: Int = 6,
+    interval: TimeInterval = 0.75,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    precondition(samples >= 5)
+
+    var screenshots: [XCUIScreenshot] = []
+
+    for index in 0..<samples {
+      screenshots.append(XCUIScreen.main.screenshot())
+      if index + 1 < samples {
+        RunLoop.current.run(until: Date().addingTimeInterval(interval))
+      }
+    }
+
+    for (index, screenshot) in screenshots.enumerated()
+      where index == 0 || index == screenshots.count - 1 {
+      let attachment = XCTAttachment(screenshot: screenshot)
+      attachment.name = index == 0 ? "system-pip-motion-start" : "system-pip-motion-end"
+      attachment.lifetime = .keepAlways
+      add(attachment)
+    }
+
+    let frames = screenshots.compactMap { makePiPMotionFrame(from: $0.image) }
+    guard frames.count == screenshots.count else {
+      let attachment = XCTAttachment(
+        string: "Could rasterize only \(frames.count) of \(screenshots.count) screenshots."
+      )
+      attachment.name = "system-pip-motion-diagnostics"
+      attachment.lifetime = .keepAlways
+      add(attachment)
+      XCTFail("Could not rasterize system PiP screenshots", file: file, line: line)
+      return
+    }
+
+    let analysis = PiPMotionRegionAnalyzer().analyze(frames)
+    let diagnostics = systemPiPMotionDiagnostics(analysis)
+    let diagnosticAttachment = XCTAttachment(string: diagnostics)
+    diagnosticAttachment.name = "system-pip-motion-diagnostics"
+    diagnosticAttachment.lifetime = .keepAlways
+    add(diagnosticAttachment)
+
+    if
+      let region = analysis.region,
+      let first = screenshots.first,
+      let last = screenshots.last {
+      for (name, screenshot) in [("start", first), ("end", last)] {
+        guard
+          let crop = croppedPiPMotionRegion(
+            screenshot.image,
+            region: region,
+            frameWidth: analysis.frameWidth,
+            frameHeight: analysis.frameHeight
+          )
+        else { continue }
+        let attachment = XCTAttachment(image: crop)
+        attachment.name = "system-pip-detected-region-\(name)"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+      }
+    }
+
+    guard let failure = analysis.failure else { return }
+    XCTFail(
+      "System PiP image oracle failed: \(failure.rawValue). \(diagnostics)",
       file: file,
       line: line
     )
@@ -288,4 +388,117 @@ private func croppedImage(_ image: UIImage, to frame: CGRect) -> UIImage? {
 
   guard let cropped = cgImage.cropping(to: pixelRect) else { return nil }
   return UIImage(cgImage: cropped, scale: image.scale, orientation: image.imageOrientation)
+}
+
+private func makePiPMotionFrame(
+  from image: UIImage,
+  maximumDimension: Int = 240
+) -> PiPMotionFrame? {
+  guard let cgImage = image.cgImage else { return nil }
+
+  let sourceWidth = cgImage.width
+  let sourceHeight = cgImage.height
+  guard sourceWidth > 0, sourceHeight > 0 else { return nil }
+
+  let scale = min(
+    1,
+    Double(maximumDimension) / Double(max(sourceWidth, sourceHeight))
+  )
+  let width = max(1, Int((Double(sourceWidth) * scale).rounded()))
+  let height = max(1, Int((Double(sourceHeight) * scale).rounded()))
+  let bytesPerPixel = 4
+  let bytesPerRow = width * bytesPerPixel
+  let colorSpace = CGColorSpaceCreateDeviceRGB()
+  let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+    | CGBitmapInfo.byteOrder32Big.rawValue
+  var bytes = [UInt8](repeating: 0, count: height * bytesPerRow)
+
+  guard
+    let context = CGContext(
+      data: &bytes,
+      width: width,
+      height: height,
+      bitsPerComponent: 8,
+      bytesPerRow: bytesPerRow,
+      space: colorSpace,
+      bitmapInfo: bitmapInfo
+    )
+  else { return nil }
+
+  context.interpolationQuality = .low
+  let bounds = CGRect(x: 0, y: 0, width: width, height: height)
+  context.draw(cgImage, in: bounds)
+
+  var pixels: [PiPMotionPixel] = []
+  pixels.reserveCapacity(width * height)
+  for y in 0..<height {
+    for x in 0..<width {
+      let offset = y * bytesPerRow + x * bytesPerPixel
+      pixels.append(
+        PiPMotionPixel(
+          red: bytes[offset],
+          green: bytes[offset + 1],
+          blue: bytes[offset + 2]
+        )
+      )
+    }
+  }
+
+  return PiPMotionFrame(width: width, height: height, pixels: pixels)
+}
+
+private func croppedPiPMotionRegion(
+  _ image: UIImage,
+  region: PiPMotionRegion,
+  frameWidth: Int,
+  frameHeight: Int
+) -> UIImage? {
+  guard
+    let cgImage = image.cgImage,
+    frameWidth > 0,
+    frameHeight > 0
+  else { return nil }
+
+  let scaleX = Double(cgImage.width) / Double(frameWidth)
+  let scaleY = Double(cgImage.height) / Double(frameHeight)
+  let imageBounds = CGRect(x: 0, y: 0, width: cgImage.width, height: cgImage.height)
+  let pixelRegion = CGRect(
+    x: Double(region.x) * scaleX,
+    y: Double(region.y) * scaleY,
+    width: Double(region.width) * scaleX,
+    height: Double(region.height) * scaleY
+  ).integral.intersection(imageBounds)
+  guard pixelRegion.width > 0, pixelRegion.height > 0 else { return nil }
+  guard let cropped = cgImage.cropping(to: pixelRegion) else { return nil }
+  return UIImage(cgImage: cropped, scale: image.scale, orientation: image.imageOrientation)
+}
+
+private func systemPiPMotionDiagnostics(_ analysis: PiPMotionRegionAnalysis) -> String {
+  let regionDescription = analysis.region.map {
+    "x=\($0.x),y=\($0.y),w=\($0.width),h=\($0.height)"
+  } ?? "none"
+  let pairMotion = analysis.pairMotionRatios
+    .map { String(format: "%.4f", $0) }
+    .joined(separator: ",")
+  let nonBlack = analysis.frameNonBlackRatios
+    .map { String(format: "%.4f", $0) }
+    .joined(separator: ",")
+
+  return """
+  result=\(analysis.failure?.rawValue ?? "pass")
+  frame=\(analysis.frameWidth)x\(analysis.frameHeight)
+  region=\(regionDescription)
+  geometry.area=\(String(format: "%.4f", analysis.regionAreaRatio))
+  geometry.aspect=\(String(format: "%.4f", analysis.regionAspectRatio))
+  geometry.persistentFill=\(String(format: "%.4f", analysis.persistentFillRatio))
+  persistent.components=\(analysis.persistentComponentCount)
+  persistent.largestArea=\(String(format: "%.4f", analysis.largestPersistentComponentAreaRatio))
+  pairs.matching=\(analysis.matchingPairCount)/\(analysis.requiredPairCount)
+  pairs.sustainedMotion=\(analysis.sustainedMotionPairCount)/\(analysis.requiredPairCount)
+  pairs.motionRatios=[\(pairMotion)]
+  frames.nonBlack=\(analysis.nonBlackFrameCount)/\(analysis.requiredNonBlackFrameCount) required
+  frames.nonBlackRatios=[\(nonBlack)]
+  drift.horizontal=\(String(format: "%.4f", analysis.horizontalCenterDriftRatio))
+  drift.vertical=\(String(format: "%.4f", analysis.verticalCenterDriftRatio))
+  """
 }

--- a/Showcase/UITests/iOS/Tests/ChaptersUITests.swift
+++ b/Showcase/UITests/iOS/Tests/ChaptersUITests.swift
@@ -22,7 +22,9 @@ final class ChaptersUITests: ShowcaseIOSTestCase {
     // Scroll so the Chapters section is in view.
     for _ in 0..<4 where !emptyLabel.exists {
       let pickerID = AccessibilityID.Chapters.picker
-      if app.descendants(matching: .any)[pickerID].firstMatch.exists { break }
+      if app.descendants(matching: .any)[pickerID].firstMatch.exists {
+        break
+      }
       app.swipeUp()
       Thread.sleep(forTimeInterval: 0.3)
     }

--- a/Showcase/UITests/iOS/Tests/PiPLiveDeviceUITests.swift
+++ b/Showcase/UITests/iOS/Tests/PiPLiveDeviceUITests.swift
@@ -1,0 +1,106 @@
+import XCTest
+
+/// End-to-end proof for indefinite MPEG-TS PiP. This test intentionally skips
+/// unless the caller supplies `SWIFTVLC_PIP_LIVE_URL`; CI and simulator lanes
+/// do not pretend to validate system PiP.
+final class PiPLiveDeviceUITests: ShowcaseIOSTestCase {
+  func test_nativeLiveMPEGTSRendersMovingFramesInSystemPiP() throws {
+    try runLivePictureInPicture(renderingPath: "native")
+  }
+
+  func test_directLiveMPEGTSRendersMovingFramesInSystemPiP() throws {
+    try runLivePictureInPicture(renderingPath: "direct")
+  }
+
+  private func runLivePictureInPicture(renderingPath: String) throws {
+    #if targetEnvironment(simulator)
+    throw XCTSkip("System Picture in Picture requires a physical iOS device")
+    #else
+    guard
+      let rawURL = ProcessInfo.processInfo.environment["SWIFTVLC_PIP_LIVE_URL"],
+      let liveURL = URL(string: rawURL)
+    else {
+      throw XCTSkip("Set SWIFTVLC_PIP_LIVE_URL to an indefinite MPEG-TS stream")
+    }
+
+    addUIInterruptionMonitor(withDescription: "Local network permission") { alert in
+      let allow = alert.buttons["Allow"]
+      guard allow.exists else { return false }
+      allow.tap()
+      return true
+    }
+
+    app.launchArguments += [LaunchArguments.pipLiveURL, liveURL.absoluteString]
+    app.launchArguments += [LaunchArguments.pipRenderingPath, renderingPath]
+    launch(route: .pipLiveValidation)
+    // UI interruption monitors run when the test sends an interaction after
+    // presentation. A harmless tap lets a fresh install accept local-network
+    // access before playback's opening timeout expires.
+    app.tap()
+
+    // Xcode 26.6 can expose SwiftUI Text with an identifier as either
+    // StaticText or Other on a physical iPad. Query by identifier across all
+    // accessibility types so the assertion measures state, not AX bridging.
+    let state = app.descendants(matching: .any)[AccessibilityID.PiPLiveValidation.stateLabel]
+    let duration = app.descendants(matching: .any)[AccessibilityID.PiPLiveValidation.durationLabel]
+    let displayedPictures = app.descendants(matching: .any)[
+      AccessibilityID.PiPLiveValidation.displayedPicturesLabel
+    ]
+    let possible = app.descendants(matching: .any)[AccessibilityID.PiPLiveValidation.possibleLabel]
+    let active = app.descendants(matching: .any)[AccessibilityID.PiPLiveValidation.activeLabel]
+    let playbackError = app.descendants(matching: .any)[AccessibilityID.PiPLiveValidation.errorLabel]
+    let toggle = app.buttons[AccessibilityID.PiPLiveValidation.toggleButton]
+    let video = app.otherElements[AccessibilityID.PiPLiveValidation.videoView]
+
+    waitForLabel(state, equals: "playing", timeout: 20)
+    waitForLabel(duration, equals: "unknown", timeout: 5)
+    waitForLabel(possible, equals: "yes", timeout: 15)
+    let displayedBeforePiP = waitForIntegerLabel(
+      displayedPictures,
+      greaterThan: 0,
+      timeout: 10
+    )
+    assertRendersNonBlackFrame(video, timeout: 10)
+
+    XCTAssertTrue(toggle.waitForExistence(timeout: 5))
+    XCTAssertTrue(toggle.isEnabled)
+    for cycle in 0..<3 {
+      toggle.tap()
+      waitForLabel(active, equals: "yes", timeout: 10)
+      if cycle < 2 {
+        toggle.tap()
+        waitForLabel(active, equals: "no", timeout: 10)
+      }
+    }
+
+    if renderingPath == "native" {
+      // Exercises VLC's placement/crop control callbacks while its PiP
+      // controller is active, then returns to a deterministic orientation for
+      // the system-window screenshot comparison below.
+      XCUIDevice.shared.orientation = .landscapeRight
+      RunLoop.current.run(until: Date().addingTimeInterval(1))
+      waitForLabel(active, equals: "yes", timeout: 5)
+      XCUIDevice.shared.orientation = .portrait
+      RunLoop.current.run(until: Date().addingTimeInterval(1))
+      waitForLabel(active, equals: "yes", timeout: 5)
+    }
+
+    XCUIDevice.shared.press(.home)
+    RunLoop.current.run(until: Date().addingTimeInterval(2))
+    assertSystemPictureInPictureRendersMotion()
+
+    app.activate()
+    waitForLabel(state, equals: "playing", timeout: 10)
+    waitForLabel(duration, equals: "unknown", timeout: 5)
+    _ = waitForIntegerLabel(
+      displayedPictures,
+      greaterThan: displayedBeforePiP,
+      timeout: 10
+    )
+    XCTAssertFalse(
+      playbackError.exists,
+      "Validation surface reported an asynchronous playback error: \(playbackError.label)"
+    )
+    #endif
+  }
+}

--- a/Showcase/UITests/iOS/Tests/PiPMotionRegionAnalyzerTests.swift
+++ b/Showcase/UITests/iOS/Tests/PiPMotionRegionAnalyzerTests.swift
@@ -1,0 +1,319 @@
+import XCTest
+
+final class PiPMotionRegionAnalyzerTests: XCTestCase {
+  private let analyzer = PiPMotionRegionAnalyzer()
+  private let screenWidth = 160
+  private let screenHeight = 240
+  private let expectedPiP = PiPMotionRegion(x: 64, y: 156, width: 80, height: 45)
+
+  func testMovingVideoInsideFixedSixteenByNinePiPRegionPasses() throws {
+    let frames = syntheticFrames { _, _, _, frameIndex in
+      .animated(region: self.expectedPiP, frameIndex: frameIndex)
+    }
+
+    let analysis = analyzer.analyze(frames)
+
+    XCTAssertTrue(analysis.passed, diagnostics(for: analysis))
+    let detected = try XCTUnwrap(analysis.region)
+    XCTAssertGreaterThanOrEqual(
+      Double(detected.intersectionArea(with: expectedPiP)) / Double(expectedPiP.area),
+      0.85,
+      diagnostics(for: analysis)
+    )
+    XCTAssertGreaterThanOrEqual(analysis.sustainedMotionPairCount, analysis.requiredPairCount)
+    XCTAssertGreaterThanOrEqual(analysis.nonBlackFrameCount, frames.count - 1)
+  }
+
+  func testWholeScreenAnimationFails() {
+    let fullScreen = PiPMotionRegion(
+      x: 0,
+      y: 0,
+      width: screenWidth,
+      height: screenHeight
+    )
+    let frames = syntheticFrames { _, _, _, frameIndex in
+      .animated(region: fullScreen, frameIndex: frameIndex)
+    }
+
+    let analysis = analyzer.analyze(frames)
+
+    XCTAssertFalse(analysis.passed, diagnostics(for: analysis))
+    XCTAssertEqual(analysis.failure, .noStablePiPSizedComponent)
+    XCTAssertGreaterThan(analysis.largestPersistentComponentAreaRatio, 0.90)
+  }
+
+  func testSmallWidgetAnimationFails() {
+    let widget = PiPMotionRegion(x: 104, y: 18, width: 36, height: 36)
+    let frames = syntheticFrames { _, _, _, frameIndex in
+      .animated(region: widget, frameIndex: frameIndex)
+    }
+
+    let analysis = analyzer.analyze(frames)
+
+    XCTAssertFalse(analysis.passed, diagnostics(for: analysis))
+    XCTAssertEqual(analysis.failure, .noStablePiPSizedComponent)
+    XCTAssertGreaterThan(analysis.largestPersistentComponentAreaRatio, 0.012)
+  }
+
+  func testMediumHomeScreenWidgetAnimationFails() {
+    let widget = PiPMotionRegion(x: 28, y: 22, width: 104, height: 48)
+    let frames = syntheticFrames { _, _, _, frameIndex in
+      .animated(region: widget, frameIndex: frameIndex)
+    }
+
+    let analysis = analyzer.analyze(frames)
+
+    XCTAssertFalse(analysis.passed, diagnostics(for: analysis))
+    XCTAssertEqual(analysis.failure, .noStablePiPSizedComponent)
+    XCTAssertGreaterThan(analysis.largestPersistentComponentAreaRatio, 0.10)
+  }
+
+  func testSpinnerSizedAnimationFails() {
+    let spinner = PiPMotionRegion(x: 132, y: 26, width: 12, height: 12)
+    let frames = syntheticFrames { _, _, _, frameIndex in
+      .animated(region: spinner, frameIndex: frameIndex)
+    }
+
+    let analysis = analyzer.analyze(frames)
+
+    XCTAssertFalse(analysis.passed, diagnostics(for: analysis))
+    XCTAssertEqual(analysis.failure, .noStablePiPSizedComponent)
+    XCTAssertLessThan(analysis.largestPersistentComponentAreaRatio, 0.012)
+  }
+
+  func testRandomScatteredChangesFail() {
+    let frames = (0..<6).map(scatteredFrame)
+
+    let analysis = analyzer.analyze(frames)
+
+    XCTAssertFalse(analysis.passed, diagnostics(for: analysis))
+    XCTAssertEqual(analysis.failure, .noStablePiPSizedComponent)
+  }
+
+  func testStaticNonBlackPiPRegionFails() {
+    let frames = syntheticFrames { x, y, _, _ in
+      self.expectedPiP.contains(x: x, y: y)
+        ? .pixel(PiPMotionPixel(red: 80, green: 170, blue: 220))
+        : .background
+    }
+
+    let analysis = analyzer.analyze(frames)
+
+    XCTAssertFalse(analysis.passed, diagnostics(for: analysis))
+    XCTAssertEqual(analysis.failure, .noStablePiPSizedComponent)
+  }
+
+  func testBlackMotionlessFramesFail() {
+    let frames = syntheticFrames { _, _, _, _ in .background }
+
+    let analysis = analyzer.analyze(frames)
+
+    XCTAssertFalse(analysis.passed, diagnostics(for: analysis))
+    XCTAssertEqual(analysis.failure, .noStablePiPSizedComponent)
+  }
+
+  func testDarkAnimatedPiPRegionFailsNonBlackGate() {
+    let frames = syntheticFrames { x, y, _, frameIndex in
+      guard self.expectedPiP.contains(x: x, y: y) else { return .background }
+      let value: UInt8 = frameIndex.isMultiple(of: 2) ? 0 : 35
+      return .pixel(PiPMotionPixel(red: value, green: value, blue: value))
+    }
+
+    let analysis = analyzer.analyze(frames)
+
+    XCTAssertFalse(analysis.passed, diagnostics(for: analysis))
+    XCTAssertEqual(analysis.failure, .insufficientNonBlackContent)
+    XCTAssertGreaterThanOrEqual(
+      analysis.sustainedMotionPairCount,
+      analysis.requiredPairCount
+    )
+    XCTAssertEqual(analysis.nonBlackFrameCount, 0)
+  }
+
+  func testPiPPositionDriftFails() {
+    let frames = syntheticFrames { _, _, _, frameIndex in
+      let region = PiPMotionRegion(
+        x: 44 + frameIndex * 4,
+        y: self.expectedPiP.y,
+        width: self.expectedPiP.width,
+        height: self.expectedPiP.height
+      )
+      return .animated(region: region, frameIndex: frameIndex)
+    }
+
+    let analysis = analyzer.analyze(frames)
+
+    XCTAssertFalse(analysis.passed, diagnostics(for: analysis))
+    XCTAssertEqual(analysis.failure, .unstableRegion, diagnostics(for: analysis))
+    XCTAssertGreaterThan(
+      analysis.horizontalCenterDriftRatio,
+      PiPMotionRegionAnalyzer.Configuration.physicalPiP.maximumCenterDriftRatio
+    )
+  }
+
+  func testRoundedCornersAndStaticControlsStillPass() throws {
+    let frames = syntheticFrames { x, y, _, frameIndex in
+      guard self.expectedPiP.contains(x: x, y: y) else { return .background }
+      guard self.isInsideRoundedPiP(x: x, y: y) else { return .background }
+      if self.isStaticControl(x: x, y: y) {
+        return .pixel(PiPMotionPixel(red: 92, green: 92, blue: 92))
+      }
+      return .animated(region: self.expectedPiP, frameIndex: frameIndex)
+    }
+
+    let analysis = analyzer.analyze(frames)
+
+    XCTAssertTrue(analysis.passed, diagnostics(for: analysis))
+    let detected = try XCTUnwrap(analysis.region)
+    XCTAssertGreaterThanOrEqual(
+      Double(detected.intersectionArea(with: expectedPiP)) / Double(expectedPiP.area),
+      0.80,
+      diagnostics(for: analysis)
+    )
+    XCTAssertGreaterThan(analysis.persistentFillRatio, 0.65)
+  }
+
+  func testOneWholeScreenTransitionDoesNotDisplaceStablePiP() {
+    let changedBackground = PiPMotionPixel(red: 110, green: 110, blue: 110)
+    let frames = syntheticFrames { x, y, _, frameIndex in
+      if self.expectedPiP.contains(x: x, y: y) {
+        return .animated(region: self.expectedPiP, frameIndex: frameIndex)
+      }
+      return frameIndex < 2 ? .background : .pixel(changedBackground)
+    }
+
+    let analysis = analyzer.analyze(frames)
+
+    XCTAssertTrue(analysis.passed, diagnostics(for: analysis))
+    XCTAssertEqual(analysis.matchingPairCount, analysis.requiredPairCount)
+    XCTAssertGreaterThanOrEqual(
+      analysis.sustainedMotionPairCount,
+      analysis.requiredPairCount
+    )
+  }
+}
+
+extension PiPMotionRegionAnalyzerTests {
+  fileprivate enum SyntheticPixel {
+    case background
+    case pixel(PiPMotionPixel)
+    case animated(region: PiPMotionRegion, frameIndex: Int)
+  }
+
+  private func syntheticFrames(
+    count: Int = 6,
+    pixel: (Int, Int, Int, Int) -> SyntheticPixel
+  ) -> [PiPMotionFrame] {
+    (0..<count).map { frameIndex in
+      var pixels: [PiPMotionPixel] = []
+      pixels.reserveCapacity(screenWidth * screenHeight)
+      for y in 0..<screenHeight {
+        for x in 0..<screenWidth {
+          switch pixel(x, y, y * screenWidth + x, frameIndex) {
+          case .background:
+            pixels.append(.black)
+          case .pixel(let value):
+            pixels.append(value)
+          case .animated(let region, let animationFrame):
+            pixels.append(
+              region.contains(x: x, y: y)
+                ? animatedPixel(x: x, y: y, frameIndex: animationFrame)
+                : .black
+            )
+          }
+        }
+      }
+      return PiPMotionFrame(
+        width: screenWidth,
+        height: screenHeight,
+        pixels: pixels
+      )
+    }
+  }
+
+  private func scatteredFrame(frameIndex: Int) -> PiPMotionFrame {
+    var pixels = [PiPMotionPixel](
+      repeating: .black,
+      count: screenWidth * screenHeight
+    )
+    var state = UInt64(frameIndex + 1) &* 0x9E37_79B9_7F4A_7C15
+    for sample in 0..<280 {
+      state = state &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+      let index = Int(state % UInt64(pixels.count))
+      pixels[index] = animatedPixel(
+        x: index % screenWidth,
+        y: index / screenWidth,
+        frameIndex: frameIndex + sample
+      )
+    }
+    return PiPMotionFrame(width: screenWidth, height: screenHeight, pixels: pixels)
+  }
+
+  private func animatedPixel(x: Int, y: Int, frameIndex: Int) -> PiPMotionPixel {
+    let palette = [
+      PiPMotionPixel(red: 225, green: 65, blue: 55),
+      PiPMotionPixel(red: 50, green: 215, blue: 90),
+      PiPMotionPixel(red: 55, green: 80, blue: 230),
+      PiPMotionPixel(red: 235, green: 205, blue: 50),
+      PiPMotionPixel(red: 190, green: 50, blue: 215),
+      PiPMotionPixel(red: 50, green: 215, blue: 215)
+    ]
+    return palette[(x / 3 + y / 3 + frameIndex) % palette.count]
+  }
+
+  private func isInsideRoundedPiP(x: Int, y: Int) -> Bool {
+    let localX = x - expectedPiP.x
+    let localY = y - expectedPiP.y
+    let radius = 8
+
+    let cornerCenters = [
+      (radius, radius),
+      (expectedPiP.width - radius - 1, radius),
+      (radius, expectedPiP.height - radius - 1),
+      (expectedPiP.width - radius - 1, expectedPiP.height - radius - 1)
+    ]
+    for (centerX, centerY) in cornerCenters {
+      let nearHorizontalEdge = centerX < expectedPiP.width / 2
+        ? localX < radius
+        : localX >= expectedPiP.width - radius
+      let nearVerticalEdge = centerY < expectedPiP.height / 2
+        ? localY < radius
+        : localY >= expectedPiP.height - radius
+      if nearHorizontalEdge, nearVerticalEdge {
+        let deltaX = localX - centerX
+        let deltaY = localY - centerY
+        return deltaX * deltaX + deltaY * deltaY <= radius * radius
+      }
+    }
+    return true
+  }
+
+  private func isStaticControl(x: Int, y: Int) -> Bool {
+    let centerX = expectedPiP.x + expectedPiP.width / 2
+    let centerY = expectedPiP.y + expectedPiP.height / 2
+    let deltaX = x - centerX
+    let deltaY = y - centerY
+    let centerControl = deltaX * deltaX + deltaY * deltaY <= 7 * 7
+    let bottomBar = y >= expectedPiP.maxY - 7
+      && y < expectedPiP.maxY - 4
+      && x >= centerX - 16
+      && x <= centerX + 16
+    return centerControl || bottomBar
+  }
+
+  private func diagnostics(for analysis: PiPMotionRegionAnalysis) -> String {
+    "failure=\(analysis.failure?.rawValue ?? "none"), "
+      + "region=\(String(describing: analysis.region)), "
+      + "pairMotion=\(analysis.pairMotionRatios), "
+      + "nonBlack=\(analysis.frameNonBlackRatios), "
+      + "matching=\(analysis.matchingPairCount)/\(analysis.requiredPairCount), "
+      + "drift=(\(analysis.horizontalCenterDriftRatio), "
+      + "\(analysis.verticalCenterDriftRatio))"
+  }
+}
+
+extension PiPMotionRegion {
+  fileprivate func contains(x: Int, y: Int) -> Bool {
+    x >= self.x && x < maxX && y >= self.y && y < maxY
+  }
+}

--- a/Showcase/UITests/iOS/Tests/SubtitlesSelectionUITests.swift
+++ b/Showcase/UITests/iOS/Tests/SubtitlesSelectionUITests.swift
@@ -19,7 +19,9 @@ final class SubtitlesSelectionUITests: ShowcaseIOSTestCase {
   private func scrollToSubtitles() {
     for _ in 0..<5 where !emptyLabel.exists {
       let id = AccessibilityID.SubtitlesSelection.picker
-      if app.descendants(matching: .any)[id].firstMatch.exists { return }
+      if app.descendants(matching: .any)[id].firstMatch.exists {
+        return
+      }
       app.swipeUp()
       Thread.sleep(forTimeInterval: 0.3)
     }

--- a/Showcase/iOS/CaseStudies/02-Transport-ThumbnailScrub.swift
+++ b/Showcase/iOS/CaseStudies/02-Transport-ThumbnailScrub.swift
@@ -56,7 +56,9 @@ struct ThumbnailScrubCase: View {
         in: 0...1,
         onEditingChanged: { editing in
           withAnimation(.easeOut(duration: 0.12)) { isScrubbing = editing }
-          if !editing { try? player.seek(to: PlaybackPosition(previewPosition)) }
+          if !editing {
+            try? player.seek(to: PlaybackPosition(previewPosition))
+          }
         }
       )
     }

--- a/Showcase/iOS/CaseStudies/04-Video-Marquee.swift
+++ b/Showcase/iOS/CaseStudies/04-Video-Marquee.swift
@@ -142,7 +142,9 @@ struct MarqueeCase: View {
 
   private func dragChanged(_ value: DragGesture.Value) {
     let origin = dragOrigin ?? CGPoint(x: x, y: y)
-    if dragOrigin == nil { dragOrigin = origin }
+    if dragOrigin == nil {
+      dragOrigin = origin
+    }
     x = (origin.x + value.translation.width).clamped(to: -400...400)
     y = (origin.y + value.translation.height).clamped(to: -400...400)
   }

--- a/Showcase/iOS/CaseStudies/06-Advanced-Recording.swift
+++ b/Showcase/iOS/CaseStudies/06-Advanced-Recording.swift
@@ -58,7 +58,9 @@ struct RecordingCase: View {
     for await event in player.events {
       if case .recordingChanged(let rec, let path) = event {
         isRecording = rec
-        if let path { outputFile = path }
+        if let path {
+          outputFile = path
+        }
       }
     }
   }

--- a/Showcase/iOS/CaseStudies/10-Diagnostics-Events.swift
+++ b/Showcase/iOS/CaseStudies/10-Diagnostics-Events.swift
@@ -58,7 +58,9 @@ struct EventsCase: View {
     try? player.play(url: TestMedia.demo)
     for await event in events {
       log.insert(LogLine(text: describe(event)), at: 0)
-      if log.count > 50 { log.removeLast() }
+      if log.count > 50 {
+        log.removeLast()
+      }
     }
   }
 

--- a/Showcase/iOS/CaseStudies/10-Diagnostics-Logs.swift
+++ b/Showcase/iOS/CaseStudies/10-Diagnostics-Logs.swift
@@ -68,7 +68,9 @@ struct LogsCase: View {
     entries.removeAll()
     for await entry in VLCInstance.shared.logStream(minimumLevel: level) {
       entries.insert(Entry(value: entry), at: 0)
-      if entries.count > 100 { entries.removeLast() }
+      if entries.count > 100 {
+        entries.removeLast()
+      }
     }
   }
 

--- a/Showcase/iOS/CaseStudies/10-Diagnostics-MultiConsumer.swift
+++ b/Showcase/iOS/CaseStudies/10-Diagnostics-MultiConsumer.swift
@@ -86,7 +86,9 @@ struct MultiConsumerEventsCase: View {
       }
       if let text {
         lifecycleLog.insert(LogLine(text: text), at: 0)
-        if lifecycleLog.count > 25 { lifecycleLog.removeLast() }
+        if lifecycleLog.count > 25 {
+          lifecycleLog.removeLast()
+        }
       }
     }
   }
@@ -103,7 +105,9 @@ struct MultiConsumerEventsCase: View {
       }
       if let text {
         trackLog.insert(LogLine(text: text), at: 0)
-        if trackLog.count > 25 { trackLog.removeLast() }
+        if trackLog.count > 25 {
+          trackLog.removeLast()
+        }
       }
     }
   }

--- a/Showcase/iOS/Internal/SeekBar.swift
+++ b/Showcase/iOS/Internal/SeekBar.swift
@@ -11,19 +11,17 @@ struct SeekBar: View {
   let player: Player
 
   var body: some View {
-    Group {
-      CompatSlider(
-        value: Binding(
-          get: { player.position },
-          set: { try? player.seek(to: PlaybackPosition($0)) }
-        ),
-        range: 0...1
-      )
-      .accessibilityIdentifier(AccessibilityID.SeekBar.slider)
+    CompatSlider(
+      value: Binding(
+        get: { player.position },
+        set: { try? player.seek(to: PlaybackPosition($0)) }
+      ),
+      range: 0...1
+    )
+    .accessibilityIdentifier(AccessibilityID.SeekBar.slider)
 
-      timeRow("Current", value: format(player.currentTime), identifier: AccessibilityID.SeekBar.currentTime)
-      timeRow("Duration", value: format(player.duration ?? .zero), identifier: AccessibilityID.SeekBar.duration)
-    }
+    timeRow("Current", value: format(player.currentTime), identifier: AccessibilityID.SeekBar.currentTime)
+    timeRow("Duration", value: format(player.duration ?? .zero), identifier: AccessibilityID.SeekBar.duration)
   }
 
   private func timeRow(_ title: String, value: String, identifier: String) -> some View {

--- a/Showcase/iOS/Internal/TemplateText.swift
+++ b/Showcase/iOS/Internal/TemplateText.swift
@@ -11,9 +11,15 @@ extension Text {
 
     func flush() {
       var text = Text(buffer)
-      if marks.contains(.code) { text = text.font(.system(style, design: .monospaced)) }
-      if marks.contains(.italic) { text = text.italic() }
-      if marks.contains(.bold) { text = text.bold() }
+      if marks.contains(.code) {
+        text = text.font(.system(style, design: .monospaced))
+      }
+      if marks.contains(.italic) {
+        text = text.italic()
+      }
+      if marks.contains(.bold) {
+        text = text.bold()
+      }
       parts.append(text)
       buffer.removeAll()
     }

--- a/Showcase/iOS/Internal/TestMedia.swift
+++ b/Showcase/iOS/Internal/TestMedia.swift
@@ -27,7 +27,9 @@ enum TestMedia {
   }
 
   private static func fixtureOverrideOr(bundled name: String, withExtension ext: String) -> URL {
-    if let override = LaunchArguments.fixtureURLValue { return override }
+    if let override = LaunchArguments.fixtureURLValue {
+      return override
+    }
     return Bundle.main.url(forResource: name, withExtension: ext)!
   }
 }

--- a/Showcase/iOS/Internal/UITestSupport.swift
+++ b/Showcase/iOS/Internal/UITestSupport.swift
@@ -125,6 +125,7 @@ extension UITestRoute {
     case .multiTrackSelection: MultiTrackSelectionCase()
     case .multiConsumer: MultiConsumerEventsCase()
     case .harnessHome: HarnessHome()
+    case .pipLiveValidation: PiPLiveValidationCase()
     }
   }
 }

--- a/Showcase/iOS/ValidationHarness/PiPLiveValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/PiPLiveValidationCase.swift
@@ -1,0 +1,230 @@
+import SwiftUI
+import SwiftVLC
+import UIKit
+
+/// A deterministic, physical-device-only lane for the live-stream PiP
+/// regression. The URL is supplied through `-UITestPiPLiveURL`; production
+/// showcase launches never discover or play it accidentally.
+struct PiPLiveValidationCase: View {
+  @State private var player = Player()
+  @State private var controller: PiPController?
+  @State private var playbackError: String?
+
+  private var renderingPath: PiPValidationRenderingPath {
+    PiPValidationRenderingPath(
+      rawValue: LaunchArguments.pipRenderingPathValue ?? "native"
+    ) ?? .native
+  }
+
+  var body: some View {
+    // Statistics are point-in-time snapshots. Reading the observable clock
+    // makes SwiftUI refresh this validation panel as playback advances.
+    _ = player.currentTime
+
+    return Form {
+      Section {
+        videoSurface
+          // Keep the measurement rows on-screen on both phones and tablets.
+          // This validation surface tests PiP pixels, not responsive inline
+          // sizing; the video layer itself remains aspect-fit.
+          .frame(height: 260)
+          .listRowInsets(EdgeInsets())
+          .accessibilityIdentifier(AccessibilityID.PiPLiveValidation.videoView)
+      }
+
+      Section("Measured state") {
+        valueRow(
+          "Playback",
+          value: String(describing: player.state),
+          identifier: AccessibilityID.PiPLiveValidation.stateLabel
+        )
+        valueRow(
+          "Duration",
+          value: player.duration == nil ? "unknown" : "known",
+          identifier: AccessibilityID.PiPLiveValidation.durationLabel
+        )
+        valueRow(
+          "Displayed pictures",
+          value: String(player.statistics?.displayedPictures ?? 0),
+          identifier: AccessibilityID.PiPLiveValidation.displayedPicturesLabel
+        )
+        valueRow(
+          "PiP possible",
+          value: controller?.isPossible == true ? "yes" : "no",
+          identifier: AccessibilityID.PiPLiveValidation.possibleLabel
+        )
+        valueRow(
+          "PiP active",
+          value: controller?.isActive == true ? "yes" : "no",
+          identifier: AccessibilityID.PiPLiveValidation.activeLabel
+        )
+      }
+
+      Section("Picture in Picture") {
+        Button(
+          controller?.isActive == true ? "Stop PiP" : "Start PiP",
+          systemImage: "pip",
+          action: togglePictureInPicture
+        )
+        .accessibilityIdentifier(AccessibilityID.PiPLiveValidation.toggleButton)
+        .disabled(controller?.isPossible != true)
+
+        if let playbackError {
+          Text(playbackError)
+            .foregroundStyle(.red)
+            .accessibilityIdentifier(AccessibilityID.PiPLiveValidation.errorLabel)
+        }
+      }
+    }
+    .showcaseFormStyle()
+    .navigationTitle("Live PiP validation")
+    .task { startPlayback() }
+    .onDisappear { player.stop() }
+  }
+
+  @ViewBuilder
+  private var videoSurface: some View {
+    switch renderingPath {
+    case .native:
+      PiPVideoView(
+        player,
+        controller: $controller,
+        startsAutomaticallyFromInline: false
+      )
+    case .direct:
+      DirectPiPValidationSurface(player: player, controller: $controller)
+    }
+  }
+
+  private func togglePictureInPicture() {
+    controller?.toggle()
+  }
+
+  private func startPlayback() {
+    guard let url = LaunchArguments.pipLiveURLValue else {
+      playbackError = "Missing -UITestPiPLiveURL"
+      return
+    }
+
+    do {
+      try player.play(url: url)
+    } catch {
+      playbackError = String(describing: error)
+    }
+  }
+
+  private func valueRow(_ title: String, value: String, identifier: String) -> some View {
+    HStack {
+      Text(title)
+      Spacer()
+      Text(value)
+        .foregroundStyle(.secondary)
+        .accessibilityIdentifier(identifier)
+    }
+  }
+}
+
+private enum PiPValidationRenderingPath: String {
+  case native
+  case direct
+}
+
+/// Hosts the public direct sample-buffer PiP layer so the device suite can
+/// validate that route independently from libVLC's native drawable backend.
+private struct DirectPiPValidationSurface: UIViewRepresentable {
+  let player: Player
+  @Binding var controller: PiPController?
+
+  func makeUIView(context: Context) -> DirectPiPLayerHostView {
+    let view = DirectPiPLayerHostView()
+    let controller = PiPController(player: player)
+    view.displayLayer = controller.layer
+    context.coordinator.controller = controller
+    context.coordinator.publish(controller, to: $controller)
+    return view
+  }
+
+  func updateUIView(_: DirectPiPLayerHostView, context: Context) {
+    context.coordinator.publish(context.coordinator.controller, to: $controller)
+  }
+
+  static func dismantleUIView(
+    _ uiView: DirectPiPLayerHostView,
+    coordinator: Coordinator
+  ) {
+    coordinator.controller?.stop()
+    uiView.displayLayer = nil
+    coordinator.clearBinding()
+    coordinator.controller = nil
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator()
+  }
+
+  @MainActor
+  final class Coordinator {
+    var controller: PiPController?
+    private var generation: UInt64 = 0
+    private var binding: Binding<PiPController?>?
+    private weak var publishedController: PiPController?
+
+    func publish(
+      _ controller: PiPController?,
+      to binding: Binding<PiPController?>
+    ) {
+      if
+        publishedController === controller,
+        binding.wrappedValue === controller {
+        self.binding = binding
+        return
+      }
+
+      generation &+= 1
+      let publicationGeneration = generation
+      self.binding = binding
+      publishedController = controller
+      Task { @MainActor [weak self, weak controller] in
+        guard
+          let self,
+          generation == publicationGeneration
+        else { return }
+        binding.wrappedValue = controller
+      }
+    }
+
+    func clearBinding() {
+      generation &+= 1
+      let previousBinding = binding
+      let previousController = publishedController
+      binding = nil
+      publishedController = nil
+      Task { @MainActor in
+        guard
+          let previousBinding,
+          let previousController,
+          previousBinding.wrappedValue === previousController
+        else { return }
+        previousBinding.wrappedValue = nil
+      }
+    }
+  }
+}
+
+@MainActor
+private final class DirectPiPLayerHostView: UIView {
+  var displayLayer: CALayer? {
+    didSet {
+      oldValue?.removeFromSuperlayer()
+      if let displayLayer {
+        layer.addSublayer(displayLayer)
+        setNeedsLayout()
+      }
+    }
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    displayLayer?.frame = bounds
+  }
+}

--- a/Showcase/iOS/ValidationHarness/SmokeScreen.swift
+++ b/Showcase/iOS/ValidationHarness/SmokeScreen.swift
@@ -92,7 +92,7 @@ struct SmokeScreen: View {
       LabeledContent("Subtitle", value: "\(player.subtitleTracks.count)")
       ForEach(player.videoTracks + player.audioTracks + player.subtitleTracks) { track in
         VStack(alignment: .leading, spacing: 2) {
-          Text("\(track.type) — \(track.name)")
+          Text(verbatim: "\(track.type) — \(track.name)")
           Text(trackDetail(for: track))
             .font(.caption.monospaced())
             .foregroundStyle(.secondary)

--- a/Showcase/macOS/Internal/MacShowcaseRootView.swift
+++ b/Showcase/macOS/Internal/MacShowcaseRootView.swift
@@ -374,7 +374,7 @@ extension MacShowcase {
     case .multiConsumer: self = .multiConsumerEvents
     case .statistics: self = .statistics
     case .logs: self = .logs
-    case .harnessHome: return nil
+    case .harnessHome, .pipLiveValidation: return nil
     }
   }
 }

--- a/Showcase/macOS/Internal/MacTestMedia.swift
+++ b/Showcase/macOS/Internal/MacTestMedia.swift
@@ -14,7 +14,9 @@ enum MacTestMedia {
   }
 
   private static func fixtureOverrideOr(remote: String) -> URL {
-    if let override = LaunchArguments.fixtureURLValue { return override }
+    if let override = LaunchArguments.fixtureURLValue {
+      return override
+    }
     guard let url = URL(string: remote) else {
       preconditionFailure("Invalid remote media URL: \(remote)")
     }
@@ -22,7 +24,9 @@ enum MacTestMedia {
   }
 
   private static func fixtureOverrideOr(bundled name: String, withExtension ext: String) -> URL {
-    if let override = LaunchArguments.fixtureURLValue { return override }
+    if let override = LaunchArguments.fixtureURLValue {
+      return override
+    }
     guard let url = Bundle.main.url(forResource: name, withExtension: ext) else {
       preconditionFailure("Missing bundled media resource: \(name).\(ext)")
     }

--- a/Showcase/tvOS/Internal/TVShowcaseRootView.swift
+++ b/Showcase/tvOS/Internal/TVShowcaseRootView.swift
@@ -505,7 +505,8 @@ extension TVShowcase {
          .pip,
          .discoveryRenderers,
          .multiConsumer,
-         .harnessHome:
+         .harnessHome,
+         .pipLiveValidation:
       return nil
     }
   }

--- a/Showcase/tvOS/Internal/TVTestMedia.swift
+++ b/Showcase/tvOS/Internal/TVTestMedia.swift
@@ -18,7 +18,9 @@ enum TVTestMedia {
   }
 
   private static func fixtureOverrideOr(remote: String) -> URL {
-    if let override = LaunchArguments.fixtureURLValue { return override }
+    if let override = LaunchArguments.fixtureURLValue {
+      return override
+    }
     guard let url = URL(string: remote) else {
       preconditionFailure("Invalid remote media URL: \(remote)")
     }
@@ -26,7 +28,9 @@ enum TVTestMedia {
   }
 
   private static func fixtureOverrideOr(bundled name: String, withExtension ext: String) -> URL {
-    if let override = LaunchArguments.fixtureURLValue { return override }
+    if let override = LaunchArguments.fixtureURLValue {
+      return override
+    }
     return bundled(name, withExtension: ext)
   }
 

--- a/Showcase/visionOS/SimplePlaybackView.swift
+++ b/Showcase/visionOS/SimplePlaybackView.swift
@@ -113,7 +113,9 @@ struct SimplePlaybackView: View {
 
 private enum VisionTestMedia {
   static var demo: URL {
-    if let override = LaunchArguments.fixtureURLValue { return override }
+    if let override = LaunchArguments.fixtureURLValue {
+      return override
+    }
     guard let url = Bundle.main.url(forResource: "demo", withExtension: "mkv") else {
       preconditionFailure("Missing bundled media resource: demo.mkv")
     }

--- a/Sources/CLibVLC/include/CLibVLC.h
+++ b/Sources/CLibVLC/include/CLibVLC.h
@@ -23,4 +23,24 @@ void *swiftvlc_log_set(libvlc_instance_t *instance,
 /// Unsets the log callback and frees the bridge context.
 void swiftvlc_log_unset(libvlc_instance_t *instance, void *context);
 
+/// Installs SwiftVLC's additive geometry-aware vmem callback when the linked
+/// pinned libVLC exports it. Returns false without mutating callback state when
+/// an older released libVLC binary is linked.
+bool swiftvlc_video_set_format_callbacks_ex_if_available(
+    libvlc_media_player_t *player,
+    swiftvlc_video_format_ex_cb setup,
+    libvlc_video_cleanup_cb cleanup);
+
+/// Returns whether the linked libVLC exports SwiftVLC's extended vmem ABI.
+bool swiftvlc_video_format_callbacks_ex_available(void);
+
+/// Captures one retained-media/length snapshot when the linked pinned libVLC
+/// exports the atomic extension. Returns false on older binaries or no media.
+bool swiftvlc_media_player_get_media_length_snapshot_if_available(
+    libvlc_media_player_t *player,
+    swiftvlc_media_player_media_length_snapshot_t *snapshot);
+
+/// Returns whether the linked libVLC exports SwiftVLC's atomic snapshot ABI.
+bool swiftvlc_media_length_snapshot_available(void);
+
 #endif /* CLibVLC_h */

--- a/Sources/CLibVLC/include/vlc/libvlc_media_player.h
+++ b/Sources/CLibVLC/include/vlc/libvlc_media_player.h
@@ -29,6 +29,7 @@
 
 /* Definitions of enum properties for video */
 #include "libvlc_video.h"
+#include "swiftvlc_vmem.h"
 
 # ifdef __cplusplus
 extern "C" {
@@ -257,6 +258,42 @@ LIBVLC_API void libvlc_media_player_set_media( libvlc_media_player_t *p_mi,
  *         media is associated
  */
 LIBVLC_API libvlc_media_t * libvlc_media_player_get_media( libvlc_media_player_t *p_mi );
+
+/**
+ * Atomic retained-media and playback-length snapshot.
+ *
+ * Both fields are captured together while holding the media player's internal
+ * player lock, so the media identity cannot change between the retained
+ * reference and its associated playback length.
+ */
+typedef struct swiftvlc_media_player_media_length_snapshot_t
+{
+    libvlc_media_t *media;  /**< retained media, or NULL; release with libvlc_media_release() */
+    libvlc_time_t length;   /**< playback length associated with @a media */
+} swiftvlc_media_player_media_length_snapshot_t;
+
+/**
+ * Version of SwiftVLC's additive pinned-libVLC extensions.
+ *
+ * Version 1 provides the geometry-aware vmem callback and atomic retained
+ * media/length snapshot.
+ */
+LIBVLC_API unsigned swiftvlc_libvlc_pip_extensions_version( void );
+
+/**
+ * Atomically capture the media player's current media and playback length.
+ *
+ * On success the caller owns one reference to the returned media and must
+ * release it with libvlc_media_release().
+ *
+ * \param p_mi the media player
+ * \param[out] snapshot destination for the retained media and length
+ * \retval true a media was captured; both output fields are initialized
+ * \retval false no media is associated; both output fields are initialized
+ */
+LIBVLC_API bool swiftvlc_libvlc_media_player_get_media_length_snapshot(
+    libvlc_media_player_t *p_mi,
+    swiftvlc_media_player_media_length_snapshot_t *snapshot );
 
 /**
  * Get the Event Manager from which the media player send event.
@@ -534,6 +571,23 @@ LIBVLC_API
 void libvlc_video_set_format_callbacks( libvlc_media_player_t *mp,
                                         libvlc_video_format_cb setup,
                                         libvlc_video_cleanup_cb cleanup );
+
+/**
+ * Set the additive extended decoded-video format callback.
+ *
+ * This is mutually exclusive with libvlc_video_set_format_callbacks(). Calling
+ * either setter clears the other setup callback. Legacy callback semantics are
+ * otherwise unchanged.
+ *
+ * \param mp the media player
+ * \param setup extended setup callback, or NULL to clear it
+ * \param cleanup callback to release setup resources, or NULL
+ */
+LIBVLC_API
+void swiftvlc_libvlc_video_set_format_callbacks_ex(
+    libvlc_media_player_t *mp,
+    swiftvlc_video_format_ex_cb setup,
+    libvlc_video_cleanup_cb cleanup );
 
 
 typedef struct libvlc_video_setup_device_cfg_t

--- a/Sources/CLibVLC/include/vlc/swiftvlc_vmem.h
+++ b/Sources/CLibVLC/include/vlc/swiftvlc_vmem.h
@@ -1,0 +1,90 @@
+/*****************************************************************************
+ * swiftvlc_vmem.h: SwiftVLC geometry-aware vmem callback ABI
+ *****************************************************************************
+ * This header intentionally depends only on fixed-width C types so the vmem
+ * core module can consume the ABI without importing LibVLC's public API.
+ *****************************************************************************/
+
+#ifndef VLC_SWIFTVLC_VMEM_H
+#define VLC_SWIFTVLC_VMEM_H 1
+
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * One atomic post-rotation source-geometry snapshot supplied to
+ * swiftvlc_video_format_ex_cb.
+ *
+ * The size, crop and sample-aspect fields describe a single post-rotation
+ * video_format_ApplyRotation() snapshot, captured together so a callback sees
+ * a consistent set of dimensions. source_orientation is the numeric value of
+ * libvlc_video_orient_t before rotation was applied, recorded for diagnostics
+ * only. It is fixed-width here so this ABI is independent of compiler enum
+ * representation.
+ */
+typedef struct swiftvlc_video_format_geometry_t
+{
+    uint32_t coded_width;        /**< coded (buffer) width in pixels */
+    uint32_t coded_height;       /**< coded (buffer) height in pixels */
+    uint32_t visible_width;      /**< visible (cropped) width in pixels */
+    uint32_t visible_height;     /**< visible (cropped) height in pixels */
+    uint32_t x_offset;           /**< left crop offset into the coded buffer */
+    uint32_t y_offset;           /**< top crop offset into the coded buffer */
+    uint32_t sar_num;            /**< sample-aspect-ratio numerator */
+    uint32_t sar_den;            /**< sample-aspect-ratio denominator */
+    uint32_t source_orientation; /**< pre-rotation libvlc_video_orient_t value */
+} swiftvlc_video_format_geometry_t;
+
+/**
+ * Geometry-aware custom-memory format callback.
+ *
+ * Unlike libvlc_video_format_cb, source_geometry preserves the exact coded,
+ * visible, crop, sample-aspect and original-orientation state seen by the vmem
+ * output. output_width and output_height select the delivered full-visible,
+ * zero-offset surface. The extended vmem path accepts only an exact
+ * square-pixel output aspect; an incompatible result fails setup.
+ *
+ * \param[in,out] opaque callback private pointer
+ * \param[in,out] chroma four-byte video format identifier
+ * \param[in] source_geometry atomic post-rotation source geometry
+ * \param[in,out] output_width delivered full-visible width
+ * \param[in,out] output_height delivered full-visible height
+ * \param[out] pitches scanline pitches for every plane
+ * \param[out] lines scanline counts for every plane
+ * \return a positive setup success count, or zero on failure
+ */
+typedef unsigned (*swiftvlc_video_format_ex_cb)(
+    void **opaque, char *chroma,
+    const swiftvlc_video_format_geometry_t *source_geometry,
+    unsigned *output_width, unsigned *output_height,
+    unsigned *pitches, unsigned *lines);
+
+#if defined(__cplusplus)
+# define SWIFTVLC_VMEM_STATIC_ASSERT(condition, message) \
+    static_assert(condition, message)
+#else
+# define SWIFTVLC_VMEM_STATIC_ASSERT(condition, message) \
+    _Static_assert(condition, message)
+#endif
+
+SWIFTVLC_VMEM_STATIC_ASSERT(sizeof(swiftvlc_video_format_geometry_t) == 36,
+    "SwiftVLC vmem geometry ABI size changed");
+SWIFTVLC_VMEM_STATIC_ASSERT(
+    offsetof(swiftvlc_video_format_geometry_t, coded_width) == 0,
+    "SwiftVLC vmem coded_width offset changed");
+SWIFTVLC_VMEM_STATIC_ASSERT(
+    offsetof(swiftvlc_video_format_geometry_t, visible_width) == 8,
+    "SwiftVLC vmem visible_width offset changed");
+SWIFTVLC_VMEM_STATIC_ASSERT(
+    offsetof(swiftvlc_video_format_geometry_t, x_offset) == 16,
+    "SwiftVLC vmem x_offset offset changed");
+SWIFTVLC_VMEM_STATIC_ASSERT(
+    offsetof(swiftvlc_video_format_geometry_t, sar_num) == 24,
+    "SwiftVLC vmem sar_num offset changed");
+SWIFTVLC_VMEM_STATIC_ASSERT(
+    offsetof(swiftvlc_video_format_geometry_t, source_orientation) == 32,
+    "SwiftVLC vmem source_orientation offset changed");
+
+#undef SWIFTVLC_VMEM_STATIC_ASSERT
+
+#endif /* VLC_SWIFTVLC_VMEM_H */

--- a/Sources/CLibVLC/shim.c
+++ b/Sources/CLibVLC/shim.c
@@ -6,6 +6,43 @@
 #include <string.h>
 #include "CLibVLC.h"
 
+#if defined(__APPLE__)
+/*
+ * The released static archive predates these symbols. Weak definitions keep
+ * that archive linkable; a patched archive's strong definitions win because
+ * the same media_player.o is already selected by SwiftVLC's standard player
+ * API references. The version function makes fallback vs. strong selection
+ * observable without relying on weak-import behavior (which still requires a
+ * provider dylib at static-link time on Darwin).
+ */
+__attribute__((weak))
+unsigned swiftvlc_libvlc_pip_extensions_version(void) {
+    return 0;
+}
+
+__attribute__((weak))
+void swiftvlc_libvlc_video_set_format_callbacks_ex(
+    libvlc_media_player_t *player,
+    swiftvlc_video_format_ex_cb setup,
+    libvlc_video_cleanup_cb cleanup) {
+    (void)player;
+    (void)setup;
+    (void)cleanup;
+}
+
+__attribute__((weak))
+bool swiftvlc_libvlc_media_player_get_media_length_snapshot(
+    libvlc_media_player_t *player,
+    swiftvlc_media_player_media_length_snapshot_t *snapshot) {
+    (void)player;
+    if (snapshot != NULL) {
+        snapshot->media = NULL;
+        snapshot->length = -1;
+    }
+    return false;
+}
+#endif
+
 /// Wrapper for libvlc_log_set that formats the va_list message in C
 /// and calls a simpler Swift-compatible callback with the formatted string.
 ///
@@ -59,4 +96,58 @@ void *swiftvlc_log_set(libvlc_instance_t *instance,
 void swiftvlc_log_unset(libvlc_instance_t *instance, void *context) {
     libvlc_log_unset(instance);
     free(context);
+}
+
+bool swiftvlc_video_set_format_callbacks_ex_if_available(
+    libvlc_media_player_t *player,
+    swiftvlc_video_format_ex_cb setup,
+    libvlc_video_cleanup_cb cleanup) {
+#if defined(__APPLE__)
+    if (swiftvlc_libvlc_pip_extensions_version() < 1) {
+        return false;
+    }
+    swiftvlc_libvlc_video_set_format_callbacks_ex(player, setup, cleanup);
+    return true;
+#else
+    (void)player;
+    (void)setup;
+    (void)cleanup;
+    return false;
+#endif
+}
+
+bool swiftvlc_video_format_callbacks_ex_available(void) {
+#if defined(__APPLE__)
+    return swiftvlc_libvlc_pip_extensions_version() >= 1;
+#else
+    return false;
+#endif
+}
+
+bool swiftvlc_media_player_get_media_length_snapshot_if_available(
+    libvlc_media_player_t *player,
+    swiftvlc_media_player_media_length_snapshot_t *snapshot) {
+    if (snapshot == NULL) {
+        return false;
+    }
+    snapshot->media = NULL;
+    snapshot->length = -1;
+#if defined(__APPLE__)
+    if (swiftvlc_libvlc_pip_extensions_version() < 1) {
+        return false;
+    }
+    return swiftvlc_libvlc_media_player_get_media_length_snapshot(
+        player, snapshot);
+#else
+    (void)player;
+    return false;
+#endif
+}
+
+bool swiftvlc_media_length_snapshot_available(void) {
+#if defined(__APPLE__)
+    return swiftvlc_libvlc_pip_extensions_version() >= 1;
+#else
+    return false;
+#endif
 }

--- a/Sources/SwiftVLC/Core/DialogHandler.swift
+++ b/Sources/SwiftVLC/Core/DialogHandler.swift
@@ -124,27 +124,47 @@ public enum DialogEvent: Sendable {
 extension DialogEvent {
   /// `LoginRequest` if this event is `.login`, otherwise `nil`.
   public var login: LoginRequest? {
-    if case .login(let value) = self { value } else { nil }
+    if case .login(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// `QuestionRequest` if this event is `.question`, otherwise `nil`.
   public var question: QuestionRequest? {
-    if case .question(let value) = self { value } else { nil }
+    if case .question(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// `ProgressInfo` if this event is `.progress`, otherwise `nil`.
   public var progress: ProgressInfo? {
-    if case .progress(let value) = self { value } else { nil }
+    if case .progress(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// `ProgressUpdate` if this event is `.progressUpdated`, otherwise `nil`.
   public var progressUpdated: ProgressUpdate? {
-    if case .progressUpdated(let value) = self { value } else { nil }
+    if case .progressUpdated(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// `DialogID` if this event is `.cancel`, otherwise `nil`.
   public var cancel: DialogID? {
-    if case .cancel(let value) = self { value } else { nil }
+    if case .cancel(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// Tuple of `(title: String, message: String)` if this event is

--- a/Sources/SwiftVLC/Core/VLCError.swift
+++ b/Sources/SwiftVLC/Core/VLCError.swift
@@ -76,46 +76,82 @@ public enum VLCError: Error, Sendable, Equatable, Hashable, LocalizedError, Cust
 extension VLCError {
   /// `Void` if this error is `.instanceCreationFailed`, otherwise `nil`.
   public var instanceCreationFailed: Void? {
-    if case .instanceCreationFailed = self { () } else { nil }
+    if case .instanceCreationFailed = self {
+      ()
+    } else {
+      nil
+    }
   }
 
   /// Source string if this error is `.mediaCreationFailed`, otherwise `nil`.
   public var mediaCreationFailed: String? {
-    if case .mediaCreationFailed(let value) = self { value } else { nil }
+    if case .mediaCreationFailed(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// Reason string if this error is `.playbackFailed`, otherwise `nil`.
   public var playbackFailed: String? {
-    if case .playbackFailed(let value) = self { value } else { nil }
+    if case .playbackFailed(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// Reason string if this error is `.parseFailed`, otherwise `nil`.
   public var parseFailed: String? {
-    if case .parseFailed(let value) = self { value } else { nil }
+    if case .parseFailed(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// `Void` if this error is `.parseTimeout`, otherwise `nil`.
   public var parseTimeout: Void? {
-    if case .parseTimeout = self { () } else { nil }
+    if case .parseTimeout = self {
+      ()
+    } else {
+      nil
+    }
   }
 
   /// Track id string if this error is `.trackNotFound`, otherwise `nil`.
   public var trackNotFound: String? {
-    if case .trackNotFound(let value) = self { value } else { nil }
+    if case .trackNotFound(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// Constraint message if this error is `.invalidState`, otherwise `nil`.
   public var invalidState: String? {
-    if case .invalidState(let value) = self { value } else { nil }
+    if case .invalidState(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// Validation message if this error is `.invalidInput`, otherwise `nil`.
   public var invalidInput: String? {
-    if case .invalidInput(let value) = self { value } else { nil }
+    if case .invalidInput(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// Operation name if this error is `.operationFailed`, otherwise `nil`.
   public var operationFailed: String? {
-    if case .operationFailed(let value) = self { value } else { nil }
+    if case .operationFailed(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 }

--- a/Sources/SwiftVLC/Discovery/RendererDiscoverer.swift
+++ b/Sources/SwiftVLC/Discovery/RendererDiscoverer.swift
@@ -184,12 +184,20 @@ public enum RendererEvent: Sendable {
 extension RendererEvent {
   /// `RendererItem` if this event is `.itemAdded`, otherwise `nil`.
   public var itemAdded: RendererItem? {
-    if case .itemAdded(let value) = self { value } else { nil }
+    if case .itemAdded(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// `RendererItem` if this event is `.itemDeleted`, otherwise `nil`.
   public var itemDeleted: RendererItem? {
-    if case .itemDeleted(let value) = self { value } else { nil }
+    if case .itemDeleted(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 }
 

--- a/Sources/SwiftVLC/Media/Track.swift
+++ b/Sources/SwiftVLC/Media/Track.swift
@@ -20,7 +20,11 @@ public struct Track: Sendable, Identifiable, Hashable {
   /// Human-readable track name.
   public let name: String
 
-  /// Codec identifier as libVLC's raw FourCC integer.
+  /// Codec as libVLC's raw FourCC integer, packed little-endian: `'h264'`
+  /// is `0x34363268` (`'h' | '2' << 8 | '6' << 16 | '4' << 24`). The first
+  /// character is the low byte. Decode it with ``codecString`` rather than
+  /// reading the bytes most-significant-first, which yields the reversed
+  /// `"462h"`.
   public let codec: Int
 
   /// ISO 639 language code (e.g. `"eng"`, `"fra"`, `"ja"`) as declared
@@ -59,6 +63,23 @@ public struct Track: Sendable, Identifiable, Hashable {
 
   /// Subtitle text encoding (`nil` for non-subtitle tracks).
   public let encoding: String?
+
+  /// The ``codec`` FourCC decoded to its text form (e.g. `"h264"`,
+  /// `"mp4a"`), or `nil` when the bytes are not a printable FourCC.
+  ///
+  /// Bytes are read low-to-high (little-endian); a trailing NUL ends the
+  /// string, and any non-trailing, non-printable byte yields `nil`.
+  public var codecString: String? {
+    let value = UInt32(truncatingIfNeeded: codec)
+    var characters: [Character] = []
+    for shift in stride(from: 0, through: 24, by: 8) {
+      let byte = UInt8((value >> shift) & 0xFF)
+      if byte == 0 { break }
+      guard byte >= 0x20, byte < 0x7F else { return nil }
+      characters.append(Character(Unicode.Scalar(byte)))
+    }
+    return characters.isEmpty ? nil : String(characters)
+  }
 
   public static func == (lhs: Track, rhs: Track) -> Bool {
     lhs.id == rhs.id

--- a/Sources/SwiftVLC/Media/Track.swift
+++ b/Sources/SwiftVLC/Media/Track.swift
@@ -67,18 +67,21 @@ public struct Track: Sendable, Identifiable, Hashable {
   /// The ``codec`` FourCC decoded to its text form (e.g. `"h264"`,
   /// `"mp4a"`), or `nil` when the bytes are not a printable FourCC.
   ///
-  /// Bytes are read low-to-high (little-endian); a trailing NUL ends the
-  /// string, and any non-trailing, non-printable byte yields `nil`.
+  /// Bytes are read low-to-high (little-endian); trailing NUL padding ends
+  /// the string, and any embedded NUL or non-printable byte yields `nil`.
   public var codecString: String? {
     let value = UInt32(truncatingIfNeeded: codec)
-    var characters: [Character] = []
-    for shift in stride(from: 0, through: 24, by: 8) {
-      let byte = UInt8((value >> shift) & 0xFF)
-      if byte == 0 { break }
-      guard byte >= 0x20, byte < 0x7F else { return nil }
-      characters.append(Character(Unicode.Scalar(byte)))
+    let bytes = stride(from: 0, through: 24, by: 8).map {
+      UInt8((value >> $0) & 0xFF)
     }
-    return characters.isEmpty ? nil : String(characters)
+    let end = bytes.firstIndex(of: 0) ?? bytes.endIndex
+    guard bytes[end...].allSatisfy({ $0 == 0 }) else { return nil }
+    let payload = bytes[..<end]
+    guard
+      !payload.isEmpty,
+      payload.allSatisfy({ $0 >= 0x20 && $0 < 0x7F })
+    else { return nil }
+    return String(validating: payload, as: UTF8.self)
   }
 
   public static func == (lhs: Track, rhs: Track) -> Bool {

--- a/Sources/SwiftVLC/PiP/PiPController+AudioSession.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+AudioSession.swift
@@ -4,6 +4,20 @@ import AVFoundation
 // MARK: - Audio-session policy
 
 extension PiPController {
+  /// Live operation for deferred managed-session activation. Kept separate
+  /// from the one-shot state machine so native-route tests can inject a
+  /// deterministic failure/success sequence.
+  static func liveAudioSessionActivation() throws {
+    #if os(iOS)
+    let session = AVAudioSession.sharedInstance()
+    // Category setup can fail transiently too. Repeat it inside the same
+    // retryable operation so a swallowed init-time failure cannot leave an
+    // otherwise successful activation in the wrong audio category.
+    try session.setCategory(.playback, mode: .moviePlayback)
+    try session.setActive(true)
+    #endif
+  }
+
   /// Sets the shared audio session's category for movie playback when
   /// ``managesAudioSession`` is enabled. Activation is intentionally
   /// **not** done here: `setActive(true)` steals audio focus from other
@@ -25,10 +39,25 @@ extension PiPController {
   /// activation, and on platforms without `AVAudioSession`.
   func activateAudioSessionIfNeeded() {
     #if os(iOS)
-    guard managesAudioSession, !hasActivatedAudioSession else { return }
-    hasActivatedAudioSession = true
-    try? AVAudioSession.sharedInstance().setActive(true)
+    activateAudioSessionIfNeeded(using: audioSessionActivation)
     #endif
+  }
+
+  /// Runs the platform activation operation at most once after it succeeds.
+  ///
+  /// A failed operation deliberately leaves ``hasActivatedAudioSession`` false
+  /// so a later playback/PiP signal can retry. The iOS production path above
+  /// uses this same state machine; accepting the operation as an argument keeps
+  /// the failure and retry behavior deterministic in platform-neutral tests.
+  func activateAudioSessionIfNeeded(using activate: () throws -> Void) {
+    guard managesAudioSession, !hasActivatedAudioSession else { return }
+    do {
+      try activate()
+      hasActivatedAudioSession = true
+    } catch {
+      // Activation can fail transiently (for example during an audio-session
+      // interruption). Leave the state unset so the next signal retries.
+    }
   }
 }
 

--- a/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
@@ -1,6 +1,7 @@
 #if os(iOS) || os(macOS)
 import AVFoundation
 import AVKit
+import CLibVLC
 import Dispatch
 import Foundation
 
@@ -151,23 +152,122 @@ final class PiPPlaybackDelegateProxy: NSObject, AVPictureInPictureSampleBufferPl
   func pictureInPictureControllerTimeRangeForPlayback(
     _: AVPictureInPictureController
   ) -> CMTimeRange {
-    let duration: Duration? = pipMainActorSync { [weak self] in
-      self?.owner?.player.duration
+    pipMainActorSync { [weak self] in
+      guard let owner = self?.owner else { return .invalid }
+      let currentTime = owner.controlTimebase.map(CMTimebaseGetTime) ?? .zero
+      return Self.nativePlaybackTimeRange(
+        playerPointer: owner.player.pointer,
+        currentTime: currentTime
+      )
     }
+  }
+
+  /// Queries the native player without consulting Swift-side media mirrors.
+  static func nativePlaybackTimeRange(
+    playerPointer: OpaquePointer,
+    currentTime: CMTime = .zero
+  ) -> CMTimeRange {
+    playbackTimeRange(
+      playerPointer: playerPointer,
+      currentTime: currentTime,
+      getSnapshot: { player in
+        retainedMediaLengthSnapshot(
+          playerPointer: player,
+          atomicSnapshotAvailable: swiftvlc_media_length_snapshot_available(),
+          getAtomicSnapshot: { player in
+            var native = swiftvlc_media_player_media_length_snapshot_t()
+            guard
+              swiftvlc_media_player_get_media_length_snapshot_if_available(
+                player,
+                &native
+              ),
+              let media = native.media
+            else { return nil }
+            return (media: media, length: native.length)
+          },
+          getRetainedMedia: { libvlc_media_player_get_media($0) },
+          getMediaDuration: { libvlc_media_get_duration($0) }
+        )
+      },
+      releaseMedia: { libvlc_media_release($0) }
+    )
+  }
+
+  /// Reads one retained media identity and its matching length. New pinned
+  /// binaries capture both under the player lock. Older binaries retain the
+  /// media first and read duration from that exact object; they never combine
+  /// `get_media` with the independently locked player-length API.
+  static func retainedMediaLengthSnapshot(
+    playerPointer: OpaquePointer,
+    atomicSnapshotAvailable: Bool,
+    getAtomicSnapshot: (OpaquePointer) -> (media: OpaquePointer, length: Int64)?,
+    getRetainedMedia: (OpaquePointer) -> OpaquePointer?,
+    getMediaDuration: (OpaquePointer) -> Int64
+  ) -> (media: OpaquePointer, length: Int64)? {
+    if atomicSnapshotAvailable {
+      return getAtomicSnapshot(playerPointer)
+    }
+
+    guard let media = getRetainedMedia(playerPointer) else { return nil }
+    return (media: media, length: getMediaDuration(media))
+  }
+
+  /// Maps one retained media/length pair and balances its media retain.
+  static func playbackTimeRange(
+    playerPointer: OpaquePointer,
+    currentTime: CMTime = .zero,
+    getSnapshot: (OpaquePointer) -> (media: OpaquePointer, length: Int64)?,
+    releaseMedia: (OpaquePointer) -> Void
+  ) -> CMTimeRange {
+    guard let snapshot = getSnapshot(playerPointer) else { return .invalid }
+    defer { releaseMedia(snapshot.media) }
+
+    return playbackTimeRange(
+      hasMedia: true,
+      duration: snapshot.length > 0 ? .milliseconds(snapshot.length) : nil,
+      currentTime: currentTime
+    )
+  }
+
+  /// Maps SwiftVLC's media lifecycle onto AVKit's sample-buffer contract:
+  /// invalid means there is no content, positive infinity means loaded
+  /// live/indefinite content, and a positive duration means seekable VOD.
+  static func playbackTimeRange(
+    hasMedia: Bool,
+    duration: Duration?,
+    currentTime: CMTime = .zero
+  ) -> CMTimeRange {
+    guard hasMedia else { return .invalid }
 
     let durationSeconds = duration.map {
       Double($0.components.seconds) + Double($0.components.attoseconds) / 1e18
     } ?? 0
 
-    let cmDuration = if durationSeconds > 0 {
-      CMTime(seconds: durationSeconds, preferredTimescale: 1000)
-    } else {
-      // Duration unknown: PiP needs a non-zero range so the scrubber
-      // renders while libVLC parses the media. Once duration arrives,
-      // the state observer invalidates and AVKit re-queries.
-      CMTime(seconds: 86400, preferredTimescale: 1000)
+    guard durationSeconds > 0 else {
+      return CMTimeRange(start: .zero, duration: .positiveInfinity)
     }
-    return CMTimeRange(start: .zero, duration: cmDuration)
+
+    let nominalDuration = CMTime(seconds: durationSeconds, preferredTimescale: 1000)
+    let nominalRange = CMTimeRange(
+      start: .zero,
+      duration: nominalDuration
+    )
+    guard currentTime.isNumeric else { return nominalRange }
+    if CMTimeRangeContainsTime(nominalRange, time: currentTime) {
+      return nominalRange
+    }
+
+    // AVKit requires every finite answer to contain the display layer's
+    // current control-timebase value. At an end boundary (which Core Media
+    // ranges exclude) or during a small event/timebase race, extend only the
+    // reported edge needed to satisfy that contract.
+    let tick = CMTime(value: 1, timescale: 1000)
+    let start = CMTimeCompare(currentTime, .zero) < 0 ? currentTime : .zero
+    let currentEnd = CMTimeAdd(currentTime, tick)
+    let end = CMTimeCompare(currentEnd, nominalDuration) > 0
+      ? currentEnd
+      : nominalDuration
+    return CMTimeRangeFromTimeToTime(start: start, end: end)
   }
 
   func pictureInPictureControllerIsPlaybackPaused(

--- a/Sources/SwiftVLC/PiP/PiPController+PlaybackState.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+PlaybackState.swift
@@ -1,0 +1,113 @@
+#if os(iOS) || os(macOS)
+
+import CoreMedia
+
+extension PiPController {
+  struct PlaybackStateUpdate: Equatable {
+    var invalidatesPlaybackState = false
+    var requiresLinearPlayback: Bool?
+  }
+
+  /// Event-side snapshot for AVKit's playback UI on either PiP backend.
+  ///
+  /// `Player` and `PiPController` consume independent streams from the same
+  /// native event. Their relative ordering is intentionally unspecified, so
+  /// payload-bearing events must update this snapshot from their payload rather
+  /// than from `Player`'s potentially stale observable mirror.
+  struct PlaybackStateObservationState {
+    private(set) var durationMilliseconds: Int64?
+    private(set) var isSeekable: Bool
+
+    init(duration: Duration?, isSeekable: Bool) {
+      durationMilliseconds = duration?.milliseconds
+      self.isSeekable = isSeekable
+    }
+
+    mutating func consume(
+      _ event: PlayerEvent,
+      observedDuration _: Duration?,
+      observedIsSeekable _: Bool
+    ) -> PlaybackStateUpdate {
+      switch event {
+      case .mediaChanged:
+        // The new input's duration/seekability have not been reported yet.
+        // Reset conservatively even if Player's event consumer still exposes
+        // the previous media's values.
+        durationMilliseconds = nil
+        isSeekable = false
+        return PlaybackStateUpdate(
+          invalidatesPlaybackState: true,
+          requiresLinearPlayback: true
+        )
+
+      case .lengthChanged(let duration):
+        durationMilliseconds = duration.milliseconds
+        return PlaybackStateUpdate(invalidatesPlaybackState: true)
+
+      case .seekableChanged(let seekable):
+        isSeekable = seekable
+        return PlaybackStateUpdate(
+          invalidatesPlaybackState: true,
+          requiresLinearPlayback: !seekable
+        )
+
+      case .stateChanged:
+        // State transitions are the only payload-free fallback that can
+        // affect availability. Invalidate so AVKit re-queries the retained
+        // native media snapshot instead of copying a potentially stale mirror.
+        return PlaybackStateUpdate(invalidatesPlaybackState: true)
+
+      default:
+        return PlaybackStateUpdate()
+      }
+    }
+  }
+
+  static func applyPlaybackStateUpdate(
+    _ update: PlaybackStateUpdate,
+    setRequiresLinearPlayback: (Bool) -> Void,
+    invalidatePlaybackState: () -> Void
+  ) {
+    if let requiresLinearPlayback = update.requiresLinearPlayback {
+      setRequiresLinearPlayback(requiresLinearPlayback)
+    }
+    if update.invalidatesPlaybackState {
+      invalidatePlaybackState()
+    }
+  }
+
+  /// Converts AVKit's interval without using a trapping floating-point-to-
+  /// integer conversion for invalid, infinite, or out-of-range `CMTime`s.
+  static func skipOffsetMilliseconds(_ interval: CMTime) -> Int64? {
+    guard interval.isNumeric else { return nil }
+    let milliseconds = interval.seconds * 1000
+    guard milliseconds.isFinite else { return nil }
+    if milliseconds >= Double(Int64.max) {
+      return .max
+    }
+    if milliseconds <= Double(Int64.min) {
+      return .min
+    }
+    return Int64(milliseconds)
+  }
+
+  /// Saturating addition followed by clamping to the playable timeline.
+  /// This keeps adversarial or malformed skip intervals from overflowing at
+  /// either end while preserving the ordinary truncation-to-milliseconds
+  /// behavior.
+  static func clampedSkipTargetMilliseconds(
+    current: Int64,
+    offset: Int64,
+    duration: Int64?
+  ) -> Int64 {
+    let upperBound = max(duration ?? .max, 0)
+    let current = max(0, min(current, upperBound))
+    let sum = current.addingReportingOverflow(offset)
+    if sum.overflow {
+      return offset >= 0 ? upperBound : 0
+    }
+    return max(0, min(sum.partialValue, upperBound))
+  }
+}
+
+#endif

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -1,8 +1,7 @@
+// swiftlint:disable file_length
 #if os(iOS) || os(macOS)
 import AVFoundation
 import AVKit
-import CLibVLC
-import Dispatch
 import Observation
 import Synchronization
 
@@ -104,9 +103,7 @@ public final class PiPController: NSObject {
   @ObservationIgnored
   var pipController: AVPictureInPictureController?
   @ObservationIgnored
-  private var rendererContext: PixelBufferRendererCallbackContext?
-  @ObservationIgnored
-  private var rendererOpaque: UnsafeMutableRawPointer?
+  private var callbackRegistration: DirectPiPVideoCallbackRegistration?
   @ObservationIgnored
   var controlTimebase: CMTimebase?
   @ObservationIgnored
@@ -140,11 +137,22 @@ public final class PiPController: NSObject {
   /// `managesAudioSession` knob; the direct public ``init(player:)``
   /// path uses `true`. When `true`, the
   /// `.playback` category is set at init but `setActive(true)` is
-  /// deferred to ``start()`` or the first active-playback signal, so
-  /// constructing a controller never re-grabs audio focus from other
-  /// apps. When `false`, the session is never touched.
+  /// deferred to ``start()`` or an active-playback signal. Direct
+  /// controller construction and inactive native-view construction do
+  /// not take audio focus. A native view adopting a Player whose playback
+  /// intent is already active activates immediately so automatic PiP cannot
+  /// start before the managed session is ready. When `false`, the session
+  /// is never touched.
   @ObservationIgnored
   let managesAudioSession: Bool
+
+  /// Operation used by the deferred audio-session activation state machine.
+  /// The native iOS initializer accepts an override so lifecycle ordering and
+  /// retry behavior can be proven without depending on process-wide audio
+  /// state. Every public/direct initializer uses the live AVAudioSession
+  /// operation.
+  @ObservationIgnored
+  let audioSessionActivation: @MainActor () throws -> Void
 
   /// Whether the deferred `AVAudioSession.setActive(true)` has been
   /// issued. One-shot per controller; see ``managesAudioSession``.
@@ -279,6 +287,7 @@ public final class PiPController: NSObject {
     pauseDebounce = .milliseconds(250)
     startsAutomaticallyFromInline = true
     managesAudioSession = true
+    audioSessionActivation = Self.liveAudioSessionActivation
     displayLayer = AVSampleBufferDisplayLayer()
     renderer = PixelBufferRenderer(displayLayer: displayLayer)
     playbackDelegateProxy = PiPPlaybackDelegateProxy()
@@ -302,13 +311,16 @@ public final class PiPController: NSObject {
     player: Player,
     nativeBackend: IOSNativePiPBackend,
     startsAutomaticallyFromInline: Bool = true,
-    managesAudioSession: Bool = true
+    managesAudioSession: Bool = true,
+    audioSessionActivation: (@MainActor () throws -> Void)? = nil
   ) {
     self.player = player
     playbackDriver = .live(player: player)
     pauseDebounce = .milliseconds(250)
     self.startsAutomaticallyFromInline = startsAutomaticallyFromInline
     self.managesAudioSession = managesAudioSession
+    self.audioSessionActivation = audioSessionActivation
+      ?? Self.liveAudioSessionActivation
     displayLayer = AVSampleBufferDisplayLayer()
     renderer = PixelBufferRenderer(displayLayer: displayLayer)
     playbackDelegateProxy = PiPPlaybackDelegateProxy()
@@ -318,7 +330,23 @@ public final class PiPController: NSObject {
 
     playbackDelegateProxy.owner = self
     configureAudioSession()
+    nativeBackend.setStartsAutomaticallyFromInline(startsAutomaticallyFromInline)
+
+    // The native AVPictureInPictureController already belongs to the open
+    // vout and may auto-start as soon as the app backgrounds. Unlike generic
+    // direct-controller construction, adopting that live route must honor an
+    // already-active playback intent before we expose this controller as the
+    // backend owner. The operation remains deferred for inactive players.
+    if player.isPlaybackRequestedActive {
+      activateAudioSessionIfNeeded()
+    }
+
     nativeBackend.owner = self
+    // A same-player SwiftUI recreation can preserve the attachment/backend
+    // while no PiPController owns it. Any seekability event in that interval
+    // is intentionally rejected by the owner gate, so resample the Player at
+    // the exact point the successor claims the current attachment.
+    nativeBackend.reconcileRequiresLinearPlayback(ifOwnedBy: self)
     updatePiPPossible(nativeBackend.isPossible)
     updatePiPActive(nativeBackend.isActive)
     startStateObserver()
@@ -338,6 +366,7 @@ public final class PiPController: NSObject {
     pauseDebounce = .milliseconds(250)
     self.startsAutomaticallyFromInline = startsAutomaticallyFromInline
     self.managesAudioSession = managesAudioSession
+    audioSessionActivation = Self.liveAudioSessionActivation
     displayLayer = AVSampleBufferDisplayLayer()
     renderer = PixelBufferRenderer(displayLayer: displayLayer)
     playbackDelegateProxy = PiPPlaybackDelegateProxy()
@@ -366,6 +395,7 @@ public final class PiPController: NSObject {
     self.pauseDebounce = pauseDebounce
     self.startsAutomaticallyFromInline = startsAutomaticallyFromInline
     self.managesAudioSession = managesAudioSession
+    audioSessionActivation = Self.liveAudioSessionActivation
     displayLayer = AVSampleBufferDisplayLayer()
     renderer = PixelBufferRenderer(displayLayer: displayLayer)
     playbackDelegateProxy = PiPPlaybackDelegateProxy()
@@ -400,9 +430,8 @@ public final class PiPController: NSObject {
     playbackDelegateProxy.owner = nil
     renderer.setDisplayLayer(nil)
     renderer.setTimebase(nil)
-    if let rendererContext, let rendererOpaque {
-      rendererContext.requestDeferredRetirement()
-      scheduleRetiredRendererContextRelease(rendererContext, opaque: rendererOpaque)
+    if let callbackRegistration {
+      player.relinquishDirectPiPVideoCallbacks(callbackRegistration)
     }
   }
 
@@ -410,9 +439,16 @@ public final class PiPController: NSObject {
 
   /// Starts Picture-in-Picture if possible and media is loaded.
   public func start() {
-    activateAudioSessionIfNeeded()
+    guard player.currentMedia != nil else { return }
     #if os(iOS)
     if let nativeBackend {
+      // Preserve the backend's one-time vout diagnostic, but do not take audio
+      // focus for a start request the native controller cannot perform.
+      guard nativeBackend.isPossible else {
+        nativeBackend.start()
+        return
+      }
+      activateAudioSessionIfNeeded()
       nativeBackend.start()
       return
     }
@@ -424,7 +460,7 @@ public final class PiPController: NSObject {
     }
     #endif
     guard let pipController else { return }
-    guard player.currentMedia != nil else { return }
+    activateAudioSessionIfNeeded()
     pipController.startPictureInPicture()
   }
 
@@ -487,46 +523,9 @@ public final class PiPController: NSObject {
   }
 
   private func attachCallbacks() {
-    let context = PixelBufferRendererCallbackContext(renderer: renderer)
-    let retained = Unmanaged.passRetained(context)
-    rendererContext = context
-    let ptr = retained.toOpaque()
-    rendererOpaque = ptr
-
-    // Set the opaque pointer for vmem callbacks
-    libvlc_video_set_callbacks(
-      player.pointer,
-      pixelBufferLockCallback,
-      pixelBufferUnlockCallback,
-      pixelBufferDisplayCallback,
-      ptr
-    )
-
-    libvlc_video_set_format_callbacks(
-      player.pointer,
-      pixelBufferFormatCallback,
-      pixelBufferCleanupCallback
-    )
-  }
-
-  private func scheduleRetiredRendererContextRelease(
-    _ context: PixelBufferRendererCallbackContext,
-    opaque: UnsafeMutableRawPointer
-  ) {
-    guard let retainedPlayer = libvlc_media_player_retain(player.pointer) else {
-      context.releaseRetiredOpaqueRetainIfNoOpenVout(opaque: opaque)
-      return
-    }
-    nonisolated(unsafe) let playerPointer = retainedPlayer
-    nonisolated(unsafe) let contextOpaque = opaque
-
-    DispatchQueue.global(qos: .utility).async {
-      context.releaseRetiredOpaqueRetainWhenPlayerIsQuiescent(
-        opaque: contextOpaque,
-        player: playerPointer
-      )
-      libvlc_media_player_release(playerPointer)
-    }
+    let registration = DirectPiPVideoCallbackRegistration(renderer: renderer)
+    callbackRegistration = registration
+    player.claimDirectPiPVideoCallbacks(registration)
   }
 
   private func setupPiPController() {
@@ -550,6 +549,7 @@ public final class PiPController: NSObject {
     )
     let controller = AVPictureInPictureController(contentSource: contentSource)
     controller.delegate = self
+    controller.requiresLinearPlayback = !player.isSeekable
     #if os(iOS)
     controller.canStartPictureInPictureAutomaticallyFromInline = startsAutomaticallyFromInline
     #endif
@@ -591,10 +591,31 @@ public final class PiPController: NSObject {
     self.isActive = isActive
   }
 
+  func applyObservedPlaybackStateUpdate(_ update: PlaybackStateUpdate) {
+    Self.applyPlaybackStateUpdate(
+      update,
+      setRequiresLinearPlayback: { setRequiresLinearPlayback($0) },
+      invalidatePlaybackState: { invalidatePictureInPicturePlaybackState() }
+    )
+  }
+
+  private func setRequiresLinearPlayback(_ requiresLinearPlayback: Bool) {
+    #if os(iOS)
+    if let nativeBackend {
+      nativeBackend.setRequiresLinearPlayback(
+        requiresLinearPlayback,
+        ifOwnedBy: self
+      )
+      return
+    }
+    #endif
+    pipController?.requiresLinearPlayback = requiresLinearPlayback
+  }
+
   func invalidatePictureInPicturePlaybackState() {
     #if os(iOS)
     if let nativeBackend {
-      nativeBackend.invalidatePlaybackState()
+      nativeBackend.invalidatePlaybackState(ifOwnedBy: self)
       return
     }
     #endif
@@ -607,10 +628,10 @@ public final class PiPController: NSObject {
     pipController?.invalidatePlaybackState()
   }
 
-  /// Cancels any in-flight scheduled pause. Mirrors the pre-refactor
-  /// semantics: this **only** cancels the `.scheduled` task. An already-
-  /// `.issued` pause is preserved — `requestResumeIfNeeded` reads it to
-  /// decide whether to issue a libVLC resume.
+  /// Cancels any in-flight scheduled pause. This **only** cancels the
+  /// `.scheduled` task; an already-`.issued` pause is preserved —
+  /// `requestResumeIfNeeded` reads it to decide whether to issue a libVLC
+  /// resume.
   private func cancelDeferredPause() {
     if case .scheduled(let task, _) = deferredPause {
       task.cancel()
@@ -664,7 +685,11 @@ public final class PiPController: NSObject {
   /// task is currently scheduled. Used by the deferred-pause loop to
   /// detect when its scheduling slot has been replaced.
   private var currentDeferredPauseGeneration: UInt64 {
-    if case .scheduled(_, let generation) = deferredPause { generation } else { 0 }
+    if case .scheduled(_, let generation) = deferredPause {
+      generation
+    } else {
+      0
+    }
   }
 
   /// Clears the `.issued` flag without cancelling a scheduled pause.
@@ -682,7 +707,11 @@ public final class PiPController: NSObject {
   /// `.issued` state (PiP actually paused libVLC) and the player's
   /// own resume hint.
   private func requestResumeIfNeeded() -> (needed: Bool, accepted: Bool) {
-    let pipIssuedPause = if case .issued = deferredPause { true } else { false }
+    let pipIssuedPause = if case .issued = deferredPause {
+      true
+    } else {
+      false
+    }
     let shouldResume = pipIssuedPause || playbackDriver.shouldResume()
     if pipIssuedPause {
       deferredPause = .idle
@@ -706,19 +735,29 @@ public final class PiPController: NSObject {
     let events = player.events
     let initialActive = player.isPlaybackRequestedActive
     let initialNativeActive = player.isActive
+    let initialDuration = player.duration
+    let initialSeekable = player.isSeekable
     pipPlaybackActive = initialActive
     syncTimebase(playing: initialNativeActive)
 
     stateObserverTask = Task { @MainActor [weak self] in
       var wasActive = initialNativeActive
-      var lastDurationMs: Int64?
       var lastRate: Float = 1.0
-      for await _ in events {
+      var playbackStateObservation = PlaybackStateObservationState(
+        duration: initialDuration,
+        isSeekable: initialSeekable
+      )
+      for await event in events {
         guard let self else { return }
 
         let active = player.isActive
-        let durationMs = player.duration?.milliseconds
         let rate = player.rate
+        let playbackStateUpdate = playbackStateObservation.consume(
+          event,
+          observedDuration: player.duration,
+          observedIsSeekable: player.isSeekable
+        )
+        applyObservedPlaybackStateUpdate(playbackStateUpdate)
 
         // State transition: sync the timebase rate.
         if active != wasActive {
@@ -751,12 +790,6 @@ public final class PiPController: NSObject {
           }
         }
 
-        // Duration became known or changed: re-query timeRange.
-        if durationMs != lastDurationMs {
-          lastDurationMs = durationMs
-          invalidatePictureInPicturePlaybackState()
-        }
-
         // Sync timebase when player position diverges significantly
         // (e.g., seek from the app's own controls outside PiP).
         // Guard against overwriting the skip handler's timebase.
@@ -776,13 +809,10 @@ public final class PiPController: NSObject {
   }
 
   private func startPlaybackIntentObserver() {
-    // The intent stream carries transitions only, with no current-value
-    // replay — a controller built while playback is already active
-    // would otherwise wait for a pause/resume cycle before activating
-    // the deferred audio session.
-    if player.isPlaybackRequestedActive {
-      activateAudioSessionIfNeeded()
-    }
+    // The transition stream intentionally has no current-value replay. Direct
+    // construction therefore remains side-effect free; the native initializer
+    // separately handles adoption of an already-active Player before backend
+    // ownership is published. Later transitions activate through this loop.
     let intents = player.playbackIntentEvents
     playbackIntentObserverTask = Task { @MainActor [weak self] in
       for await active in intents {
@@ -915,6 +945,15 @@ public final class PiPController: NSObject {
   /// native-handle replacement (player swap, renderer recast) tearing
   /// PiP down. See ``pipEvents``.
   func handleNativePictureInPictureActiveChanged(_ isActive: Bool) {
+    #if os(iOS)
+    if isActive {
+      // Native auto-start does not deliver SwiftVLC's AVKit delegate
+      // `willStart` callback. Retry here so a transient ownership-time audio
+      // activation failure cannot leave an already-running PiP session
+      // without the playback audio category/session.
+      activateAudioSessionIfNeeded()
+    }
+    #endif
     let changed = self.isActive != isActive
     updatePiPActive(isActive)
     guard changed else { return }
@@ -950,9 +989,15 @@ public final class PiPController: NSObject {
     cancelDeferredPause()
 
     let currentMs = player.currentTime.milliseconds
-    let durationMs = player.duration?.milliseconds ?? Int64.max
-    let offsetMs = Int64(skipInterval.seconds * 1000)
-    let targetMs = max(0, min(currentMs + offsetMs, durationMs))
+    guard let offsetMs = Self.skipOffsetMilliseconds(skipInterval) else {
+      completionHandler()
+      return
+    }
+    let targetMs = Self.clampedSkipTargetMilliseconds(
+      current: currentMs,
+      offset: offsetMs,
+      duration: player.duration?.milliseconds
+    )
 
     playbackDriver.seek(.milliseconds(targetMs))
 

--- a/Sources/SwiftVLC/PiP/PiPControllerBindingPublication.swift
+++ b/Sources/SwiftVLC/PiP/PiPControllerBindingPublication.swift
@@ -1,0 +1,87 @@
+#if os(iOS) || os(macOS)
+import SwiftUI
+
+/// Owns deferred writes to a representable's optional controller binding.
+///
+/// `Binding` exposes no public storage identity. This publisher therefore
+/// owns only the sink it demonstrably wrote: if another binding already
+/// contains the same controller, publication is a no-op and ownership does
+/// not move. That rule both avoids nil/rewrite feedback for an unchanged sink
+/// and keeps retained binding storage bounded. The ownership check also
+/// prevents a late dismantle from erasing a newer representable's controller
+/// in shared storage.
+@MainActor
+final class PiPControllerBindingPublication {
+  private var generation: UInt64 = 0
+  private var publicationTask: Task<Void, Never>?
+  private var ownedBinding: Binding<PiPController?>?
+  private weak var publishedController: PiPController?
+
+  var currentBinding: Binding<PiPController?>? {
+    ownedBinding
+  }
+
+  var retainedBindingCountForTesting: Int {
+    ownedBinding == nil ? 0 : 1
+  }
+
+  func publish(
+    _ controller: PiPController?,
+    to newBinding: Binding<PiPController?>?
+  ) {
+    // SwiftUI can call update repeatedly with fresh wrappers around unchanged
+    // storage. A distinct sink can also arrive prepopulated with the same
+    // controller; public `Binding` cannot distinguish those cases. In both,
+    // retain ownership of only the sink this publisher actually wrote.
+    if
+      publicationTask == nil,
+      let controller,
+      publishedController === controller,
+      let newBinding,
+      newBinding.wrappedValue === controller {
+      return
+    }
+
+    generation &+= 1
+    let publicationGeneration = generation
+    publicationTask?.cancel()
+
+    let previousBinding = ownedBinding
+    let previousController = publishedController
+    ownedBinding = newBinding
+    publishedController = newBinding != nil ? controller : nil
+
+    publicationTask = Task { @MainActor [weak previousController, weak controller] in
+      guard
+        !Task.isCancelled,
+        self.generation == publicationGeneration
+      else { return }
+
+      if let previousBinding, let previousController {
+        Self.clearBinding(previousBinding, ifOwnedBy: previousController)
+      }
+      newBinding?.wrappedValue = controller
+
+      if self.generation == publicationGeneration {
+        self.publicationTask = nil
+      }
+    }
+  }
+
+  func clear() {
+    publish(nil, to: nil)
+  }
+
+  func waitForPendingPublication() async {
+    await publicationTask?.value
+  }
+
+  static func clearBinding(
+    _ binding: Binding<PiPController?>,
+    ifOwnedBy controller: PiPController
+  ) {
+    guard binding.wrappedValue === controller else { return }
+    binding.wrappedValue = nil
+  }
+}
+#endif

--- a/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
@@ -20,13 +20,39 @@ final class MacNativePiPBackend: NSObject, @unchecked Sendable {
   private(set) var isPossible = false
   private(set) var isActive = false
 
+  func adopt(
+    hostView: MacNativePiPHostView,
+    drawableView: MacNativePiPDrawableView
+  ) {
+    self.hostView = hostView
+    self.drawableView = drawableView
+    presenter.adopt(hostView: hostView, drawableView: drawableView)
+  }
+
+  func relinquish(
+    hostView: MacNativePiPHostView,
+    drawableView: MacNativePiPDrawableView
+  ) {
+    guard self.hostView === hostView, self.drawableView === drawableView else { return }
+    self.hostView = nil
+    self.drawableView = nil
+    presenter.relinquish(hostView: hostView, drawableView: drawableView)
+  }
+
   func attach(to player: Player) {
     mediaController.player = player
     refreshPossible()
   }
 
   func detach() {
+    // A full surface retirement means this host is either disappearing with
+    // no open vout or has been repurposed for a different Player. Do not let
+    // an asynchronous private-PiP close restore the retired drawable into a
+    // host that now belongs to another Player.
+    presenter.abandonRestorationTarget()
     presenter.stop()
+    hostView = nil
+    drawableView = nil
     mediaController.player = nil
     setPossible(false)
     setActive(false)
@@ -136,6 +162,28 @@ private final class MacPrivatePiPPresenter {
 
   var isActive: Bool {
     pictureInPictureViewController != nil && !isClosing
+  }
+
+  func adopt(
+    hostView: MacNativePiPHostView,
+    drawableView: MacNativePiPDrawableView
+  ) {
+    self.hostView = hostView
+    self.drawableView = drawableView
+  }
+
+  func abandonRestorationTarget() {
+    hostView = nil
+    drawableView = nil
+  }
+
+  func relinquish(
+    hostView: MacNativePiPHostView,
+    drawableView: MacNativePiPDrawableView
+  ) {
+    guard self.hostView === hostView, self.drawableView === drawableView else { return }
+    self.hostView = nil
+    self.drawableView = nil
   }
 
   func start(
@@ -484,8 +532,11 @@ final class MacNativePiPMediaController: NSObject, @unchecked Sendable {
         return
       }
 
-      let duration = player.duration?.milliseconds ?? Int64.max
-      let target = max(0, min(player.currentTime.milliseconds + offset, duration))
+      let target = PiPController.clampedSkipTargetMilliseconds(
+        current: player.currentTime.milliseconds,
+        offset: offset,
+        duration: player.duration?.milliseconds
+      )
       try? player.seek(to: .milliseconds(target))
       completion?()
     }

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -1,0 +1,974 @@
+#if os(iOS)
+import AVFoundation
+import AVKit
+import CLibVLC
+import os
+import Synchronization
+import UIKit
+
+final class IOSNativePiPHostView: UIView {
+  let drawableView: IOSNativePiPDrawableView
+
+  var nativePiPBackend: IOSNativePiPBackend {
+    drawableView.nativePiPBackend
+  }
+
+  init(startsAutomaticallyFromInline: Bool = true) {
+    drawableView = IOSNativePiPDrawableView(
+      startsAutomaticallyFromInline: startsAutomaticallyFromInline
+    )
+    super.init(frame: .zero)
+    backgroundColor = .black
+    clipsToBounds = true
+
+    nativePiPBackend.hostView = self
+    drawableView.frame = bounds
+    drawableView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    addSubview(drawableView)
+  }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError()
+  }
+
+  func attach(to player: Player) {
+    drawableView.attach(to: player)
+    nativePiPBackend.hostView = self
+  }
+
+  func detach() {
+    drawableView.detach()
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    drawableView.frame = bounds
+  }
+}
+
+typealias IOSNativePictureInPictureReadyBlock = @convention(block) (AnyObject) -> Void
+typealias IOSNativePiPStateChangeEventHandler = @convention(block) (Bool) -> Void
+
+/// Thread-safe identity for work originating in libVLC's native PiP
+/// callbacks. The drawable callbacks arrive off-main and can remain queued
+/// while the SwiftUI view detaches, reattaches, or receives a replacement
+/// native window controller.
+final class IOSNativePiPCallbackGenerations: Sendable {
+  struct Attachment: Equatable {
+    fileprivate let rawValue: UInt64
+  }
+
+  struct ReadyCallback: Equatable {
+    fileprivate let attachment: Attachment
+    fileprivate let rawValue: UInt64
+  }
+
+  private struct State {
+    var nextAttachment: UInt64 = 0
+    var currentAttachment: Attachment?
+    var nextReadyCallback: UInt64 = 0
+    var currentReadyCallback: ReadyCallback?
+  }
+
+  private let state = Mutex(State())
+
+  @MainActor
+  func beginAttachment() -> Attachment {
+    state.withLock { state in
+      state.nextAttachment &+= 1
+      let attachment = Attachment(rawValue: state.nextAttachment)
+      state.currentAttachment = attachment
+      state.currentReadyCallback = nil
+      return attachment
+    }
+  }
+
+  @MainActor
+  func invalidateAttachment() {
+    state.withLock { state in
+      state.currentAttachment = nil
+      state.currentReadyCallback = nil
+    }
+  }
+
+  @MainActor
+  func currentAttachment() -> Attachment? {
+    state.withLock { $0.currentAttachment }
+  }
+
+  @MainActor
+  func reserveReadyCallback(for attachment: Attachment) -> ReadyCallback? {
+    state.withLock { state in
+      guard state.currentAttachment == attachment else { return nil }
+      state.nextReadyCallback &+= 1
+      let callback = ReadyCallback(
+        attachment: attachment,
+        rawValue: state.nextReadyCallback
+      )
+      state.currentReadyCallback = callback
+      return callback
+    }
+  }
+
+  @MainActor
+  func isCurrent(_ callback: ReadyCallback) -> Bool {
+    state.withLock {
+      $0.currentAttachment == callback.attachment
+        && $0.currentReadyCallback == callback
+    }
+  }
+
+  /// Applies UI state only for the currently selected callback. Both callback
+  /// reservation and this check/action are main-actor isolated, so a newer
+  /// ready callback cannot invalidate the generation between the check and
+  /// UIKit/KVO mutation. The mutex remains for attachment invalidation reads
+  /// originating in diagnostic/test code; it is never held across UI work.
+  @MainActor
+  @discardableResult
+  func performIfCurrent(
+    _ callback: ReadyCallback,
+    _ action: @MainActor () -> Void
+  ) -> Bool {
+    guard isCurrent(callback) else { return false }
+    action()
+    return true
+  }
+}
+
+@objc(VLCPictureInPictureDrawable)
+private protocol IOSNativePiPDrawable: NSObjectProtocol {
+  @objc(mediaController)
+  func mediaController() -> AnyObject
+
+  @objc(pictureInPictureReady)
+  func pictureInPictureReady() -> IOSNativePictureInPictureReadyBlock
+
+  @objc(canStartPictureInPictureAutomaticallyFromInline)
+  optional func canStartPictureInPictureAutomaticallyFromInline() -> Bool
+}
+
+@objc(VLCPictureInPictureMediaControlling)
+private protocol IOSNativePiPMediaControlling: NSObjectProtocol {
+  @objc func play()
+  @objc func pause()
+
+  @objc(seekBy:completion:)
+  func seek(by offset: Int64, completion: (() -> Void)?)
+
+  @objc func mediaLength() -> Int64
+  @objc func mediaTime() -> Int64
+  @objc func isMediaSeekable() -> Bool
+  @objc func isMediaPlaying() -> Bool
+}
+
+/// The `UIView` libVLC renders into for one callback generation. It owns that
+/// generation's `attachment` and bridges the `@objc` hooks — media controller,
+/// PiP-ready block, and auto-start policy — that AVKit's inline PiP path calls.
+@MainActor
+final class IOSNativePiPDrawableAttachment: UIView, IOSNativePiPDrawable {
+  nonisolated let attachment: IOSNativePiPCallbackGenerations.Attachment
+  nonisolated let nativeMediaController: IOSNativePiPMediaController
+  nonisolated let startsAutomaticallyFromInline: Bool
+  nonisolated let nativePiPBackend: IOSNativePiPBackend
+
+  init(
+    nativePiPBackend: IOSNativePiPBackend,
+    attachment: IOSNativePiPCallbackGenerations.Attachment,
+    mediaController: IOSNativePiPMediaController,
+    startsAutomaticallyFromInline: Bool
+  ) {
+    self.nativePiPBackend = nativePiPBackend
+    self.attachment = attachment
+    nativeMediaController = mediaController
+    self.startsAutomaticallyFromInline = startsAutomaticallyFromInline
+    super.init(frame: .zero)
+    backgroundColor = .black
+    clipsToBounds = true
+    autoresizingMask = [.flexibleWidth, .flexibleHeight]
+  }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError()
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    resizeRenderingChildren()
+  }
+
+  override func didAddSubview(_ subview: UIView) {
+    super.didAddSubview(subview)
+    resizeRenderingSubview(subview)
+  }
+
+  override func layoutSublayers(of layer: CALayer) {
+    super.layoutSublayers(of: layer)
+    guard layer === self.layer else { return }
+    resizeRenderingLayers()
+  }
+
+  @objc(mediaController)
+  nonisolated func mediaController() -> AnyObject {
+    nativeMediaController
+  }
+
+  func reserveReadyCallbackGeneration()
+    -> IOSNativePiPCallbackGenerations.ReadyCallback? {
+    nativePiPBackend.callbackGenerations.reserveReadyCallback(for: attachment)
+  }
+
+  @objc(pictureInPictureReady)
+  nonisolated func pictureInPictureReady() -> IOSNativePictureInPictureReadyBlock {
+    let attachment = attachment
+    return { [weak nativePiPBackend] windowController in
+      nonisolated(unsafe) let windowController = windowController
+      Task { @MainActor in
+        guard
+          let nativePiPBackend,
+          let generation = nativePiPBackend.callbackGenerations.reserveReadyCallback(
+            for: attachment
+          )
+        else { return }
+        nativePiPBackend.handlePictureInPictureReady(
+          windowController,
+          generation: generation
+        )
+      }
+    }
+  }
+
+  @objc(canStartPictureInPictureAutomaticallyFromInline)
+  nonisolated func canStartPictureInPictureAutomaticallyFromInline() -> Bool {
+    startsAutomaticallyFromInline
+  }
+
+  private var hasDrawableBounds: Bool {
+    bounds.width > 0 && bounds.height > 0
+  }
+
+  private func resizeRenderingChildren() {
+    guard hasDrawableBounds else { return }
+    subviews.forEach(resizeRenderingSubview)
+    resizeRenderingLayers()
+  }
+
+  private func resizeRenderingSubview(_ subview: UIView) {
+    guard hasDrawableBounds else { return }
+    subview.frame = bounds
+    subview.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    syncContentScale(to: subview)
+    subview.setNeedsLayout()
+    subview.layoutIfNeeded()
+    reshapeVLCSubviewIfNeeded(subview)
+  }
+
+  private func resizeRenderingLayers() {
+    guard hasDrawableBounds else { return }
+    layer.sublayers?.forEach { sublayer in
+      CATransaction.begin()
+      CATransaction.setDisableActions(true)
+      sublayer.frame = bounds
+      CATransaction.commit()
+    }
+  }
+
+  private func syncContentScale(to subview: UIView) {
+    let scale = window?.screen.scale
+      ?? subview.window?.screen.scale
+      ?? UIScreen.main.scale
+    subview.contentScaleFactor = scale
+    subview.layer.contentsScale = scale
+  }
+}
+
+@MainActor
+final class IOSNativePiPDrawableView: UIView {
+  private(set) var nativePiPBackend = IOSNativePiPBackend()
+
+  /// Answer copied into each attachment proxy for libVLC's off-main
+  /// auto-PiP probe.
+  let startsAutomaticallyFromInline: Bool
+
+  private weak var attachedPlayer: Player?
+  /// The active attachment is owned here and by `Player`. A retiring vout
+  /// remains safe without a host-level retirement list: pinned libVLC's
+  /// ARC-built `VLCVideoUIView` holds its drawable in strong `_viewContainer`
+  /// storage until that vout closes. With no vout there can be no late PiP
+  /// selector, so keeping every swapped attachment would only leak surfaces.
+  private(set) var drawableAttachment: IOSNativePiPDrawableAttachment?
+
+  init(startsAutomaticallyFromInline: Bool = true) {
+    self.startsAutomaticallyFromInline = startsAutomaticallyFromInline
+    super.init(frame: .zero)
+    backgroundColor = .black
+    clipsToBounds = true
+    nativePiPBackend.drawableView = self
+  }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError()
+  }
+
+  func attach(to player: Player) {
+    if let attachedPlayer, attachedPlayer !== player {
+      detachCompletely(from: attachedPlayer)
+      installFreshBackend()
+    }
+
+    // Pinned libVLC copies `drawable-nsobject` into a strong
+    // `VLCVideoUIView._viewContainer` exactly once at vout open. Updating the
+    // player variable to a new UIView cannot redirect that live vout. During
+    // a same-player SwiftUI recreation the existing Player-held attachment
+    // is therefore the lease: adopt and reparent that exact object together
+    // with its native backend instead of manufacturing a successor surface.
+    if !adoptCurrentAttachment(from: player) {
+      if
+        attachedPlayer != nil
+        || drawableAttachment != nil
+        || nativePiPBackend.mediaController.player != nil {
+        abandonLocalReferences()
+        installFreshBackend()
+      }
+      makeAttachment(for: player)
+    }
+
+    player.claimDrawableOwnership(self)
+    publishDrawableIfReady()
+  }
+
+  func detach() {
+    guard let player = attachedPlayer else { return }
+
+    // A successor host may already have adopted this exact attachment. Its
+    // claim wins; stale dismantle must not remove the reparented view or tear
+    // down the shared backend/controller wiring.
+    guard player.isDrawableOwner(self) else {
+      abandonLocalReferences()
+      return
+    }
+
+    if mustPreserveAttachment(for: player) {
+      // Leave `Player.drawable` untouched. It is already the strong O(1)
+      // lease required by both possible SwiftUI lifecycle orderings, and it
+      // is retained/released with the exact native handle. Keeping only the
+      // active attachment also avoids a Player -> PiPController cycle: the
+      // backend owner and media-controller player links remain weak.
+      player.releaseDrawableOwnership(self)
+      abandonLocalReferences()
+      return
+    }
+
+    // No SwiftVLC- or list-player-driven playback has started, no live native
+    // state is reported, and no vout is observed. Nothing can have latched
+    // this attachment, so ordinary view churn releases it immediately.
+    detachCompletely(from: player)
+    installFreshBackend()
+  }
+
+  private func mustPreserveAttachment(for player: Player) -> Bool {
+    if
+      player.nativePlayerHasStartedPlayback
+      || player.nativePlayerNeedsReplacementBeforePlayback
+      || player.attachedMediaListPlayer != nil
+      || player.activeVideoOutputs > 0 {
+      return true
+    }
+
+    // A MediaListPlayer (or another in-module native driver) starts the same
+    // libVLC media-player handle without entering `Player.play()`, so the
+    // direct-path `nativePlayerHasStartedPlayback` bit is not sufficient.
+    // The live native state closes that gap before the mirrored vout count or
+    // observable state reaches the main actor.
+    switch player.nativePlaybackState {
+    case .idle, .stopped, .error:
+      return false
+    case .opening, .buffering, .playing, .paused, .stopping:
+      return true
+    }
+  }
+
+  private func adoptCurrentAttachment(from player: Player) -> Bool {
+    guard
+      let attachment = player.drawable as? IOSNativePiPDrawableAttachment,
+      attachment.nativePiPBackend.mediaController.player === player,
+      attachment.nativePiPBackend.callbackGenerations.currentAttachment()
+      == attachment.attachment
+    else { return false }
+
+    let backend = attachment.nativePiPBackend
+    nativePiPBackend = backend
+    backend.drawableView = self
+    if let hostView = superview as? IOSNativePiPHostView {
+      backend.hostView = hostView
+    }
+    attachedPlayer = player
+    drawableAttachment = attachment
+    // The pinned native PiP controller snapshots this selector at vout open.
+    // Preserve that original policy with the exact attachment/backend; merely
+    // changing the proxy's answer here would not reconfigure the live native
+    // controller and would make Swift state disagree with system behavior.
+    reparent(attachment)
+    return true
+  }
+
+  private func makeAttachment(for player: Player) {
+    attachedPlayer = player
+    nativePiPBackend.drawableView = self
+    if let hostView = superview as? IOSNativePiPHostView {
+      nativePiPBackend.hostView = hostView
+    }
+    let attachment = nativePiPBackend.attach(to: player)
+    let drawableAttachment = IOSNativePiPDrawableAttachment(
+      nativePiPBackend: nativePiPBackend,
+      attachment: attachment,
+      mediaController: nativePiPBackend.mediaController,
+      startsAutomaticallyFromInline: startsAutomaticallyFromInline
+    )
+    self.drawableAttachment = drawableAttachment
+    reparent(drawableAttachment)
+  }
+
+  private func reparent(_ attachment: IOSNativePiPDrawableAttachment) {
+    if attachment.superview !== self {
+      attachment.removeFromSuperview()
+      addSubview(attachment)
+    }
+    attachment.frame = bounds
+    attachment.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    attachment.setNeedsLayout()
+  }
+
+  private func detachCompletely(from player: Player) {
+    guard player.isDrawableOwner(self) else {
+      abandonLocalReferences()
+      return
+    }
+
+    player.releaseDrawableOwnership(self)
+    if let drawableAttachment {
+      player.clearDrawable(ifCurrent: drawableAttachment)
+      if drawableAttachment.superview === self {
+        drawableAttachment.removeFromSuperview()
+      }
+    }
+    nativePiPBackend.detach()
+    abandonLocalReferences()
+  }
+
+  private func abandonLocalReferences() {
+    if let drawableAttachment, drawableAttachment.superview === self {
+      drawableAttachment.removeFromSuperview()
+    }
+    drawableAttachment = nil
+    attachedPlayer = nil
+  }
+
+  private func installFreshBackend() {
+    let backend = IOSNativePiPBackend()
+    backend.drawableView = self
+    if let hostView = superview as? IOSNativePiPHostView {
+      backend.hostView = hostView
+    }
+    nativePiPBackend = backend
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+
+    guard hasDrawableBounds else { return }
+
+    publishDrawableIfReady()
+    resizeRenderingChildren()
+  }
+
+  override func didAddSubview(_ subview: UIView) {
+    super.didAddSubview(subview)
+    resizeRenderingSubview(subview)
+  }
+
+  override func layoutSublayers(of layer: CALayer) {
+    super.layoutSublayers(of: layer)
+    guard layer === self.layer else { return }
+    resizeRenderingLayers()
+  }
+
+  override func didMoveToWindow() {
+    super.didMoveToWindow()
+    if window != nil {
+      publishDrawableIfReady()
+      setNeedsLayout()
+      layer.setNeedsLayout()
+    }
+  }
+
+  private var hasDrawableBounds: Bool {
+    bounds.width > 0 && bounds.height > 0
+  }
+
+  private func publishDrawableIfReady() {
+    guard
+      let player = attachedPlayer,
+      let drawableAttachment,
+      player.isDrawableOwner(self)
+    else { return }
+    if !player.isCurrentDrawable(drawableAttachment) {
+      player.setDrawable(drawableAttachment, owner: self)
+      resizeRenderingChildren()
+    }
+  }
+
+  private func resizeRenderingChildren() {
+    guard hasDrawableBounds else { return }
+    subviews.forEach(resizeRenderingSubview)
+    resizeRenderingLayers()
+  }
+
+  private func resizeRenderingSubview(_ subview: UIView) {
+    guard hasDrawableBounds else { return }
+    subview.frame = bounds
+    subview.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    syncContentScale(to: subview)
+    subview.setNeedsLayout()
+    subview.layoutIfNeeded()
+    reshapeVLCSubviewIfNeeded(subview)
+  }
+
+  private func resizeRenderingLayers() {
+    guard hasDrawableBounds else { return }
+    layer.sublayers?.forEach { sublayer in
+      CATransaction.begin()
+      CATransaction.setDisableActions(true)
+      sublayer.frame = bounds
+      CATransaction.commit()
+    }
+  }
+
+  private func syncContentScale(to subview: UIView) {
+    let scale = window?.screen.scale
+      ?? subview.window?.screen.scale
+      ?? UIScreen.main.scale
+    subview.contentScaleFactor = scale
+    subview.layer.contentsScale = scale
+  }
+}
+
+@MainActor
+final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
+  private(set) var mediaController = IOSNativePiPMediaController()
+  nonisolated let callbackGenerations = IOSNativePiPCallbackGenerations()
+  weak var owner: PiPController? {
+    didSet {
+      mediaController.owner = owner
+      if
+        let owner,
+        mediaController.player === owner.player,
+        let attachment = callbackGenerations.currentAttachment() {
+        ownerAttachment = attachment
+      } else {
+        ownerAttachment = nil
+      }
+    }
+  }
+
+  /// Exact attachment generation claimed by ``owner``. A non-nil current
+  /// generation alone is not enough: after detach/reattach, an old owner must
+  /// not be treated as owning whichever generation happens to be current.
+  private var ownerAttachment: IOSNativePiPCallbackGenerations.Attachment?
+
+  weak var hostView: IOSNativePiPHostView?
+  weak var drawableView: IOSNativePiPDrawableView?
+
+  private static var supportsNativePictureInPictureRendering: Bool {
+    #if targetEnvironment(simulator)
+    // The system can report active sample-buffer PiP while rendering a black window.
+    false
+    #else
+    true
+    #endif
+  }
+
+  private weak var windowController: NSObject?
+  private var avPictureInPictureController: AVPictureInPictureController?
+  private var possibleObservation: NSKeyValueObservation?
+  private var activeObservation: NSKeyValueObservation?
+  private var stateChangeEventHandler: IOSNativePiPStateChangeEventHandler?
+
+  private(set) var isPossible = false
+  private(set) var isActive = false
+  private(set) var requiresLinearPlayback = true
+  private(set) var startsAutomaticallyFromInline = true
+  private(set) var playbackStateInvalidationCount: UInt64 = 0
+  private var didWarnAboutVideoOutput = false
+
+  private static let logger = Logger(
+    subsystem: Signposts.subsystem,
+    category: "PictureInPicture"
+  )
+
+  @discardableResult
+  func attach(to player: Player) -> IOSNativePiPCallbackGenerations.Attachment {
+    let attachment = callbackGenerations.beginAttachment()
+    let mediaController = IOSNativePiPMediaController()
+    mediaController.player = player
+    mediaController.owner = owner?.player === player ? owner : nil
+    self.mediaController = mediaController
+    ownerAttachment = mediaController.owner == nil ? nil : attachment
+    requiresLinearPlayback = !player.isSeekable
+    setPossible(false)
+    setActive(false)
+    return attachment
+  }
+
+  func detach() {
+    // Invalidate before stopping the old controller: stop/KVO callbacks can
+    // be delivered synchronously or remain queued after teardown.
+    callbackGenerations.invalidateAttachment()
+    stop()
+    clearWindowController()
+    mediaController.player = nil
+    mediaController.owner = nil
+    ownerAttachment = nil
+    setPossible(false)
+    setActive(false)
+  }
+
+  func handlePictureInPictureReady(_ controller: AnyObject) {
+    guard
+      let attachment = callbackGenerations.currentAttachment(),
+      let generation = callbackGenerations.reserveReadyCallback(for: attachment)
+    else { return }
+    handlePictureInPictureReady(controller, generation: generation)
+  }
+
+  func handlePictureInPictureReady(
+    _ controller: AnyObject,
+    generation: IOSNativePiPCallbackGenerations.ReadyCallback
+  ) {
+    guard let controller = controller as? NSObject else { return }
+
+    callbackGenerations.performIfCurrent(generation) {
+      clearWindowController()
+      guard Self.supportsNativePictureInPictureRendering else {
+        setPossible(false)
+        setActive(false)
+        return
+      }
+
+      windowController = controller
+      installStateChangeHandler(on: controller, generation: generation)
+      observeAVPictureInPictureController(on: controller, generation: generation)
+
+      if avPictureInPictureController == nil {
+        setPossible(true)
+      }
+    }
+  }
+
+  func start() {
+    guard isPossible, mediaController.player?.currentMedia != nil else {
+      warnIfVideoOutputBlocksPictureInPicture()
+      return
+    }
+    performWindowControllerAction(IOSNativePiPSelector.start)
+  }
+
+  /// One-time diagnostic for the common misconfiguration where a custom
+  /// ``VLCInstance`` forces a non-default video output (e.g. `--vout=gles2`
+  /// or `--no-video`): libVLC then never selects the sample-buffer display
+  /// PiP needs, the PiP-ready callback never fires, and ``isPossible``
+  /// stays `false` with no other signal.
+  private func warnIfVideoOutputBlocksPictureInPicture() {
+    guard !didWarnAboutVideoOutput else { return }
+    guard
+      let instance = mediaController.player?.instance,
+      !instance.usesPiPSafeDarwinDisplay
+    else { return }
+    didWarnAboutVideoOutput = true
+    Self.logger.warning(
+      """
+      Picture in Picture is unavailable: this VLCInstance's video-output \
+      arguments (e.g. --vout or --no-video) stop libVLC from selecting the \
+      sample-buffer display that native PiP requires. Use the default video \
+      output to enable PiP.
+      """
+    )
+  }
+
+  func stop() {
+    performWindowControllerAction(IOSNativePiPSelector.stop)
+  }
+
+  func invalidatePlaybackState() {
+    playbackStateInvalidationCount &+= 1
+    performWindowControllerAction(IOSNativePiPSelector.invalidatePlaybackState)
+  }
+
+  func setStartsAutomaticallyFromInline(_ enabled: Bool) {
+    startsAutomaticallyFromInline = enabled
+    avPictureInPictureController?.canStartPictureInPictureAutomaticallyFromInline = enabled
+  }
+
+  func invalidatePlaybackState(ifOwnedBy expectedOwner: PiPController) {
+    guard ownsCurrentAttachment(expectedOwner) else { return }
+    invalidatePlaybackState()
+  }
+
+  /// Updates AVKit's transport policy only for the controller that owns the
+  /// current attachment. A retired controller can still drain a queued player
+  /// event after a swap; these checks keep it from mutating the successor.
+  func setRequiresLinearPlayback(
+    _ requiresLinearPlayback: Bool,
+    ifOwnedBy expectedOwner: PiPController
+  ) {
+    guard ownsCurrentAttachment(expectedOwner) else { return }
+
+    self.requiresLinearPlayback = requiresLinearPlayback
+    avPictureInPictureController?.requiresLinearPlayback = requiresLinearPlayback
+  }
+
+  /// Re-samples the current attachment's player when a controller claims an
+  /// existing native backend. Both owner identity and the live attachment
+  /// generation are checked before mutation, so neither a retired controller
+  /// nor a controller constructed before attachment can change AVKit policy.
+  func reconcileRequiresLinearPlayback(ifOwnedBy expectedOwner: PiPController) {
+    guard ownsCurrentAttachment(expectedOwner) else { return }
+
+    let requiresLinearPlayback = !expectedOwner.player.isSeekable
+    self.requiresLinearPlayback = requiresLinearPlayback
+    avPictureInPictureController?.requiresLinearPlayback = requiresLinearPlayback
+  }
+
+  private func ownsCurrentAttachment(_ expectedOwner: PiPController) -> Bool {
+    owner === expectedOwner
+      && mediaController.player === expectedOwner.player
+      && ownerAttachment == callbackGenerations.currentAttachment()
+      && ownerAttachment != nil
+  }
+
+  private func clearWindowController() {
+    if
+      let windowController,
+      windowController.responds(to: IOSNativePiPSelector.setStateChangeEventHandler) {
+      windowController.setValue(nil, forKey: "stateChangeEventHandler")
+    }
+    possibleObservation = nil
+    activeObservation = nil
+    avPictureInPictureController = nil
+    stateChangeEventHandler = nil
+    windowController = nil
+  }
+
+  private func installStateChangeHandler(
+    on controller: NSObject,
+    generation: IOSNativePiPCallbackGenerations.ReadyCallback
+  ) {
+    guard controller.responds(to: IOSNativePiPSelector.setStateChangeEventHandler) else { return }
+
+    let handler: IOSNativePiPStateChangeEventHandler = { [weak self] isStarted in
+      Task { @MainActor in
+        guard let self else { return }
+        self.callbackGenerations.performIfCurrent(generation) {
+          self.setActive(isStarted)
+        }
+      }
+    }
+    stateChangeEventHandler = handler
+    controller.setValue(handler, forKey: "stateChangeEventHandler")
+  }
+
+  private func observeAVPictureInPictureController(
+    on controller: NSObject,
+    generation: IOSNativePiPCallbackGenerations.ReadyCallback
+  ) {
+    guard controller.responds(to: IOSNativePiPSelector.avPictureInPictureController) else { return }
+    guard let avController = controller.value(forKey: "avPipController") as? AVPictureInPictureController else { return }
+
+    avPictureInPictureController = avController
+    avController.requiresLinearPlayback = requiresLinearPlayback
+    avController.canStartPictureInPictureAutomaticallyFromInline =
+      startsAutomaticallyFromInline
+    setPossible(avController.isPictureInPicturePossible)
+    setActive(avController.isPictureInPictureActive)
+
+    possibleObservation = avController.observe(
+      \.isPictureInPicturePossible,
+      options: [.initial, .new]
+    ) { [weak self] controller, _ in
+      let isPossible = controller.isPictureInPicturePossible
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        callbackGenerations.performIfCurrent(generation) {
+          self.setPossible(isPossible)
+        }
+      }
+    }
+
+    activeObservation = avController.observe(
+      \.isPictureInPictureActive,
+      options: [.initial, .new]
+    ) { [weak self] controller, _ in
+      let isActive = controller.isPictureInPictureActive
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        callbackGenerations.performIfCurrent(generation) {
+          self.setActive(isActive)
+        }
+      }
+    }
+  }
+
+  private func performWindowControllerAction(_ selector: Selector) {
+    guard let windowController, windowController.responds(to: selector) else { return }
+    _ = windowController.perform(selector)
+  }
+
+  func makeValidationProbe() -> NativePiPProbe {
+    let delegateSelectorNames = [
+      "pictureInPictureControllerWillStartPictureInPicture:",
+      "pictureInPictureControllerDidStartPictureInPicture:",
+      "pictureInPictureControllerDidStopPictureInPicture:",
+      "pictureInPictureController:failedToStartPictureInPictureWithError:",
+      "pictureInPictureController:restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:"
+    ]
+
+    let delegate = avPictureInPictureController?.delegate
+    var delegateResponds: [String: Bool] = [:]
+    if let delegate {
+      for name in delegateSelectorNames {
+        delegateResponds[name] = delegate.responds(to: Selector((name)))
+      }
+    }
+
+    return NativePiPProbe(
+      windowControllerClassName: windowController.map { NSStringFromClass(type(of: $0)) },
+      hasAVController: avPictureInPictureController != nil,
+      avDelegateClassName: delegate.flatMap { object_getClass($0) }.map { NSStringFromClass($0) },
+      delegateResponds: delegateResponds,
+      isPossible: isPossible,
+      isActive: isActive
+    )
+  }
+
+  private func setPossible(_ isPossible: Bool) {
+    guard self.isPossible != isPossible else { return }
+    self.isPossible = isPossible
+    owner?.handleNativePictureInPictureReady()
+  }
+
+  private func setActive(_ isActive: Bool) {
+    guard self.isActive != isActive else { return }
+    self.isActive = isActive
+    owner?.handleNativePictureInPictureActiveChanged(isActive)
+  }
+}
+
+final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling, @unchecked Sendable {
+  weak var player: Player?
+  weak var owner: PiPController?
+
+  @objc func play() {
+    Task { @MainActor [weak self] in
+      guard let self, let player else { return }
+      // A cold start after playback ended is not a resume — begin afresh.
+      if player.state == .idle || player.state == .stopped {
+        try? player.play()
+        return
+      }
+      // Otherwise route through the controller so the AVKit-transient pause
+      // debouncer and PiP playback-state reconciliation engage. Fall back to
+      // a direct resume when constructed without a controller (the public
+      // direct-`PiPController` usage path).
+      if let owner {
+        owner.handleNativePictureInPictureSetPlaying(true)
+      } else {
+        player.resume()
+      }
+    }
+  }
+
+  @objc func pause() {
+    Task { @MainActor [weak self] in
+      guard let self else { return }
+      if let owner {
+        owner.handleNativePictureInPictureSetPlaying(false)
+      } else {
+        player?.pause()
+      }
+    }
+  }
+
+  @objc(seekBy:completion:)
+  func seek(by offset: Int64, completion: (() -> Void)?) {
+    nonisolated(unsafe) let completion = completion
+    Task { @MainActor [weak self] in
+      guard let player = self?.player else {
+        completion?()
+        return
+      }
+
+      let target = PiPController.clampedSkipTargetMilliseconds(
+        current: player.currentTime.milliseconds,
+        offset: offset,
+        duration: player.duration?.milliseconds
+      )
+      try? player.seek(to: .milliseconds(target))
+      completion?()
+    }
+  }
+
+  @objc func mediaLength() -> Int64 {
+    pipMainActorSync { [weak self] in
+      guard let player = self?.player else { return 0 }
+      let length = libvlc_media_player_get_length(player.pointer)
+      // VLC's native PiP module checks for VLC_TICK_INVALID (0), not
+      // libvlc's public unknown-length sentinel (-1).
+      return length > 0 ? length : 0
+    }
+  }
+
+  @objc func mediaTime() -> Int64 {
+    pipMainActorSync { [weak self] in
+      guard let player = self?.player else { return 0 }
+      return max(libvlc_media_player_get_time(player.pointer), 0)
+    }
+  }
+
+  @objc func isMediaSeekable() -> Bool {
+    pipMainActorSync { [weak self] in
+      guard let player = self?.player else { return false }
+      return libvlc_media_player_is_seekable(player.pointer)
+    }
+  }
+
+  @objc func isMediaPlaying() -> Bool {
+    pipMainActorSync { [weak self] in
+      guard let player = self?.player else { return false }
+      return player.isPlaybackRequestedActive
+    }
+  }
+}
+
+private enum IOSNativePiPSelector {
+  static let start = NSSelectorFromString("startPictureInPicture")
+  static let stop = NSSelectorFromString("stopPictureInPicture")
+  static let invalidatePlaybackState = NSSelectorFromString("invalidatePlaybackState")
+  static let setStateChangeEventHandler = NSSelectorFromString("setStateChangeEventHandler:")
+  static let avPictureInPictureController = NSSelectorFromString("avPipController")
+}
+
+private let vlcUIViewReshapeSelector = NSSelectorFromString("reshape")
+
+@MainActor
+private func reshapeVLCSubviewIfNeeded(_ subview: UIView) {
+  guard
+    subview.responds(to: vlcUIViewReshapeSelector),
+    subview.bounds.width > 0,
+    subview.bounds.height > 0
+  else { return }
+  _ = subview.perform(vlcUIViewReshapeSelector)
+}
+
+#endif

--- a/Sources/SwiftVLC/PiP/PiPVideoView.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView.swift
@@ -1,8 +1,4 @@
 #if os(iOS)
-import AVFoundation
-import AVKit
-import CLibVLC
-import os
 import SwiftUI
 import UIKit
 
@@ -45,9 +41,10 @@ public struct PiPVideoView: UIViewRepresentable {
   ///     `AVAudioSession` (`.playback` category) and activates it on the
   ///     first PiP start or active-playback signal. Defaults to `true`.
   ///     Pass `false` if your app owns its audio-session policy; SwiftVLC
-  ///     then never touches the session. Constructing the view never
-  ///     activates the session either way, so other apps' audio focus is
-  ///     not stolen at view-build time.
+  ///     then never touches the session. Constructing a view for an inactive
+  ///     Player does not activate the session. Recreating the native view for
+  ///     a Player whose playback intent is already active does activate it so
+  ///     automatic PiP cannot outrun the managed audio-session setup.
   public init(
     _ player: Player,
     controller: Binding<PiPController?>? = nil,
@@ -86,7 +83,11 @@ public struct PiPVideoView: UIViewRepresentable {
   public func updateUIView(_ uiView: UIView, context: Context) {
     guard let container = uiView as? IOSNativePiPHostView else { return }
     if context.coordinator.player !== player {
-      container.detach()
+      // `attach(to:)` performs an ownership-checked player handoff. Keeping
+      // the transition in one operation is important: a representable
+      // dismantle uses `detach()` as a same-player recreation lease when a
+      // vout has already opened, while an actual player swap must fully
+      // retire the old backend instead.
       container.attach(to: player)
 
       let controller = PiPController(
@@ -110,12 +111,10 @@ public struct PiPVideoView: UIViewRepresentable {
       coordinator.pipController?.stop()
     }
     coordinator.pipController = nil
-    // Clear any external binding so callers who observe it don't
-    // retain a stopped controller.
-    if let binding = coordinator.controllerBinding {
-      Task { @MainActor in binding.wrappedValue = nil }
-      coordinator.controllerBinding = nil
-    }
+    // Clear any external binding so callers who observe it don't retain a
+    // stopped controller. The publisher cancels stale make/update work and
+    // clears only values this coordinator owns.
+    coordinator.clearControllerBinding()
   }
 
   public func makeCoordinator() -> Coordinator {
@@ -130,557 +129,32 @@ public struct PiPVideoView: UIViewRepresentable {
   public final class Coordinator {
     weak var player: Player?
     var pipController: PiPController?
-    var controllerBinding: Binding<PiPController?>?
+    private let bindingPublication = PiPControllerBindingPublication()
+
+    var controllerBinding: Binding<PiPController?>? {
+      bindingPublication.currentBinding
+    }
+
+    func publishController(
+      _ controller: PiPController?,
+      to binding: Binding<PiPController?>?
+    ) {
+      bindingPublication.publish(controller, to: binding)
+    }
+
+    func clearControllerBinding() {
+      bindingPublication.clear()
+    }
+
+    func waitForControllerBindingPublication() async {
+      await bindingPublication.waitForPendingPublication()
+    }
   }
 
   @MainActor
   private func pushControllerBinding(_ controller: PiPController?, via coordinator: Coordinator) {
-    let binding = controllerBinding
-    coordinator.controllerBinding = binding
-    Task { @MainActor in
-      binding?.wrappedValue = controller
-    }
+    coordinator.publishController(controller, to: controllerBinding)
   }
-}
-
-final class IOSNativePiPHostView: UIView {
-  let drawableView: IOSNativePiPDrawableView
-
-  var nativePiPBackend: IOSNativePiPBackend {
-    drawableView.nativePiPBackend
-  }
-
-  init(startsAutomaticallyFromInline: Bool = true) {
-    drawableView = IOSNativePiPDrawableView(
-      startsAutomaticallyFromInline: startsAutomaticallyFromInline
-    )
-    super.init(frame: .zero)
-    backgroundColor = .black
-    clipsToBounds = true
-
-    nativePiPBackend.hostView = self
-    drawableView.frame = bounds
-    drawableView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-    addSubview(drawableView)
-  }
-
-  @available(*, unavailable)
-  required init?(coder _: NSCoder) {
-    fatalError()
-  }
-
-  func attach(to player: Player) {
-    drawableView.attach(to: player)
-  }
-
-  func detach() {
-    drawableView.detach()
-  }
-
-  override func layoutSubviews() {
-    super.layoutSubviews()
-    drawableView.frame = bounds
-  }
-}
-
-typealias IOSNativePictureInPictureReadyBlock = @convention(block) (AnyObject) -> Void
-typealias IOSNativePiPStateChangeEventHandler = @convention(block) (Bool) -> Void
-
-@objc(VLCPictureInPictureDrawable)
-private protocol IOSNativePiPDrawable: NSObjectProtocol {
-  @objc(mediaController)
-  func mediaController() -> AnyObject
-
-  @objc(pictureInPictureReady)
-  func pictureInPictureReady() -> IOSNativePictureInPictureReadyBlock
-
-  @objc(canStartPictureInPictureAutomaticallyFromInline)
-  optional func canStartPictureInPictureAutomaticallyFromInline() -> Bool
-}
-
-@objc(VLCPictureInPictureMediaControlling)
-private protocol IOSNativePiPMediaControlling: NSObjectProtocol {
-  @objc func play()
-  @objc func pause()
-
-  @objc(seekBy:completion:)
-  func seek(by offset: Int64, completion: (() -> Void)?)
-
-  @objc func mediaLength() -> Int64
-  @objc func mediaTime() -> Int64
-  @objc func isMediaSeekable() -> Bool
-  @objc func isMediaPlaying() -> Bool
-}
-
-@MainActor
-final class IOSNativePiPDrawableView: UIView, IOSNativePiPDrawable {
-  let nativePiPBackend = IOSNativePiPBackend()
-
-  /// Answer for libVLC's auto-PiP probe. Immutable after init and of a
-  /// `Sendable` type, so the nonisolated drawable-protocol method below
-  /// can read it from libVLC's vout thread without synchronization.
-  let startsAutomaticallyFromInline: Bool
-
-  private weak var attachedPlayer: Player?
-
-  init(startsAutomaticallyFromInline: Bool = true) {
-    self.startsAutomaticallyFromInline = startsAutomaticallyFromInline
-    super.init(frame: .zero)
-    backgroundColor = .black
-    clipsToBounds = true
-    nativePiPBackend.drawableView = self
-  }
-
-  @available(*, unavailable)
-  required init?(coder _: NSCoder) {
-    fatalError()
-  }
-
-  func attach(to player: Player) {
-    if attachedPlayer !== player {
-      // Fully tear the backend down before re-attaching: `attach(to:)` only
-      // resets the media controller and possible/active flags, so without
-      // this the previous player's window-controller wiring (KVO
-      // observations + state-change handler) would survive a swap and keep
-      // driving PiP state for the wrong player. The production swap path
-      // (`updateUIView`) already detaches first; this keeps the method
-      // correct for any caller.
-      attachedPlayer?.releaseDrawableOwnership(self)
-      nativePiPBackend.detach()
-      attachedPlayer = player
-      nativePiPBackend.attach(to: player)
-    }
-    player.claimDrawableOwnership(self)
-    publishDrawableIfReady()
-  }
-
-  func detach() {
-    guard let player = attachedPlayer else { return }
-    player.releaseDrawableOwnership(self)
-    nativePiPBackend.detach()
-    attachedPlayer = nil
-  }
-
-  override func layoutSubviews() {
-    super.layoutSubviews()
-
-    guard hasDrawableBounds else { return }
-
-    publishDrawableIfReady()
-    resizeRenderingChildren()
-  }
-
-  override func didAddSubview(_ subview: UIView) {
-    super.didAddSubview(subview)
-    resizeRenderingSubview(subview)
-  }
-
-  override func layoutSublayers(of layer: CALayer) {
-    super.layoutSublayers(of: layer)
-    guard layer === self.layer else { return }
-    resizeRenderingLayers()
-  }
-
-  override func didMoveToWindow() {
-    super.didMoveToWindow()
-    if window != nil {
-      publishDrawableIfReady()
-      setNeedsLayout()
-      layer.setNeedsLayout()
-    }
-  }
-
-  // The three VLCPictureInPictureDrawable methods below are invoked by
-  // libVLC from its vout thread, not the main actor, so they are
-  // `nonisolated`. Their bodies may only touch immutable-after-init
-  // `let` state of `Sendable` type (enforced by the compiler); any
-  // future mutable access must hop to the main actor or go through a
-  // lock.
-
-  /// Off-main contract: called from libVLC's vout thread. Reads only
-  /// the immutable `nativePiPBackend` reference and its immutable
-  /// `mediaController`.
-  @objc(mediaController)
-  nonisolated func mediaController() -> AnyObject {
-    nativePiPBackend.mediaController
-  }
-
-  /// Off-main contract: called from libVLC's vout thread. Builds a
-  /// block that hops to the main actor before touching the backend.
-  @objc(pictureInPictureReady)
-  nonisolated func pictureInPictureReady() -> IOSNativePictureInPictureReadyBlock {
-    { [weak nativePiPBackend] windowController in
-      // libVLC hands its freshly created PiP window controller across
-      // this nonisolated block; it is not used until the main-actor hop
-      // below, where all subsequent access stays.
-      nonisolated(unsafe) let windowController = windowController
-      Task { @MainActor in
-        nativePiPBackend?.handlePictureInPictureReady(windowController)
-      }
-    }
-  }
-
-  /// Off-main contract: called from libVLC's vout thread. Reads only
-  /// the immutable ``startsAutomaticallyFromInline`` flag.
-  @objc(canStartPictureInPictureAutomaticallyFromInline)
-  nonisolated func canStartPictureInPictureAutomaticallyFromInline() -> Bool {
-    startsAutomaticallyFromInline
-  }
-
-  private var hasDrawableBounds: Bool {
-    bounds.width > 0 && bounds.height > 0
-  }
-
-  private func publishDrawableIfReady() {
-    guard let player = attachedPlayer, player.isDrawableOwner(self) else { return }
-    if !player.isCurrentDrawable(self) {
-      player.setDrawable(self, owner: self)
-      resizeRenderingChildren()
-    }
-  }
-
-  private func resizeRenderingChildren() {
-    guard hasDrawableBounds else { return }
-    subviews.forEach(resizeRenderingSubview)
-    resizeRenderingLayers()
-  }
-
-  private func resizeRenderingSubview(_ subview: UIView) {
-    guard hasDrawableBounds else { return }
-    subview.frame = bounds
-    subview.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-    syncContentScale(to: subview)
-    subview.setNeedsLayout()
-    subview.layoutIfNeeded()
-    reshapeVLCSubviewIfNeeded(subview)
-  }
-
-  private func resizeRenderingLayers() {
-    guard hasDrawableBounds else { return }
-    layer.sublayers?.forEach { sublayer in
-      CATransaction.begin()
-      CATransaction.setDisableActions(true)
-      sublayer.frame = bounds
-      CATransaction.commit()
-    }
-  }
-
-  private func syncContentScale(to subview: UIView) {
-    let scale = window?.screen.scale
-      ?? subview.window?.screen.scale
-      ?? UIScreen.main.scale
-    subview.contentScaleFactor = scale
-    subview.layer.contentsScale = scale
-  }
-}
-
-@MainActor
-final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
-  let mediaController = IOSNativePiPMediaController()
-  weak var owner: PiPController? {
-    didSet { mediaController.owner = owner }
-  }
-
-  weak var hostView: IOSNativePiPHostView?
-  weak var drawableView: IOSNativePiPDrawableView?
-
-  private static var supportsNativePictureInPictureRendering: Bool {
-    #if targetEnvironment(simulator)
-    // The system can report active sample-buffer PiP while rendering a black window.
-    false
-    #else
-    true
-    #endif
-  }
-
-  private weak var windowController: NSObject?
-  private var avPictureInPictureController: AVPictureInPictureController?
-  private var possibleObservation: NSKeyValueObservation?
-  private var activeObservation: NSKeyValueObservation?
-  private var stateChangeEventHandler: IOSNativePiPStateChangeEventHandler?
-
-  private(set) var isPossible = false
-  private(set) var isActive = false
-  private var didWarnAboutVideoOutput = false
-
-  private static let logger = Logger(
-    subsystem: Signposts.subsystem,
-    category: "PictureInPicture"
-  )
-
-  func attach(to player: Player) {
-    mediaController.player = player
-    setPossible(false)
-    setActive(false)
-  }
-
-  func detach() {
-    stop()
-    clearWindowController()
-    mediaController.player = nil
-    setPossible(false)
-    setActive(false)
-  }
-
-  func handlePictureInPictureReady(_ controller: AnyObject) {
-    guard let controller = controller as? NSObject else { return }
-
-    clearWindowController()
-    guard Self.supportsNativePictureInPictureRendering else {
-      setPossible(false)
-      setActive(false)
-      return
-    }
-
-    windowController = controller
-    installStateChangeHandler(on: controller)
-    observeAVPictureInPictureController(on: controller)
-
-    if avPictureInPictureController == nil {
-      setPossible(true)
-    }
-  }
-
-  func start() {
-    guard isPossible, mediaController.player?.currentMedia != nil else {
-      warnIfVideoOutputBlocksPictureInPicture()
-      return
-    }
-    performWindowControllerAction(IOSNativePiPSelector.start)
-  }
-
-  /// One-time diagnostic for the common misconfiguration where a custom
-  /// ``VLCInstance`` forces a non-default video output (e.g. `--vout=gles2`
-  /// or `--no-video`): libVLC then never selects the sample-buffer display
-  /// PiP needs, the PiP-ready callback never fires, and ``isPossible``
-  /// stays `false` with no other signal.
-  private func warnIfVideoOutputBlocksPictureInPicture() {
-    guard !didWarnAboutVideoOutput else { return }
-    guard
-      let instance = mediaController.player?.instance,
-      !instance.usesPiPSafeDarwinDisplay
-    else { return }
-    didWarnAboutVideoOutput = true
-    Self.logger.warning(
-      """
-      Picture in Picture is unavailable: this VLCInstance's video-output \
-      arguments (e.g. --vout or --no-video) stop libVLC from selecting the \
-      sample-buffer display that native PiP requires. Use the default video \
-      output to enable PiP.
-      """
-    )
-  }
-
-  func stop() {
-    performWindowControllerAction(IOSNativePiPSelector.stop)
-  }
-
-  func invalidatePlaybackState() {
-    performWindowControllerAction(IOSNativePiPSelector.invalidatePlaybackState)
-  }
-
-  private func clearWindowController() {
-    if
-      let windowController,
-      windowController.responds(to: IOSNativePiPSelector.setStateChangeEventHandler) {
-      windowController.setValue(nil, forKey: "stateChangeEventHandler")
-    }
-    possibleObservation = nil
-    activeObservation = nil
-    avPictureInPictureController = nil
-    stateChangeEventHandler = nil
-    windowController = nil
-  }
-
-  private func installStateChangeHandler(on controller: NSObject) {
-    guard controller.responds(to: IOSNativePiPSelector.setStateChangeEventHandler) else { return }
-
-    let handler: IOSNativePiPStateChangeEventHandler = { [weak self] isStarted in
-      Task { @MainActor in
-        self?.setActive(isStarted)
-      }
-    }
-    stateChangeEventHandler = handler
-    controller.setValue(handler, forKey: "stateChangeEventHandler")
-  }
-
-  private func observeAVPictureInPictureController(on controller: NSObject) {
-    guard controller.responds(to: IOSNativePiPSelector.avPictureInPictureController) else { return }
-    guard let avController = controller.value(forKey: "avPipController") as? AVPictureInPictureController else { return }
-
-    avPictureInPictureController = avController
-    setPossible(avController.isPictureInPicturePossible)
-    setActive(avController.isPictureInPictureActive)
-
-    possibleObservation = avController.observe(
-      \.isPictureInPicturePossible,
-      options: [.initial, .new]
-    ) { [weak self] controller, _ in
-      let isPossible = controller.isPictureInPicturePossible
-      Task { @MainActor [weak self] in
-        self?.setPossible(isPossible)
-      }
-    }
-
-    activeObservation = avController.observe(
-      \.isPictureInPictureActive,
-      options: [.initial, .new]
-    ) { [weak self] controller, _ in
-      let isActive = controller.isPictureInPictureActive
-      Task { @MainActor [weak self] in
-        self?.setActive(isActive)
-      }
-    }
-  }
-
-  private func performWindowControllerAction(_ selector: Selector) {
-    guard let windowController, windowController.responds(to: selector) else { return }
-    _ = windowController.perform(selector)
-  }
-
-  func makeValidationProbe() -> NativePiPProbe {
-    let delegateSelectorNames = [
-      "pictureInPictureControllerWillStartPictureInPicture:",
-      "pictureInPictureControllerDidStartPictureInPicture:",
-      "pictureInPictureControllerDidStopPictureInPicture:",
-      "pictureInPictureController:failedToStartPictureInPictureWithError:",
-      "pictureInPictureController:restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:"
-    ]
-
-    let delegate = avPictureInPictureController?.delegate
-    var delegateResponds: [String: Bool] = [:]
-    if let delegate {
-      for name in delegateSelectorNames {
-        delegateResponds[name] = delegate.responds(to: Selector((name)))
-      }
-    }
-
-    return NativePiPProbe(
-      windowControllerClassName: windowController.map { NSStringFromClass(type(of: $0)) },
-      hasAVController: avPictureInPictureController != nil,
-      avDelegateClassName: delegate.flatMap { object_getClass($0) }.map { NSStringFromClass($0) },
-      delegateResponds: delegateResponds,
-      isPossible: isPossible,
-      isActive: isActive
-    )
-  }
-
-  private func setPossible(_ isPossible: Bool) {
-    guard self.isPossible != isPossible else { return }
-    self.isPossible = isPossible
-    Task { @MainActor [weak owner] in
-      owner?.handleNativePictureInPictureReady()
-    }
-  }
-
-  private func setActive(_ isActive: Bool) {
-    guard self.isActive != isActive else { return }
-    self.isActive = isActive
-    Task { @MainActor [weak owner] in
-      owner?.handleNativePictureInPictureActiveChanged(isActive)
-    }
-  }
-}
-
-final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling, @unchecked Sendable {
-  weak var player: Player?
-  weak var owner: PiPController?
-
-  @objc func play() {
-    Task { @MainActor [weak self] in
-      guard let self, let player else { return }
-      // A cold start after playback ended is not a resume — begin afresh.
-      if player.state == .idle || player.state == .stopped {
-        try? player.play()
-        return
-      }
-      // Otherwise route through the controller so the AVKit-transient pause
-      // debouncer and PiP playback-state reconciliation engage. Fall back to
-      // a direct resume when constructed without a controller (the public
-      // direct-`PiPController` usage path).
-      if let owner {
-        owner.handleNativePictureInPictureSetPlaying(true)
-      } else {
-        player.resume()
-      }
-    }
-  }
-
-  @objc func pause() {
-    Task { @MainActor [weak self] in
-      guard let self else { return }
-      if let owner {
-        owner.handleNativePictureInPictureSetPlaying(false)
-      } else {
-        player?.pause()
-      }
-    }
-  }
-
-  @objc(seekBy:completion:)
-  func seek(by offset: Int64, completion: (() -> Void)?) {
-    nonisolated(unsafe) let completion = completion
-    Task { @MainActor [weak self] in
-      guard let player = self?.player else {
-        completion?()
-        return
-      }
-
-      let duration = player.duration?.milliseconds ?? Int64.max
-      let target = max(0, min(player.currentTime.milliseconds + offset, duration))
-      try? player.seek(to: .milliseconds(target))
-      completion?()
-    }
-  }
-
-  @objc func mediaLength() -> Int64 {
-    pipMainActorSync { [weak self] in
-      guard let player = self?.player else { return -1 }
-      let length = libvlc_media_player_get_length(player.pointer)
-      return length > 0 ? length : -1
-    }
-  }
-
-  @objc func mediaTime() -> Int64 {
-    pipMainActorSync { [weak self] in
-      guard let player = self?.player else { return 0 }
-      return max(libvlc_media_player_get_time(player.pointer), 0)
-    }
-  }
-
-  @objc func isMediaSeekable() -> Bool {
-    pipMainActorSync { [weak self] in
-      guard let player = self?.player else { return false }
-      return libvlc_media_player_is_seekable(player.pointer)
-    }
-  }
-
-  @objc func isMediaPlaying() -> Bool {
-    pipMainActorSync { [weak self] in
-      guard let player = self?.player else { return false }
-      return player.isPlaybackRequestedActive
-    }
-  }
-}
-
-private enum IOSNativePiPSelector {
-  static let start = NSSelectorFromString("startPictureInPicture")
-  static let stop = NSSelectorFromString("stopPictureInPicture")
-  static let invalidatePlaybackState = NSSelectorFromString("invalidatePlaybackState")
-  static let setStateChangeEventHandler = NSSelectorFromString("setStateChangeEventHandler:")
-  static let avPictureInPictureController = NSSelectorFromString("avPipController")
-}
-
-private let vlcUIViewReshapeSelector = NSSelectorFromString("reshape")
-
-@MainActor
-private func reshapeVLCSubviewIfNeeded(_ subview: UIView) {
-  guard
-    subview.responds(to: vlcUIViewReshapeSelector),
-    subview.bounds.width > 0,
-    subview.bounds.height > 0
-  else { return }
-  _ = subview.perform(vlcUIViewReshapeSelector)
 }
 
 #elseif os(macOS)
@@ -749,7 +223,6 @@ public struct PiPVideoView: NSViewRepresentable {
   public func updateNSView(_ nsView: NSView, context: Context) {
     guard let container = nsView as? MacNativePiPHostView else { return }
     if context.coordinator.player !== player {
-      container.detach()
       container.attach(to: player)
 
       let controller = PiPController(
@@ -773,10 +246,7 @@ public struct PiPVideoView: NSViewRepresentable {
       coordinator.pipController?.stop()
     }
     coordinator.pipController = nil
-    if let binding = coordinator.controllerBinding {
-      Task { @MainActor in binding.wrappedValue = nil }
-      coordinator.controllerBinding = nil
-    }
+    coordinator.clearControllerBinding()
   }
 
   public func makeCoordinator() -> Coordinator {
@@ -791,16 +261,31 @@ public struct PiPVideoView: NSViewRepresentable {
   public final class Coordinator {
     weak var player: Player?
     var pipController: PiPController?
-    var controllerBinding: Binding<PiPController?>?
+    private let bindingPublication = PiPControllerBindingPublication()
+
+    var controllerBinding: Binding<PiPController?>? {
+      bindingPublication.currentBinding
+    }
+
+    func publishController(
+      _ controller: PiPController?,
+      to binding: Binding<PiPController?>?
+    ) {
+      bindingPublication.publish(controller, to: binding)
+    }
+
+    func clearControllerBinding() {
+      bindingPublication.clear()
+    }
+
+    func waitForControllerBindingPublication() async {
+      await bindingPublication.waitForPendingPublication()
+    }
   }
 
   @MainActor
   private func pushControllerBinding(_ controller: PiPController?, via coordinator: Coordinator) {
-    let binding = controllerBinding
-    coordinator.controllerBinding = binding
-    Task { @MainActor in
-      binding?.wrappedValue = controller
-    }
+    coordinator.publishController(controller, to: controllerBinding)
   }
 }
 
@@ -808,20 +293,21 @@ public struct PiPVideoView: NSViewRepresentable {
 /// Keeping those responsibilities separate avoids AppKit's unsupported
 /// "add PiP internals directly under NSHostingController.view" path.
 final class MacNativePiPHostView: NSView {
-  let drawableView = MacNativePiPDrawableView()
+  private(set) var drawableView: MacNativePiPDrawableView
 
   var nativePiPBackend: MacNativePiPBackend {
     drawableView.nativePiPBackend
   }
 
   override init(frame frameRect: NSRect) {
+    drawableView = MacNativePiPDrawableView()
     super.init(frame: frameRect)
     wantsLayer = true
     autoresizesSubviews = true
     layer?.backgroundColor = NSColor.black.cgColor
     layer?.masksToBounds = true
 
-    nativePiPBackend.hostView = self
+    nativePiPBackend.adopt(hostView: self, drawableView: drawableView)
     drawableView.frame = bounds
     drawableView.autoresizingMask = [.width, .height]
     addSubview(drawableView)
@@ -833,14 +319,56 @@ final class MacNativePiPHostView: NSView {
   }
 
   func attach(to player: Player) {
-    drawableView.attach(to: player)
+    // A representable can be updated to a different Player in place. Fully
+    // retire that Player's attachment while this host still owns the claim;
+    // its open vout keeps the exact old drawable alive through Player's
+    // native-handle retirement list, while the new Player gets an isolated
+    // drawable/backend pair.
+    if
+      let attachedPlayer = drawableView.attachedPlayer,
+      attachedPlayer !== player {
+      _ = drawableView.detach(
+        owner: self,
+        preservingActiveAttachment: false
+      )
+      install(MacNativePiPDrawableView())
+    }
+
+    // Pinned libVLC's macOS vout captures `drawable-nsobject` into the
+    // strong `sys->container` exactly once at vout open. A same-Player
+    // SwiftUI recreation must therefore adopt and move this exact drawable
+    // together with its backend; assigning a new NSView cannot redirect the
+    // already-open vout.
+    if
+      let currentDrawable = player.drawable as? MacNativePiPDrawableView,
+      currentDrawable.isAttachment(for: player) {
+      install(currentDrawable)
+    }
+
+    // `detach()` clears a fully retired backend's weak presentation target.
+    // Re-adopting here also makes reuse of the same no-vout host complete.
+    install(drawableView)
+    if !drawableView.attach(to: player, owner: self) {
+      // A stale host can still reference a drawable already claimed by a
+      // successor. Never repurpose that shared attachment for another
+      // Player; give this host a fresh, isolated surface instead.
+      install(MacNativePiPDrawableView())
+      _ = drawableView.attach(to: player, owner: self)
+    }
   }
 
   func detach() {
-    drawableView.detach()
+    _ = drawableView.detach(owner: self)
+    if drawableView.superview === self {
+      drawableView.removeFromSuperview()
+    }
   }
 
   func restoreDrawableView(_ drawableView: MacNativePiPDrawableView) {
+    // A closing presenter from a retired Player must not overwrite a host
+    // that has since installed a different Player's drawable.
+    guard self.drawableView === drawableView else { return }
+
     if drawableView.superview !== self {
       drawableView.removeFromSuperview()
       addSubview(drawableView)
@@ -860,6 +388,28 @@ final class MacNativePiPHostView: NSView {
     }
   }
 
+  private func install(_ drawableView: MacNativePiPDrawableView) {
+    if self.drawableView !== drawableView {
+      self.drawableView.nativePiPBackend.relinquish(
+        hostView: self,
+        drawableView: self.drawableView
+      )
+      if self.drawableView.superview === self {
+        self.drawableView.removeFromSuperview()
+      }
+      self.drawableView = drawableView
+    }
+
+    let backend = drawableView.nativePiPBackend
+    backend.adopt(hostView: self, drawableView: drawableView)
+    // During active private PiP the presenter owns the drawable's view
+    // hierarchy. Updating its restoration target is enough; pulling the
+    // drawable inline here would tear it out of the floating window.
+    if !backend.isActive {
+      restoreDrawableView(drawableView)
+    }
+  }
+
   override func layout() {
     super.layout()
     guard drawableView.superview === self else { return }
@@ -872,7 +422,8 @@ final class MacNativePiPHostView: NSView {
 
 final class MacNativePiPDrawableView: NSView {
   let nativePiPBackend = MacNativePiPBackend()
-  private weak var attachedPlayer: Player?
+  private(set) weak var attachedPlayer: Player?
+  private weak var attachmentOwner: AnyObject?
   private var lastBounds: CGRect = .zero
 
   init() {
@@ -890,20 +441,84 @@ final class MacNativePiPDrawableView: NSView {
   }
 
   func attach(to player: Player) {
-    guard attachedPlayer !== player else { return }
-    attachedPlayer?.releaseDrawableOwnership(self)
-    attachedPlayer = player
-    nativePiPBackend.attach(to: player)
-    player.claimDrawableOwnership(self)
-    player.setDrawable(self, owner: self)
+    _ = attach(to: player, owner: self)
   }
 
   func detach() {
-    guard let player = attachedPlayer else { return }
-    player.releaseDrawableOwnership(self)
+    _ = detach(owner: self)
+  }
+
+  func isAttachment(for player: Player) -> Bool {
+    attachedPlayer === player
+      && nativePiPBackend.mediaController.player === player
+  }
+
+  @discardableResult
+  func attach(to player: Player, owner: AnyObject) -> Bool {
+    if
+      let attachedPlayer,
+      attachedPlayer !== player,
+      !detach(owner: owner, preservingActiveAttachment: false) {
+      return false
+    }
+
+    if attachedPlayer !== player {
+      attachedPlayer = player
+      nativePiPBackend.attach(to: player)
+    }
+    nativePiPBackend.drawableView = self
+    attachmentOwner = owner
+    player.claimDrawableOwnership(owner)
+    if !player.isCurrentDrawable(self) {
+      player.setDrawable(self, owner: owner)
+    }
+    return true
+  }
+
+  @discardableResult
+  func detach(
+    owner: AnyObject,
+    preservingActiveAttachment: Bool = true
+  ) -> Bool {
+    guard let player = attachedPlayer else { return true }
+
+    // A successor host can already have adopted this same drawable/backend.
+    // Its host claim wins; stale teardown must be a complete no-op.
+    guard player.isDrawableOwner(owner) else { return false }
+
+    if preservingActiveAttachment, mustPreserveAttachment(for: player) {
+      // Keep `Player.drawable` unchanged as the O(1) handoff lease. The host
+      // removes only its own inline parent; an active PiP presenter is left
+      // untouched and receives the successor host through backend adoption.
+      player.releaseDrawableOwnership(owner)
+      attachmentOwner = nil
+      return true
+    }
+
+    player.releaseDrawableOwnership(owner)
+    player.clearDrawable(ifCurrent: self)
     nativePiPBackend.detach()
     attachedPlayer = nil
+    attachmentOwner = nil
     lastBounds = .zero
+    return true
+  }
+
+  private func mustPreserveAttachment(for player: Player) -> Bool {
+    if
+      player.nativePlayerHasStartedPlayback
+      || player.nativePlayerNeedsReplacementBeforePlayback
+      || player.attachedMediaListPlayer != nil
+      || player.activeVideoOutputs > 0 {
+      return true
+    }
+
+    switch player.nativePlaybackState {
+    case .idle, .stopped, .error:
+      return false
+    case .opening, .buffering, .playing, .paused, .stopping:
+      return true
+    }
   }
 
   @objc(addVoutSubview:)
@@ -933,12 +548,13 @@ final class MacNativePiPDrawableView: NSView {
 
     if
       let player = attachedPlayer,
-      player.isDrawableOwner(self),
+      let attachmentOwner,
+      player.isDrawableOwner(attachmentOwner),
       !player.isCurrentDrawable(self),
       lastBounds == .zero,
       bounds.width > 0,
       bounds.height > 0 {
-      player.setDrawable(self, owner: self)
+      player.setDrawable(self, owner: attachmentOwner)
     }
     if bounds.width > 0, bounds.height > 0 {
       lastBounds = bounds

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer+Enqueue.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer+Enqueue.swift
@@ -1,0 +1,146 @@
+#if os(iOS) || os(macOS)
+import AVFoundation
+import CoreMedia
+import Foundation
+import Synchronization
+
+/// Carries media objects onto the serial enqueue queue. Pending ownership is
+/// held by one replaceable slot, never by one closure per decoded frame.
+struct EnqueuedSampleBuffer: @unchecked Sendable {
+  let layer: AVSampleBufferDisplayLayer
+  let sample: CMSampleBuffer
+  let generation: UInt64
+}
+
+struct PixelBufferEnqueueState: @unchecked Sendable {
+  var pending: EnqueuedSampleBuffer?
+  var isDrainScheduled = false
+  var scheduledDrainCount: UInt64 = 0
+  var drainedSampleCount: UInt64 = 0
+  var replacementCount: UInt64 = 0
+}
+
+struct PixelBufferEnqueueSnapshot: Equatable {
+  let pendingCount: Int
+  let isDrainScheduled: Bool
+  let scheduledDrainCount: UInt64
+  let drainedSampleCount: UInt64
+  let replacementCount: UInt64
+}
+
+/// Injectable display-layer operations make queue saturation, backpressure,
+/// flush, and delivery ordering deterministic in tests.
+struct PixelBufferDisplayLayerAPI: @unchecked Sendable {
+  let status: (AVSampleBufferDisplayLayer) -> AVQueuedSampleBufferRenderingStatus
+  let requiresFlush: (AVSampleBufferDisplayLayer) -> Bool
+  let flush: (AVSampleBufferDisplayLayer) -> Void
+  let isReadyForMoreMediaData: (AVSampleBufferDisplayLayer) -> Bool
+  let enqueue: (AVSampleBufferDisplayLayer, CMSampleBuffer) -> Void
+
+  static var live: Self {
+    Self(
+      status: { $0.sampleBufferRenderer.status },
+      requiresFlush: { $0.sampleBufferRenderer.requiresFlushToResumeDecoding },
+      flush: { $0.sampleBufferRenderer.flush() },
+      isReadyForMoreMediaData: { $0.sampleBufferRenderer.isReadyForMoreMediaData },
+      enqueue: { $0.sampleBufferRenderer.enqueue($1) }
+    )
+  }
+}
+
+extension PixelBufferRenderer {
+  func canEnqueueFrame(generation: UInt64, on layer: AVSampleBufferDisplayLayer) -> Bool {
+    state.withLock {
+      $0.renderGeneration == generation && $0.displayLayer.layer === layer
+    }
+  }
+
+  /// Replaces the one pending frame with the newest frame. At most one drain
+  /// closure exists; it captures only the renderer, so a suspended queue owns
+  /// O(1) samples regardless of decode rate or suspension duration.
+  func enqueue(
+    _ sample: CMSampleBuffer,
+    generation: UInt64,
+    on layer: AVSampleBufferDisplayLayer
+  ) {
+    let pending = EnqueuedSampleBuffer(
+      layer: layer,
+      sample: sample,
+      generation: generation
+    )
+    let shouldSchedule = enqueueState.withLock { state -> Bool in
+      if state.pending != nil {
+        state.replacementCount &+= 1
+      }
+      state.pending = pending
+      guard !state.isDrainScheduled else { return false }
+      state.isDrainScheduled = true
+      state.scheduledDrainCount &+= 1
+      return true
+    }
+
+    guard shouldSchedule else { return }
+    enqueueQueue.async { [self] in
+      drainPendingSamples()
+    }
+  }
+
+  var enqueueSnapshotForTesting: PixelBufferEnqueueSnapshot {
+    enqueueState.withLock {
+      PixelBufferEnqueueSnapshot(
+        pendingCount: $0.pending == nil ? 0 : 1,
+        isDrainScheduled: $0.isDrainScheduled,
+        scheduledDrainCount: $0.scheduledDrainCount,
+        drainedSampleCount: $0.drainedSampleCount,
+        replacementCount: $0.replacementCount
+      )
+    }
+  }
+
+  private func drainPendingSamples() {
+    while let pending = takePendingSampleOrFinishDrain() {
+      processPendingSample(pending)
+    }
+  }
+
+  /// Clearing `isDrainScheduled` and observing an empty slot happen under the
+  /// same mutex used by producers. A producer therefore either populates the
+  /// slot before this check or observes the cleared flag and schedules the
+  /// successor drain; there is no lost-wakeup window.
+  private func takePendingSampleOrFinishDrain() -> EnqueuedSampleBuffer? {
+    enqueueState.withLock { state in
+      guard let pending = state.pending else {
+        state.isDrainScheduled = false
+        return nil
+      }
+      state.pending = nil
+      state.drainedSampleCount &+= 1
+      return pending
+    }
+  }
+
+  private func processPendingSample(_ pending: EnqueuedSampleBuffer) {
+    guard canEnqueueFrame(generation: pending.generation, on: pending.layer) else { return }
+
+    let shouldFlush = displayLayerAPI.status(pending.layer) == .failed
+      || displayLayerAPI.requiresFlush(pending.layer)
+    if shouldFlush {
+      guard canEnqueueFrame(generation: pending.generation, on: pending.layer) else { return }
+      displayLayerAPI.flush(pending.layer)
+    }
+
+    guard displayLayerAPI.isReadyForMoreMediaData(pending.layer) else { return }
+
+    // The final validation and enqueue share one state-lock linearization
+    // point. A generation/layer mutation either happens first and rejects this
+    // sample, or happens after this enqueue; stale work cannot cross it.
+    state.withLock { state in
+      guard
+        state.renderGeneration == pending.generation,
+        state.displayLayer.layer === pending.layer
+      else { return }
+      displayLayerAPI.enqueue(pending.layer, pending.sample)
+    }
+  }
+}
+#endif

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer+FormatCallback.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer+FormatCallback.swift
@@ -1,0 +1,157 @@
+#if os(iOS) || os(macOS)
+import CLibVLC
+import CoreVideo
+import Foundation
+import Synchronization
+
+/// Compatibility callback for released libVLC binaries. Its ABI exposes only
+/// delivery dimensions, so it cannot prove nonzero crop offsets or residual
+/// pixel aspect ratio. Patched binaries use ``pixelBufferFormatCallbackEx``.
+func pixelBufferFormatCallback(
+  opaque: UnsafeMutablePointer<UnsafeMutableRawPointer?>?,
+  chroma: UnsafeMutablePointer<CChar>?,
+  width: UnsafeMutablePointer<UInt32>?,
+  height: UnsafeMutablePointer<UInt32>?,
+  pitches: UnsafeMutablePointer<UInt32>?,
+  lines: UnsafeMutablePointer<UInt32>?
+) -> UInt32 {
+  guard
+    let width,
+    let height
+  else { return 0 }
+  let geometry = PixelBufferSourceGeometry(
+    fullFrameWidth: width.pointee,
+    height: height.pointee
+  )
+  return configurePixelBufferFormat(
+    opaque: opaque,
+    chroma: chroma,
+    sourceGeometry: geometry,
+    deliveryWidth: width.pointee,
+    deliveryHeight: height.pointee,
+    pitches: pitches,
+    lines: lines
+  )
+}
+
+/// Geometry-aware callback used by the patched pinned libVLC. It copies the
+/// single C geometry snapshot immediately, chooses an exact square-pixel
+/// output, and rejects formats that cannot be normalized without approximation.
+func pixelBufferFormatCallbackEx(
+  opaque: UnsafeMutablePointer<UnsafeMutableRawPointer?>?,
+  chroma: UnsafeMutablePointer<CChar>?,
+  sourceGeometry: UnsafePointer<swiftvlc_video_format_geometry_t>?,
+  outputWidth: UnsafeMutablePointer<UInt32>?,
+  outputHeight: UnsafeMutablePointer<UInt32>?,
+  pitches: UnsafeMutablePointer<UInt32>?,
+  lines: UnsafeMutablePointer<UInt32>?
+) -> UInt32 {
+  guard
+    let sourceGeometry,
+    let outputWidth,
+    let outputHeight
+  else { return 0 }
+
+  let geometry = PixelBufferSourceGeometry(sourceGeometry.pointee)
+  guard let delivery = geometry.squarePixelDeliveryDimensions else { return 0 }
+  outputWidth.pointee = delivery.width
+  outputHeight.pointee = delivery.height
+
+  return configurePixelBufferFormat(
+    opaque: opaque,
+    chroma: chroma,
+    sourceGeometry: geometry,
+    deliveryWidth: delivery.width,
+    deliveryHeight: delivery.height,
+    pitches: pitches,
+    lines: lines
+  )
+}
+
+private func configurePixelBufferFormat(
+  opaque: UnsafeMutablePointer<UnsafeMutableRawPointer?>?,
+  chroma: UnsafeMutablePointer<CChar>?,
+  sourceGeometry: PixelBufferSourceGeometry,
+  deliveryWidth: UInt32,
+  deliveryHeight: UInt32,
+  pitches: UnsafeMutablePointer<UInt32>?,
+  lines: UnsafeMutablePointer<UInt32>?
+) -> UInt32 {
+  guard
+    let opaque,
+    let chroma,
+    let pitches,
+    let lines,
+    sourceGeometry.isValid,
+    deliveryWidth > 0,
+    deliveryHeight > 0,
+    let handleOpaque = opaque.pointee,
+    let handleContext = pixelBufferHandleCallbackContext(from: handleOpaque)
+  else { return 0 }
+
+  let width = Int(deliveryWidth)
+  let height = Int(deliveryHeight)
+
+  // BGRA makes the vmem converter physically crop, orient and square-pixel
+  // normalize into the exact one-plane Core Video surface requested above.
+  let bgra: (CChar, CChar, CChar, CChar) = (0x42, 0x47, 0x52, 0x41)
+  chroma[0] = bgra.0
+  chroma[1] = bgra.1
+  chroma[2] = bgra.2
+  chroma[3] = bgra.3
+
+  let poolAttributes: [String: Any] = [
+    kCVPixelBufferPoolMinimumBufferCountKey as String:
+      pixelBufferRendererPoolMinimumBufferCount(width: width, height: height)
+  ]
+  let pixelBufferAttributes: [String: Any] = [
+    kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+    kCVPixelBufferWidthKey as String: width,
+    kCVPixelBufferHeightKey as String: height,
+    kCVPixelBufferIOSurfacePropertiesKey as String: [:] as [String: Any],
+    kCVPixelBufferCGImageCompatibilityKey as String: true,
+    kCVPixelBufferCGBitmapContextCompatibilityKey as String: true
+  ]
+
+  var newPool: CVPixelBufferPool?
+  let status = CVPixelBufferPoolCreate(
+    kCFAllocatorDefault,
+    poolAttributes as CFDictionary,
+    pixelBufferAttributes as CFDictionary,
+    &newPool
+  )
+  guard status == kCVReturnSuccess, let pool = newPool else { return 0 }
+
+  let testAllocation = pixelBufferRendererAllocatePixelBuffer(
+    from: pool,
+    width: width,
+    height: height
+  )
+  guard
+    testAllocation.status == kCVReturnSuccess,
+    let testBuffer = testAllocation.buffer
+  else { return 0 }
+  let actualPitch = CVPixelBufferGetBytesPerRow(testBuffer)
+  guard actualPitch <= Int(UInt32.max) else { return 0 }
+
+  pitches.pointee = UInt32(actualPitch)
+  lines.pointee = deliveryHeight
+
+  let decodeRenderer = PixelBufferRenderer()
+  decodeRenderer.state.withLock {
+    $0.pool = pool
+    $0.width = width
+    $0.height = height
+  }
+  guard
+    let voutContext = handleContext.makeVoutContext(
+      handleOpaque: handleOpaque,
+      decodeRenderer: decodeRenderer,
+      sourceGeometry: sourceGeometry
+    )
+  else { return 0 }
+
+  opaque.pointee = Unmanaged.passRetained(voutContext).toOpaque()
+  return pixelBufferRendererFormatSuccessCount
+}
+#endif

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer+FormatDescription.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer+FormatDescription.swift
@@ -1,0 +1,52 @@
+#if os(iOS) || os(macOS)
+import CoreMedia
+import CoreVideo
+import Foundation
+import Synchronization
+
+extension PixelBufferRenderer {
+  /// Returns a description valid for this exact output generation and image
+  /// buffer format. Core Media's match operation covers dimensions, pixel
+  /// format, bytes-per-row, and every format attachment common to image
+  /// buffers (including clean aperture, pixel aspect ratio, color metadata,
+  /// and HDR metadata). A stale generation is rejected instead of being
+  /// allowed to replace the current generation's cache entry.
+  func formatDescription(
+    for imageBuffer: CVImageBuffer,
+    generation: UInt64
+  ) -> CMVideoFormatDescription? {
+    state.withLock { state in
+      guard state.renderGeneration == generation else { return nil }
+
+      if
+        let cached = state.cachedFormatDescription,
+        cached.generation == generation,
+        CMVideoFormatDescriptionMatchesImageBuffer(
+          cached.description,
+          imageBuffer: imageBuffer
+        ) {
+        return cached.description
+      }
+
+      // Never leave an incompatible description installed if replacement
+      // creation fails. The next valid frame can retry from an empty cache.
+      state.cachedFormatDescription = nil
+
+      var description: CMVideoFormatDescription?
+      let status = CMVideoFormatDescriptionCreateForImageBuffer(
+        allocator: kCFAllocatorDefault,
+        imageBuffer: imageBuffer,
+        formatDescriptionOut: &description
+      )
+      guard status == noErr, let description else { return nil }
+
+      state.cachedFormatDescription = State.CachedFormatDescription(
+        generation: generation,
+        description: description
+      )
+      state.formatDescriptionCreationCount &+= 1
+      return description
+    }
+  }
+}
+#endif

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer+Geometry.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer+Geometry.swift
@@ -1,0 +1,120 @@
+#if os(iOS) || os(macOS)
+import CLibVLC
+import Foundation
+
+/// One atomic post-rotation vmem source geometry snapshot. The orientation is
+/// the original pre-rotation source value retained only for diagnostics; all
+/// dimensions, crop offsets and SAR describe the normalized post-rotation
+/// coordinate space delivered to the extended callback.
+struct PixelBufferSourceGeometry: Equatable, Sendable {
+  let codedWidth: UInt32
+  let codedHeight: UInt32
+  let visibleWidth: UInt32
+  let visibleHeight: UInt32
+  let xOffset: UInt32
+  let yOffset: UInt32
+  let sarNumerator: UInt32
+  let sarDenominator: UInt32
+  let sourceOrientationRawValue: UInt32
+
+  init(_ geometry: swiftvlc_video_format_geometry_t) {
+    codedWidth = geometry.coded_width
+    codedHeight = geometry.coded_height
+    visibleWidth = geometry.visible_width
+    visibleHeight = geometry.visible_height
+    xOffset = geometry.x_offset
+    yOffset = geometry.y_offset
+    sarNumerator = geometry.sar_num
+    sarDenominator = geometry.sar_den
+    sourceOrientationRawValue = geometry.source_orientation
+  }
+
+  init(fullFrameWidth width: UInt32, height: UInt32) {
+    codedWidth = width
+    codedHeight = height
+    visibleWidth = width
+    visibleHeight = height
+    xOffset = 0
+    yOffset = 0
+    sarNumerator = 1
+    sarDenominator = 1
+    sourceOrientationRawValue = 0
+  }
+
+  var isValid: Bool {
+    guard
+      codedWidth > 0,
+      codedHeight > 0,
+      visibleWidth > 0,
+      visibleHeight > 0,
+      xOffset <= codedWidth,
+      visibleWidth <= codedWidth - xOffset,
+      yOffset <= codedHeight,
+      visibleHeight <= codedHeight - yOffset,
+      sarNumerator > 0,
+      sarDenominator > 0
+    else { return false }
+    return sourceOrientationRawValue <= 7
+  }
+
+  /// Chooses an exact square-pixel delivery size without approximating PAR.
+  /// Prefer expanding the affected axis so visible source resolution is not
+  /// discarded. If that quotient is non-integral, the reciprocal contraction
+  /// is accepted only when it is exact; otherwise setup fails closed.
+  var squarePixelDeliveryDimensions: (width: UInt32, height: UInt32)? {
+    guard isValid else { return nil }
+    if sarNumerator == sarDenominator {
+      return (visibleWidth, visibleHeight)
+    }
+
+    if sarNumerator > sarDenominator {
+      if
+        let width = exactScale(
+          visibleWidth,
+          multiplier: sarNumerator,
+          divisor: sarDenominator
+        ) {
+        return (width, visibleHeight)
+      }
+      if
+        let height = exactScale(
+          visibleHeight,
+          multiplier: sarDenominator,
+          divisor: sarNumerator
+        ) {
+        return (visibleWidth, height)
+      }
+    } else {
+      if
+        let height = exactScale(
+          visibleHeight,
+          multiplier: sarDenominator,
+          divisor: sarNumerator
+        ) {
+        return (visibleWidth, height)
+      }
+      if
+        let width = exactScale(
+          visibleWidth,
+          multiplier: sarNumerator,
+          divisor: sarDenominator
+        ) {
+        return (width, visibleHeight)
+      }
+    }
+    return nil
+  }
+
+  private func exactScale(
+    _ value: UInt32,
+    multiplier: UInt32,
+    divisor: UInt32
+  ) -> UInt32? {
+    let product = UInt64(value) * UInt64(multiplier)
+    guard product.isMultiple(of: UInt64(divisor)) else { return nil }
+    let quotient = product / UInt64(divisor)
+    guard quotient > 0, quotient <= UInt64(UInt32.max) else { return nil }
+    return UInt32(quotient)
+  }
+}
+#endif

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer+Pool.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer+Pool.swift
@@ -1,0 +1,86 @@
+#if os(iOS) || os(macOS)
+import CoreVideo
+import Foundation
+
+/// Pinned VLC treats the format callback's return as a success/failure count:
+/// zero rejects the vout and any positive value accepts it. SwiftVLC proves one
+/// buffer allocation while negotiating the pool, so report that one allocation
+/// instead of claiming decode headroom the pinned vmem module does not use.
+let pixelBufferRendererFormatSuccessCount: UInt32 = 1
+
+/// Upper bound for the recycled pool floor on small frames. This affects only
+/// Core Video's resident reuse policy; it is independent of the format
+/// callback's success count above.
+let pixelBufferRendererPoolMaximumBufferCount = 12
+
+/// Soft cap on the bytes a single `CVPixelBufferPool` keeps resident as
+/// its recycled floor. This governs how many *returned* buffers the pool
+/// retains; pinned vmem does not derive decoder headroom from setup's count.
+/// Without it, a 4K BGRA pool with a 12-buffer floor pins ~380 MiB even
+/// when idle. ~96 MiB keeps HD/SD generously buffered while letting 4K
+/// drain its recycled buffers.
+let pixelBufferRendererPoolMaximumResidentBytes = 96 * 1024 * 1024
+
+private final class PixelBufferPoolAuxiliaryAttributes: @unchecked Sendable {
+  let dictionary: CFDictionary
+
+  init(allocationThreshold: Int) {
+    dictionary = [
+      kCVPixelBufferPoolAllocationThresholdKey as String: allocationThreshold
+    ] as CFDictionary
+  }
+}
+
+/// Thresholds are constrained to 3...12. Build each immutable auxiliary
+/// dictionary once so the per-frame allocation guard does not itself allocate
+/// a Swift dictionary on the decode hot path.
+private let pixelBufferRendererPoolAuxiliaryAttributes = (3...12).map {
+  PixelBufferPoolAuxiliaryAttributes(allocationThreshold: $0)
+}
+
+/// Byte-budgeted resident floor for a BGRA pool of the given dimensions.
+/// Frames for which a three-buffer floor would exceed the complete resident
+/// budget use a floor of one; smaller frames keep the 3...12 range.
+func pixelBufferRendererPoolMinimumBufferCount(width: Int, height: Int) -> Int {
+  let (pixelCount, pixelCountOverflow) = max(1, width).multipliedReportingOverflow(
+    by: max(1, height)
+  )
+  guard !pixelCountOverflow else { return 1 }
+  let (bytesPerBuffer, byteCountOverflow) = pixelCount.multipliedReportingOverflow(by: 4)
+  guard !byteCountOverflow else { return 1 }
+
+  let threeBufferThreshold = pixelBufferRendererPoolMaximumResidentBytes / 3
+  if bytesPerBuffer > threeBufferThreshold {
+    return 1
+  }
+
+  let budgeted = pixelBufferRendererPoolMaximumResidentBytes / bytesPerBuffer
+  return max(3, min(pixelBufferRendererPoolMaximumBufferCount, budgeted))
+}
+
+/// Hard upper bound for buffers allocated from one pool. Three is the minimum
+/// safe pipeline shape (one being produced, one pending, one processing), and
+/// the threshold never undercuts the configured recycled pool floor.
+func pixelBufferRendererPoolAllocationThreshold(width: Int, height: Int) -> Int {
+  max(3, pixelBufferRendererPoolMinimumBufferCount(width: width, height: height))
+}
+
+/// Allocates with an explicit threshold so a stalled display layer cannot turn
+/// either the decode pool or resize pool into an unbounded memory queue.
+func pixelBufferRendererAllocatePixelBuffer(
+  from pool: CVPixelBufferPool,
+  width: Int,
+  height: Int
+) -> (status: CVReturn, buffer: CVPixelBuffer?) {
+  let threshold = pixelBufferRendererPoolAllocationThreshold(width: width, height: height)
+  let auxiliaryAttributes = pixelBufferRendererPoolAuxiliaryAttributes[threshold - 3]
+  var buffer: CVPixelBuffer?
+  let status = CVPixelBufferPoolCreatePixelBufferWithAuxAttributes(
+    kCFAllocatorDefault,
+    pool,
+    auxiliaryAttributes.dictionary,
+    &buffer
+  )
+  return (status, buffer)
+}
+#endif

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer.swift
@@ -4,44 +4,16 @@ import CLibVLC
 import CoreImage
 import CoreMedia
 import CoreVideo
-import Darwin
 import Foundation
 import os
 import Synchronization
 
-/// Number of in-flight pictures libVLC's vmem output allocates, returned
-/// from the format callback. Higher gives the decoder more headroom and
-/// smoother playback; it is the dominant driver of peak in-flight memory.
-private let pixelBufferRendererPictureBufferCount: UInt32 = 12
-
-/// Soft cap on the bytes a single `CVPixelBufferPool` keeps resident as
-/// its recycled floor. Decode headroom (above) governs peak in-flight
-/// memory; this governs how many *returned* buffers the pool retains.
-/// Without it, a 4K BGRA pool with a 12-buffer floor pins ~380 MiB even
-/// when idle. ~96 MiB keeps HD/SD generously buffered while letting 4K
-/// drain its recycled buffers.
-private let pixelBufferRendererPoolMaximumResidentBytes = 96 * 1024 * 1024
-
-/// Byte-budgeted resident floor for a BGRA pool of the given dimensions:
-/// at most the picture count, at least 3, capped by the resident budget.
-/// Decoupled from `pixelBufferRendererPictureBufferCount` so smoothness
-/// (decode headroom) and idle memory footprint can be tuned independently.
-private func pixelBufferRendererPoolMinimumBufferCount(width: Int, height: Int) -> Int {
-  let bytesPerBuffer = max(1, width * height * 4)
-  let budgeted = pixelBufferRendererPoolMaximumResidentBytes / bytesPerBuffer
-  return max(3, min(Int(pixelBufferRendererPictureBufferCount), budgeted))
-}
-
-/// Carries media objects onto the serial enqueue queue. The queue only reads
-/// these references; ownership is transferred to the layer when enqueued.
-private final class EnqueuedSampleBuffer: @unchecked Sendable {
-  let layer: AVSampleBufferDisplayLayer
-  let sample: CMSampleBuffer
-
-  init(layer: AVSampleBufferDisplayLayer, sample: CMSampleBuffer) {
-    self.layer = layer
-    self.sample = sample
-  }
+/// Core Image objects shared by every scaled frame produced by one renderer.
+/// Kept in a reference type so tests can verify identity reuse and `State`
+/// copies never duplicate resource ownership.
+final class PixelBufferScalingResources: @unchecked Sendable {
+  let context = CIContext(options: [.cacheIntermediates: false])
+  let colorSpace = CGColorSpaceCreateDeviceRGB()
 }
 
 /// Renders libVLC video frames into `CVPixelBuffer`s via vmem callbacks,
@@ -54,6 +26,11 @@ final class PixelBufferRenderer: Sendable {
   /// Sendable conformance. Thread safety is guaranteed by the enclosing
   /// Mutex.
   struct State: @unchecked Sendable {
+    struct CachedFormatDescription: @unchecked Sendable {
+      let generation: UInt64
+      let description: CMVideoFormatDescription
+    }
+
     var pool: CVPixelBufferPool?
     var width: Int = 0
     var height: Int = 0
@@ -62,6 +39,9 @@ final class PixelBufferRenderer: Sendable {
     var renderPoolWidth: Int = 0
     var renderPoolHeight: Int = 0
     var renderGeneration: UInt64 = 0
+    var cachedFormatDescription: CachedFormatDescription?
+    var formatDescriptionCreationCount: UInt64 = 0
+    var scalingResources: PixelBufferScalingResources?
     /// The display layer is held inside a class box rather than as a
     /// direct `weak var` on the struct. `Mutex` stores `State` in raw
     /// managed memory and any `withLock { $0 }` read produces a struct
@@ -75,15 +55,28 @@ final class PixelBufferRenderer: Sendable {
     init(displayLayer: AVSampleBufferDisplayLayer?) {
       self.displayLayer = DisplayLayerBox(displayLayer)
     }
+
+    mutating func advanceRenderGeneration() {
+      renderGeneration &+= 1
+      cachedFormatDescription = nil
+    }
   }
 
   let state: Mutex<State>
-  private let ciContext = CIContext(options: [.cacheIntermediates: false])
-  private let colorSpace = CGColorSpaceCreateDeviceRGB()
-  private let enqueueQueue = DispatchQueue(label: "org.swiftvlc.pixel-buffer-renderer.enqueue")
+  let enqueueQueue: DispatchQueue
+  let enqueueState = Mutex(PixelBufferEnqueueState())
+  let displayLayerAPI: PixelBufferDisplayLayerAPI
 
-  init(displayLayer: AVSampleBufferDisplayLayer) {
+  init(
+    displayLayer: AVSampleBufferDisplayLayer? = nil,
+    enqueueQueue: DispatchQueue? = nil,
+    displayLayerAPI: PixelBufferDisplayLayerAPI = .live
+  ) {
     state = Mutex(State(displayLayer: displayLayer))
+    self.enqueueQueue = enqueueQueue ?? DispatchQueue(
+      label: "org.swiftvlc.pixel-buffer-renderer.enqueue"
+    )
+    self.displayLayerAPI = displayLayerAPI
   }
 
   func setDisplayLayer(_ layer: AVSampleBufferDisplayLayer?) {
@@ -103,7 +96,7 @@ final class PixelBufferRenderer: Sendable {
       $0.renderPool = nil
       $0.renderPoolWidth = 0
       $0.renderPoolHeight = 0
-      $0.renderGeneration &+= 1
+      $0.advanceRenderGeneration()
     }
   }
 
@@ -163,33 +156,24 @@ final class PixelBufferRenderer: Sendable {
       .transformed(by: transform)
       .composited(over: background)
 
-    ciContext.render(image, to: output, bounds: frame, colorSpace: colorSpace)
+    let resources = scalingResourcesForResize()
+    resources.context.render(
+      image,
+      to: output,
+      bounds: frame,
+      colorSpace: resources.colorSpace
+    )
     return (output, generation)
   }
 
-  func canEnqueueFrame(generation: UInt64, on layer: AVSampleBufferDisplayLayer) -> Bool {
-    state.withLock {
-      $0.renderGeneration == generation && $0.displayLayer.layer === layer
-    }
-  }
-
-  func enqueue(
-    _ sample: CMSampleBuffer,
-    generation: UInt64,
-    on layer: AVSampleBufferDisplayLayer
-  ) {
-    let enqueued = EnqueuedSampleBuffer(layer: layer, sample: sample)
-
-    enqueueQueue.async { [enqueued, self] in
-      guard canEnqueueFrame(generation: generation, on: enqueued.layer) else { return }
-
-      let sampleBufferRenderer = enqueued.layer.sampleBufferRenderer
-      if sampleBufferRenderer.status == .failed || sampleBufferRenderer.requiresFlushToResumeDecoding {
-        sampleBufferRenderer.flush()
+  private func scalingResourcesForResize() -> PixelBufferScalingResources {
+    state.withLock { state in
+      if let resources = state.scalingResources {
+        return resources
       }
-      guard sampleBufferRenderer.isReadyForMoreMediaData else { return }
-
-      sampleBufferRenderer.enqueue(enqueued.sample)
+      let resources = PixelBufferScalingResources()
+      state.scalingResources = resources
+      return resources
     }
   }
 
@@ -228,42 +212,236 @@ final class PixelBufferRenderer: Sendable {
     }
 
     guard let pool else { return nil }
-    var pixelBuffer: CVPixelBuffer?
-    let status = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &pixelBuffer)
-    guard status == kCVReturnSuccess else { return nil }
-    return pixelBuffer
+    let allocation = pixelBufferRendererAllocatePixelBuffer(
+      from: pool,
+      width: width,
+      height: height
+    )
+    guard allocation.status == kCVReturnSuccess else { return nil }
+    return allocation.buffer
+  }
+}
+
+/// Injectable native registration operations. Production uses libVLC; tests
+/// record the exact handle each install/clear targets without requiring a
+/// timing-sensitive video output.
+struct DirectPiPVideoCallbackAPI {
+  let install: @MainActor (OpaquePointer, UnsafeMutableRawPointer) -> Void
+  let clear: @MainActor (OpaquePointer) -> Void
+
+  static var live: Self {
+    Self(
+      install: { player, opaque in
+        libvlc_video_set_callbacks(
+          player,
+          pixelBufferLockCallback,
+          pixelBufferUnlockCallback,
+          pixelBufferDisplayCallback,
+          opaque
+        )
+        let installedExtended = swiftvlc_video_set_format_callbacks_ex_if_available(
+          player,
+          pixelBufferFormatCallbackEx,
+          pixelBufferCleanupCallback
+        )
+        if !installedExtended {
+          // A libVLC binary without the extended `_ex` format callbacks cannot
+          // supply atomic vmem geometry. Fall back to the legacy callback,
+          // which cannot prove crop/PAR.
+          libvlc_video_set_format_callbacks(
+            player,
+            pixelBufferFormatCallback,
+            pixelBufferCleanupCallback
+          )
+        }
+      },
+      clear: { player in
+        libvlc_video_set_callbacks(player, nil, nil, nil, nil)
+        if !swiftvlc_video_set_format_callbacks_ex_if_available(player, nil, nil) {
+          libvlc_video_set_format_callbacks(player, nil, nil)
+        }
+      }
+    )
+  }
+}
+
+/// The stable callback slot for one exact native-player handle.
+///
+/// libVLC copies `vmem` callbacks and their opaque value when a video output
+/// opens. Replacing the media-player variables does not update that copy, so
+/// every controller using the same native handle must share this slot. The
+/// copied handle opaque routes display to the current controller; setup then
+/// replaces each vout's copy with a retained per-vout opaque and decode pool.
+/// A replacement native handle receives a new slot and handle opaque.
+@MainActor
+final class DirectPiPVideoCallbackSlot {
+  let lifetime: NativePlayerHandleLifetime
+  let context: PixelBufferRendererCallbackContext
+  let opaque: UnsafeMutableRawPointer
+  private let api: DirectPiPVideoCallbackAPI
+  private var callbacksInstalled = false
+  private(set) var isRetired = false
+
+  init(
+    lifetime: NativePlayerHandleLifetime,
+    decodeRenderer: PixelBufferRenderer,
+    api: DirectPiPVideoCallbackAPI
+  ) {
+    precondition(!lifetime.isReleased)
+    self.lifetime = lifetime
+    self.api = api
+    let context = PixelBufferRendererCallbackContext(renderer: decodeRenderer)
+    self.context = context
+    let retained = Unmanaged.passRetained(context)
+    let opaque = retained.toOpaque()
+    self.opaque = opaque
+    nonisolated(unsafe) let callbackOpaque = opaque
+    let accepted = lifetime.whenReleased { [context] in
+      context.nativePlayerHandleDidRelease(opaque: callbackOpaque)
+    }
+    precondition(accepted, "Cannot create callbacks for a released native player handle")
+  }
+
+  /// Makes `renderer` the destination for this handle's frames and restores
+  /// the same handle opaque into the media-player variables for future vouts.
+  /// An already-open vout owns a child opaque that resolves through this same
+  /// handle context and observes the handoff on its next display callback.
+  func activate(renderer: PixelBufferRenderer) {
+    precondition(!isRetired && !lifetime.isReleased)
+    precondition(context.setDisplayRenderer(renderer))
+    if !callbacksInstalled {
+      api.install(lifetime.pointer, opaque)
+      callbacksInstalled = true
+    }
+  }
+
+  /// Removes the controller target while preserving the per-handle slot.
+  /// A later controller can reactivate this same opaque, including when an
+  /// already-open vout still holds it. The media-player variables are cleared
+  /// while the slot is dormant and reinstalled with this same opaque on the
+  /// next activation.
+  func deactivate() {
+    guard !isRetired else { return }
+    _ = context.setDisplayRenderer(nil)
+    clearCallbacksIfInstalled()
+  }
+
+  /// Permanently retires the slot because its exact handle is being replaced
+  /// or released. The opaque remains retained by `lifetime` until native
+  /// teardown has joined that handle's vout.
+  func retire() {
+    guard !isRetired else { return }
+    isRetired = true
+    context.requestRetirement()
+    clearCallbacksIfInstalled()
+  }
+
+  private func clearCallbacksIfInstalled() {
+    guard callbacksInstalled else { return }
+    callbacksInstalled = false
+    api.clear(lifetime.pointer)
+  }
+}
+
+/// One logical direct-PiP controller claim. The Player binds it to the stable
+/// slot for the current native handle and uses the generation to reject stale
+/// teardown from a superseded controller.
+@MainActor
+final class DirectPiPVideoCallbackRegistration {
+  private struct Binding {
+    let slot: DirectPiPVideoCallbackSlot
+    let generation: UInt64
+  }
+
+  private let renderer: PixelBufferRenderer
+  private let api: DirectPiPVideoCallbackAPI
+  private var current: Binding?
+
+  init(
+    renderer: PixelBufferRenderer,
+    api: DirectPiPVideoCallbackAPI = .live
+  ) {
+    self.renderer = renderer
+    self.api = api
+  }
+
+  func makeSlot(on lifetime: NativePlayerHandleLifetime) -> DirectPiPVideoCallbackSlot {
+    DirectPiPVideoCallbackSlot(
+      lifetime: lifetime,
+      decodeRenderer: renderer,
+      api: api
+    )
+  }
+
+  func bind(to slot: DirectPiPVideoCallbackSlot, generation: UInt64) {
+    slot.activate(renderer: renderer)
+    current = Binding(slot: slot, generation: generation)
+  }
+
+  func unbind(generation: UInt64) {
+    guard current?.generation == generation else { return }
+    current = nil
+  }
+
+  var currentGeneration: UInt64? {
+    current?.generation
+  }
+
+  var currentLifetime: NativePlayerHandleLifetime? {
+    current?.slot.lifetime
+  }
+
+  var currentSlot: DirectPiPVideoCallbackSlot? {
+    current?.slot
+  }
+
+  var currentContextForTesting: PixelBufferRendererCallbackContext? {
+    current?.slot.context
+  }
+
+  var currentOpaqueForTesting: UnsafeMutableRawPointer? {
+    current?.slot.opaque
   }
 }
 
 /// Stable object passed to libVLC's vmem callbacks.
 ///
-/// libVLC copies the callback function pointers and `opaque` value into
-/// the vmem video output when that output opens. Clearing the media
-/// player's callback variables later does not update an already-open
-/// vout, so this context must stay alive until that vout calls the
-/// cleanup callback.
+/// libVLC copies the callback function pointers and `opaque` value into a
+/// video output while it opens. Clearing or replacing the media-player
+/// variables cannot prove that no future callback will use that copy. The
+/// opaque retain is therefore released only when its exact
+/// ``NativePlayerHandleLifetime`` ends, never from a timeout or a transient
+/// `voutOpen == false` observation.
 final class PixelBufferRendererCallbackContext: Sendable {
   private struct CallbackEntry {
-    var renderer: PixelBufferRenderer?
+    let displayRenderer: PixelBufferRenderer?
   }
 
   private struct State: @unchecked Sendable {
-    var renderer: PixelBufferRenderer?
+    var displayRenderer: PixelBufferRenderer?
     var activeCallbacks = 0
-    var voutOpen = false
+    var openVoutCount = 0
     var retirementRequested = false
-    var deferReleaseUntilQuiescent = false
+    var nativePlayerHandleReleased = false
     var opaqueRetainReleased = false
   }
 
   private let state: Mutex<State>
 
   init(renderer: PixelBufferRenderer) {
-    state = Mutex(State(renderer: renderer))
+    state = Mutex(State(displayRenderer: renderer))
   }
 
   var hasOpenVoutForTesting: Bool {
-    state.withLock { $0.voutOpen }
+    state.withLock { $0.openVoutCount > 0 }
+  }
+
+  var retirementRequestedForTesting: Bool {
+    state.withLock { $0.retirementRequested }
+  }
+
+  var nativePlayerHandleReleasedForTesting: Bool {
+    state.withLock { $0.nativePlayerHandleReleased }
   }
 
   func withRenderer<T>(
@@ -272,40 +450,81 @@ final class PixelBufferRendererCallbackContext: Sendable {
   ) -> T? {
     guard let entry = beginCallback() else { return nil }
     defer { endCallback(opaque: opaque) }
-    guard let renderer = entry.renderer else { return nil }
+    guard let renderer = entry.displayRenderer else { return nil }
     return body(renderer)
   }
 
-  func noteVoutOpened() {
-    state.withLock {
-      guard !$0.opaqueRetainReleased else { return }
-      $0.voutOpen = true
+  /// Atomically hands an already-open vout's future display callbacks to a
+  /// successor controller. Returns `false` only after permanent retirement
+  /// or exact native-handle release.
+  @discardableResult
+  func setDisplayRenderer(_ renderer: PixelBufferRenderer?) -> Bool {
+    state.withLock { state -> Bool in
+      guard
+        !state.retirementRequested,
+        !state.nativePlayerHandleReleased,
+        !state.opaqueRetainReleased
+      else { return false }
+      state.displayRenderer = renderer
+      return true
     }
   }
 
-  func noteVoutClosed(opaque: UnsafeMutableRawPointer) {
-    state.withLock {
-      $0.voutOpen = false
+  /// Creates the callback object for one negotiated vout. Every vout owns a
+  /// separate decode renderer/pool, while display forwarding remains dynamic
+  /// through this handle context so a successor PiPController can take over an
+  /// already-open output.
+  func makeVoutContext(
+    handleOpaque: UnsafeMutableRawPointer,
+    decodeRenderer: PixelBufferRenderer,
+    sourceGeometry: PixelBufferSourceGeometry
+  ) -> PixelBufferRendererVoutCallbackContext? {
+    let accepted = state.withLock { state -> Bool in
+      guard !state.nativePlayerHandleReleased, !state.opaqueRetainReleased else {
+        return false
+      }
+      state.openVoutCount += 1
+      return true
     }
-    releaseOpaqueRetainIfNeeded(opaque: opaque)
+    guard accepted else { return nil }
+    return PixelBufferRendererVoutCallbackContext(
+      handleContext: self,
+      handleOpaque: handleOpaque,
+      decodeRenderer: decodeRenderer,
+      sourceGeometry: sourceGeometry
+    )
   }
 
-  func requestRetirement(
-    opaque: UnsafeMutableRawPointer,
-    deferIfVoutMayBeOpening: Bool
-  ) {
+  func noteVoutClosed() {
+    state.withLock {
+      $0.openVoutCount = max(0, $0.openVoutCount - 1)
+    }
+  }
+
+  /// Permanently removes the display target and suppresses future display
+  /// work. Decode storage remains available to a vout that already copied the
+  /// callbacks, and cleanup can still return its pool. In-flight callbacks
+  /// retain their captured renderer(s) until they return. The opaque itself
+  /// stays retained until
+  /// `nativePlayerHandleDidRelease`, because an opening vout may have copied
+  /// it before this retirement became visible.
+  func requestRetirement() {
+    state.withLock { state in
+      state.retirementRequested = true
+      state.displayRenderer = nil
+    }
+  }
+
+  /// Called only after `libvlc_media_player_release` for the exact handle
+  /// carrying this opaque has returned. No new callback can begin after this
+  /// point. If a callback was already in flight, it performs the balancing
+  /// release on exit.
+  func nativePlayerHandleDidRelease(opaque: UnsafeMutableRawPointer) {
     let shouldRelease = state.withLock { state -> Bool in
       guard !state.opaqueRetainReleased else { return false }
-      state.retirementRequested = true
-      state.deferReleaseUntilQuiescent =
-        state.deferReleaseUntilQuiescent || deferIfVoutMayBeOpening
-      // In-flight callbacks already hold a strong local renderer from
-      // `beginCallback`. Future callbacks should see a live context but no
-      // renderer, so a late libVLC call becomes a no-op instead of touching
-      // deinitializing PiP state.
-      state.renderer = nil
-      guard !state.deferReleaseUntilQuiescent else { return false }
-      guard state.activeCallbacks == 0, !state.voutOpen else { return false }
+      state.nativePlayerHandleReleased = true
+      state.displayRenderer = nil
+      guard state.activeCallbacks == 0 else { return false }
       state.opaqueRetainReleased = true
       return true
     }
@@ -314,66 +533,13 @@ final class PixelBufferRendererCallbackContext: Sendable {
     }
   }
 
-  func requestDeferredRetirement() {
-    state.withLock { state in
-      guard !state.opaqueRetainReleased else { return }
-      state.retirementRequested = true
-      state.deferReleaseUntilQuiescent = true
-    }
-  }
-
-  @discardableResult
-  func releaseRetiredOpaqueRetainIfNoOpenVout(opaque: UnsafeMutableRawPointer) -> Bool {
-    releaseOpaqueRetainIfNeeded(opaque: opaque)
-  }
-
-  func releaseRetiredOpaqueRetainWhenPlayerIsQuiescent(
-    opaque: UnsafeMutableRawPointer,
-    player: OpaquePointer
-  ) {
-    let deadline = CFAbsoluteTimeGetCurrent() + 5
-    var quiescentSince: CFAbsoluteTime?
-    while CFAbsoluteTimeGetCurrent() < deadline {
-      let nativeState = PlayerState(from: libvlc_media_player_get_state(player))
-      let isStopped = switch nativeState {
-      case .idle, .stopped, .error:
-        true
-      case .opening, .buffering, .playing, .paused, .stopping:
-        false
-      }
-
-      if isStopped, libvlc_media_player_has_vout(player) == 0 {
-        let now = CFAbsoluteTimeGetCurrent()
-        let started = quiescentSince ?? now
-        quiescentSince = started
-        if now - started >= 0.5 {
-          libvlc_video_set_callbacks(player, nil, nil, nil, nil)
-          libvlc_video_set_format_callbacks(player, nil, nil)
-          releaseRetiredOpaqueRetainAfterPlayerQuiesced(opaque: opaque)
-          return
-        }
-      } else {
-        quiescentSince = nil
-      }
-
-      usleep(20000)
-    }
-
-    // Deadline elapsed without ever observing a clean quiescent window
-    // (the player never reported stopped with no open vout). Fall back to
-    // the vout-gated release so the retained context is still relinquished
-    // instead of leaking. The guard inside ensures we never release while
-    // a vout still holds the callbacks — that would reintroduce the
-    // use-after-free this deferral exists to prevent; in that case the
-    // later cleanup callback performs the release.
-    releaseRetiredOpaqueRetainIfNoOpenVout(opaque: opaque)
-  }
-
   private func beginCallback() -> CallbackEntry? {
     state.withLock { state -> CallbackEntry? in
       guard !state.opaqueRetainReleased else { return nil }
       state.activeCallbacks += 1
-      return CallbackEntry(renderer: state.renderer)
+      return CallbackEntry(
+        displayRenderer: state.displayRenderer
+      )
     }
   }
 
@@ -381,11 +547,7 @@ final class PixelBufferRendererCallbackContext: Sendable {
     let shouldRelease = state.withLock { state -> Bool in
       state.activeCallbacks -= 1
       guard state.activeCallbacks == 0 else { return false }
-      guard state.retirementRequested, !state.voutOpen, !state.opaqueRetainReleased else {
-        return false
-      }
-      guard !state.deferReleaseUntilQuiescent else { return false }
-      state.renderer = nil
+      guard state.nativePlayerHandleReleased, !state.opaqueRetainReleased else { return false }
       state.opaqueRetainReleased = true
       return true
     }
@@ -393,40 +555,137 @@ final class PixelBufferRendererCallbackContext: Sendable {
       Unmanaged<PixelBufferRendererCallbackContext>.fromOpaque(opaque).release()
     }
   }
+}
 
-  @discardableResult
-  private func releaseOpaqueRetainIfNeeded(
-    opaque: UnsafeMutableRawPointer
-  ) -> Bool {
-    let shouldRelease = state.withLock { state -> Bool in
-      guard state.retirementRequested, !state.opaqueRetainReleased else { return false }
-      guard state.activeCallbacks == 0, !state.voutOpen else { return false }
-      state.deferReleaseUntilQuiescent = false
-      state.renderer = nil
-      state.opaqueRetainReleased = true
-      return true
-    }
-    if shouldRelease {
-      Unmanaged<PixelBufferRendererCallbackContext>.fromOpaque(opaque).release()
-    }
-    return shouldRelease
+/// Callback storage owned by one exact pinned-vmem vout.
+///
+/// The media-player variables contain a handle-level context before setup.
+/// The format callback replaces that vout's copied opaque with a retained
+/// instance of this class. Its decode pool therefore cannot be replaced or
+/// cleared by an overlapping vout, while display callbacks still consult the
+/// handle context's current controller target.
+final class PixelBufferRendererVoutCallbackContext: @unchecked Sendable {
+  private struct PendingPicture: @unchecked Sendable {
+    let buffer: CVPixelBuffer
+    let opaque: UnsafeMutableRawPointer
+    var isLocked: Bool
   }
 
-  private func releaseRetiredOpaqueRetainAfterPlayerQuiesced(
-    opaque: UnsafeMutableRawPointer
+  private struct LifecycleState: @unchecked Sendable {
+    var isCleaned = false
+    var pendingPicture: PendingPicture?
+  }
+
+  let decodeRenderer: PixelBufferRenderer
+  let sourceGeometry: PixelBufferSourceGeometry
+  private let handleContext: PixelBufferRendererCallbackContext
+  private let handleOpaque: UnsafeMutableRawPointer
+  private let lifecycleState = Mutex(LifecycleState())
+
+  init(
+    handleContext: PixelBufferRendererCallbackContext,
+    handleOpaque: UnsafeMutableRawPointer,
+    decodeRenderer: PixelBufferRenderer,
+    sourceGeometry: PixelBufferSourceGeometry
   ) {
-    let shouldRelease = state.withLock { state -> Bool in
-      guard state.retirementRequested, !state.opaqueRetainReleased else { return false }
-      state.voutOpen = false
-      state.deferReleaseUntilQuiescent = false
-      state.renderer = nil
-      guard state.activeCallbacks == 0 else { return false }
-      state.opaqueRetainReleased = true
+    self.handleContext = handleContext
+    self.handleOpaque = handleOpaque
+    self.decodeRenderer = decodeRenderer
+    self.sourceGeometry = sourceGeometry
+  }
+
+  func withDisplayRenderer<T>(
+    _ body: (PixelBufferRenderer) -> T
+  ) -> T? {
+    handleContext.withRenderer(opaque: handleOpaque, body)
+  }
+
+  /// Pins one callback picture until display consumes it, a later lock
+  /// supersedes it, or vout cleanup drains it. Pinned vmem exposes only one
+  /// `pic_opaque` slot, so a second successful lock proves the predecessor can
+  /// no longer be delivered by that vout. If a malformed callback sequence
+  /// skipped unlock as well as display, drain also balances the Core Video
+  /// base-address lock before releasing the final strong reference.
+  func installPendingPicture(
+    _ buffer: CVPixelBuffer,
+    isLocked: Bool
+  ) -> UnsafeMutableRawPointer? {
+    let opaque = Unmanaged.passUnretained(buffer as AnyObject).toOpaque()
+    let accepted = lifecycleState.withLock { state -> Bool in
+      guard !state.isCleaned else { return false }
+      drainPendingPicture(&state)
+      state.pendingPicture = PendingPicture(
+        buffer: buffer,
+        opaque: opaque,
+        isLocked: isLocked
+      )
       return true
     }
-    if shouldRelease {
-      Unmanaged<PixelBufferRendererCallbackContext>.fromOpaque(opaque).release()
+    return accepted ? opaque : nil
+  }
+
+  /// Balances the base-address lock only for the currently owned picture.
+  /// A stale unlock after replacement is ignored without dereferencing its
+  /// potentially deallocated opaque pointer.
+  func unlockPendingPicture(matching opaque: UnsafeMutableRawPointer) {
+    lifecycleState.withLock { state in
+      guard
+        state.pendingPicture?.opaque == opaque,
+        state.pendingPicture?.isLocked == true
+      else { return }
+      CVPixelBufferUnlockBaseAddress(state.pendingPicture!.buffer, [])
+      state.pendingPicture!.isLocked = false
     }
+  }
+
+  /// Transfers the exact pending buffer to display. A duplicate or stale
+  /// display callback observes no match and therefore cannot over-release or
+  /// dereference an already-drained picture.
+  func consumePendingPicture(
+    matching opaque: UnsafeMutableRawPointer
+  ) -> CVPixelBuffer? {
+    lifecycleState.withLock { state -> CVPixelBuffer? in
+      guard state.pendingPicture?.opaque == opaque else { return nil }
+      if state.pendingPicture?.isLocked == true {
+        CVPixelBufferUnlockBaseAddress(state.pendingPicture!.buffer, [])
+      }
+      let buffer = state.pendingPicture?.buffer
+      state.pendingPicture = nil
+      return buffer
+    }
+  }
+
+  var hasPendingPictureForTesting: Bool {
+    lifecycleState.withLock { $0.pendingPicture != nil }
+  }
+
+  func cleanupDecodeStorage() {
+    let shouldClean = lifecycleState.withLock { state -> Bool in
+      guard !state.isCleaned else { return false }
+      state.isCleaned = true
+      drainPendingPicture(&state)
+      return true
+    }
+    guard shouldClean else { return }
+
+    decodeRenderer.state.withLock {
+      $0.pool = nil
+      $0.width = 0
+      $0.height = 0
+      $0.renderPool = nil
+      $0.renderPoolWidth = 0
+      $0.renderPoolHeight = 0
+      $0.advanceRenderGeneration()
+    }
+    handleContext.noteVoutClosed()
+  }
+
+  private func drainPendingPicture(_ state: inout LifecycleState) {
+    guard let pending = state.pendingPicture else { return }
+    if pending.isLocked {
+      CVPixelBufferUnlockBaseAddress(pending.buffer, [])
+    }
+    state.pendingPicture = nil
   }
 }
 
@@ -442,88 +701,20 @@ final class DisplayLayerBox: @unchecked Sendable {
 
 // MARK: - Free Function Callbacks
 
-private func pixelBufferCallbackContext(
+func pixelBufferHandleCallbackContext(
   from opaque: UnsafeMutableRawPointer?
 ) -> PixelBufferRendererCallbackContext? {
   guard let opaque else { return nil }
-  return Unmanaged<PixelBufferRendererCallbackContext>.fromOpaque(opaque).takeUnretainedValue()
+  let object = Unmanaged<AnyObject>.fromOpaque(opaque).takeUnretainedValue()
+  return object as? PixelBufferRendererCallbackContext
 }
 
-/// Format callback, invoked by libVLC when video format is negotiated.
-/// Overrides chroma to BGRA and creates a `CVPixelBufferPool`.
-func pixelBufferFormatCallback(
-  opaque: UnsafeMutablePointer<UnsafeMutableRawPointer?>?,
-  chroma: UnsafeMutablePointer<CChar>?,
-  width: UnsafeMutablePointer<UInt32>?,
-  height: UnsafeMutablePointer<UInt32>?,
-  pitches: UnsafeMutablePointer<UInt32>?,
-  lines: UnsafeMutablePointer<UInt32>?
-) -> UInt32 {
-  guard
-    let opaque, let chroma, let width, let height,
-    let pitches, let lines else { return 0 }
-
-  // libVLC populates `*opaque` with the context we passed to
-  // `libvlc_video_set_callbacks`. Guard against an unattached context.
-  guard
-    let contextOpaque = opaque.pointee,
-    let context = pixelBufferCallbackContext(from: contextOpaque)
-  else { return 0 }
-
-  return context.withRenderer(opaque: contextOpaque) { renderer -> UInt32 in
-    let w = Int(width.pointee)
-    let h = Int(height.pointee)
-
-    // Force BGRA: native to iOS, no color space conversion needed.
-    let bgra: (CChar, CChar, CChar, CChar) = (0x42, 0x47, 0x52, 0x41) // "BGRA"
-    chroma[0] = bgra.0
-    chroma[1] = bgra.1
-    chroma[2] = bgra.2
-    chroma[3] = bgra.3
-
-    // Create CVPixelBufferPool. The pool's resident floor is byte-budgeted
-    // (small at 4K), decoupled from the decode headroom returned below
-    // which stays at the full picture count for smooth playback.
-    let poolAttrs: [String: Any] = [
-      kCVPixelBufferPoolMinimumBufferCountKey as String:
-        pixelBufferRendererPoolMinimumBufferCount(width: w, height: h)
-    ]
-    let pixelBufferAttrs: [String: Any] = [
-      kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
-      kCVPixelBufferWidthKey as String: w,
-      kCVPixelBufferHeightKey as String: h,
-      kCVPixelBufferIOSurfacePropertiesKey as String: [:] as [String: Any],
-      kCVPixelBufferCGImageCompatibilityKey as String: true,
-      kCVPixelBufferCGBitmapContextCompatibilityKey as String: true
-    ]
-
-    var newPool: CVPixelBufferPool?
-    let status = CVPixelBufferPoolCreate(
-      kCFAllocatorDefault,
-      poolAttrs as CFDictionary,
-      pixelBufferAttrs as CFDictionary,
-      &newPool
-    )
-    guard status == kCVReturnSuccess, let pool = newPool else { return 0 }
-
-    // Get actual bytesPerRow from a real buffer so VLC pitch matches exactly
-    var testBuffer: CVPixelBuffer?
-    CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &testBuffer)
-    guard let tb = testBuffer else { return 0 }
-    let actualPitch = CVPixelBufferGetBytesPerRow(tb)
-
-    pitches.pointee = UInt32(actualPitch)
-    lines.pointee = UInt32(h)
-
-    renderer.state.withLock {
-      $0.pool = pool
-      $0.width = w
-      $0.height = h
-    }
-    context.noteVoutOpened()
-
-    return pixelBufferRendererPictureBufferCount
-  } ?? 0
+func pixelBufferVoutCallbackContext(
+  from opaque: UnsafeMutableRawPointer?
+) -> PixelBufferRendererVoutCallbackContext? {
+  guard let opaque else { return nil }
+  let object = Unmanaged<AnyObject>.fromOpaque(opaque).takeUnretainedValue()
+  return object as? PixelBufferRendererVoutCallbackContext
 }
 
 /// Lock callback. Dequeues a `CVPixelBuffer` from the pool for libVLC to write into.
@@ -532,37 +723,46 @@ func pixelBufferLockCallback(
   planes: UnsafeMutablePointer<UnsafeMutableRawPointer?>?
 ) -> UnsafeMutableRawPointer? {
   guard let opaque, let planes else { return nil }
-  guard let context = pixelBufferCallbackContext(from: opaque) else { return nil }
+  guard let context = pixelBufferVoutCallbackContext(from: opaque) else { return nil }
 
-  return context.withRenderer(opaque: opaque) { renderer -> UnsafeMutableRawPointer? in
-    let pool = renderer.state.withLock { $0.pool }
+  let renderer = context.decodeRenderer
+  let storage = renderer.state.withLock { ($0.pool, $0.width, $0.height) }
+  guard let pool = storage.0 else { return nil }
 
-    guard let pool else { return nil }
+  let allocation = pixelBufferRendererAllocatePixelBuffer(
+    from: pool,
+    width: storage.1,
+    height: storage.2
+  )
+  guard allocation.status == kCVReturnSuccess, let pb = allocation.buffer else { return nil }
 
-    var pixelBuffer: CVPixelBuffer?
-    let status = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &pixelBuffer)
-    guard status == kCVReturnSuccess, let pb = pixelBuffer else { return nil }
+  let lockStatus = CVPixelBufferLockBaseAddress(pb, [])
+  guard lockStatus == kCVReturnSuccess, let baseAddress = CVPixelBufferGetBaseAddress(pb) else {
+    if lockStatus == kCVReturnSuccess {
+      CVPixelBufferUnlockBaseAddress(pb, [])
+    }
+    return nil
+  }
 
-    CVPixelBufferLockBaseAddress(pb, [])
-    planes[0] = CVPixelBufferGetBaseAddress(pb)
-
-    let retained = Unmanaged.passRetained(pb as AnyObject)
-    return retained.toOpaque()
-  } ?? nil
+  guard let picture = context.installPendingPicture(pb, isLocked: true) else {
+    CVPixelBufferUnlockBaseAddress(pb, [])
+    return nil
+  }
+  planes[0] = baseAddress
+  return picture
 }
 
 /// Unlock callback. Unlocks the `CVPixelBuffer` base address.
 func pixelBufferUnlockCallback(
-  opaque _: UnsafeMutableRawPointer?,
+  opaque: UnsafeMutableRawPointer?,
   picture: UnsafeMutableRawPointer?,
   planes _: UnsafePointer<UnsafeMutableRawPointer?>?
 ) {
-  guard let picture else { return }
-
-  // `as!` (not `as?`): the compiler emits "conditional downcast will
-  // always succeed" for CoreFoundation bridged types.
-  let pb = Unmanaged<AnyObject>.fromOpaque(picture).takeUnretainedValue() as! CVPixelBuffer
-  CVPixelBufferUnlockBaseAddress(pb, [])
+  guard
+    let picture,
+    let context = pixelBufferVoutCallbackContext(from: opaque)
+  else { return }
+  context.unlockPendingPicture(matching: picture)
 }
 
 /// Display callback. Wraps the `CVPixelBuffer` in a `CMSampleBuffer`
@@ -571,27 +771,26 @@ func pixelBufferDisplayCallback(
   opaque: UnsafeMutableRawPointer?,
   picture: UnsafeMutableRawPointer?
 ) {
-  guard let picture else { return }
-  // `takeRetainedValue` balances the `passRetained` in `pixelBufferLockCallback`.
-  let pb = Unmanaged<AnyObject>.fromOpaque(picture).takeRetainedValue() as! CVPixelBuffer
-  guard let opaque, let context = pixelBufferCallbackContext(from: opaque) else { return }
+  guard
+    let picture,
+    let context = pixelBufferVoutCallbackContext(from: opaque),
+    let pb = context.consumePendingPicture(matching: picture)
+  else { return }
 
-  _ = context.withRenderer(opaque: opaque) { renderer in
+  _ = context.withDisplayRenderer { renderer in
     guard let output = renderer.outputPixelBuffer(from: pb) else { return }
     let outputBuffer = output.buffer
     let renderGeneration = output.generation
 
-    var formatDesc: CMVideoFormatDescription?
-    let fmtStatus = CMVideoFormatDescriptionCreateForImageBuffer(
-      allocator: kCFAllocatorDefault,
-      imageBuffer: outputBuffer,
-      formatDescriptionOut: &formatDesc
-    )
-    guard fmtStatus == noErr, let desc = formatDesc else { return }
-
     let (timebase, layer) = renderer.state.withLock { ($0.timebase, $0.displayLayer.layer) }
 
     guard let layer else { return }
+    guard
+      let desc = renderer.formatDescription(
+        for: outputBuffer,
+        generation: renderGeneration
+      )
+    else { return }
 
     let pts: CMTime = if let timebase {
       CMTimebaseGetTime(timebase)
@@ -638,18 +837,14 @@ func pixelBufferDisplayCallback(
 
 /// Cleanup callback. Releases the pixel buffer pool.
 func pixelBufferCleanupCallback(opaque: UnsafeMutableRawPointer?) {
-  guard let opaque, let context = pixelBufferCallbackContext(from: opaque) else { return }
+  guard
+    let opaque,
+    let context = pixelBufferVoutCallbackContext(from: opaque)
+  else { return }
 
-  _ = context.withRenderer(opaque: opaque) { renderer in
-    renderer.state.withLock {
-      $0.pool = nil
-      $0.renderPool = nil
-      $0.renderPoolWidth = 0
-      $0.renderPoolHeight = 0
-      $0.renderGeneration &+= 1
-    }
-  }
-  context.noteVoutClosed(opaque: opaque)
+  context.cleanupDecodeStorage()
+  // Balance the per-vout retain installed by the successful format callback.
+  Unmanaged<PixelBufferRendererVoutCallbackContext>.fromOpaque(opaque).release()
 }
 
 #endif

--- a/Sources/SwiftVLC/Player/Player+Drawable.swift
+++ b/Sources/SwiftVLC/Player/Player+Drawable.swift
@@ -51,17 +51,20 @@ extension Player {
   }
 
   func applyDrawable(_ newDrawable: AnyObject?) {
-    // Bind the outgoing reference to a local so it outlives the libVLC
-    // call. After the ivar is reassigned, ARC would otherwise release
-    // the previous view immediately; the vout thread could still be
-    // mid-deref of that `drawable-nsobject` pointer. `previous`
-    // keeps the previous view alive until this function returns, by which
-    // point libVLC has atomically swapped the variable.
+    // libVLC stores `drawable-nsobject` as a raw pointer. Once this exact
+    // handle has started, replacing the variable cannot revoke a pointer an
+    // opening or draining vout already copied. Retain every outgoing drawable
+    // until that handle is released; the replacement/shutdown/deinit paths
+    // move this array into the closure that performs the native release.
+    //
+    // Before first playback there is no vout, so the local `previous` retain
+    // only needs to cover libVLC's synchronous variable swap.
     let previous = drawable
     if
       let previous,
-      nativePlayerNeedsReplacementBeforePlayback,
-      newDrawable.map({ previous !== $0 }) ?? true {
+      nativePlayerHasStartedPlayback || nativePlayerNeedsReplacementBeforePlayback,
+      newDrawable.map({ previous !== $0 }) ?? true,
+      !retainedDrawablesUntilNativePlayerRelease.contains(where: { $0 === previous }) {
       retainedDrawablesUntilNativePlayerRelease.append(previous)
     }
     drawable = newDrawable
@@ -95,6 +98,7 @@ extension Player {
   )
     throws(VLCError) {
     let oldPointer = pointer
+    let oldLifetime = nativeHandleLifetime
     let newPointer = Self.makeNativePlayer(instance: instance)
     guard let newEventManager = libvlc_media_player_event_manager(newPointer) else {
       libvlc_media_player_release(newPointer)
@@ -106,7 +110,18 @@ extension Player {
     let audioDelay = libvlc_audio_get_delay(oldPointer)
     let subtitleDelay = libvlc_video_get_spu_delay(oldPointer)
     let subtitleScale = libvlc_video_get_spu_text_scale(oldPointer)
-    let retainedDrawables = retainedDrawablesUntilNativePlayerRelease
+    // The outgoing handle may already have copied `target` into an opening or
+    // draining vout. The successor's strong drawable reference is not a lease
+    // for that predecessor: its teardown runs independently and can finish
+    // first. Charge the current target to the exact outgoing lifetime, just as
+    // shutdown/deinit do, so rapid replacements cannot release it out of
+    // generation order.
+    var retainedDrawables = retainedDrawablesUntilNativePlayerRelease
+    if
+      let target,
+      !retainedDrawables.contains(where: { $0 === target }) {
+      retainedDrawables.append(target)
+    }
 
     if let currentMedia {
       libvlc_media_player_set_media(newPointer, currentMedia.pointer)
@@ -115,6 +130,7 @@ extension Player {
       libvlc_media_player_release(newPointer)
       throw .operationFailed("Set renderer")
     }
+    let newLifetime = NativePlayerHandleLifetime(pointer: newPointer)
     _ = libvlc_audio_set_volume(newPointer, Int32(_volume * 100))
     libvlc_audio_set_mute(newPointer, _isMuted ? 1 : 0)
     _ = libvlc_media_player_set_rate(newPointer, playbackRate)
@@ -139,7 +155,11 @@ extension Player {
     // leaving it pinned to the dead handle's outputs.
     endCoordinator.clearForHandleReplacement()
     activeVideoOutputs = 0
+    #if os(iOS) || os(macOS)
+    moveDirectPiPVideoCallbacks(to: newLifetime)
+    #endif
     pointer = newPointer
+    nativeHandleLifetime = newLifetime
     attachedMediaListPlayer?.rebindMediaPlayerHandle()
     applyAspectRatio()
 
@@ -151,6 +171,7 @@ extension Player {
 
     releaseNativePlayer(
       oldPointer,
+      lifetime: oldLifetime,
       retaining: retainedDrawables,
       resumeBeforeStop: resumeBeforeRelease
     )

--- a/Sources/SwiftVLC/Player/Player+NativeLifecycle.swift
+++ b/Sources/SwiftVLC/Player/Player+NativeLifecycle.swift
@@ -1,19 +1,255 @@
 import CLibVLC
 import Foundation
+import Synchronization
+
+/// Owns work that must remain alive until one exact native media-player
+/// handle has finished releasing.
+///
+/// A libVLC video output copies callback pointers and their opaque value when
+/// it opens. Replacing or clearing the media-player variables does not revoke
+/// a copy already in flight, so callback opaques cannot be reclaimed based on
+/// the Swift `Player.pointer` (which may already name a successor) or on a
+/// timeout. Release actions registered here run only after SwiftVLC and every
+/// native list-player owner release this exact handle, so libVLC's final
+/// release has joined its output teardown.
+final class NativePlayerHandleLifetime: @unchecked Sendable {
+  private struct State {
+    var nativeOwnerCount = 1
+    var initialOwnerEnded = false
+    var isReleased = false
+    var releaseActionsPerformed = false
+    var releaseActions: [@Sendable () -> Void] = []
+    var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+  }
+
+  private struct ReleaseCompletion {
+    var actions: [@Sendable () -> Void] = []
+  }
+
+  private final class RetainedObjects: @unchecked Sendable {
+    private struct Contents: @unchecked Sendable {
+      var objects: [AnyObject]
+    }
+
+    private let contents: Mutex<Contents>
+
+    init(_ objects: [AnyObject]) {
+      contents = Mutex(Contents(objects: objects))
+    }
+
+    /// Moves the retained objects into a fresh box. The release action itself
+    /// remains stored in its completion array until `perform` returns, so a
+    /// second capture of the same box would still let that array perform the
+    /// final release on the native teardown thread.
+    func takeContents() -> RetainedObjects? {
+      let objects = contents.withLock { contents -> [AnyObject] in
+        let objects = contents.objects
+        contents.objects = []
+        return objects
+      }
+      return objects.isEmpty ? nil : RetainedObjects(objects)
+    }
+  }
+
+  let pointer: OpaquePointer
+  private let state = Mutex(State())
+
+  init(pointer: OpaquePointer) {
+    self.pointer = pointer
+  }
+
+  /// Registers an action for the end of this handle's native lifetime.
+  /// Returns `false` if the handle had already ended; callers must not install
+  /// new native callbacks in that case.
+  @discardableResult
+  func whenReleased(_ action: @escaping @Sendable () -> Void) -> Bool {
+    let accepted = state.withLock { state -> Bool in
+      guard !state.isReleased else { return false }
+      state.releaseActions.append(action)
+      return true
+    }
+    if !accepted {
+      action()
+    }
+    return accepted
+  }
+
+  /// Accounts for one additional native owner of this exact media-player
+  /// handle. The lease must be acquired before the native retain happens and
+  /// ended only after the matching native release call returns.
+  func acquireNativeOwnerLease() -> NativePlayerHandleLease {
+    state.withLock { state in
+      precondition(!state.isReleased, "Cannot retain a released native player handle")
+      state.nativeOwnerCount += 1
+    }
+    return NativePlayerHandleLease(lifetime: self)
+  }
+
+  /// Ends SwiftVLC's initial ownership after its
+  /// `libvlc_media_player_release` call returns. A media-list player can still
+  /// own the same native handle, so this is not necessarily the end of the
+  /// handle's lifetime.
+  func initialOwnerDidRelease() {
+    let completion = state.withLock { state -> ReleaseCompletion? in
+      precondition(!state.initialOwnerEnded, "Initial native-player owner ended twice")
+      state.initialOwnerEnded = true
+      return Self.endOneNativeOwner(in: &state)
+    }
+    if let completion {
+      perform(completion)
+    }
+  }
+
+  fileprivate func leasedOwnerDidRelease() {
+    let completion = state.withLock { state in
+      Self.endOneNativeOwner(in: &state)
+    }
+    if let completion {
+      perform(completion)
+    }
+  }
+
+  /// Ends one native owner. Returns the release completion only when this was
+  /// the final owner (the handle just reached release); returns `nil` while
+  /// other owners remain, so callers skip `perform` until the terminal release.
+  private static func endOneNativeOwner(in state: inout State) -> ReleaseCompletion? {
+    precondition(state.nativeOwnerCount > 0, "Native-player owner count underflow")
+    state.nativeOwnerCount -= 1
+    guard state.nativeOwnerCount == 0 else { return nil }
+
+    precondition(!state.isReleased, "Native player handle released twice")
+    state.isReleased = true
+    let completion = ReleaseCompletion(actions: state.releaseActions)
+    state.releaseActions.removeAll()
+    return completion
+  }
+
+  private func perform(_ completion: ReleaseCompletion) {
+    for action in completion.actions {
+      action()
+    }
+    let waiters = state.withLock { state -> [CheckedContinuation<Void, Never>] in
+      precondition(state.isReleased && !state.releaseActionsPerformed)
+      state.releaseActionsPerformed = true
+      let waiters = state.releaseWaiters
+      state.releaseWaiters.removeAll()
+      return waiters
+    }
+    for waiter in waiters {
+      waiter.resume()
+    }
+  }
+
+  /// Holds objects until every counted native owner has released the exact
+  /// handle. This is intentionally tied to native ownership rather than the
+  /// return of SwiftVLC's own release call: a media-list player may keep the
+  /// player and its vout callbacks alive past that point.
+  func retainUntilReleased(_ objects: [AnyObject]) {
+    guard !objects.isEmpty else { return }
+    let retained = RetainedObjects(objects)
+    whenReleased { [retained] in
+      guard let releaseOwner = retained.takeContents() else { return }
+      if Thread.isMainThread {
+        withExtendedLifetime(releaseOwner) {}
+      } else {
+        // The box commonly holds UIKit/AppKit drawables. Native ownership can
+        // end on either teardown utility queue, but the final strong reference
+        // must not deinitialize a platform view there. `takeContents` emptied
+        // the release action's long-lived capture; this nested closure is now
+        // the sole lifetime owner and drops it on the main queue after the
+        // exact native lifetime has ended.
+        DispatchQueue.main.async { [releaseOwner] in
+          withExtendedLifetime(releaseOwner) {}
+        }
+      }
+    }
+  }
+
+  func waitUntilReleased() async {
+    if !releaseActionsPerformed {
+      await withCheckedContinuation { continuation in
+        let resumeImmediately = state.withLock { state -> Bool in
+          guard !state.releaseActionsPerformed else { return true }
+          state.releaseWaiters.append(continuation)
+          return false
+        }
+        if resumeImmediately {
+          continuation.resume()
+        }
+      }
+    }
+
+    // Retained UIKit/AppKit objects are moved to the main queue by their
+    // release action. That action is always enqueued before
+    // `releaseActionsPerformed` flips, so a main-queue fence proves their final
+    // release has happened without ever blocking the main actor.
+    await withCheckedContinuation { continuation in
+      DispatchQueue.main.async {
+        continuation.resume()
+      }
+    }
+  }
+
+  private var releaseActionsPerformed: Bool {
+    state.withLock { $0.releaseActionsPerformed }
+  }
+
+  var isReleased: Bool {
+    state.withLock { $0.isReleased }
+  }
+
+  var nativeOwnerCount: Int {
+    state.withLock { $0.nativeOwnerCount }
+  }
+}
+
+/// A counted claim corresponding to one native retain of a media-player
+/// handle. Ending a lease is explicit and idempotent. It deliberately does not
+/// auto-end in `deinit`: losing the token before the native release would make
+/// callbacks eligible for reclamation while native code can still invoke them.
+final class NativePlayerHandleLease: @unchecked Sendable {
+  private let lifetime: NativePlayerHandleLifetime
+  private let didEnd = Mutex(false)
+
+  fileprivate init(lifetime: NativePlayerHandleLifetime) {
+    self.lifetime = lifetime
+  }
+
+  func endAfterNativeOwnerRelease() {
+    let shouldEnd = didEnd.withLock { didEnd -> Bool in
+      guard !didEnd else { return false }
+      didEnd = true
+      return true
+    }
+    if shouldEnd {
+      lifetime.leasedOwnerDidRelease()
+    }
+  }
+}
 
 extension Player {
+  /// Whether teardown must first cancel a native pause (including one whose
+  /// async state event has not arrived yet). Capture this before clearing
+  /// `pauseTransition`; otherwise a shutdown racing `.pausing` can skip the
+  /// resume and stop libVLC while its audio output still has a pending pause.
+  var shouldResumeNativePlayerBeforeStop: Bool {
+    pauseTransition == .pausing || nativePlaybackState == .paused
+  }
+
   func releaseNativePlayer(
     _ nativePlayer: OpaquePointer,
+    lifetime: NativePlayerHandleLifetime,
     retaining drawables: [AnyObject] = [],
     resumeBeforeStop: Bool = false
   ) {
+    precondition(lifetime.pointer == nativePlayer)
+    lifetime.retainUntilReleased(drawables)
     nonisolated(unsafe) let nativePlayer = nativePlayer
-    nonisolated(unsafe) let drawables = drawables
     DispatchQueue.global(qos: .utility).async {
       libvlc_media_player_set_nsobject(nativePlayer, nil)
       Self.stopNativePlayerBeforeRelease(nativePlayer, resumeBeforeStop: resumeBeforeStop)
       libvlc_media_player_release(nativePlayer)
-      _ = drawables
+      lifetime.initialOwnerDidRelease()
     }
   }
 
@@ -44,3 +280,99 @@ extension Player {
     }
   }
 }
+
+#if os(iOS) || os(macOS)
+extension Player {
+  /// Makes `registration` the sole display owner of the stable direct-PiP
+  /// callback slot for the current native handle. Same-handle successors
+  /// reuse its opaque so a vout that already copied the predecessor's value
+  /// observes the new renderer target without reopening.
+  func claimDirectPiPVideoCallbacks(_ registration: DirectPiPVideoCallbackRegistration) {
+    let previous = directPiPVideoCallbackRegistration
+    let previousGeneration = directPiPVideoCallbackGeneration
+
+    directPiPVideoCallbackGeneration &+= 1
+    let generation = directPiPVideoCallbackGeneration
+    let slot: DirectPiPVideoCallbackSlot
+    if let existing = directPiPVideoCallbackSlot {
+      precondition(existing.lifetime === nativeHandleLifetime && !existing.isRetired)
+      slot = existing
+    } else {
+      slot = registration.makeSlot(on: nativeHandleLifetime)
+      directPiPVideoCallbackSlot = slot
+    }
+    registration.bind(to: slot, generation: generation)
+    directPiPVideoCallbackRegistration = registration
+
+    if let previous, previous !== registration {
+      previous.unbind(generation: previousGeneration)
+    }
+  }
+
+  /// Creates a fresh slot for a replacement native handle before retiring
+  /// the prior handle's slot. Different handles never share an opaque.
+  func moveDirectPiPVideoCallbacks(to lifetime: NativePlayerHandleLifetime) {
+    let previousSlot = directPiPVideoCallbackSlot
+    if let previousSlot {
+      precondition(previousSlot.lifetime === nativeHandleLifetime)
+      precondition(previousSlot.lifetime !== lifetime)
+    }
+    guard let registration = directPiPVideoCallbackRegistration else {
+      directPiPVideoCallbackSlot = nil
+      previousSlot?.retire()
+      return
+    }
+
+    directPiPVideoCallbackGeneration &+= 1
+    let generation = directPiPVideoCallbackGeneration
+    let successorSlot = registration.makeSlot(on: lifetime)
+    registration.bind(to: successorSlot, generation: generation)
+    directPiPVideoCallbackSlot = successorSlot
+    previousSlot?.retire()
+  }
+
+  /// Relinquishes the display target only if the caller still owns the current
+  /// handle and generation. Native callback variables are cleared, while the
+  /// dormant per-handle slot remains reusable by a sequential successor whose
+  /// already-open vout still holds its opaque.
+  func relinquishDirectPiPVideoCallbacks(_ registration: DirectPiPVideoCallbackRegistration) {
+    let generation = registration.currentGeneration
+    let ownsCurrentRegistration = directPiPVideoCallbackRegistration === registration
+      && generation == directPiPVideoCallbackGeneration
+      && registration.currentSlot === directPiPVideoCallbackSlot
+      && registration.currentLifetime === nativeHandleLifetime
+
+    if ownsCurrentRegistration {
+      directPiPVideoCallbackRegistration = nil
+      directPiPVideoCallbackGeneration &+= 1
+      directPiPVideoCallbackSlot?.deactivate()
+    }
+
+    if let generation {
+      registration.unbind(generation: generation)
+    }
+  }
+
+  /// Permanently retires the current handle's slot during native replacement
+  /// or final teardown. This differs from controller relinquishment: no later
+  /// owner may reuse an opaque belonging to the outgoing handle.
+  func retireDirectPiPVideoCallbacksForHandleEnd() {
+    let registration = directPiPVideoCallbackRegistration
+    let generation = registration?.currentGeneration
+    let slot = directPiPVideoCallbackSlot
+    if let slot {
+      precondition(slot.lifetime === nativeHandleLifetime)
+    }
+
+    directPiPVideoCallbackRegistration = nil
+    directPiPVideoCallbackSlot = nil
+    if registration != nil || slot != nil {
+      directPiPVideoCallbackGeneration &+= 1
+    }
+    if let registration, let generation {
+      registration.unbind(generation: generation)
+    }
+    slot?.retire()
+  }
+}
+#endif

--- a/Sources/SwiftVLC/Player/Player+Programs.swift
+++ b/Sources/SwiftVLC/Player/Player+Programs.swift
@@ -166,7 +166,9 @@ extension Player {
     while ContinuousClock.now < deadline {
       let audioReady = audio == nil || !audioTracks.isEmpty
       let subtitleReady = subtitle == nil || !subtitleTracks.isEmpty
-      if audioReady && subtitleReady { break }
+      if audioReady && subtitleReady {
+        break
+      }
       try? await Task.sleep(for: .milliseconds(50))
     }
 
@@ -219,7 +221,9 @@ extension Player {
   private func awaitSeekability() async -> Bool {
     let deadline = ContinuousClock.now + .seconds(2)
     while !isSeekable {
-      if ContinuousClock.now >= deadline { return false }
+      if ContinuousClock.now >= deadline {
+        return false
+      }
       try? await Task.sleep(for: .milliseconds(50))
     }
     return true

--- a/Sources/SwiftVLC/Player/Player+Teardown.swift
+++ b/Sources/SwiftVLC/Player/Player+Teardown.swift
@@ -104,6 +104,10 @@ extension Player {
     if let listPlayer = attachedMediaListPlayer {
       listPlayer.mediaPlayer = nil
     }
+    // Capture before the transition state is cleared below. The native
+    // `.paused` event can lag a just-issued pause command, so consulting only
+    // `nativePlaybackState` afterwards loses the race signal.
+    let resumeBeforeRelease = shouldResumeNativePlayerBeforeStop
     publishPlaybackIntent(false)
     pauseTransition = nil
     deferredPauseCommand = nil
@@ -118,15 +122,22 @@ extension Player {
       drawable.map { retainedDrawablesUntilNativePlayerRelease + [$0] }
         ?? retainedDrawablesUntilNativePlayerRelease
     nonisolated(unsafe) let p = pointer
-    let resumeBeforeRelease = pauseTransition == .pausing || nativePlaybackState == .paused
+    let lifetime = nativeHandleLifetime
     drawable = nil
     retainedDrawablesUntilNativePlayerRelease.removeAll()
-    pointer = Self.makeNativePlayer(instance: instance)
+    #if os(iOS) || os(macOS)
+    retireDirectPiPVideoCallbacksForHandleEnd()
+    #endif
+    let replacement = Self.makeNativePlayer(instance: instance)
+    let replacementLifetime = NativePlayerHandleLifetime(pointer: replacement)
+    pointer = replacement
+    nativeHandleLifetime = replacementLifetime
 
     await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
       DispatchQueue.global(qos: .utility).async {
         Self.teardownNativePlayer(
           p,
+          lifetime: lifetime,
           bridge: bridge,
           retainedDrawables: drawables,
           resumeBeforeStop: resumeBeforeRelease
@@ -134,6 +145,11 @@ extension Player {
         continuation.resume()
       }
     }
+    // `libvlc_media_player_release` only decrements a reference count. A
+    // retiring MediaListPlayer can still own this exact handle after our own
+    // release returns, so the full-teardown contract requires every counted
+    // native owner to finish releasing before shutdown returns.
+    await lifetime.waitUntilReleased()
     publishPlaybackState(.idle)
     currentMedia = nil
   }
@@ -147,14 +163,17 @@ extension Player {
   /// ``shutdown()``.
   nonisolated static func teardownNativePlayer(
     _ pointer: OpaquePointer,
+    lifetime: NativePlayerHandleLifetime,
     bridge: EventBridge,
     retainedDrawables: [AnyObject],
     resumeBeforeStop: Bool
   ) {
+    precondition(lifetime.pointer == pointer)
+    lifetime.retainUntilReleased(retainedDrawables)
     bridge.invalidate()
     stopNativePlayerBeforeRelease(pointer, resumeBeforeStop: resumeBeforeStop)
     libvlc_media_player_release(pointer)
-    _ = retainedDrawables
+    lifetime.initialOwnerDidRelease()
   }
 
   /// Re-applies per-player state that lives on the native handle and

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -368,7 +368,9 @@ public final class Player {
     let upstream = eventBridge.makeStream(
       policy: .unbounded,
       filter: { event in
-        if case .stateChanged = event { return true }
+        if case .stateChanged = event {
+          return true
+        }
         return false
       }
     )
@@ -397,6 +399,16 @@ public final class Player {
 
   @ObservationIgnored
   nonisolated(unsafe) var pointer: OpaquePointer // libvlc_media_player_t*
+  @ObservationIgnored
+  var nativeHandleLifetime: NativePlayerHandleLifetime
+  #if os(iOS) || os(macOS)
+  @ObservationIgnored
+  weak var directPiPVideoCallbackRegistration: DirectPiPVideoCallbackRegistration?
+  @ObservationIgnored
+  var directPiPVideoCallbackSlot: DirectPiPVideoCallbackSlot?
+  @ObservationIgnored
+  var directPiPVideoCallbackGeneration: UInt64 = 0
+  #endif
   let eventBridge: EventBridge
   nonisolated let endCoordinator = PlaybackEndCoordinator()
   nonisolated let playbackIntentBridge: Broadcaster<Bool>
@@ -474,6 +486,7 @@ public final class Player {
   public init(instance: VLCInstance = .shared) {
     let p = Self.makeNativePlayer(instance: instance)
     pointer = p
+    nativeHandleLifetime = NativePlayerHandleLifetime(pointer: p)
     self.instance = instance
     eventBridge = EventBridge(
       eventManager: libvlc_media_player_event_manager(p)!,
@@ -494,6 +507,9 @@ public final class Player {
     eventTask?.cancel()
     _marqueeRestoreTask?.cancel()
     playbackIntentBridge.finishAll()
+    #if os(iOS) || os(macOS)
+    retireDirectPiPVideoCallbacksForHandleEnd()
+    #endif
     // Tell libVLC to forget the drawable *before* release so the
     // vout thread observes a nil pointer rather than dereferencing a
     // view that is about to be released when `self`'s storage is torn
@@ -525,10 +541,12 @@ public final class Player {
       drawable.map { retainedDrawablesUntilNativePlayerRelease + [$0] }
         ?? retainedDrawablesUntilNativePlayerRelease
     nonisolated(unsafe) let p = pointer
-    let resumeBeforeRelease = pauseTransition == .pausing || nativePlaybackState == .paused
+    let lifetime = nativeHandleLifetime
+    let resumeBeforeRelease = shouldResumeNativePlayerBeforeStop
     DispatchQueue.global(qos: .utility).async {
       Self.teardownNativePlayer(
         p,
+        lifetime: lifetime,
         bridge: bridge,
         retainedDrawables: drawables,
         resumeBeforeStop: resumeBeforeRelease
@@ -571,7 +589,7 @@ public final class Player {
   ///   cannot be applied to a replacement native player.
   public func play(_ media: sending Media) throws(VLCError) {
     if shouldReplaceNativePlayerBeforePlaybackLoad {
-      let resumeBeforeRelease = pauseTransition == .pausing || nativePlaybackState == .paused
+      let resumeBeforeRelease = shouldResumeNativePlayerBeforeStop
       currentMedia = media
       resetMediaDerivedState()
       try replaceNativePlayerForDrawablePlayback(
@@ -751,7 +769,7 @@ public final class Player {
   /// teardown must not race the audio/video output drain (for example
   /// before deactivating a shared `AVAudioSession`).
   public func stop() {
-    if pauseTransition == .pausing || nativePlaybackState == .paused {
+    if shouldResumeNativePlayerBeforeStop {
       libvlc_media_player_set_pause(pointer, 0)
     }
     pauseTransition = nil

--- a/Sources/SwiftVLC/Player/PlayerEvent.swift
+++ b/Sources/SwiftVLC/Player/PlayerEvent.swift
@@ -117,72 +117,128 @@ public enum PlayerEvent: Sendable, CustomStringConvertible {
 extension PlayerEvent {
   /// `PlayerState` if this event is `.stateChanged`, otherwise `nil`.
   public var stateChanged: PlayerState? {
-    if case .stateChanged(let value) = self { value } else { nil }
+    if case .stateChanged(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// `Duration` if this event is `.timeChanged`, otherwise `nil`.
   public var timeChanged: Duration? {
-    if case .timeChanged(let value) = self { value } else { nil }
+    if case .timeChanged(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// `Double` if this event is `.positionChanged`, otherwise `nil`.
   public var positionChanged: Double? {
-    if case .positionChanged(let value) = self { value } else { nil }
+    if case .positionChanged(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// `Duration` if this event is `.lengthChanged`, otherwise `nil`.
   public var lengthChanged: Duration? {
-    if case .lengthChanged(let value) = self { value } else { nil }
+    if case .lengthChanged(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// `Bool` if this event is `.seekableChanged`, otherwise `nil`.
   public var seekableChanged: Bool? {
-    if case .seekableChanged(let value) = self { value } else { nil }
+    if case .seekableChanged(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// `Bool` if this event is `.pausableChanged`, otherwise `nil`.
   public var pausableChanged: Bool? {
-    if case .pausableChanged(let value) = self { value } else { nil }
+    if case .pausableChanged(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// `Void` if this event is `.tracksChanged`, otherwise `nil`.
   public var tracksChanged: Void? {
-    if case .tracksChanged = self { () } else { nil }
+    if case .tracksChanged = self {
+      ()
+    } else {
+      nil
+    }
   }
 
   /// `Void` if this event is `.mediaChanged`, otherwise `nil`.
   public var mediaChanged: Void? {
-    if case .mediaChanged = self { () } else { nil }
+    if case .mediaChanged = self {
+      ()
+    } else {
+      nil
+    }
   }
 
   /// `Void` if this event is `.encounteredError`, otherwise `nil`.
   public var encounteredError: Void? {
-    if case .encounteredError = self { () } else { nil }
+    if case .encounteredError = self {
+      ()
+    } else {
+      nil
+    }
   }
 
   /// `Float` if this event is `.volumeChanged`, otherwise `nil`.
   public var volumeChanged: Float? {
-    if case .volumeChanged(let value) = self { value } else { nil }
+    if case .volumeChanged(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// `Void` if this event is `.muted`, otherwise `nil`.
   public var muted: Void? {
-    if case .muted = self { () } else { nil }
+    if case .muted = self {
+      ()
+    } else {
+      nil
+    }
   }
 
   /// `Void` if this event is `.unmuted`, otherwise `nil`.
   public var unmuted: Void? {
-    if case .unmuted = self { () } else { nil }
+    if case .unmuted = self {
+      ()
+    } else {
+      nil
+    }
   }
 
   /// `Void` if this event is `.corked`, otherwise `nil`.
   public var corked: Void? {
-    if case .corked = self { () } else { nil }
+    if case .corked = self {
+      ()
+    } else {
+      nil
+    }
   }
 
   /// `Void` if this event is `.uncorked`, otherwise `nil`.
   public var uncorked: Void? {
-    if case .uncorked = self { () } else { nil }
+    if case .uncorked = self {
+      ()
+    } else {
+      nil
+    }
   }
 
   /// Optional `String?` if this event is `.audioDeviceChanged`,
@@ -190,32 +246,56 @@ extension PlayerEvent {
   /// didn't fire) from the inner nil (the device was unspecified)
   /// requires `if case .audioDeviceChanged(let device) = event`.
   public var audioDeviceChanged: String?? {
-    if case .audioDeviceChanged(let value) = self { value } else { nil }
+    if case .audioDeviceChanged(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// `Void` if this event is `.mediaStopping`, otherwise `nil`.
   public var mediaStopping: Void? {
-    if case .mediaStopping = self { () } else { nil }
+    if case .mediaStopping = self {
+      ()
+    } else {
+      nil
+    }
   }
 
   /// `Void` if this event is `.endReached`, otherwise `nil`.
   public var endReached: Void? {
-    if case .endReached = self { () } else { nil }
+    if case .endReached = self {
+      ()
+    } else {
+      nil
+    }
   }
 
   /// `Int` if this event is `.voutChanged`, otherwise `nil`.
   public var voutChanged: Int? {
-    if case .voutChanged(let value) = self { value } else { nil }
+    if case .voutChanged(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// `Float` if this event is `.bufferingProgress`, otherwise `nil`.
   public var bufferingProgress: Float? {
-    if case .bufferingProgress(let value) = self { value } else { nil }
+    if case .bufferingProgress(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// `Int` if this event is `.chapterChanged`, otherwise `nil`.
   public var chapterChanged: Int? {
-    if case .chapterChanged(let value) = self { value } else { nil }
+    if case .chapterChanged(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// Tuple of `(isRecording: Bool, filePath: String?)` if this event is
@@ -230,27 +310,47 @@ extension PlayerEvent {
 
   /// `Void` if this event is `.titleListChanged`, otherwise `nil`.
   public var titleListChanged: Void? {
-    if case .titleListChanged = self { () } else { nil }
+    if case .titleListChanged = self {
+      ()
+    } else {
+      nil
+    }
   }
 
   /// `Int` if this event is `.titleSelectionChanged`, otherwise `nil`.
   public var titleSelectionChanged: Int? {
-    if case .titleSelectionChanged(let value) = self { value } else { nil }
+    if case .titleSelectionChanged(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// `String` (path) if this event is `.snapshotTaken`, otherwise `nil`.
   public var snapshotTaken: String? {
-    if case .snapshotTaken(let value) = self { value } else { nil }
+    if case .snapshotTaken(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// Program group ID if this event is `.programAdded`, otherwise `nil`.
   public var programAdded: Int? {
-    if case .programAdded(let value) = self { value } else { nil }
+    if case .programAdded(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// Program group ID if this event is `.programDeleted`, otherwise `nil`.
   public var programDeleted: Int? {
-    if case .programDeleted(let value) = self { value } else { nil }
+    if case .programDeleted(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 
   /// Tuple of `(unselectedId: Int, selectedId: Int)` if this event is
@@ -265,6 +365,10 @@ extension PlayerEvent {
 
   /// Program group ID if this event is `.programUpdated`, otherwise `nil`.
   public var programUpdated: Int? {
-    if case .programUpdated(let value) = self { value } else { nil }
+    if case .programUpdated(let value) = self {
+      value
+    } else {
+      nil
+    }
   }
 }

--- a/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
+++ b/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
@@ -26,6 +26,10 @@ public final class MediaListPlayer {
   // `nonisolated(unsafe) let oldPointer` capture.
   nonisolated(unsafe) var pointer: OpaquePointer // libvlc_media_list_player_t*
   private var _mediaPlayer: Player?
+  /// Counted ownership matching the native retain performed by
+  /// `libvlc_media_list_player_set_media_player`. It moves with the exact
+  /// native list-player handle that owns that retain.
+  private var nativePlayerBindingLease: NativePlayerHandleLease?
   private var _mediaList: MediaList?
   private var _playbackMode: PlaybackMode = .default
   private let instance: VLCInstance
@@ -52,9 +56,11 @@ public final class MediaListPlayer {
     // Release off the main actor. `stop_async` and `release` can block
     // waiting for VLC's internal threads, stalling all async work.
     nonisolated(unsafe) let p = pointer
+    let bindingLease = nativePlayerBindingLease
     DispatchQueue.global(qos: .utility).async {
       libvlc_media_list_player_stop_async(p)
       libvlc_media_list_player_release(p)
+      bindingLease?.endAfterNativeOwnerRelease()
     }
   }
 
@@ -65,44 +71,63 @@ public final class MediaListPlayer {
   /// handle
   /// between items through list-player C calls the player cannot tell
   /// apart from a natural end. Observe list-level completion instead.
+  /// A player has one live list-player owner: assigning a player already
+  /// attached elsewhere transfers it from the previous list player without
+  /// stopping the shared native playback handle.
   public var mediaPlayer: Player? {
     get { _mediaPlayer }
     set {
-      if let previous = _mediaPlayer, previous !== newValue {
-        detachForEndSynthesis(previous)
+      guard _mediaPlayer !== newValue else { return }
+
+      if
+        let newValue,
+        let previousOwner = newValue.attachedMediaListPlayer,
+        previousOwner !== self {
+        previousOwner.detachForOwnershipTransfer(newValue)
       }
-      _mediaPlayer = newValue
+
+      let previous = _mediaPlayer
       if let newValue {
+        let replacementLease = newValue.nativeHandleLifetime.acquireNativeOwnerLease()
+        let previousLease = nativePlayerBindingLease
+        libvlc_media_list_player_set_media_player(pointer, newValue.pointer)
+        nativePlayerBindingLease = replacementLease
+        previousLease?.endAfterNativeOwnerRelease()
+
+        if let previous {
+          detachForEndSynthesis(previous, nativeStopWillFollow: false)
+        }
+        _mediaPlayer = newValue
         newValue.endCoordinator.setSuppressed(true)
         newValue.attachedMediaListPlayer = self
-        libvlc_media_list_player_set_media_player(pointer, newValue.pointer)
       } else {
-        rebuildNativePlayer()
+        if let previous {
+          detachForEndSynthesis(previous, nativeStopWillFollow: true)
+        }
+        _mediaPlayer = nil
+        rebuildNativePlayer(stopSharedPlayerBeforeDetaching: true)
       }
     }
   }
 
   /// Detach-time end-synthesis bookkeeping for a previously attached
-  /// player. The native list player's teardown (rebuild or replacement)
-  /// stops the still-bound handle on a background queue *after* this
-  /// runs, so a mid-playback detach must record that stop as
-  /// library-initiated before lifting suppression — otherwise the
-  /// deferred `Stopped` lands un-suppressed and unmarked and reads as a
-  /// natural end of the item the user detached. Suppression is lifted
-  /// unless another list player has since taken over the attachment: a
-  /// stale detach must not un-suppress a player that is still being
-  /// driven. The back-reference is `weak`, and weak references to an
-  /// object read `nil` once its deinit has begun — so on the deinit
-  /// path `attachedMediaListPlayer === self` can never hold and `nil`
-  /// must also count as "ours"; a `nil` that instead came from a third
-  /// list player's earlier teardown already lifted suppression, making
-  /// the repeat lift a no-op.
-  private func detachForEndSynthesis(_ previous: Player) {
-    switch previous.nativePlaybackState {
-    case .idle, .stopped, .error:
-      break
-    default:
-      previous.endCoordinator.markLibraryStop()
+  /// player. A nil detach or final list-player teardown stops the still-bound
+  /// handle later, so it records that stop as library-initiated before lifting
+  /// suppression. Replacing or transferring an attachment does not stop the
+  /// old player and must not leave a stale stop mark that can swallow its next
+  /// genuine end. Suppression is lifted unless another list player has since
+  /// taken over the attachment.
+  private func detachForEndSynthesis(
+    _ previous: Player,
+    nativeStopWillFollow: Bool = true
+  ) {
+    if nativeStopWillFollow {
+      switch previous.nativePlaybackState {
+      case .idle, .stopped, .error:
+        break
+      default:
+        previous.endCoordinator.markLibraryStop()
+      }
     }
     let owner = previous.attachedMediaListPlayer
     guard owner === self || owner == nil else { return }
@@ -116,10 +141,18 @@ public final class MediaListPlayer {
   /// without it the list player keeps driving the released handle.
   func rebindMediaPlayerHandle() {
     guard let player = _mediaPlayer else { return }
+    let replacementLease = player.nativeHandleLifetime.acquireNativeOwnerLease()
+    let previousLease = nativePlayerBindingLease
     libvlc_media_list_player_set_media_player(pointer, player.pointer)
+    nativePlayerBindingLease = replacementLease
+    previousLease?.endAfterNativeOwnerRelease()
   }
 
   /// The media list to play.
+  ///
+  /// Clearing the list rebuilds this wrapper because libVLC has no nullable
+  /// list setter. If a media player is attached, its current playback keeps
+  /// running on the replacement wrapper's shared native handle.
   public var mediaList: MediaList? {
     get { _mediaList }
     set {
@@ -127,7 +160,9 @@ public final class MediaListPlayer {
       if let newValue {
         libvlc_media_list_player_set_media_list(pointer, newValue.pointer)
       } else {
-        rebuildNativePlayer()
+        // The successor retains and adopts the same media-player handle. The
+        // retiring wrapper must release without stopping that shared handle.
+        rebuildNativePlayer(stopSharedPlayerBeforeDetaching: _mediaPlayer == nil)
       }
     }
   }
@@ -240,21 +275,55 @@ public final class MediaListPlayer {
     }
   }
 
-  private func rebuildNativePlayer() {
+  /// Relinquishes a player that another list player is about to adopt. Keep
+  /// end synthesis suppressed across the atomic main-actor transfer, and do
+  /// not stop the shared native player from the retiring wrapper.
+  private func detachForOwnershipTransfer(_ player: Player) {
+    guard _mediaPlayer === player else { return }
+    _mediaPlayer = nil
+    if player.attachedMediaListPlayer === self {
+      player.attachedMediaListPlayer = nil
+    }
+    rebuildNativePlayer(stopSharedPlayerBeforeDetaching: false)
+  }
+
+  private func rebuildNativePlayer(stopSharedPlayerBeforeDetaching: Bool) {
     guard let replacement = libvlc_media_list_player_new(instance.pointer) else {
       preconditionFailure("Failed to rebuild libvlc media list player. Is the libvlc.xcframework linked correctly?")
     }
 
     libvlc_media_list_player_set_playback_mode(replacement, _playbackMode.cValue)
+    var replacementLease: NativePlayerHandleLease?
     if let mediaPlayer = _mediaPlayer {
+      let lease = mediaPlayer.nativeHandleLifetime.acquireNativeOwnerLease()
       libvlc_media_list_player_set_media_player(replacement, mediaPlayer.pointer)
+      replacementLease = lease
     }
     if let mediaList = _mediaList {
       libvlc_media_list_player_set_media_list(replacement, mediaList.pointer)
     }
 
     let previous = pointer
+    let previousLease = nativePlayerBindingLease
+    if let previousLease {
+      // `release` is intentionally off-main, but merely queueing it leaves the
+      // retiring list player able to receive an end callback and advance the
+      // shared player after this method returns. Rebind it synchronously to an
+      // independent neutral player: pinned libVLC removes the old observer and
+      // releases the old player inside this call. Subsequent stop/release work
+      // can then affect only the neutral handle.
+      if stopSharedPlayerBeforeDetaching {
+        libvlc_media_list_player_stop_async(previous)
+      }
+      guard let neutralPlayer = libvlc_media_player_new(instance.pointer) else {
+        preconditionFailure("Failed to create a neutral libVLC media player during list-player rebuild.")
+      }
+      libvlc_media_list_player_set_media_player(previous, neutralPlayer)
+      previousLease.endAfterNativeOwnerRelease()
+      libvlc_media_player_release(neutralPlayer)
+    }
     pointer = replacement
+    nativePlayerBindingLease = replacementLease
     nonisolated(unsafe) let oldPointer = previous
     DispatchQueue.global(qos: .utility).async {
       libvlc_media_list_player_stop_async(oldPointer)

--- a/Sources/SwiftVLC/SwiftVLC.docc/MediaPlaylists.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/MediaPlaylists.md
@@ -46,6 +46,12 @@ listPlayer.playbackMode = .loop
 listPlayer.play()
 ```
 
+A `Player` has one live list-player owner. Assigning the same player to a
+second `MediaListPlayer` transfers ownership without stopping its current
+playback. Setting `mediaList = nil` also leaves the attached player's current
+playback running; set `mediaPlayer = nil` or call `stop()` when the player
+itself should stop.
+
 Control is per-item:
 
 ```swift

--- a/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
@@ -8,8 +8,11 @@ working native backend uses private Apple framework symbols.
 
 ``PiPVideoView`` replaces ``VideoView`` and configures the PiP-capable
 surface on your behalf. On iOS it attaches libVLC's native drawable and
-implements libVLC's Picture in Picture selectors, so the bundled iOS
-video output owns the `AVPictureInPictureController` integration.
+implements libVLC's Picture in Picture selectors. The bundled iOS video
+output renders inline into that drawable and owns the system
+`AVPictureInPictureController`; SwiftVLC receives the native controller
+only for control and observable state. ``PiPVideoView`` does not place
+``PiPController/layer`` in its view hierarchy.
 
 On macOS, ``PiPVideoView`` still hosts libVLC's native drawable for
 inline playback. Its native PiP start path remains unavailable unless
@@ -35,10 +38,10 @@ struct PlayerScreen: View {
 ```
 
 The `controller` binding is populated during view construction and
-stays in sync with the view's lifetime. It's `nil` on platforms that
-don't expose SwiftVLC's PiP APIs (e.g. tvOS and visionOS). On macOS the
-binding is non-`nil`, but ``PiPController/isPossible`` remains `false`
-unless the SPI native backend is enabled and available at runtime.
+stays in sync with the view's lifetime. On macOS the binding is non-`nil`,
+but ``PiPController/isPossible`` remains `false` unless the SPI native
+backend is enabled and available at runtime. SwiftVLC's PiP types are not
+compiled on tvOS or visionOS.
 
 Use the binding's controller for PiP *control and state*
 (``PiPController/toggle()``, ``PiPController/isPossible``,
@@ -52,17 +55,42 @@ instantiate ``PiPController`` yourself and host the layer directly.
 On iOS Simulator, SwiftVLC reports native PiP as unavailable. Simulator
 AVSampleBufferDisplayLayer PiP can reach `isPictureInPictureActive` while
 rendering a black system PiP window, so validate iOS PiP rendering on
-device.
+a physical device. Simulator success is not evidence that frames reach
+the system PiP window.
+
+### Native PiP subtitle limitation
+
+The bundled native iOS PiP route does not currently include VLC-rendered
+subtitles, bitmap subpictures, or on-screen-display regions in the system PiP
+video. VLC draws those regions into a sibling overlay view for inline playback,
+while AVKit receives only the video sample-buffer layer. Core Animation
+sublayers and sibling views are not composited into that content source.
+
+Supporting subtitles without degrading the zero-copy and HDR paths requires a
+separate, same-format burn-in stage before sample enqueue. That compositor is
+not part of SwiftVLC today. Do not rely on an inline subtitle appearing in the
+system PiP window; validate the exact subtitle behavior your app requires on a
+physical device.
 
 ## Audio session (iOS only)
 
 PiP requires a playback-category audio session. ``PiPController``
-configures one automatically on `init`:
+sets the `.playback` category automatically when it is constructed, but
+direct controller construction and native-view construction for an inactive
+Player deliberately do not activate the session. Merely building an idle view
+therefore does not take audio focus.
 
-```swift
-try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .moviePlayback)
-try? AVAudioSession.sharedInstance().setActive(true)
-```
+`setActive(true)` is deferred until ``PiPController/start()`` or the
+first active-playback signal. When a native iOS view adopts an already-playing
+Player, SwiftVLC activates before publishing the successor controller as the
+native backend owner; libVLC's AVKit controller may otherwise auto-start
+without SwiftVLC receiving a will-start callback. The direct route retries at
+will-start, and the native route retries when it observes did-start. If
+activation fails transiently, SwiftVLC leaves it pending for either fallback.
+
+Pass `managesAudioSession: false` to ``PiPVideoView`` when your app owns
+audio-session policy. In that mode SwiftVLC neither changes the category
+nor activates the shared session.
 
 Your app must also declare background modes in its Info.plist:
 
@@ -91,6 +119,32 @@ sample-buffer path may reflect system support but is not the recommended
 production path because it can crop video incorrectly on supported macOS
 releases.
 
+The direct renderer asks libVLC for 8-bit BGRA frames and uses an SDR RGB
+conversion path when AVKit requests resized output. It does not preserve
+HDR or wide-color metadata; use it only when that limitation is acceptable.
+
+## Playback ranges and live media
+
+The direct public sample-buffer route distinguishes three AVKit
+playback-range states:
+
+- No loaded media produces an invalid range because there is no content.
+- Loaded media with no positive native duration produces an indefinite
+  range with positive-infinite duration. Live playback can render before
+  a duration is known.
+- A positive native duration produces a finite range of that length.
+
+Media, length, and seekability event payloads invalidate AVKit's playback
+state so it re-queries the current native media handle. SwiftVLC uses the
+event payload rather than a potentially stale ``Player`` property because
+the player and PiP observers consume independent event streams. Seekability
+also keeps AVKit's `requiresLinearPlayback` setting synchronized on both
+iOS PiP routes. A successor controller adopting a preserved native attachment
+also re-samples current seekability under the backend's owner and attachment-
+generation checks, covering events that arrived while no controller owned the
+backend. Playback-state transitions provide a conservative fallback
+invalidation.
+
 ## Common pitfalls
 
 - **Never mix rendering paths.** A player attached to direct
@@ -100,6 +154,14 @@ releases.
 - **Put the PiP surface on screen before calling `player.play()`.**
   libVLC creates the native PiP controller after the visible drawable's
   video output opens.
+- **Do not wait for a duration before showing live PiP.** A loaded input
+  with an unknown duration is reported to AVKit as indefinite content,
+  not as an empty or fabricated finite range.
+- **Validate system PiP video on a physical iOS device.** Simulator PiP
+  state can become active while its system window remains black.
+- **Native PiP does not currently carry VLC's subtitle overlay.** Inline
+  subtitle visibility is not evidence that the same region reaches AVKit's
+  system PiP video.
 - **Keep the macOS PiP-safe VLC defaults if you opt into SPI.** Passing
   a completely custom ``VLCInstance`` argument list on macOS can disable
   video output or force an unsupported vout. Start from

--- a/Sources/SwiftVLC/SwiftVLC.docc/VLCKitPortingGuide.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/VLCKitPortingGuide.md
@@ -249,8 +249,37 @@ The awaitable forms are the port targets:
   it when the player's end-of-life must complete *before* something
   else, rather than on `deinit`'s background schedule.
 
+## Aspect ratio and fill
+
+VLCKit drove the picture shape through `videoAspectRatio` (a `"w:h"`
+C string) and `videoCropGeometry`. SwiftVLC replaces both with the
+typed ``Player/aspectRatio`` / ``AspectRatio``:
+
+| VLCKit | SwiftVLC |
+| --- | --- |
+| `videoAspectRatio = nil` (source shape) | ``AspectRatio/default`` |
+| `videoAspectRatio = "16:9"` (force shape) | ``AspectRatio/ratio(_:_:)`` |
+| Fill/cover the view | ``AspectRatio/fill`` |
+
+The semantics match VLCKit/libVLC 3:
+
+- ``AspectRatio/default`` keeps the source aspect, fitted inside the
+  view with letterbox/pillarbox bars.
+- ``AspectRatio/ratio(_:_:)`` forces the display aspect, **stretching**
+  the source to that shape (so `.ratio(4, 3)` on a 2.40:1 source shows a
+  distorted 4:3 picture), then fits the shaped picture in the view.
+- ``AspectRatio/fill`` covers the view, preserving the source aspect and
+  cropping the overflow — no distortion.
+
+The mode is a `Player` property: it survives the native-handle swaps that
+back ``Player/recast(to:)`` and a stopped drawable-hosted restart, and it
+tracks live drawable-size changes (rotation, split-screen) — set it once
+and it sticks.
+
 ## Topics
 
+- ``Player/aspectRatio``
+- ``AspectRatio``
 - ``Player/seek(toPosition:fast:)``
 - ``Player/jump(by:)``
 - ``PlayerEvent/endReached-enum.case``

--- a/Sources/SwiftVLC/SwiftVLC.docc/VLCKitPortingGuide.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/VLCKitPortingGuide.md
@@ -129,16 +129,39 @@ before playback starts**: once the player is `.playing`, later
 ``Player/bufferFill`` without demoting the lifecycle state, so a
 brief network stall does not bounce your UI through a state change.
 
-Derive mid-playback rebuffer spinners from the fill level instead:
+Derive mid-playback rebuffer spinners from the fill level instead.
+``Player/bufferFill`` is published continuously and is not gated by the
+state enum, so it covers the initial load too. A bare
+`bufferFill < 1` check flickers, though: ``Player/bufferFill`` updates
+constantly during playback and a healthy live stream hovers a little
+below `1.0`. Use hysteresis — demote on a clear dip, promote at full or
+as soon as playback advances:
 
 ```swift
-var isRebuffering: Bool {
-  player.state == .playing && player.bufferFill < 1
+@Observable @MainActor
+final class RebufferModel {
+  private(set) var isRebuffering = false
+  private var lastTime: Duration = .zero
+
+  func update(state: PlayerState, event: PlayerEvent) {
+    guard state == .playing else { isRebuffering = false; return }
+    switch event {
+    case .bufferingProgress(let fill):
+      if fill < 0.9 { isRebuffering = true }       // clear dip: show
+      else if fill >= 1.0 { isRebuffering = false } // full: hide
+    case .timeChanged(let time):
+      if time > lastTime { isRebuffering = false }  // advanced: not stalled
+      lastTime = time
+    default:
+      break
+    }
+  }
 }
 ```
 
-``Player/bufferFill`` is published continuously and is not gated by
-the state enum, so this works for the initial load too.
+The split thresholds (`0.9` down, `1.0` up) keep a value oscillating
+around one level from toggling the spinner, and the `timeChanged`
+promotion hides it for live streams that play steadily below `1.0`.
 
 ## Live metadata
 
@@ -276,10 +299,49 @@ back ``Player/recast(to:)`` and a stopped drawable-hosted restart, and it
 tracks live drawable-size changes (rotation, split-screen) — set it once
 and it sticks.
 
+## Subtitle auto-selection
+
+libVLC picks a subtitle track on each load, following its own
+preferences: a stream's *forced* or *default* subtitle flag, then the
+`sub-language` preference, then the `sub-track` index. SwiftVLC does
+not override this, so by default a freshly loaded media may come up with
+a subtitle already showing — ``Player/selectedSubtitleTrack`` is
+non-`nil` after the track list arrives.
+
+Two ways to get "off unless the user asks":
+
+- **Bias the instance.** Leave `sub-language` empty and `sub-track`
+  at `-1` (both are the libVLC defaults), and disable external-file
+  detection if you never side-load `.srt` files:
+
+  ```swift
+  let instance = try VLCInstance(
+    arguments: VLCInstance.defaultArguments + ["--no-sub-autodetect-file"]
+  )
+  ```
+
+  This suppresses language/index/file-driven selection, but a stream that
+  flags a *forced* or *default* subtitle can still auto-select it.
+
+- **Deselect per media (authoritative).** When the subtitle tracks first
+  appear for a media, clear the selection unless the user has chosen one:
+
+  ```swift
+  for await event in player.events {
+    if case .tracksChanged = event, !userPickedSubtitle {
+      player.selectedSubtitleTrack = nil
+    }
+  }
+  ```
+
+  This is the only way to guarantee "off" regardless of stream flags;
+  set ``Player/selectedSubtitleTrack`` again when the user opts in.
+
 ## Topics
 
 - ``Player/aspectRatio``
 - ``AspectRatio``
+- ``Player/selectedSubtitleTrack``
 - ``Player/seek(toPosition:fast:)``
 - ``Player/jump(by:)``
 - ``PlayerEvent/endReached-enum.case``

--- a/Sources/SwiftVLC/Video/AspectRatio.swift
+++ b/Sources/SwiftVLC/Video/AspectRatio.swift
@@ -4,14 +4,17 @@
 /// player.aspectRatio = .ratio(16, 9)
 /// ```
 public enum AspectRatio: Sendable, Hashable, CustomStringConvertible {
-  /// Preserve the source aspect ratio by fitting into the smaller dimension
-  /// of the display (may add letterbox/pillarbox bars).
+  /// Preserve the source aspect ratio, fitted inside the display
+  /// (letterbox/pillarbox bars where the shapes differ).
   case `default`
 
-  /// Force a specific aspect ratio (e.g. `.ratio(16, 9)`).
+  /// Force the picture to a specific display aspect ratio, stretching the
+  /// source to that shape (e.g. `.ratio(16, 9)`); the shaped picture is then
+  /// fitted inside the display.
   case ratio(Int, Int)
 
-  /// Fill the display by fitting to the larger dimension (may crop content).
+  /// Fill the display, preserving the source aspect and cropping the
+  /// overflow (cover).
   case fill
 
   public var description: String {

--- a/Tests/SwiftVLCTests/Core/DialogHandlerNetworkTests.swift
+++ b/Tests/SwiftVLCTests/Core/DialogHandlerNetworkTests.swift
@@ -179,7 +179,9 @@ private final class BasicAuthProbeServer: @unchecked Sendable {
   private static func acceptLoop(socketFD: Int32, state: StateBox) {
     while true {
       let client = accept(socketFD, nil, nil)
-      if client < 0 { return }
+      if client < 0 {
+        return
+      }
       handle(client: client, state: state)
       close(client)
     }
@@ -226,7 +228,9 @@ private final class BasicAuthProbeServer: @unchecked Sendable {
       let count = recv(client, &buffer, buffer.count, 0)
       guard count > 0 else { break }
       bytes.append(contentsOf: buffer.prefix(count))
-      if bytes.containsCRLFCRLF { break }
+      if bytes.containsCRLFCRLF {
+        break
+      }
     }
 
     return String(bytes: bytes, encoding: .utf8) ?? ""

--- a/Tests/SwiftVLCTests/Core/LoggingExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Core/LoggingExtendedTests.swift
@@ -12,7 +12,9 @@ extension Integration {
       let collectTask = Task.detached {
         for await entry in stream {
           collected.withLock { $0.append(entry) }
-          if collected.withLock({ $0.count }) >= 5 { break }
+          if collected.withLock({ $0.count }) >= 5 {
+            break
+          }
         }
       }
       // Start playback to generate log entries
@@ -67,7 +69,9 @@ extension Integration {
         var count = 0
         for await _ in stream {
           count += 1
-          if count >= 1 { break }
+          if count >= 1 {
+            break
+          }
         }
       }
       // Cancel after a brief pause so the test doesn't hang if no entries arrive

--- a/Tests/SwiftVLCTests/Core/VLCInstanceIdentityTests.swift
+++ b/Tests/SwiftVLCTests/Core/VLCInstanceIdentityTests.swift
@@ -176,7 +176,9 @@ private final class UserAgentProbeServer: @unchecked Sendable {
   private static func acceptLoop(socketFD: Int32, state: StateBox) {
     while true {
       let client = accept(socketFD, nil, nil)
-      if client < 0 { return }
+      if client < 0 {
+        return
+      }
       handle(client: client, state: state)
       close(client)
     }
@@ -217,7 +219,9 @@ private final class UserAgentProbeServer: @unchecked Sendable {
       let count = recv(client, &buffer, buffer.count, 0)
       guard count > 0 else { break }
       bytes.append(contentsOf: buffer.prefix(count))
-      if bytes.containsCRLFCRLF { break }
+      if bytes.containsCRLFCRLF {
+        break
+      }
     }
 
     return String(bytes: bytes, encoding: .utf8) ?? ""

--- a/Tests/SwiftVLCTests/Media/TrackCodecStringTests.swift
+++ b/Tests/SwiftVLCTests/Media/TrackCodecStringTests.swift
@@ -1,0 +1,65 @@
+@testable import SwiftVLC
+import Testing
+
+/// `Track.codecString` decodes the little-endian-packed FourCC in
+/// ``Track/codec`` so callers do not reverse the bytes (the `"462h"` bug).
+extension Logic {
+  struct TrackCodecStringTests {
+    /// Packs a FourCC the way libVLC stores it: first character in the low
+    /// byte. Bytes beyond the string stay zero (trailing NUL padding).
+    private func packed(_ string: String) -> Int {
+      var value: UInt32 = 0
+      for (index, byte) in string.utf8.enumerated() where index < 4 {
+        value |= UInt32(byte) << (8 * index)
+      }
+      return Int(value)
+    }
+
+    private func track(codec: Int) -> Track {
+      Track(
+        id: "t",
+        type: .video,
+        name: "Track",
+        codec: codec,
+        language: nil,
+        trackDescription: nil,
+        isSelected: false,
+        bitrate: 0,
+        channels: nil,
+        sampleRate: nil,
+        width: nil,
+        height: nil,
+        frameRate: nil,
+        encoding: nil
+      )
+    }
+
+    @Test(arguments: ["h264", "mp4a", "hvc1", "avc1"])
+    func `decodes a four-character codec`(fourcc: String) {
+      #expect(track(codec: packed(fourcc)).codecString == fourcc)
+    }
+
+    @Test
+    func `a trailing NUL ends the string`() {
+      // 'm','p','3', 0x00
+      #expect(track(codec: packed("mp3")).codecString == "mp3")
+    }
+
+    @Test
+    func `a trailing space is kept`() {
+      #expect(track(codec: packed("mp2 ")).codecString == "mp2 ")
+    }
+
+    @Test
+    func `a non-printable non-trailing byte yields nil`() {
+      // 'h', 0xFF, '6', '4' — the 0xFF is not a printable FourCC byte.
+      let codec = Int(UInt32(0x68) | (UInt32(0xFF) << 8) | (UInt32(0x36) << 16) | (UInt32(0x34) << 24))
+      #expect(track(codec: codec).codecString == nil)
+    }
+
+    @Test
+    func `a zero codec yields nil`() {
+      #expect(track(codec: 0).codecString == nil)
+    }
+  }
+}

--- a/Tests/SwiftVLCTests/Media/TrackCodecStringTests.swift
+++ b/Tests/SwiftVLCTests/Media/TrackCodecStringTests.swift
@@ -52,8 +52,15 @@ extension Logic {
 
     @Test
     func `a non-printable non-trailing byte yields nil`() {
-      // 'h', 0xFF, '6', '4' — the 0xFF is not a printable FourCC byte.
+      // 'h', 0xFF, '6', '4': the 0xFF is not a printable FourCC byte.
       let codec = Int(UInt32(0x68) | (UInt32(0xFF) << 8) | (UInt32(0x36) << 16) | (UInt32(0x34) << 24))
+      #expect(track(codec: codec).codecString == nil)
+    }
+
+    @Test
+    func `an embedded NUL with later bytes yields nil`() {
+      // 'h', 0x00, '6', '4': the NUL is not trailing padding.
+      let codec = Int(UInt32(0x68) | (UInt32(0x36) << 16) | (UInt32(0x34) << 24))
       #expect(track(codec: codec).codecString == nil)
     }
 

--- a/Tests/SwiftVLCTests/MemoryPressureTests.swift
+++ b/Tests/SwiftVLCTests/MemoryPressureTests.swift
@@ -191,7 +191,9 @@ extension Integration {
           // Simulate a slow consumer — 5ms per event is slower than
           // VLC's timeChanged cadence, so the buffer will churn.
           try? await Task.sleep(for: .milliseconds(5))
-          if n > 200 { break }
+          if n > 200 {
+            break
+          }
         }
         consumed.withLock { $0 = n }
       }
@@ -227,7 +229,9 @@ extension Integration {
             var count = 0
             for await _ in stream {
               count += 1
-              if count > 10 { break }
+              if count > 10 {
+                break
+              }
             }
             finished.withLock { $0 += 1 }
           }
@@ -435,7 +439,9 @@ extension Integration {
           var n = 0
           for await _ in stream {
             n += 1
-            if n > 5 { break }
+            if n > 5 {
+              break
+            }
           }
         }
         try? await Task.sleep(for: .milliseconds(40))
@@ -942,7 +948,9 @@ extension Integration {
           var n = 0
           for await _ in logStream {
             n += 1
-            if n > 3 { break }
+            if n > 3 {
+              break
+            }
           }
         }
 
@@ -951,7 +959,9 @@ extension Integration {
           var n = 0
           for await _ in eventStream {
             n += 1
-            if n > 5 { break }
+            if n > 5 {
+              break
+            }
           }
         }
 

--- a/Tests/SwiftVLCTests/PiP/PiPCallbackRegistrationTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPCallbackRegistrationTests.swift
@@ -1,0 +1,391 @@
+#if os(iOS) || os(macOS)
+@testable import SwiftVLC
+import AVFoundation
+import CoreMedia
+import Foundation
+import Synchronization
+import Testing
+
+private enum DirectPiPCallbackOperation: Equatable {
+  case install(UInt)
+  case clear(UInt)
+}
+
+@MainActor
+private final class DirectPiPCallbackRecorder {
+  private(set) var operations: [DirectPiPCallbackOperation] = []
+  private(set) var installedHandles: [UInt] = []
+  private(set) var installedOpaques: [UInt] = []
+  private(set) var clearedHandles: [UInt] = []
+
+  var api: DirectPiPVideoCallbackAPI {
+    DirectPiPVideoCallbackAPI(
+      install: { [weak self] handle, opaque in
+        let address = UInt(bitPattern: handle)
+        self?.operations.append(.install(address))
+        self?.installedHandles.append(address)
+        self?.installedOpaques.append(UInt(bitPattern: opaque))
+      },
+      clear: { [weak self] handle in
+        let address = UInt(bitPattern: handle)
+        self?.operations.append(.clear(address))
+        self?.clearedHandles.append(address)
+      }
+    )
+  }
+}
+
+extension Integration {
+  /// Deterministic coverage for direct `PiPController` vmem registration.
+  /// The tests inject native install/clear operations, so ownership races are
+  /// asserted as exact handle/generation transitions rather than inferred
+  /// from a real vout's timing.
+  @Suite(.tags(.mainActor, .async), .serialized)
+  @MainActor struct PiPCallbackRegistrationTests {
+    @Test
+    func `Older PiPController deinit leaves newer controller registered`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      var first: PiPController? = PiPController(player: player)
+      weak let firstProbe = first
+      let firstGeneration = player.directPiPVideoCallbackGeneration
+
+      var successor: PiPController? = PiPController(player: player)
+      weak let successorProbe = successor
+      let successorGeneration = player.directPiPVideoCallbackGeneration
+      #expect(successorGeneration > firstGeneration)
+
+      first = nil
+
+      #expect(firstProbe == nil)
+      #expect(successorProbe != nil)
+      #expect(player.directPiPVideoCallbackRegistration != nil)
+      #expect(player.directPiPVideoCallbackGeneration == successorGeneration)
+
+      successor = nil
+
+      #expect(successorProbe == nil)
+      #expect(player.directPiPVideoCallbackRegistration == nil)
+      #expect(player.directPiPVideoCallbackGeneration > successorGeneration)
+      await player.shutdown()
+    }
+
+    @Test
+    func `Superseded controller and its late cleanup cannot clear successor callbacks`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = DirectPiPCallbackRecorder()
+      let handle = UInt(bitPattern: player.pointer)
+      let firstRenderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+
+      let first = DirectPiPVideoCallbackRegistration(
+        renderer: firstRenderer,
+        api: recorder.api
+      )
+      player.claimDirectPiPVideoCallbacks(first)
+      let firstGeneration = try #require(first.currentGeneration)
+      let firstOpaque = try #require(first.currentOpaqueForTesting)
+      weak let firstContext = first.currentContextForTesting
+
+      // A vmem output copies its opaque when it opens. Replacing the native
+      // variables does not update that already-open copy. Negotiate this vout
+      // while the first controller owns the slot, then prove the resulting
+      // child opaque dynamically routes display to a successor.
+      var opaqueSlot: UnsafeMutableRawPointer? = firstOpaque
+      var chroma = [CChar](repeating: 0, count: 4)
+      var width: UInt32 = 96
+      var height: UInt32 = 54
+      var pitch: UInt32 = 0
+      var lines: UInt32 = 0
+      let bufferCount = withUnsafeMutablePointer(to: &opaqueSlot) { opaquePointer in
+        chroma.withUnsafeMutableBufferPointer { chromaBuffer in
+          withUnsafeMutablePointer(to: &width) { widthPointer in
+            withUnsafeMutablePointer(to: &height) { heightPointer in
+              withUnsafeMutablePointer(to: &pitch) { pitchPointer in
+                withUnsafeMutablePointer(to: &lines) { linesPointer in
+                  pixelBufferFormatCallback(
+                    opaque: opaquePointer,
+                    chroma: chromaBuffer.baseAddress,
+                    width: widthPointer,
+                    height: heightPointer,
+                    pitches: pitchPointer,
+                    lines: linesPointer
+                  )
+                }
+              }
+            }
+          }
+        }
+      }
+      #expect(bufferCount > 0)
+      let voutOpaque = try #require(opaqueSlot)
+      weak var voutContext: PixelBufferRendererVoutCallbackContext?
+      voutContext = pixelBufferVoutCallbackContext(from: voutOpaque)
+      #expect(voutOpaque != firstOpaque)
+      let voutDimensions = try {
+        let context = try #require(voutContext)
+        return context.decodeRenderer.state.withLock { ($0.width, $0.height) }
+      }()
+      #expect(voutDimensions == (96, 54))
+      #expect(firstRenderer.state.withLock { ($0.width, $0.height) } == (0, 0))
+
+      let successorRenderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      successorRenderer.setRenderSize(CMVideoDimensions(width: 48, height: 28))
+      let successor = DirectPiPVideoCallbackRegistration(renderer: successorRenderer, api: recorder.api)
+      player.claimDirectPiPVideoCallbacks(successor)
+      let successorGeneration = try #require(successor.currentGeneration)
+      let successorOpaque = try #require(successor.currentOpaqueForTesting)
+      weak let successorContext = successor.currentContextForTesting
+
+      #expect(successorGeneration > firstGeneration)
+      #expect(recorder.installedHandles == [handle])
+      #expect(Set(recorder.installedOpaques).count == 1)
+      #expect(successorOpaque == firstOpaque)
+      #expect(firstContext === successorContext)
+      #expect(recorder.clearedHandles.isEmpty)
+      #expect(recorder.operations == [.install(handle)])
+      #expect(player.directPiPVideoCallbackRegistration === successor)
+      #expect(successorRenderer.state.withLock { ($0.width, $0.height) } == (0, 0))
+
+      var plane: UnsafeMutableRawPointer?
+      let picture = withUnsafeMutablePointer(to: &plane) {
+        pixelBufferLockCallback(opaque: voutOpaque, planes: $0)
+      }
+      #expect(picture != nil)
+      pixelBufferUnlockCallback(opaque: voutOpaque, picture: picture, planes: nil)
+      pixelBufferDisplayCallback(opaque: voutOpaque, picture: picture)
+      #expect(firstRenderer.state.withLock { $0.renderPool } == nil)
+      #expect(
+        successorRenderer.state.withLock { ($0.renderPoolWidth, $0.renderPoolHeight) }
+          == (48, 28)
+      )
+
+      // Stale controller teardown owns neither the Player registry nor the
+      // native variables anymore.
+      player.relinquishDirectPiPVideoCallbacks(first)
+
+      #expect(recorder.clearedHandles.isEmpty)
+      #expect(player.directPiPVideoCallbackRegistration === successor)
+      #expect(player.directPiPVideoCallbackGeneration == successorGeneration)
+      #expect(firstContext != nil)
+
+      player.relinquishDirectPiPVideoCallbacks(successor)
+      #expect(recorder.clearedHandles == [handle])
+      #expect(recorder.operations == [.install(handle), .clear(handle)])
+
+      // An already-open vout keeps its per-vout opaque after the media-player
+      // callback variables are cleared. A dormant slot keeps that decode
+      // storage valid while dropping only display output; a sequential
+      // successor then reuses the same handle-level routing opaque.
+      var dormantPlane: UnsafeMutableRawPointer?
+      let dormantPicture = withUnsafeMutablePointer(to: &dormantPlane) {
+        pixelBufferLockCallback(opaque: voutOpaque, planes: $0)
+      }
+      #expect(dormantPicture != nil)
+      #expect(dormantPlane != nil)
+      pixelBufferUnlockCallback(
+        opaque: voutOpaque,
+        picture: dormantPicture,
+        planes: nil
+      )
+      pixelBufferDisplayCallback(opaque: voutOpaque, picture: dormantPicture)
+      #expect(firstContext != nil)
+      // After this vout's cleanup there can be no later lock from that vout;
+      // a racing future vout runs format first and recreates the decode pool.
+      pixelBufferCleanupCallback(opaque: voutOpaque)
+      #expect(voutContext == nil)
+      let third = DirectPiPVideoCallbackRegistration(
+        renderer: PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer()),
+        api: recorder.api
+      )
+      player.claimDirectPiPVideoCallbacks(third)
+      #expect(third.currentOpaqueForTesting == firstOpaque)
+      #expect(third.currentContextForTesting === firstContext)
+      #expect(
+        recorder.operations == [.install(handle), .clear(handle), .install(handle)]
+      )
+      player.relinquishDirectPiPVideoCallbacks(third)
+
+      await player.shutdown()
+      #expect(player.directPiPVideoCallbackSlot == nil)
+      #expect(
+        recorder.operations
+          == [.install(handle), .clear(handle), .install(handle), .clear(handle)]
+      )
+      #expect(firstContext == nil)
+      #expect(successorContext == nil)
+    }
+
+    @Test
+    func `Dormant slot is retired instead of copied to a replacement handle`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = DirectPiPCallbackRecorder()
+      let registration = DirectPiPVideoCallbackRegistration(
+        renderer: PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer()),
+        api: recorder.api
+      )
+      player.claimDirectPiPVideoCallbacks(registration)
+
+      let oldPointer = player.pointer
+      let oldHandle = UInt(bitPattern: oldPointer)
+      let oldLifetime = player.nativeHandleLifetime
+      weak let oldContext = registration.currentContextForTesting
+      player.relinquishDirectPiPVideoCallbacks(registration)
+
+      #expect(player.directPiPVideoCallbackRegistration == nil)
+      #expect(player.directPiPVideoCallbackSlot != nil)
+      #expect(recorder.operations == [.install(oldHandle), .clear(oldHandle)])
+
+      player.setDrawable(NSObject())
+      player.stop()
+      try player.prepareDrawableForPlayback()
+
+      #expect(player.pointer != oldPointer)
+      #expect(player.directPiPVideoCallbackSlot == nil)
+      #expect(recorder.operations == [.install(oldHandle), .clear(oldHandle)])
+
+      try #require(
+        await poll(timeout: .seconds(5)) { oldLifetime.isReleased },
+        "offloaded release did not finish for the dormant callback slot"
+      )
+      #expect(oldContext == nil)
+      await player.shutdown()
+    }
+
+    @Test
+    func `Native handle replacement installs successor generation before clearing old handle`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = DirectPiPCallbackRecorder()
+      let registration = DirectPiPVideoCallbackRegistration(
+        renderer: PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer()),
+        api: recorder.api
+      )
+      player.claimDirectPiPVideoCallbacks(registration)
+
+      let oldPointer = player.pointer
+      let oldLifetime = player.nativeHandleLifetime
+      let oldHandle = UInt(bitPattern: oldPointer)
+      let oldGeneration = try #require(registration.currentGeneration)
+      weak let oldContext = registration.currentContextForTesting
+
+      player.setDrawable(NSObject())
+      player.stop()
+      try player.prepareDrawableForPlayback()
+
+      let newPointer = player.pointer
+      let newHandle = UInt(bitPattern: newPointer)
+      let newGeneration = try #require(registration.currentGeneration)
+      #expect(newPointer != oldPointer)
+      #expect(newGeneration > oldGeneration)
+      #expect(recorder.installedHandles == [oldHandle, newHandle])
+      #expect(Set(recorder.installedOpaques).count == 2)
+      #expect(recorder.clearedHandles == [oldHandle])
+      #expect(
+        recorder.operations == [.install(oldHandle), .install(newHandle), .clear(oldHandle)]
+      )
+      #expect(registration.currentLifetime === player.nativeHandleLifetime)
+
+      player.relinquishDirectPiPVideoCallbacks(registration)
+      #expect(recorder.clearedHandles == [oldHandle, newHandle])
+
+      await player.shutdown()
+      try #require(
+        await poll(timeout: .seconds(5)) { oldLifetime.isReleased },
+        "offloaded release did not finish for the replaced native handle"
+      )
+      #expect(oldContext == nil)
+    }
+
+    @Test
+    func `Player shutdown retires callbacks on the handle being released`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = DirectPiPCallbackRecorder()
+      let registration = DirectPiPVideoCallbackRegistration(
+        renderer: PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer()),
+        api: recorder.api
+      )
+      player.claimDirectPiPVideoCallbacks(registration)
+      let handle = UInt(bitPattern: player.pointer)
+      weak let context = registration.currentContextForTesting
+
+      await player.shutdown()
+
+      #expect(recorder.operations == [.install(handle), .clear(handle)])
+      #expect(player.directPiPVideoCallbackRegistration == nil)
+      #expect(registration.currentGeneration == nil)
+      #expect(context == nil)
+    }
+
+    @Test
+    func `Retired future-vout opaque stays alive until every native owner releases`() throws {
+      let recorder = DirectPiPCallbackRecorder()
+      let pointer = try #require(OpaquePointer(bitPattern: 0xD1CE_CAFE))
+      let lifetime = NativePlayerHandleLifetime(pointer: pointer)
+      let listPlayerLease = lifetime.acquireNativeOwnerLease()
+      var opaque: UnsafeMutableRawPointer?
+      weak var context: PixelBufferRendererCallbackContext?
+      do {
+        let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+        let slot = DirectPiPVideoCallbackSlot(
+          lifetime: lifetime,
+          decodeRenderer: renderer,
+          api: recorder.api
+        )
+        slot.activate(renderer: renderer)
+        opaque = slot.opaque
+        context = slot.context
+        slot.retire()
+      }
+      let retainedOpaque = try #require(opaque)
+
+      #expect(context != nil)
+      #expect(context?.retirementRequestedForTesting == true)
+      #expect(context?.nativePlayerHandleReleasedForTesting == false)
+
+      // Model another callback arriving after retirement but before vout
+      // cleanup and exact native-handle release. Its plane remains valid even
+      // though the display target has been removed.
+      var opaqueSlot: UnsafeMutableRawPointer? = retainedOpaque
+      var chroma: [CChar] = Array(repeating: 0, count: 4)
+      var width: UInt32 = 96
+      var height: UInt32 = 54
+      var pitch: UInt32 = 0
+      var lines: UInt32 = 0
+      let bufferCount = withUnsafeMutablePointer(to: &opaqueSlot) { opaquePointer in
+        chroma.withUnsafeMutableBufferPointer { chromaBuffer in
+          pixelBufferFormatCallback(
+            opaque: opaquePointer,
+            chroma: chromaBuffer.baseAddress,
+            width: &width,
+            height: &height,
+            pitches: &pitch,
+            lines: &lines
+          )
+        }
+      }
+      #expect(bufferCount > 0)
+      let voutOpaque = try #require(opaqueSlot)
+      #expect(voutOpaque != retainedOpaque)
+      var plane: UnsafeMutableRawPointer?
+      let lateLock = withUnsafeMutablePointer(to: &plane) {
+        pixelBufferLockCallback(opaque: voutOpaque, planes: $0)
+      }
+      #expect(lateLock != nil)
+      #expect(plane != nil)
+      pixelBufferUnlockCallback(opaque: voutOpaque, picture: lateLock, planes: nil)
+      pixelBufferDisplayCallback(opaque: voutOpaque, picture: lateLock)
+      pixelBufferCleanupCallback(opaque: voutOpaque)
+      #expect(context != nil)
+
+      // SwiftVLC releasing its own reference is insufficient: a
+      // MediaListPlayer still owns the same handle and can drive a vout.
+      lifetime.initialOwnerDidRelease()
+      #expect(context != nil)
+      #expect(context?.nativePlayerHandleReleasedForTesting == false)
+
+      listPlayerLease.endAfterNativeOwnerRelease()
+
+      #expect(context == nil)
+      #expect(recorder.clearedHandles == [UInt(bitPattern: pointer)])
+    }
+  }
+}
+#endif

--- a/Tests/SwiftVLCTests/PiP/PiPControllerBindingPublicationTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerBindingPublicationTests.swift
@@ -1,0 +1,242 @@
+#if os(iOS) || os(macOS)
+@testable import SwiftVLC
+import SwiftUI
+import Testing
+
+extension Integration {
+  @Suite(.tags(.mainActor))
+  @MainActor struct PiPControllerBindingPublicationTests {
+    @Test
+    func `binding publication drops superseded controller work`() async {
+      let player = Player(instance: TestInstance.shared)
+      let coordinator = PiPVideoView(player).makeCoordinator()
+      let storage = Box<PiPController?>(nil)
+      let binding = Binding<PiPController?>(
+        get: { storage.value },
+        set: { storage.value = $0 }
+      )
+      let first = PiPController(player: player)
+      let second = PiPController(player: player)
+
+      coordinator.publishController(first, to: binding)
+      coordinator.publishController(second, to: binding)
+      await coordinator.waitForControllerBindingPublication()
+
+      #expect(storage.value === second)
+    }
+
+    @Test
+    func `unchanged binding publication performs no additional writes`() async {
+      let player = Player(instance: TestInstance.shared)
+      let coordinator = PiPVideoView(player).makeCoordinator()
+      let storage = Box<PiPController?>(nil)
+      let writeCount = Box(0)
+      let binding = Binding<PiPController?>(
+        get: { storage.value },
+        set: {
+          writeCount.value += 1
+          storage.value = $0
+        }
+      )
+      let controller = PiPController(player: player)
+
+      coordinator.publishController(controller, to: binding)
+      await coordinator.waitForControllerBindingPublication()
+      #expect(storage.value === controller)
+      #expect(writeCount.value == 1)
+
+      coordinator.publishController(controller, to: binding)
+      await coordinator.waitForControllerBindingPublication()
+      #expect(storage.value === controller)
+      #expect(writeCount.value == 1)
+    }
+
+    /// `Binding` exposes no storage identity. A replacement sink can already
+    /// contain the controller, which is observationally identical to SwiftUI
+    /// handing the publisher another wrapper around the unchanged sink. The
+    /// publisher therefore keeps ownership of the sink it demonstrably wrote
+    /// and treats the prepopulated sink as externally owned.
+    @Test
+    func `prepopulated replacement preserves demonstrable sink ownership`() async {
+      let player = Player(instance: TestInstance.shared)
+      let coordinator = PiPVideoView(player).makeCoordinator()
+      let firstStorage = Box<PiPController?>(nil)
+      let secondStorage = Box<PiPController?>(nil)
+      let firstWriteCount = Box(0)
+      let secondWriteCount = Box(0)
+      let firstBinding = Binding<PiPController?>(
+        get: { firstStorage.value },
+        set: {
+          firstWriteCount.value += 1
+          firstStorage.value = $0
+        }
+      )
+      let secondBinding = Binding<PiPController?>(
+        get: { secondStorage.value },
+        set: {
+          secondWriteCount.value += 1
+          secondStorage.value = $0
+        }
+      )
+      let controller = PiPController(player: player)
+
+      coordinator.publishController(controller, to: firstBinding)
+      await coordinator.waitForControllerBindingPublication()
+      #expect(firstStorage.value === controller)
+
+      // Model a genuinely different sink that was prepopulated elsewhere.
+      secondStorage.value = controller
+      coordinator.publishController(controller, to: secondBinding)
+      await coordinator.waitForControllerBindingPublication()
+      #expect(firstWriteCount.value == 1)
+      #expect(secondWriteCount.value == 0)
+
+      coordinator.clearControllerBinding()
+      await coordinator.waitForControllerBindingPublication()
+
+      #expect(firstStorage.value == nil)
+      #expect(secondStorage.value === controller)
+      #expect(firstWriteCount.value == 2)
+      #expect(secondWriteCount.value == 0)
+    }
+
+    @Test
+    func `fresh unchanged binding wrappers retain constant storage`() async {
+      let player = Player(instance: TestInstance.shared)
+      let publication = PiPControllerBindingPublication()
+      let storage = Box<PiPController?>(nil)
+      let writeCount = Box(0)
+      let controller = PiPController(player: player)
+      let makeBinding = {
+        Binding<PiPController?>(
+          get: { storage.value },
+          set: {
+            writeCount.value += 1
+            storage.value = $0
+          }
+        )
+      }
+
+      publication.publish(controller, to: makeBinding())
+      await publication.waitForPendingPublication()
+
+      for _ in 0..<10000 {
+        publication.publish(controller, to: makeBinding())
+      }
+      await publication.waitForPendingPublication()
+
+      #expect(storage.value === controller)
+      #expect(writeCount.value == 1)
+      #expect(publication.retainedBindingCountForTesting == 1)
+
+      publication.clear()
+      await publication.waitForPendingPublication()
+      #expect(storage.value == nil)
+      #expect(writeCount.value == 2)
+      #expect(publication.retainedBindingCountForTesting == 0)
+    }
+
+    @Test
+    func `replacing or removing a binding clears the prior sink`() async {
+      let player = Player(instance: TestInstance.shared)
+      let coordinator = PiPVideoView(player).makeCoordinator()
+      let firstStorage = Box<PiPController?>(nil)
+      let secondStorage = Box<PiPController?>(nil)
+      let firstBinding = Binding<PiPController?>(
+        get: { firstStorage.value },
+        set: { firstStorage.value = $0 }
+      )
+      let secondBinding = Binding<PiPController?>(
+        get: { secondStorage.value },
+        set: { secondStorage.value = $0 }
+      )
+      let first = PiPController(player: player)
+      let second = PiPController(player: player)
+
+      coordinator.publishController(first, to: firstBinding)
+      await coordinator.waitForControllerBindingPublication()
+      #expect(firstStorage.value === first)
+
+      coordinator.publishController(second, to: secondBinding)
+      await coordinator.waitForControllerBindingPublication()
+      #expect(firstStorage.value == nil)
+      #expect(secondStorage.value === second)
+
+      coordinator.publishController(second, to: nil)
+      await coordinator.waitForControllerBindingPublication()
+      #expect(secondStorage.value == nil)
+    }
+
+    @Test
+    func `removed binding no longer retains its detached controller`() async {
+      let player = Player(instance: TestInstance.shared)
+      let coordinator = PiPVideoView(player).makeCoordinator()
+      let storage = Box<PiPController?>(nil)
+      let binding = Binding<PiPController?>(
+        get: { storage.value },
+        set: { storage.value = $0 }
+      )
+      var controller: PiPController? = PiPController(player: player)
+      let detachedController = WeakBox(controller)
+
+      coordinator.publishController(controller, to: binding)
+      await coordinator.waitForControllerBindingPublication()
+      controller = nil
+      #expect(
+        detachedController.value != nil,
+        "The binding should be the remaining owner before removal"
+      )
+
+      coordinator.publishController(nil, to: nil)
+      await coordinator.waitForControllerBindingPublication()
+
+      #expect(storage.value == nil)
+      #expect(detachedController.value == nil)
+    }
+
+    /// A deferred dismantle from an old representable may run after its
+    /// successor has published into the same binding. Clearing is ownership
+    /// conditional so the stale teardown cannot erase the successor.
+    @Test
+    func `stale binding clear preserves a successor controller`() async {
+      let player = Player(instance: TestInstance.shared)
+      let oldCoordinator = PiPVideoView(player).makeCoordinator()
+      let successorCoordinator = PiPVideoView(player).makeCoordinator()
+      let storage = Box<PiPController?>(nil)
+      let binding = Binding<PiPController?>(
+        get: { storage.value },
+        set: { storage.value = $0 }
+      )
+      let oldController = PiPController(player: player)
+      let successor = PiPController(player: player)
+
+      oldCoordinator.publishController(oldController, to: binding)
+      await oldCoordinator.waitForControllerBindingPublication()
+      successorCoordinator.publishController(successor, to: binding)
+      await successorCoordinator.waitForControllerBindingPublication()
+
+      // Model the old representable's dismantle task running last.
+      oldCoordinator.clearControllerBinding()
+      await oldCoordinator.waitForControllerBindingPublication()
+
+      #expect(storage.value === successor)
+    }
+  }
+}
+
+private final class Box<T> {
+  var value: T
+
+  init(_ initial: T) {
+    value = initial
+  }
+}
+
+private final class WeakBox<T: AnyObject> {
+  weak var value: T?
+
+  init(_ value: T?) {
+    self.value = value
+  }
+}
+#endif

--- a/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
@@ -1,7 +1,9 @@
+// swiftlint:disable file_length
 #if os(iOS) || os(macOS)
 @testable import SwiftVLC
 import AVFoundation
 import AVKit
+import CLibVLC
 import CoreMedia
 import CustomDump
 import Synchronization
@@ -550,6 +552,39 @@ extension Integration {
     }
 
     @Test
+    func `skip interval conversion rejects nonnumeric Core Media times`() {
+      #expect(PiPController.skipOffsetMilliseconds(.invalid) == nil)
+      #expect(PiPController.skipOffsetMilliseconds(.indefinite) == nil)
+      #expect(PiPController.skipOffsetMilliseconds(.positiveInfinity) == nil)
+      #expect(PiPController.skipOffsetMilliseconds(.negativeInfinity) == nil)
+    }
+
+    @Test
+    func `skip target arithmetic saturates before timeline clamp`() {
+      #expect(
+        PiPController.clampedSkipTargetMilliseconds(
+          current: Int64.max - 5,
+          offset: 10,
+          duration: nil
+        ) == Int64.max
+      )
+      #expect(
+        PiPController.clampedSkipTargetMilliseconds(
+          current: 5,
+          offset: Int64.min,
+          duration: nil
+        ) == 0
+      )
+      #expect(
+        PiPController.clampedSkipTargetMilliseconds(
+          current: Int64.max,
+          offset: Int64.max,
+          duration: 10000
+        ) == 10000
+      )
+    }
+
+    @Test
     func `playback delegate proxy forwards setPlaying to owner`() {
       let player = Player(instance: TestInstance.shared)
       player._setStateForTesting(state: .playing)
@@ -614,32 +649,192 @@ extension Integration {
 
     // MARK: - Delegate TimeRangeForPlayback
 
-    /// Without a known duration, the delegate must report a 24-hour
-    /// sentinel so the PiP scrubber doesn't collapse to 100%.
+    /// With no media loaded there is no playable content. AVKit's
+    /// sample-buffer playback-delegate contract requires an invalid range
+    /// for this state.
     @Test
-    func `timeRangeForPlayback reports sentinel when duration is unknown`() {
+    func `timeRangeForPlayback is invalid when no media is loaded`() {
+      let expected = PiPPlaybackDelegateProxy.playbackTimeRange(
+        hasMedia: false,
+        duration: nil
+      )
+      #expect(!expected.isValid)
+
       let player = Player(instance: TestInstance.shared)
       let controller = PiPController(player: player)
       guard let pip = makePictureInPictureController(for: controller) else { return }
 
       let range = controller._timeRangeForPlaybackForTesting(pip)
 
-      #expect(range.start == .zero)
-      #expect(range.duration.seconds >= 86399, "Should be approximately 24 hours")
+      #expect(range == expected)
     }
 
-    /// When a duration is set, the delegate reports the matching range.
+    /// A loaded input whose duration is still unknown is live/indefinite
+    /// content, not an empty controller. AVKit requires an infinite duration
+    /// so it renders linear live controls instead of a fabricated VOD range.
     @Test
-    func `timeRangeForPlayback reports real duration when known`() {
+    func `timeRangeForPlayback is infinite when loaded media duration is unknown`() throws {
+      let expected = PiPPlaybackDelegateProxy.playbackTimeRange(
+        hasMedia: true,
+        duration: nil
+      )
+      #expect(expected.isValid)
+      #expect(expected.duration.isPositiveInfinity)
+
       let player = Player(instance: TestInstance.shared)
-      player._setStateForTesting(duration: .seconds(120))
+      try player.load(Media(url: TestMedia.twosecURL))
       let controller = PiPController(player: player)
       guard let pip = makePictureInPictureController(for: controller) else { return }
 
       let range = controller._timeRangeForPlaybackForTesting(pip)
+
+      #expect(range == expected)
+    }
+
+    /// The repository's released v0.10 binary predates the additive atomic
+    /// symbol. After parsing and loading a real VOD, the compatibility path
+    /// must still report the duration stored on that retained media object.
+    @Test(.tags(.async, .media))
+    func `released binary fallback reports loaded parsed VOD duration`() async throws {
+      guard !swiftvlc_media_length_snapshot_available() else { return }
+
+      let media = try Media(url: TestMedia.twosecURL)
+      _ = try await media.parse(timeout: .seconds(5), instance: TestInstance.shared)
+      let expectedMilliseconds = libvlc_media_get_duration(media.pointer)
+      #expect(expectedMilliseconds > 0)
+
+      let player = Player(instance: TestInstance.shared)
+      player.load(media)
+      let range = PiPPlaybackDelegateProxy.nativePlaybackTimeRange(
+        playerPointer: player.pointer
+      )
+
+      #expect(range.isValid)
+      #expect(range.duration.isNumeric)
+      #expect(
+        abs(range.duration.seconds - Double(expectedMilliseconds) / 1000) < 0.001
+      )
+    }
+
+    /// An unparsed network input has no finite duration. The same released-
+    /// binary fallback must distinguish that loaded identity from no media and
+    /// report a live/indefinite range.
+    @Test(.tags(.media))
+    func `released binary fallback reports loaded unknown stream as live`() throws {
+      guard !swiftvlc_media_length_snapshot_available() else { return }
+
+      let url = try #require(URL(string: "http://127.0.0.1:1/swiftvlc-live-proof"))
+      let media = try Media(url: url)
+      #expect(libvlc_media_get_duration(media.pointer) <= 0)
+
+      let player = Player(instance: TestInstance.shared)
+      player.load(media)
+      let range = PiPPlaybackDelegateProxy.nativePlaybackTimeRange(
+        playerPointer: player.pointer
+      )
+
+      #expect(range.isValid)
+      #expect(range.duration.isPositiveInfinity)
+    }
+
+    /// A retained native media snapshot with a finite libVLC length maps to
+    /// the matching AVKit playback range and balances the media reference.
+    @Test
+    func `timeRangeForPlayback reports native duration when known`() throws {
+      let retainedMedia = try #require(OpaquePointer(bitPattern: 0x1))
+      var releaseCount = 0
+      let range = try PiPPlaybackDelegateProxy.playbackTimeRange(
+        playerPointer: #require(OpaquePointer(bitPattern: 0x2)),
+        getSnapshot: { _ in (retainedMedia, 120_000) },
+        releaseMedia: { media in
+          #expect(media == retainedMedia)
+          releaseCount += 1
+        }
+      )
 
       #expect(range.start == .zero)
       #expect(abs(range.duration.seconds - 120) < 0.01)
+      #expect(releaseCount == 1)
+    }
+
+    /// When the additive atomic symbol is absent, the compatibility path must
+    /// ask duration about the same retained media object returned by the
+    /// player. Calling the independent player-length API would reintroduce the
+    /// replacement race this snapshot is designed to remove.
+    @Test
+    func `legacy snapshot reads duration from the retained media identity`() throws {
+      let player = try #require(OpaquePointer(bitPattern: 0x10))
+      let retainedMedia = try #require(OpaquePointer(bitPattern: 0x20))
+      var atomicCalls = 0
+      var durationInputs: [OpaquePointer] = []
+
+      let snapshot = PiPPlaybackDelegateProxy.retainedMediaLengthSnapshot(
+        playerPointer: player,
+        atomicSnapshotAvailable: false,
+        getAtomicSnapshot: { _ in
+          atomicCalls += 1
+          return nil
+        },
+        getRetainedMedia: { receivedPlayer in
+          #expect(receivedPlayer == player)
+          return retainedMedia
+        },
+        getMediaDuration: { media in
+          durationInputs.append(media)
+          return 120_000
+        }
+      )
+
+      #expect(snapshot?.media == retainedMedia)
+      #expect(snapshot?.length == 120_000)
+      #expect(atomicCalls == 0)
+      #expect(durationInputs == [retainedMedia])
+    }
+
+    /// Once the additive symbol exists, a failed atomic query means no loaded
+    /// media. Falling through to legacy calls could mix identities across a
+    /// concurrent replacement, so the operation must fail closed.
+    @Test
+    func `available atomic snapshot never falls through to legacy calls`() throws {
+      let player = try #require(OpaquePointer(bitPattern: 0x10))
+      var retainedMediaCalls = 0
+
+      let snapshot = PiPPlaybackDelegateProxy.retainedMediaLengthSnapshot(
+        playerPointer: player,
+        atomicSnapshotAvailable: true,
+        getAtomicSnapshot: { receivedPlayer in
+          #expect(receivedPlayer == player)
+          return nil
+        },
+        getRetainedMedia: { _ in
+          retainedMediaCalls += 1
+          return OpaquePointer(bitPattern: 0x20)
+        },
+        getMediaDuration: { _ in 120_000 }
+      )
+
+      #expect(snapshot == nil)
+      #expect(retainedMediaCalls == 0)
+    }
+
+    /// Core Media ranges exclude their end. A timebase exactly at duration,
+    /// or a briefly advanced timebase awaiting the terminal player event,
+    /// therefore requires a minimally extended finite answer for AVKit's
+    /// documented contains-current-time invariant.
+    @Test(arguments: [120.0, 120.25])
+    func `finite playback range contains timebase at and beyond nominal end`(
+      currentSeconds: Double
+    ) {
+      let current = CMTime(seconds: currentSeconds, preferredTimescale: 1000)
+      let range = PiPPlaybackDelegateProxy.playbackTimeRange(
+        hasMedia: true,
+        duration: .seconds(120),
+        currentTime: current
+      )
+
+      #expect(range.isValid)
+      #expect(range.duration.isNumeric)
+      #expect(CMTimeRangeContainsTime(range, time: current))
     }
 
     // MARK: - Delegate size transition hook

--- a/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
@@ -273,7 +273,63 @@ extension Integration {
       controller.stop()
     }
 
+    @Test
+    func `audio session activation retries after failure and is idempotent after success`() {
+      enum ActivationError: Error {
+        case rejected
+      }
+
+      let player = Player(instance: TestInstance.shared)
+      let recorder = PlaybackRecorder()
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(250),
+        managesAudioSession: true
+      )
+      var activationAttempts = 0
+      let activate: () throws -> Void = {
+        activationAttempts += 1
+        if activationAttempts == 1 {
+          throw ActivationError.rejected
+        }
+      }
+
+      controller.activateAudioSessionIfNeeded(using: activate)
+      #expect(activationAttempts == 1)
+      #expect(controller.hasActivatedAudioSession == false)
+
+      controller.activateAudioSessionIfNeeded(using: activate)
+      #expect(activationAttempts == 2)
+      #expect(controller.hasActivatedAudioSession == true)
+
+      controller.activateAudioSessionIfNeeded(using: activate)
+      #expect(activationAttempts == 2)
+      #expect(controller.hasActivatedAudioSession == true)
+    }
+
     #if os(iOS)
+    /// A start request cannot open PiP without loaded media and therefore
+    /// must not activate the shared audio session or take audio focus.
+    @Test
+    func `start without media does not activate the audio session`() {
+      let player = Player(instance: TestInstance.shared)
+      let recorder = PlaybackRecorder()
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(250),
+        managesAudioSession: true
+      )
+
+      #expect(player.currentMedia == nil)
+      #expect(controller.hasActivatedAudioSession == false)
+
+      controller.start()
+
+      #expect(controller.hasActivatedAudioSession == false)
+    }
+
     /// With `managesAudioSession: false` neither init nor `start()` may
     /// touch the shared audio session — category and activation both
     /// stay exactly as they were.
@@ -300,10 +356,13 @@ extension Integration {
 
     /// With `managesAudioSession: true` the category is set at init but
     /// activation is deferred: constructing the controller never grabs
-    /// audio focus, `start()` does.
+    /// audio focus. A start request activates only when AVKit supplied a
+    /// controller that can actually receive it; generic/simulator test
+    /// destinations legitimately have no PiP controller.
     @Test
-    func `managesAudioSession true defers activation out of init`() {
+    func `managesAudioSession true defers activation until a viable start`() throws {
       let player = Player(instance: TestInstance.shared)
+      try player.load(Media(url: TestMedia.twosecURL))
       let recorder = PlaybackRecorder()
       let controller = PiPController(
         player: player,
@@ -315,8 +374,25 @@ extension Integration {
       #expect(AVAudioSession.sharedInstance().category == .playback)
       #expect(controller.hasActivatedAudioSession == false)
 
+      let hasViableBackend = controller.pipController != nil
       controller.start()
-      #expect(controller.hasActivatedAudioSession == true)
+      #expect(controller.hasActivatedAudioSession == hasViableBackend)
+    }
+
+    @Test
+    func `constructing a direct controller during active intent does not activate audio session`() {
+      let player = Player(instance: TestInstance.shared)
+      player.setPlaybackIntentFromExternalControl(true)
+
+      let controller = PiPController(
+        player: player,
+        playbackDriver: PlaybackRecorder().driver,
+        pauseDebounce: .milliseconds(250),
+        managesAudioSession: true
+      )
+
+      #expect(player.isPlaybackRequestedActive)
+      #expect(controller.hasActivatedAudioSession == false)
     }
 
     /// The sample-buffer path mirrors the knob onto AVKit's

--- a/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
@@ -33,7 +33,9 @@ extension Integration {
       var collected: [PiPEvent] = []
       for await event in stream {
         collected.append(event)
-        if collected.count == count { break }
+        if collected.count == count {
+          break
+        }
       }
       return collected
     }

--- a/Tests/SwiftVLCTests/PiP/PiPPlaybackStateTransitionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPPlaybackStateTransitionTests.swift
@@ -1,0 +1,187 @@
+#if os(iOS) || os(macOS)
+@testable import SwiftVLC
+import CoreMedia
+import Testing
+
+@Suite(.tags(.logic, .mainActor))
+@MainActor struct PiPPlaybackStateTransitionTests {
+  @Test
+  func `loading live media invalidates even when duration remains unknown`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: nil,
+      isSeekable: false
+    )
+
+    let update = state.consume(
+      .mediaChanged,
+      observedDuration: nil,
+      observedIsSeekable: false
+    )
+
+    #expect(update.invalidatesPlaybackState)
+    #expect(update.requiresLinearPlayback == true)
+    assertEffects(of: update, expectedLinearPlayback: true)
+  }
+
+  @Test
+  func `media replacement ignores stale pre-event player state`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: .seconds(120),
+      isSeekable: true
+    )
+
+    let update = state.consume(
+      .mediaChanged,
+      observedDuration: .seconds(120),
+      observedIsSeekable: true
+    )
+
+    #expect(update.invalidatesPlaybackState)
+    #expect(update.requiresLinearPlayback == true)
+    #expect(state.durationMilliseconds == nil)
+    #expect(state.isSeekable == false)
+  }
+
+  @Test
+  func `seekability payload wins subscriber race and updates linear playback`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: nil,
+      isSeekable: false
+    )
+
+    let becameSeekable = state.consume(
+      .seekableChanged(true),
+      observedDuration: nil,
+      observedIsSeekable: false
+    )
+    #expect(becameSeekable.invalidatesPlaybackState)
+    #expect(becameSeekable.requiresLinearPlayback == false)
+    #expect(state.isSeekable)
+    assertEffects(of: becameSeekable, expectedLinearPlayback: false)
+
+    let becameLinear = state.consume(
+      .seekableChanged(false),
+      observedDuration: nil,
+      observedIsSeekable: true
+    )
+    #expect(becameLinear.invalidatesPlaybackState)
+    #expect(becameLinear.requiresLinearPlayback == true)
+    #expect(state.isSeekable == false)
+    assertEffects(of: becameLinear, expectedLinearPlayback: true)
+  }
+
+  @Test
+  func `seekability payload survives following events while player mirror is stale`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: nil,
+      isSeekable: false
+    )
+
+    let payloadUpdate = state.consume(
+      .seekableChanged(true),
+      observedDuration: nil,
+      observedIsSeekable: false
+    )
+    #expect(payloadUpdate.invalidatesPlaybackState)
+    #expect(payloadUpdate.requiresLinearPlayback == false)
+
+    let whileStale = state.consume(
+      .timeChanged(.seconds(1)),
+      observedDuration: nil,
+      observedIsSeekable: false
+    )
+    #expect(whileStale == PiPController.PlaybackStateUpdate())
+    #expect(state.isSeekable)
+
+    let mirrorCaughtUp = state.consume(
+      .timeChanged(.seconds(2)),
+      observedDuration: nil,
+      observedIsSeekable: true
+    )
+    #expect(mirrorCaughtUp == PiPController.PlaybackStateUpdate())
+    #expect(state.isSeekable)
+  }
+
+  @Test
+  func `media reset survives following events while player mirrors are stale`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: .seconds(120),
+      isSeekable: true
+    )
+
+    _ = state.consume(
+      .mediaChanged,
+      observedDuration: .seconds(120),
+      observedIsSeekable: true
+    )
+    let whileStale = state.consume(
+      .timeChanged(.zero),
+      observedDuration: .seconds(120),
+      observedIsSeekable: true
+    )
+
+    #expect(whileStale == PiPController.PlaybackStateUpdate())
+    #expect(state.durationMilliseconds == nil)
+    #expect(state.isSeekable == false)
+  }
+
+  @Test
+  func `duration payload wins subscriber race and invalidates`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: nil,
+      isSeekable: false
+    )
+
+    let update = state.consume(
+      .lengthChanged(.seconds(90)),
+      observedDuration: nil,
+      observedIsSeekable: false
+    )
+
+    #expect(update.invalidatesPlaybackState)
+    #expect(state.durationMilliseconds == 90000)
+    assertEffects(of: update, expectedLinearPlayback: nil)
+  }
+
+  @Test
+  func `native range query ignores a stale finite Player mirror after live media change`() throws {
+    let staleMirrorRange = PiPPlaybackDelegateProxy.playbackTimeRange(
+      hasMedia: true,
+      duration: .seconds(120)
+    )
+    #expect(staleMirrorRange.duration.seconds == 120)
+
+    let retainedMedia = try #require(OpaquePointer(bitPattern: 0x1))
+    var releaseCount = 0
+    let nativeRange = try PiPPlaybackDelegateProxy.playbackTimeRange(
+      playerPointer: #require(OpaquePointer(bitPattern: 0x2)),
+      getSnapshot: { _ in (retainedMedia, 0) },
+      releaseMedia: { media in
+        #expect(media == retainedMedia)
+        releaseCount += 1
+      }
+    )
+
+    #expect(nativeRange.isValid)
+    #expect(nativeRange.duration.isPositiveInfinity)
+    #expect(releaseCount == 1)
+  }
+
+  private func assertEffects(
+    of update: PiPController.PlaybackStateUpdate,
+    expectedLinearPlayback: Bool?
+  ) {
+    var invalidationCount = 0
+    var linearPlaybackValues: [Bool] = []
+
+    PiPController.applyPlaybackStateUpdate(
+      update,
+      setRequiresLinearPlayback: { linearPlaybackValues.append($0) },
+      invalidatePlaybackState: { invalidationCount += 1 }
+    )
+
+    #expect(invalidationCount == 1)
+    #expect(linearPlaybackValues == expectedLinearPlayback.map { [$0] } ?? [])
+  }
+}
+#endif

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewIOSNativeTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewIOSNativeTests.swift
@@ -1,0 +1,896 @@
+#if os(iOS)
+@testable import SwiftVLC
+import CLibVLC
+import CustomDump
+import SwiftUI
+import Testing
+import UIKit
+
+extension Integration {
+  @Suite(.tags(.mainActor))
+  @MainActor struct PiPVideoViewIOSNativeTests {
+    private func nativeDrawable(of player: Player) -> UnsafeMutableRawPointer? {
+      libvlc_media_player_get_nsobject(player.pointer)
+    }
+
+    /// Pinned libVLC copies `drawable-nsobject` into
+    /// `VLCVideoUIView._viewContainer` once, when the vout opens. Replacing
+    /// the player's variable cannot move that already-open vout. This probe
+    /// models the strong, immutable container reference so the representable
+    /// lifecycle regression is deterministic without relying on decoder
+    /// timing.
+    @Test
+    func `same-player make before dismantle reparents the vout-latched attachment`() throws {
+      let player = Player(instance: TestInstance.shared)
+      let originalHost = IOSNativePiPHostView()
+      originalHost.attach(to: player)
+      let originalAttachment = try #require(originalHost.drawableView.drawableAttachment)
+      let originalBackend = originalAttachment.nativePiPBackend
+      let openVout = OpenVoutContainerProbe(viewContainer: originalAttachment)
+      let nativeHandle = player.pointer
+      player.nativePlayerHasStartedPlayback = true
+
+      let successorHost = IOSNativePiPHostView()
+      successorHost.attach(to: player)
+      originalHost.detach()
+
+      let successorAttachment = try #require(successorHost.drawableView.drawableAttachment)
+      #expect(successorAttachment === openVout.viewContainer)
+      #expect(successorAttachment === originalAttachment)
+      #expect(successorAttachment.superview === successorHost.drawableView)
+      #expect(successorHost.nativePiPBackend === originalBackend)
+      #expect(player.drawable === originalAttachment)
+      #expect(nativeDrawable(of: player) == Unmanaged.passUnretained(originalAttachment).toOpaque())
+      #expect(player.pointer == nativeHandle)
+      #expect(originalAttachment.reserveReadyCallbackGeneration() != nil)
+    }
+
+    /// SwiftUI is also allowed to dismantle the old representable before it
+    /// constructs the replacement. While a native handle has started, the
+    /// exact attachment must remain installed on `Player`: that existing
+    /// strong reference is the handoff lease, and avoids both a timing guess
+    /// and a second Player-owned controller/session cycle.
+    @Test
+    func `same-player dismantle before make preserves and reparents the vout-latched attachment`() throws {
+      let player = Player(instance: TestInstance.shared)
+      let originalHost = IOSNativePiPHostView()
+      originalHost.attach(to: player)
+      let originalAttachment = try #require(originalHost.drawableView.drawableAttachment)
+      let originalBackend = originalAttachment.nativePiPBackend
+      let openVout = OpenVoutContainerProbe(viewContainer: originalAttachment)
+      let nativeHandle = player.pointer
+      player.nativePlayerHasStartedPlayback = true
+
+      originalHost.detach()
+
+      #expect(player.drawable === openVout.viewContainer)
+      #expect(originalAttachment.superview == nil)
+
+      let successorHost = IOSNativePiPHostView()
+      successorHost.attach(to: player)
+      let successorAttachment = try #require(successorHost.drawableView.drawableAttachment)
+
+      #expect(successorAttachment === openVout.viewContainer)
+      #expect(successorAttachment.superview === successorHost.drawableView)
+      #expect(successorHost.nativePiPBackend === originalBackend)
+      #expect(player.drawable === originalAttachment)
+      #expect(nativeDrawable(of: player) == Unmanaged.passUnretained(originalAttachment).toOpaque())
+      #expect(player.pointer == nativeHandle)
+      #expect(originalAttachment.reserveReadyCallbackGeneration() != nil)
+    }
+
+    @Test
+    func `iOS native PiP host attaches drawable child`() throws {
+      let player = Player(instance: TestInstance.shared)
+      let host = IOSNativePiPHostView()
+
+      host.attach(to: player)
+      let attachment = try #require(host.drawableView.drawableAttachment)
+      #expect(player.drawable === attachment)
+
+      host.detach()
+      #expect(player.drawable == nil)
+    }
+
+    /// A stopped player's vout can first evaluate `pictureInPictureReady`
+    /// after the host has already attached a successor player. The selector
+    /// source itself therefore needs immutable attachment identity; reading
+    /// the backend's current token at callback time would mis-tag the old
+    /// window controller as belonging to the successor.
+    @Test
+    func `late old-vout ready selector cannot claim successor attachment`() throws {
+      let firstPlayer = Player(instance: TestInstance.shared)
+      let secondPlayer = Player(instance: TestInstance.shared)
+      let view = IOSNativePiPDrawableView()
+
+      view.attach(to: firstPlayer)
+      let firstAttachment = try #require(view.drawableAttachment)
+
+      view.attach(to: secondPlayer)
+      let secondAttachment = try #require(view.drawableAttachment)
+
+      #expect(firstAttachment !== secondAttachment)
+      #expect(firstAttachment.reserveReadyCallbackGeneration() == nil)
+      #expect(secondAttachment.reserveReadyCallbackGeneration() != nil)
+
+      view.detach()
+    }
+
+    @Test
+    func `attachment churn releases surfaces that have no vout`() throws {
+      let player = Player(instance: TestInstance.shared)
+      let view = IOSNativePiPDrawableView()
+      var attachments: [WeakBox<IOSNativePiPDrawableAttachment>] = []
+
+      try autoreleasepool {
+        for _ in 0..<16 {
+          view.attach(to: player)
+          let attachment = try #require(view.drawableAttachment)
+          attachments.append(WeakBox(attachment))
+          view.detach()
+        }
+      }
+
+      #expect(attachments.allSatisfy { $0.value == nil })
+      #expect(player.drawable == nil)
+      #expect(nativeDrawable(of: player) == nil)
+      #expect(player.retainedDrawablesUntilNativePlayerRelease.isEmpty)
+      withExtendedLifetime(player) {}
+    }
+
+    @Test
+    func `active same-player host churn keeps one attachment and no retirement list`() throws {
+      let player = Player(instance: TestInstance.shared)
+      var host = IOSNativePiPHostView()
+      host.attach(to: player)
+      let originalAttachment = try #require(host.drawableView.drawableAttachment)
+      let originalBackend = host.nativePiPBackend
+      let nativeHandle = player.pointer
+      player.nativePlayerHasStartedPlayback = true
+      var retiredDrawableViews: [WeakBox<IOSNativePiPDrawableView>] = []
+
+      for _ in 0..<128 {
+        let retiredDrawableView = host.drawableView
+        let successor = IOSNativePiPHostView()
+        successor.attach(to: player)
+        host.detach()
+        retiredDrawableViews.append(WeakBox(retiredDrawableView))
+        host = successor
+
+        #expect(host.drawableView.drawableAttachment === originalAttachment)
+        #expect(host.nativePiPBackend === originalBackend)
+      }
+
+      #expect(player.drawable === originalAttachment)
+      #expect(nativeDrawable(of: player) == Unmanaged.passUnretained(originalAttachment).toOpaque())
+      #expect(player.pointer == nativeHandle)
+      #expect(player.retainedDrawablesUntilNativePlayerRelease.isEmpty)
+      #expect(retiredDrawableViews.allSatisfy { $0.value == nil })
+    }
+
+    @Test
+    func `observed externally-driven vout also leases the exact attachment`() throws {
+      let player = Player(instance: TestInstance.shared)
+      let originalHost = IOSNativePiPHostView()
+      originalHost.attach(to: player)
+      let attachment = try #require(originalHost.drawableView.drawableAttachment)
+      #expect(player.nativePlayerHasStartedPlayback == false)
+      player.activeVideoOutputs = 1
+
+      originalHost.detach()
+
+      #expect(player.drawable === attachment)
+      #expect(attachment.superview == nil)
+
+      let successorHost = IOSNativePiPHostView()
+      successorHost.attach(to: player)
+      #expect(successorHost.drawableView.drawableAttachment === attachment)
+    }
+
+    @Test
+    func `successor policy overrides the adopted vout snapshot`() throws {
+      let player = Player(instance: TestInstance.shared)
+      let originalHost = IOSNativePiPHostView(startsAutomaticallyFromInline: true)
+      originalHost.attach(to: player)
+      let attachment = try #require(originalHost.drawableView.drawableAttachment)
+      player.nativePlayerHasStartedPlayback = true
+      originalHost.detach()
+
+      let successorHost = IOSNativePiPHostView(startsAutomaticallyFromInline: false)
+      successorHost.attach(to: player)
+      let successorController = PiPController(
+        player: player,
+        nativeBackend: successorHost.nativePiPBackend,
+        startsAutomaticallyFromInline: false
+      )
+
+      #expect(successorHost.drawableView.drawableAttachment === attachment)
+      // The C controller may already have snapshotted this selector, so the
+      // immutable attachment keeps its original answer. SwiftVLC overrides
+      // the actual AVPictureInPictureController through the adopted backend.
+      #expect(attachment.canStartPictureInPictureAutomaticallyFromInline())
+      #expect(successorHost.nativePiPBackend.startsAutomaticallyFromInline == false)
+      #expect(successorController.startsAutomaticallyFromInline == false)
+    }
+
+    @Test
+    func `different-player swap gets an isolated attachment and backend`() throws {
+      let firstPlayer = Player(instance: TestInstance.shared)
+      let secondPlayer = Player(instance: TestInstance.shared)
+      let host = IOSNativePiPHostView()
+      host.attach(to: firstPlayer)
+      let firstAttachment = try #require(host.drawableView.drawableAttachment)
+      let firstBackend = host.nativePiPBackend
+      firstPlayer.nativePlayerHasStartedPlayback = true
+
+      host.attach(to: secondPlayer)
+      let secondAttachment = try #require(host.drawableView.drawableAttachment)
+      let secondBackend = host.nativePiPBackend
+
+      #expect(firstAttachment !== secondAttachment)
+      #expect(firstBackend !== secondBackend)
+      #expect(firstPlayer.drawable == nil)
+      #expect(secondPlayer.drawable === secondAttachment)
+      #expect(firstBackend.mediaController.player == nil)
+      #expect(secondBackend.mediaController.player === secondPlayer)
+      #expect(firstAttachment.reserveReadyCallbackGeneration() == nil)
+      #expect(secondAttachment.reserveReadyCallbackGeneration() != nil)
+      #expect(firstPlayer.retainedDrawablesUntilNativePlayerRelease.count == 1)
+
+      host.detach()
+    }
+
+    @Test
+    func `detached stale host cannot repurpose an orphaned player's backend`() throws {
+      let firstPlayer = Player(instance: TestInstance.shared)
+      let secondPlayer = Player(instance: TestInstance.shared)
+      let host = IOSNativePiPHostView()
+      host.attach(to: firstPlayer)
+      let firstAttachment = try #require(host.drawableView.drawableAttachment)
+      let firstBackend = host.nativePiPBackend
+      firstPlayer.nativePlayerHasStartedPlayback = true
+      host.detach()
+
+      host.attach(to: secondPlayer)
+      let secondAttachment = try #require(host.drawableView.drawableAttachment)
+
+      #expect(firstPlayer.drawable === firstAttachment)
+      #expect(firstAttachment.nativePiPBackend === firstBackend)
+      #expect(firstBackend.mediaController.player === firstPlayer)
+      #expect(firstAttachment.reserveReadyCallbackGeneration() != nil)
+      #expect(host.nativePiPBackend !== firstBackend)
+      #expect(secondPlayer.drawable === secondAttachment)
+      #expect(secondAttachment.nativePiPBackend === host.nativePiPBackend)
+    }
+
+    @Test
+    func `orphaned active attachment does not retain its controller or player`() async throws {
+      weak var releasedController: PiPController?
+      weak var releasedPlayer: Player?
+
+      do {
+        var player: Player? = Player(instance: TestInstance.shared)
+        releasedPlayer = player
+        let host = IOSNativePiPHostView()
+        try host.attach(to: #require(player))
+        player?.nativePlayerHasStartedPlayback = true
+
+        var controller: PiPController? = try PiPController(
+          player: #require(player),
+          nativeBackend: host.nativePiPBackend
+        )
+        releasedController = controller
+
+        host.detach()
+        controller = nil
+        await Task.yield()
+
+        #expect(releasedController == nil)
+        #expect(host.nativePiPBackend.owner == nil)
+        player = nil
+      }
+
+      #expect(releasedPlayer == nil)
+    }
+
+    @Test
+    func `dismantle-first successor controller claims the preserved backend`() async {
+      let player = Player(instance: TestInstance.shared)
+      let originalHost = IOSNativePiPHostView()
+      originalHost.attach(to: player)
+      let backend = originalHost.nativePiPBackend
+      var originalController: PiPController? = PiPController(
+        player: player,
+        nativeBackend: backend
+      )
+      weak var releasedController: PiPController?
+      releasedController = originalController
+      player.nativePlayerHasStartedPlayback = true
+
+      originalHost.detach()
+      originalController = nil
+      await Task.yield()
+
+      #expect(releasedController == nil)
+      #expect(backend.owner == nil)
+
+      let successorHost = IOSNativePiPHostView()
+      successorHost.attach(to: player)
+      let successorController = PiPController(
+        player: player,
+        nativeBackend: successorHost.nativePiPBackend
+      )
+
+      #expect(successorHost.nativePiPBackend === backend)
+      #expect(backend.owner === successorController)
+      withExtendedLifetime(successorController) {}
+    }
+
+    /// Regression for the exact ownerless handoff window: the drawable and
+    /// native backend remain latched to the live vout, the old controller is
+    /// gone, and a seekability event updates Player while no backend owner can
+    /// accept it. The successor must resample Player as part of its guarded
+    /// ownership claim instead of waiting for another seekability transition.
+    @Test
+    func `successor reconciles seekability changed during ownerless preserved attachment`() async throws {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(isSeekable: false)
+
+      let originalHost = IOSNativePiPHostView()
+      originalHost.attach(to: player)
+      let attachment = try #require(originalHost.drawableView.drawableAttachment)
+      let backend = originalHost.nativePiPBackend
+      var originalController: PiPController? = PiPController(
+        player: player,
+        nativeBackend: backend
+      )
+      player.nativePlayerHasStartedPlayback = true
+
+      expectNoDifference(backend.requiresLinearPlayback, true)
+      #expect(backend.owner === originalController)
+
+      originalHost.detach()
+      originalController = nil
+      await Task.yield()
+
+      #expect(backend.owner == nil)
+      player._handleEventForTesting(.seekableChanged(true))
+      expectNoDifference(player.isSeekable, true)
+      // No owner means the old linear policy is deliberately untouched.
+      expectNoDifference(backend.requiresLinearPlayback, true)
+
+      let successorHost = IOSNativePiPHostView()
+      successorHost.attach(to: player)
+      #expect(successorHost.drawableView.drawableAttachment === attachment)
+      #expect(successorHost.nativePiPBackend === backend)
+
+      let successorController = PiPController(
+        player: player,
+        nativeBackend: successorHost.nativePiPBackend
+      )
+
+      #expect(backend.owner === successorController)
+      expectNoDifference(backend.requiresLinearPlayback, false)
+      withExtendedLifetime(successorController) {}
+    }
+
+    @Test
+    func `successor controller and binding claim the adopted backend before stale teardown`() async {
+      let player = Player(instance: TestInstance.shared)
+      let storage = ValueBox<PiPController?>(nil)
+      let binding = Binding<PiPController?>(
+        get: { storage.value },
+        set: { storage.value = $0 }
+      )
+      let originalHost = IOSNativePiPHostView()
+      originalHost.attach(to: player)
+      let backend = originalHost.nativePiPBackend
+      let originalCoordinator = PiPVideoView(player).makeCoordinator()
+      let originalController = PiPController(player: player, nativeBackend: backend)
+      originalCoordinator.pipController = originalController
+      originalCoordinator.publishController(originalController, to: binding)
+      await originalCoordinator.waitForControllerBindingPublication()
+      player.nativePlayerHasStartedPlayback = true
+
+      let successorHost = IOSNativePiPHostView()
+      successorHost.attach(to: player)
+      let successorCoordinator = PiPVideoView(player).makeCoordinator()
+      let successorController = PiPController(
+        player: player,
+        nativeBackend: successorHost.nativePiPBackend
+      )
+      successorCoordinator.pipController = successorController
+      successorCoordinator.publishController(successorController, to: binding)
+      await successorCoordinator.waitForControllerBindingPublication()
+
+      originalHost.detach()
+      originalCoordinator.pipController = nil
+      originalCoordinator.clearControllerBinding()
+      await originalCoordinator.waitForControllerBindingPublication()
+
+      #expect(successorHost.nativePiPBackend === backend)
+      #expect(backend.owner === successorController)
+      #expect(storage.value === successorController)
+      #expect(player.drawable === successorHost.drawableView.drawableAttachment)
+    }
+
+    @Test
+    func `iOS native PiP drawable exposes VLC PiP selectors`() throws {
+      let player = Player(instance: TestInstance.shared)
+      let view = IOSNativePiPDrawableView()
+      view.attach(to: player)
+      let attachment = try #require(view.drawableAttachment)
+
+      #expect(attachment.responds(to: NSSelectorFromString("addSubview:")))
+      #expect(attachment.responds(to: NSSelectorFromString("bounds")))
+      #expect(attachment.responds(to: NSSelectorFromString("mediaController")))
+      #expect(attachment.responds(to: NSSelectorFromString("pictureInPictureReady")))
+      #expect(attachment.responds(to: NSSelectorFromString("canStartPictureInPictureAutomaticallyFromInline")))
+      if let protocolObject = NSProtocolFromString("VLCPictureInPictureDrawable") {
+        // Bind `conforms(to:)` to a plain Bool first. Calling it through an
+        // `AnyObject` (below) inside the `#expect` autoclosure makes SILGen
+        // emit a reabstraction thunk that crashes the iOS compiler (Swift
+        // 6.3.2); hoisting the call out of the autoclosure sidesteps it, and
+        // we keep both conformance checks consistent.
+        let conformsToDrawable = attachment.conforms(to: protocolObject)
+        #expect(conformsToDrawable)
+      } else {
+        Issue.record("VLCPictureInPictureDrawable protocol is not registered")
+      }
+
+      let mediaController = attachment.mediaController()
+      if let protocolObject = NSProtocolFromString("VLCPictureInPictureMediaControlling") {
+        let conformsToMediaControlling = mediaController.conforms(to: protocolObject)
+        #expect(conformsToMediaControlling)
+      } else {
+        Issue.record("VLCPictureInPictureMediaControlling protocol is not registered")
+      }
+      view.detach()
+    }
+
+    /// The VLCPictureInPictureDrawable selectors are invoked by libVLC
+    /// from its vout thread; their bodies are `nonisolated` and must be
+    /// callable (and return correct values) off the main actor.
+    @Test
+    func `iOS native PiP drawable selectors are callable off the main actor`() async throws {
+      let player = Player(instance: TestInstance.shared)
+      let view = IOSNativePiPDrawableView(startsAutomaticallyFromInline: false)
+      view.attach(to: player)
+      let attachment = try #require(view.drawableAttachment)
+
+      struct Refs: @unchecked Sendable {
+        let attachment: IOSNativePiPDrawableAttachment
+      }
+      let refs = Refs(attachment: attachment)
+
+      let (canStart, hasMediaController) = await withCheckedContinuation { (continuation: CheckedContinuation<(Bool, Bool), Never>) in
+        DispatchQueue.global().async {
+          let canStart = refs.attachment.canStartPictureInPictureAutomaticallyFromInline()
+          let mediaController = refs.attachment.mediaController()
+          // Building the ready block off-main must also be safe; it only
+          // captures a weak backend reference.
+          _ = refs.attachment.pictureInPictureReady()
+          continuation.resume(returning: (canStart, mediaController is IOSNativePiPMediaController))
+        }
+      }
+
+      #expect(canStart == false)
+      #expect(hasMediaController)
+      view.detach()
+    }
+
+    @Test
+    func `iOS native PiP drawable reports the configured auto-start flag`() throws {
+      let enabledPlayer = Player(instance: TestInstance.shared)
+      let enabledView = IOSNativePiPDrawableView(startsAutomaticallyFromInline: true)
+      enabledView.attach(to: enabledPlayer)
+      let enabled = try #require(enabledView.drawableAttachment)
+      #expect(enabled.canStartPictureInPictureAutomaticallyFromInline() == true)
+
+      let disabledPlayer = Player(instance: TestInstance.shared)
+      let disabledView = IOSNativePiPDrawableView(startsAutomaticallyFromInline: false)
+      disabledView.attach(to: disabledPlayer)
+      let disabled = try #require(disabledView.drawableAttachment)
+      #expect(disabled.canStartPictureInPictureAutomaticallyFromInline() == false)
+
+      // Omitting the argument defaults to auto-start enabled.
+      let defaultPlayer = Player(instance: TestInstance.shared)
+      let defaultView = IOSNativePiPDrawableView()
+      defaultView.attach(to: defaultPlayer)
+      let defaultAttachment = try #require(defaultView.drawableAttachment)
+      #expect(defaultAttachment.canStartPictureInPictureAutomaticallyFromInline() == true)
+
+      enabledView.detach()
+      disabledView.detach()
+      defaultView.detach()
+    }
+
+    @Test
+    func `iOS native PiP host propagates the auto-start flag to its drawable`() throws {
+      let player = Player(instance: TestInstance.shared)
+      let host = IOSNativePiPHostView(startsAutomaticallyFromInline: false)
+      host.attach(to: player)
+      let attachment = try #require(host.drawableView.drawableAttachment)
+      #expect(attachment.canStartPictureInPictureAutomaticallyFromInline() == false)
+
+      let defaultPlayer = Player(instance: TestInstance.shared)
+      let defaultHost = IOSNativePiPHostView()
+      defaultHost.attach(to: defaultPlayer)
+      let defaultAttachment = try #require(defaultHost.drawableView.drawableAttachment)
+      #expect(defaultAttachment.canStartPictureInPictureAutomaticallyFromInline() == true)
+
+      host.detach()
+      defaultHost.detach()
+    }
+
+    @Test
+    func `iOS native PiP drawable sizes VLC content to its bounds`() throws {
+      let player = Player(instance: TestInstance.shared)
+      let view = IOSNativePiPDrawableView()
+      view.frame = CGRect(x: 0, y: 0, width: 640, height: 360)
+      view.attach(to: player)
+      let attachment = try #require(view.drawableAttachment)
+      let vlcSubview = UIView()
+      attachment.addSubview(vlcSubview)
+      view.layoutIfNeeded()
+      attachment.layoutIfNeeded()
+
+      #expect(vlcSubview.frame.size == CGSize(width: 640, height: 360))
+      #expect(vlcSubview.autoresizingMask == [.flexibleWidth, .flexibleHeight])
+
+      view.frame = CGRect(x: 0, y: 0, width: 480, height: 270)
+      view.layoutIfNeeded()
+      attachment.layoutIfNeeded()
+
+      #expect(vlcSubview.frame.size == CGSize(width: 480, height: 270))
+      #expect(vlcSubview.autoresizingMask == [.flexibleWidth, .flexibleHeight])
+
+      view.detach()
+    }
+
+    @Test
+    func `iOS native PiP media controller reports playback intent`() {
+      let player = Player(instance: TestInstance.shared)
+      let mediaController = IOSNativePiPMediaController()
+      mediaController.player = player
+
+      #expect(mediaController.isMediaPlaying() == false)
+
+      player.setPlaybackIntentFromExternalControl(true)
+      #expect(mediaController.isMediaPlaying() == true)
+
+      player.setPlaybackIntentFromExternalControl(false)
+      #expect(mediaController.isMediaPlaying() == false)
+    }
+
+    /// libVLC's native PiP controller compares this callback result against
+    /// `VLC_TICK_INVALID`, which is 0 in the pinned libVLC build. Returning
+    /// libvlc's public `-1` length sentinel would instead make AVKit receive a
+    /// finite negative time range for live/unknown-duration media.
+    @Test
+    func `iOS native PiP media controller maps unknown length to VLC tick invalid`() {
+      let player = Player(instance: TestInstance.shared)
+      let mediaController = IOSNativePiPMediaController()
+      mediaController.player = player
+
+      #expect(mediaController.mediaLength() == 0)
+    }
+
+    /// A ready block can outlive the drawable/player attachment that created
+    /// it. Once a successor attachment starts, the old block must be unable
+    /// to install its window controller or publish state into that successor.
+    @Test
+    func `iOS native PiP generation rejects callbacks from an old attachment`() throws {
+      let generations = IOSNativePiPCallbackGenerations()
+      let firstAttachment = generations.beginAttachment()
+      let firstReady = try #require(
+        generations.reserveReadyCallback(for: firstAttachment)
+      )
+
+      let secondAttachment = generations.beginAttachment()
+      var staleMutationRan = false
+
+      #expect(generations.reserveReadyCallback(for: firstAttachment) == nil)
+      #expect(generations.reserveReadyCallback(for: secondAttachment) != nil)
+      #expect(!generations.isCurrent(firstReady))
+      #expect(!generations.performIfCurrent(firstReady) { staleMutationRan = true })
+      #expect(!staleMutationRan)
+    }
+
+    /// libVLC may rebuild its native PiP window controller without changing
+    /// players. Work queued by the previous ready callback must not overwrite
+    /// state published by the replacement controller.
+    @Test
+    func `iOS native PiP generation keeps only the newest ready callback`() throws {
+      let generations = IOSNativePiPCallbackGenerations()
+      let attachment = generations.beginAttachment()
+      let firstReady = try #require(
+        generations.reserveReadyCallback(for: attachment)
+      )
+      let secondReady = try #require(
+        generations.reserveReadyCallback(for: attachment)
+      )
+      var appliedGeneration = 0
+
+      #expect(!generations.performIfCurrent(firstReady) { appliedGeneration = 1 })
+      #expect(generations.performIfCurrent(secondReady) { appliedGeneration = 2 })
+      #expect(appliedGeneration == 2)
+    }
+
+    @Test
+    func `iOS native PiP controller delegates to native backend`() {
+      let player = Player(instance: TestInstance.shared)
+      let backend = IOSNativePiPBackend()
+      let controller = PiPController(player: player, nativeBackend: backend)
+
+      controller.start()
+      controller.invalidatePictureInPicturePlaybackState()
+      controller.stop()
+      controller.handleNativePictureInPictureReady()
+      controller.handleNativePictureInPictureActiveChanged(true)
+      #expect(controller.isActive == true)
+      controller.handleNativePictureInPictureActiveChanged(false)
+      #expect(controller.isActive == false)
+      controller.handleNativePictureInPictureSetPlaying(true)
+      #expect(controller._pipPlaybackActiveForTesting() == true)
+    }
+
+    @Test
+    func `active native adoption retries failed audio activation on didStart`() {
+      enum ActivationFailure: Error {
+        case interrupted
+      }
+
+      let player = Player(instance: TestInstance.shared)
+      player.setPlaybackIntentFromExternalControl(true)
+      let originalHost = IOSNativePiPHostView()
+      originalHost.attach(to: player)
+      let backend = originalHost.nativePiPBackend
+      player.nativePlayerHasStartedPlayback = true
+      originalHost.detach()
+
+      let successorHost = IOSNativePiPHostView()
+      successorHost.attach(to: player)
+      #expect(successorHost.nativePiPBackend === backend)
+      #expect(backend.owner == nil)
+
+      var activationAttempts: [Int] = []
+      var ownerWasInstalled: [Bool] = []
+
+      let controller = PiPController(
+        player: player,
+        nativeBackend: successorHost.nativePiPBackend,
+        managesAudioSession: true,
+        audioSessionActivation: {
+          activationAttempts.append(activationAttempts.count + 1)
+          ownerWasInstalled.append(backend.owner != nil)
+          if activationAttempts.count == 1 {
+            throw ActivationFailure.interrupted
+          }
+        }
+      )
+
+      // Active intent is sampled synchronously during native construction, but
+      // the failed attempt stays retryable. The first attempt precedes owner
+      // publication so native auto-PiP cannot outrun it.
+      expectNoDifference(activationAttempts, [1])
+      expectNoDifference(ownerWasInstalled, [false])
+      expectNoDifference(controller.hasActivatedAudioSession, false)
+
+      controller.handleNativePictureInPictureActiveChanged(true)
+      expectNoDifference(activationAttempts, [1, 2])
+      expectNoDifference(ownerWasInstalled, [false, true])
+      expectNoDifference(controller.hasActivatedAudioSession, true)
+
+      // A later stop/start cannot repeat a successful one-shot activation.
+      controller.handleNativePictureInPictureActiveChanged(false)
+      controller.handleNativePictureInPictureActiveChanged(true)
+      expectNoDifference(activationAttempts, [1, 2])
+    }
+
+    @Test
+    func `native didStart activates when construction had no active intent`() {
+      let player = Player(instance: TestInstance.shared)
+      let backend = IOSNativePiPBackend()
+      backend.attach(to: player)
+      var activationAttempts = 0
+
+      let controller = PiPController(
+        player: player,
+        nativeBackend: backend,
+        managesAudioSession: true,
+        audioSessionActivation: { activationAttempts += 1 }
+      )
+
+      expectNoDifference(activationAttempts, 0)
+      expectNoDifference(controller.hasActivatedAudioSession, false)
+
+      controller.handleNativePictureInPictureActiveChanged(true)
+      expectNoDifference(activationAttempts, 1)
+      expectNoDifference(controller.hasActivatedAudioSession, true)
+    }
+
+    @Test
+    func `native managesAudioSession false never invokes activation policy`() {
+      let player = Player(instance: TestInstance.shared)
+      player.setPlaybackIntentFromExternalControl(true)
+      let backend = IOSNativePiPBackend()
+      backend.attach(to: player)
+      var activationAttempts = 0
+
+      let controller = PiPController(
+        player: player,
+        nativeBackend: backend,
+        managesAudioSession: false,
+        audioSessionActivation: { activationAttempts += 1 }
+      )
+      controller.handleNativePictureInPictureActiveChanged(true)
+
+      expectNoDifference(activationAttempts, 0)
+      expectNoDifference(controller.hasActivatedAudioSession, false)
+    }
+
+    @Test
+    func `iOS native route updates linear playback and rejects retired owner`() {
+      let firstPlayer = Player(instance: TestInstance.shared)
+      let successorPlayer = Player(instance: TestInstance.shared)
+      let backend = IOSNativePiPBackend()
+
+      backend.attach(to: firstPlayer)
+      let firstController = PiPController(
+        player: firstPlayer,
+        nativeBackend: backend
+      )
+      firstController.applyObservedPlaybackStateUpdate(
+        PiPController.PlaybackStateUpdate(
+          invalidatesPlaybackState: true,
+          requiresLinearPlayback: false
+        )
+      )
+      #expect(backend.requiresLinearPlayback == false)
+      #expect(backend.playbackStateInvalidationCount == 1)
+
+      backend.detach()
+      backend.attach(to: successorPlayer)
+      let successor = PiPController(
+        player: successorPlayer,
+        nativeBackend: backend
+      )
+      #expect(backend.requiresLinearPlayback)
+      #expect(backend.playbackStateInvalidationCount == 1)
+
+      // A queued seekability event from the old controller must not mutate
+      // the new attachment, even though both controllers share the backend.
+      firstController.applyObservedPlaybackStateUpdate(
+        PiPController.PlaybackStateUpdate(
+          invalidatesPlaybackState: true,
+          requiresLinearPlayback: false
+        )
+      )
+      #expect(backend.requiresLinearPlayback)
+      #expect(backend.playbackStateInvalidationCount == 1)
+
+      successor.applyObservedPlaybackStateUpdate(
+        PiPController.PlaybackStateUpdate(
+          invalidatesPlaybackState: true,
+          requiresLinearPlayback: false
+        )
+      )
+      #expect(backend.requiresLinearPlayback == false)
+      #expect(backend.playbackStateInvalidationCount == 2)
+
+      successor.applyObservedPlaybackStateUpdate(
+        PiPController.PlaybackStateUpdate(
+          invalidatesPlaybackState: true,
+          requiresLinearPlayback: true
+        )
+      )
+      #expect(backend.requiresLinearPlayback)
+      #expect(backend.playbackStateInvalidationCount == 3)
+
+      backend.detach()
+      withExtendedLifetime(firstController) {}
+      withExtendedLifetime(successor) {}
+    }
+
+    /// Regression: a player swap builds a new controller on the *same*
+    /// shared native backend, then releases the old controller. The old
+    /// controller's deinit must not null the successor's ownership, or the
+    /// new controller's PiP state callbacks go silently dead.
+    @Test
+    func `Controller deinit does not clobber a successor's backend claim`() async {
+      let player = Player(instance: TestInstance.shared)
+      let backend = IOSNativePiPBackend()
+
+      var first: PiPController? = PiPController(player: player, nativeBackend: backend)
+      #expect(backend.owner === first)
+
+      let second = PiPController(player: player, nativeBackend: backend)
+      #expect(backend.owner === second)
+
+      first = nil
+      await Task.yield()
+
+      #expect(backend.owner === second)
+      withExtendedLifetime(second) {}
+    }
+
+    /// Teardown of the native backend's window-controller wiring must be
+    /// idempotent, and every private selector / KVC access must be gated by
+    /// `responds(to:)` so a non-conforming controller (or none) never
+    /// crashes. After `detach()` readiness is cleared regardless of whether
+    /// a controller was installed.
+    @Test
+    func `iOS native backend teardown is idempotent and selector-gated`() {
+      let player = Player(instance: TestInstance.shared)
+      let backend = IOSNativePiPBackend()
+      backend.attach(to: player)
+
+      // A non-conforming controller must not crash.
+      backend.handlePictureInPictureReady(NSObject())
+
+      // Start/stop/invalidate are safe whether or not a controller installed.
+      backend.start()
+      backend.stop()
+      backend.invalidatePlaybackState()
+
+      // Detach clears readiness and is idempotent.
+      backend.detach()
+      backend.detach()
+      #expect(backend.isPossible == false)
+      #expect(backend.isActive == false)
+    }
+
+    /// iOS native play/pause must route through the controller — engaging
+    /// the AVKit-transient pause debouncer and PiP playback-state
+    /// reconciliation — rather than poking the player directly. Verifies the
+    /// shared media controller is wired to its owning controller and that a
+    /// native pause flows through it.
+    @Test
+    func `iOS media controller routes pause through the controller`() async {
+      let player = Player(instance: TestInstance.shared)
+      let backend = IOSNativePiPBackend()
+      let controller = PiPController(player: player, nativeBackend: backend)
+
+      #expect(backend.mediaController.owner === controller)
+
+      // Prime PiP playback state to "playing", then a native pause must flow
+      // through the controller and flip it back off.
+      controller.handleNativePictureInPictureSetPlaying(true)
+      #expect(controller._pipPlaybackActiveForTesting() == true)
+
+      backend.mediaController.pause()
+      await Task.yield()
+      #expect(controller._pipPlaybackActiveForTesting() == false)
+
+      withExtendedLifetime(controller) {}
+    }
+  }
+}
+
+private final class WeakBox<T: AnyObject> {
+  weak var value: T?
+
+  init(_ value: T?) {
+    self.value = value
+  }
+}
+
+private final class ValueBox<T> {
+  var value: T
+
+  init(_ value: T) {
+    self.value = value
+  }
+}
+
+/// Behavioral stand-in for pinned VLCKit's ARC-strong
+/// `VLCVideoUIView._viewContainer` ivar.
+private final class OpenVoutContainerProbe {
+  let viewContainer: IOSNativePiPDrawableAttachment
+
+  init(viewContainer: IOSNativePiPDrawableAttachment) {
+    self.viewContainer = viewContainer
+  }
+}
+#endif

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
@@ -1,6 +1,7 @@
 #if os(iOS) || os(macOS)
 @_spi(PrivateMacOSPiP) @testable import SwiftVLC
 import AVFoundation
+import CLibVLC
 import SwiftUI
 import Testing
 
@@ -90,101 +91,6 @@ extension Integration {
       #expect(coordinator.pipController == nil)
     }
 
-    #if canImport(UIKit)
-    @Test
-    func `iOS native PiP host attaches drawable child`() {
-      let player = Player(instance: TestInstance.shared)
-      let host = IOSNativePiPHostView()
-
-      host.attach(to: player)
-      #expect(player.drawable === host.drawableView)
-
-      host.detach()
-      #expect(player.drawable == nil)
-    }
-
-    @Test
-    func `iOS native PiP drawable exposes VLC PiP selectors`() {
-      let view = IOSNativePiPDrawableView()
-
-      #expect(view.responds(to: NSSelectorFromString("mediaController")))
-      #expect(view.responds(to: NSSelectorFromString("pictureInPictureReady")))
-      #expect(view.responds(to: NSSelectorFromString("canStartPictureInPictureAutomaticallyFromInline")))
-      if let protocolObject = NSProtocolFromString("VLCPictureInPictureDrawable") {
-        // Bind `conforms(to:)` to a plain Bool first. Calling it through an
-        // `AnyObject` (below) inside the `#expect` autoclosure makes SILGen
-        // emit a reabstraction thunk that crashes the iOS compiler (Swift
-        // 6.3.2); hoisting the call out of the autoclosure sidesteps it, and
-        // we keep both conformance checks consistent.
-        let conformsToDrawable = view.conforms(to: protocolObject)
-        #expect(conformsToDrawable)
-      } else {
-        Issue.record("VLCPictureInPictureDrawable protocol is not registered")
-      }
-
-      let mediaController = view.mediaController()
-      if let protocolObject = NSProtocolFromString("VLCPictureInPictureMediaControlling") {
-        let conformsToMediaControlling = mediaController.conforms(to: protocolObject)
-        #expect(conformsToMediaControlling)
-      } else {
-        Issue.record("VLCPictureInPictureMediaControlling protocol is not registered")
-      }
-    }
-
-    /// The VLCPictureInPictureDrawable selectors are invoked by libVLC
-    /// from its vout thread; their bodies are `nonisolated` and must be
-    /// callable (and return correct values) off the main actor.
-    @Test
-    func `iOS native PiP drawable selectors are callable off the main actor`() async {
-      let view = IOSNativePiPDrawableView(startsAutomaticallyFromInline: false)
-
-      struct Refs: @unchecked Sendable {
-        let view: IOSNativePiPDrawableView
-      }
-      let refs = Refs(view: view)
-
-      let (canStart, hasMediaController) = await withCheckedContinuation { (continuation: CheckedContinuation<(Bool, Bool), Never>) in
-        DispatchQueue.global().async {
-          let canStart = refs.view.canStartPictureInPictureAutomaticallyFromInline()
-          let mediaController = refs.view.mediaController()
-          // Building the ready block off-main must also be safe; it only
-          // captures a weak backend reference.
-          _ = refs.view.pictureInPictureReady()
-          continuation.resume(returning: (canStart, mediaController is IOSNativePiPMediaController))
-        }
-      }
-
-      #expect(canStart == false)
-      #expect(hasMediaController)
-    }
-
-    @Test
-    func `iOS native PiP drawable reports the configured auto-start flag`() {
-      #expect(
-        IOSNativePiPDrawableView(startsAutomaticallyFromInline: true)
-          .canStartPictureInPictureAutomaticallyFromInline() == true
-      )
-      #expect(
-        IOSNativePiPDrawableView(startsAutomaticallyFromInline: false)
-          .canStartPictureInPictureAutomaticallyFromInline() == false
-      )
-      // Omitting the argument defaults to auto-start enabled.
-      #expect(
-        IOSNativePiPDrawableView()
-          .canStartPictureInPictureAutomaticallyFromInline() == true
-      )
-    }
-
-    @Test
-    func `iOS native PiP host propagates the auto-start flag to its drawable`() {
-      let host = IOSNativePiPHostView(startsAutomaticallyFromInline: false)
-      #expect(host.drawableView.canStartPictureInPictureAutomaticallyFromInline() == false)
-
-      let defaultHost = IOSNativePiPHostView()
-      #expect(defaultHost.drawableView.canStartPictureInPictureAutomaticallyFromInline() == true)
-    }
-    #endif
-
     @Test
     func `Init with policy knobs does not crash`() {
       let player = Player(instance: TestInstance.shared)
@@ -200,132 +106,6 @@ extension Integration {
       )
     }
 
-    #if canImport(UIKit)
-    @Test
-    func `iOS native PiP drawable sizes VLC content to its bounds`() {
-      let view = IOSNativePiPDrawableView()
-      view.frame = CGRect(x: 0, y: 0, width: 640, height: 360)
-      let vlcSubview = UIView()
-      view.addSubview(vlcSubview)
-      view.layoutIfNeeded()
-
-      #expect(vlcSubview.frame.size == CGSize(width: 640, height: 360))
-      #expect(vlcSubview.autoresizingMask == [.flexibleWidth, .flexibleHeight])
-
-      view.frame = CGRect(x: 0, y: 0, width: 480, height: 270)
-      view.layoutIfNeeded()
-
-      #expect(vlcSubview.frame.size == CGSize(width: 480, height: 270))
-      #expect(vlcSubview.autoresizingMask == [.flexibleWidth, .flexibleHeight])
-    }
-
-    @Test
-    func `iOS native PiP media controller reports playback intent`() {
-      let player = Player(instance: TestInstance.shared)
-      let mediaController = IOSNativePiPMediaController()
-      mediaController.player = player
-
-      #expect(mediaController.isMediaPlaying() == false)
-
-      player.setPlaybackIntentFromExternalControl(true)
-      #expect(mediaController.isMediaPlaying() == true)
-
-      player.setPlaybackIntentFromExternalControl(false)
-      #expect(mediaController.isMediaPlaying() == false)
-    }
-
-    @Test
-    func `iOS native PiP controller delegates to native backend`() {
-      let player = Player(instance: TestInstance.shared)
-      let backend = IOSNativePiPBackend()
-      let controller = PiPController(player: player, nativeBackend: backend)
-
-      controller.start()
-      controller.invalidatePictureInPicturePlaybackState()
-      controller.stop()
-      controller.handleNativePictureInPictureReady()
-      controller.handleNativePictureInPictureActiveChanged(true)
-      #expect(controller.isActive == true)
-      controller.handleNativePictureInPictureActiveChanged(false)
-      #expect(controller.isActive == false)
-      controller.handleNativePictureInPictureSetPlaying(true)
-      #expect(controller._pipPlaybackActiveForTesting() == true)
-    }
-
-    /// Regression: a player swap builds a new controller on the *same*
-    /// shared native backend, then releases the old controller. The old
-    /// controller's deinit must not null the successor's ownership, or the
-    /// new controller's PiP state callbacks go silently dead.
-    @Test
-    func `Controller deinit does not clobber a successor's backend claim`() async {
-      let player = Player(instance: TestInstance.shared)
-      let backend = IOSNativePiPBackend()
-
-      var first: PiPController? = PiPController(player: player, nativeBackend: backend)
-      #expect(backend.owner === first)
-
-      let second = PiPController(player: player, nativeBackend: backend)
-      #expect(backend.owner === second)
-
-      first = nil
-      await Task.yield()
-
-      #expect(backend.owner === second)
-      withExtendedLifetime(second) {}
-    }
-
-    /// Teardown of the native backend's window-controller wiring must be
-    /// idempotent, and every private selector / KVC access must be gated by
-    /// `responds(to:)` so a non-conforming controller (or none) never
-    /// crashes. After `detach()` readiness is cleared regardless of whether
-    /// a controller was installed.
-    @Test
-    func `iOS native backend teardown is idempotent and selector-gated`() {
-      let player = Player(instance: TestInstance.shared)
-      let backend = IOSNativePiPBackend()
-      backend.attach(to: player)
-
-      // A non-conforming controller must not crash.
-      backend.handlePictureInPictureReady(NSObject())
-
-      // Start/stop/invalidate are safe whether or not a controller installed.
-      backend.start()
-      backend.stop()
-      backend.invalidatePlaybackState()
-
-      // Detach clears readiness and is idempotent.
-      backend.detach()
-      backend.detach()
-      #expect(backend.isPossible == false)
-      #expect(backend.isActive == false)
-    }
-
-    /// iOS native play/pause must route through the controller — engaging
-    /// the AVKit-transient pause debouncer and PiP playback-state
-    /// reconciliation — rather than poking the player directly. Verifies the
-    /// shared media controller is wired to its owning controller and that a
-    /// native pause flows through it.
-    @Test
-    func `iOS media controller routes pause through the controller`() async {
-      let player = Player(instance: TestInstance.shared)
-      let backend = IOSNativePiPBackend()
-      let controller = PiPController(player: player, nativeBackend: backend)
-
-      #expect(backend.mediaController.owner === controller)
-
-      // Prime PiP playback state to "playing", then a native pause must flow
-      // through the controller and flip it back off.
-      controller.handleNativePictureInPictureSetPlaying(true)
-      #expect(controller._pipPlaybackActiveForTesting() == true)
-
-      backend.mediaController.pause()
-      await Task.yield()
-      #expect(controller._pipPlaybackActiveForTesting() == false)
-
-      withExtendedLifetime(controller) {}
-    }
-    #endif
-
     @Test
     func `dismantle fallback stops controller and clears binding`() async {
       #if canImport(AppKit)
@@ -339,12 +119,13 @@ extension Integration {
       let coordinator = view.makeCoordinator()
       let controller = PiPController(player: player)
 
-      storage.value = controller
       coordinator.pipController = controller
-      coordinator.controllerBinding = binding
+      coordinator.publishController(controller, to: binding)
+      await coordinator.waitForControllerBindingPublication()
+      #expect(storage.value === controller)
 
       PiPVideoView.dismantleNSView(NSView(), coordinator: coordinator)
-      await Task.yield()
+      await coordinator.waitForControllerBindingPublication()
 
       #expect(coordinator.pipController == nil)
       #expect(coordinator.controllerBinding == nil)
@@ -355,6 +136,259 @@ extension Integration {
     }
 
     #if canImport(AppKit)
+    private func nativeDrawable(of player: Player) -> UnsafeMutableRawPointer? {
+      libvlc_media_player_get_nsobject(player.pointer)
+    }
+
+    /// Pinned libVLC's `macosx` vout copies `drawable-nsobject` into its
+    /// strong `sys->container` once at vout open. Replacing the Player
+    /// variable cannot redirect that open vout, so this probe models the
+    /// immutable native reference without depending on decoder timing.
+    @Test
+    func `macOS same-player make before dismantle reparents the vout-latched drawable`() {
+      let player = Player(instance: TestInstance.shared)
+      let originalHost = MacNativePiPHostView()
+      originalHost.attach(to: player)
+      let originalDrawable = originalHost.drawableView
+      let originalBackend = originalHost.nativePiPBackend
+      let openVout = OpenMacVoutContainerProbe(container: originalDrawable)
+      let nativeHandle = player.pointer
+      player.nativePlayerHasStartedPlayback = true
+
+      let successorHost = MacNativePiPHostView()
+      successorHost.attach(to: player)
+      originalHost.detach()
+
+      #expect(successorHost.drawableView === openVout.container)
+      #expect(successorHost.drawableView === originalDrawable)
+      #expect(originalDrawable.superview === successorHost)
+      #expect(successorHost.nativePiPBackend === originalBackend)
+      #expect(originalBackend.hostView === successorHost)
+      #expect(originalBackend.drawableView === originalDrawable)
+      #expect(player.drawable === originalDrawable)
+      #expect(nativeDrawable(of: player) == Unmanaged.passUnretained(originalDrawable).toOpaque())
+      #expect(player.pointer == nativeHandle)
+    }
+
+    @Test
+    func `macOS same-player dismantle before make preserves and reparents the vout-latched drawable`() {
+      let player = Player(instance: TestInstance.shared)
+      let originalHost = MacNativePiPHostView()
+      originalHost.attach(to: player)
+      let originalDrawable = originalHost.drawableView
+      let originalBackend = originalHost.nativePiPBackend
+      let openVout = OpenMacVoutContainerProbe(container: originalDrawable)
+      let nativeHandle = player.pointer
+      player.nativePlayerHasStartedPlayback = true
+
+      originalHost.detach()
+
+      #expect(player.drawable === openVout.container)
+      #expect(originalDrawable.superview == nil)
+
+      let successorHost = MacNativePiPHostView()
+      successorHost.attach(to: player)
+
+      #expect(successorHost.drawableView === openVout.container)
+      #expect(successorHost.drawableView === originalDrawable)
+      #expect(originalDrawable.superview === successorHost)
+      #expect(successorHost.nativePiPBackend === originalBackend)
+      #expect(originalBackend.hostView === successorHost)
+      #expect(originalBackend.drawableView === originalDrawable)
+      #expect(player.drawable === originalDrawable)
+      #expect(nativeDrawable(of: player) == Unmanaged.passUnretained(originalDrawable).toOpaque())
+      #expect(player.pointer == nativeHandle)
+    }
+
+    @Test
+    func `macOS observed external vout also leases the exact drawable`() {
+      let player = Player(instance: TestInstance.shared)
+      let originalHost = MacNativePiPHostView()
+      originalHost.attach(to: player)
+      let originalDrawable = originalHost.drawableView
+      let originalBackend = originalHost.nativePiPBackend
+      player.activeVideoOutputs = 1
+
+      originalHost.detach()
+
+      #expect(player.drawable === originalDrawable)
+      #expect(originalDrawable.superview == nil)
+
+      let successorHost = MacNativePiPHostView()
+      successorHost.attach(to: player)
+
+      #expect(successorHost.drawableView === originalDrawable)
+      #expect(successorHost.nativePiPBackend === originalBackend)
+      #expect(originalDrawable.superview === successorHost)
+    }
+
+    @Test
+    func `macOS active same-player host churn keeps one drawable and backend`() {
+      let player = Player(instance: TestInstance.shared)
+      let result = churnMacHosts(for: player, count: 128)
+
+      #expect(result.currentHost.drawableView === result.originalDrawable)
+      #expect(result.currentHost.nativePiPBackend === result.originalBackend)
+      #expect(player.drawable === result.originalDrawable)
+      #expect(nativeDrawable(of: player) == Unmanaged.passUnretained(result.originalDrawable).toOpaque())
+      #expect(player.pointer == result.nativeHandle)
+      #expect(player.retainedDrawablesUntilNativePlayerRelease.isEmpty)
+      #expect(
+        result.retiredHosts.enumerated().compactMap { index, host in
+          host.value == nil ? nil : index
+        } == []
+      )
+      withExtendedLifetime(result.currentHost) {}
+    }
+
+    @Test
+    func `macOS host churn releases drawables when no vout can have opened`() {
+      let player = Player(instance: TestInstance.shared)
+      var retiredDrawables: [MacWeakBox<MacNativePiPDrawableView>] = []
+
+      for _ in 0..<64 {
+        autoreleasepool {
+          let host = MacNativePiPHostView()
+          host.attach(to: player)
+          let drawable = host.drawableView
+          host.detach()
+          retiredDrawables.append(MacWeakBox(drawable))
+        }
+      }
+
+      #expect(retiredDrawables.allSatisfy { $0.value == nil })
+      #expect(player.drawable == nil)
+      #expect(nativeDrawable(of: player) == nil)
+      #expect(player.retainedDrawablesUntilNativePlayerRelease.isEmpty)
+      withExtendedLifetime(player) {}
+    }
+
+    @Test
+    func `macOS different-player update isolates drawable backend and native pointer`() {
+      let firstPlayer = Player(instance: TestInstance.shared)
+      let secondPlayer = Player(instance: TestInstance.shared)
+      let host = MacNativePiPHostView()
+      host.attach(to: firstPlayer)
+      let firstDrawable = host.drawableView
+      let firstBackend = host.nativePiPBackend
+      let openVout = OpenMacVoutContainerProbe(container: firstDrawable)
+      firstPlayer.nativePlayerHasStartedPlayback = true
+
+      host.attach(to: secondPlayer)
+      let secondDrawable = host.drawableView
+      let secondBackend = host.nativePiPBackend
+
+      #expect(firstDrawable === openVout.container)
+      #expect(firstDrawable !== secondDrawable)
+      #expect(firstBackend !== secondBackend)
+      #expect(firstPlayer.drawable == nil)
+      #expect(nativeDrawable(of: firstPlayer) == nil)
+      #expect(firstBackend.mediaController.player == nil)
+      #expect(firstBackend.hostView == nil)
+      #expect(firstBackend.drawableView == nil)
+      #expect(firstPlayer.retainedDrawablesUntilNativePlayerRelease.count == 1)
+      #expect(secondPlayer.drawable === secondDrawable)
+      #expect(nativeDrawable(of: secondPlayer) == Unmanaged.passUnretained(secondDrawable).toOpaque())
+      #expect(secondBackend.mediaController.player === secondPlayer)
+      #expect(secondBackend.hostView === host)
+      #expect(secondBackend.drawableView === secondDrawable)
+
+      host.detach()
+    }
+
+    @Test
+    func `macOS detached stale host cannot repurpose an orphaned backend`() {
+      let firstPlayer = Player(instance: TestInstance.shared)
+      let secondPlayer = Player(instance: TestInstance.shared)
+      let host = MacNativePiPHostView()
+      host.attach(to: firstPlayer)
+      let firstDrawable = host.drawableView
+      let firstBackend = host.nativePiPBackend
+      firstPlayer.nativePlayerHasStartedPlayback = true
+      host.detach()
+
+      host.attach(to: secondPlayer)
+      let secondDrawable = host.drawableView
+
+      #expect(firstPlayer.drawable === firstDrawable)
+      #expect(nativeDrawable(of: firstPlayer) == Unmanaged.passUnretained(firstDrawable).toOpaque())
+      #expect(firstBackend.mediaController.player === firstPlayer)
+      #expect(firstBackend.hostView == nil)
+      #expect(firstBackend.drawableView == nil)
+      #expect(host.nativePiPBackend !== firstBackend)
+      #expect(secondDrawable !== firstDrawable)
+      #expect(secondPlayer.drawable === secondDrawable)
+      #expect(host.nativePiPBackend.mediaController.player === secondPlayer)
+    }
+
+    @Test
+    func `macOS orphaned active drawable does not retain controller or player`() async throws {
+      weak var releasedController: PiPController?
+      weak var releasedPlayer: Player?
+
+      do {
+        var player: Player? = Player(instance: TestInstance.shared)
+        releasedPlayer = player
+        let requiredPlayer = try #require(player)
+        let host = MacNativePiPHostView()
+        host.attach(to: requiredPlayer)
+        requiredPlayer.nativePlayerHasStartedPlayback = true
+
+        var controller: PiPController? = PiPController(
+          player: requiredPlayer,
+          nativeBackend: host.nativePiPBackend
+        )
+        releasedController = controller
+
+        host.detach()
+        controller = nil
+        await Task.yield()
+
+        #expect(releasedController == nil)
+        #expect(host.nativePiPBackend.owner == nil)
+        player = nil
+      }
+
+      #expect(releasedPlayer == nil)
+    }
+
+    @Test
+    func `macOS successor controller claims adopted backend and requested policy`() async {
+      let player = Player(instance: TestInstance.shared)
+      let originalHost = MacNativePiPHostView()
+      originalHost.attach(to: player)
+      let backend = originalHost.nativePiPBackend
+      var originalController: PiPController? = PiPController(
+        player: player,
+        nativeBackend: backend
+      )
+      weak var releasedController: PiPController?
+      releasedController = originalController
+      player.nativePlayerHasStartedPlayback = true
+
+      originalHost.detach()
+      originalController = nil
+      await Task.yield()
+
+      #expect(releasedController == nil)
+      #expect(backend.owner == nil)
+
+      let successorHost = MacNativePiPHostView()
+      successorHost.attach(to: player)
+      let successorController = PiPController(
+        player: player,
+        nativeBackend: successorHost.nativePiPBackend,
+        startsAutomaticallyFromInline: false,
+        managesAudioSession: false
+      )
+
+      #expect(successorHost.nativePiPBackend === backend)
+      #expect(backend.owner === successorController)
+      #expect(successorController.startsAutomaticallyFromInline == false)
+      #expect(successorController.managesAudioSession == false)
+      withExtendedLifetime(successorController) {}
+    }
+
     @Test
     func `macOS native PiP host attaches drawable child`() {
       let player = Player(instance: TestInstance.shared)
@@ -365,6 +399,13 @@ extension Integration {
 
       host.detach()
       #expect(player.drawable == nil)
+
+      host.attach(to: player)
+      #expect(player.drawable === host.drawableView)
+      #expect(host.nativePiPBackend.hostView === host)
+      #expect(host.nativePiPBackend.drawableView === host.drawableView)
+
+      host.detach()
     }
 
     @Test
@@ -769,6 +810,78 @@ private final class PiPReshapeProbeView: NSView {
   func reshapeForTesting() {
     reshapeCount += 1
   }
+}
+
+private final class OpenMacVoutContainerProbe {
+  let container: MacNativePiPDrawableView
+
+  init(container: MacNativePiPDrawableView) {
+    self.container = container
+  }
+}
+
+private final class MacWeakBox<T: AnyObject> {
+  weak var value: T?
+
+  init(_ value: T?) {
+    self.value = value
+  }
+}
+
+private struct MacHostChurnResult {
+  let currentHost: MacNativePiPHostView
+  let originalDrawable: MacNativePiPDrawableView
+  let originalBackend: MacNativePiPBackend
+  let nativeHandle: OpaquePointer
+  let retiredHosts: [MacWeakBox<MacNativePiPHostView>]
+}
+
+@MainActor
+private func churnMacHosts(
+  for player: Player,
+  count: Int
+) -> MacHostChurnResult {
+  var currentHost = autoreleasepool {
+    let host = MacNativePiPHostView()
+    host.attach(to: player)
+    return host
+  }
+  let originalDrawable = currentHost.drawableView
+  let originalBackend = currentHost.nativePiPBackend
+  let nativeHandle = player.pointer
+  player.nativePlayerHasStartedPlayback = true
+  var retiredHosts: [MacWeakBox<MacNativePiPHostView>] = []
+
+  for _ in 0..<count {
+    currentHost = autoreleasepool {
+      replaceMacHost(
+        currentHost,
+        for: player,
+        recording: &retiredHosts
+      )
+    }
+  }
+
+  return MacHostChurnResult(
+    currentHost: currentHost,
+    originalDrawable: originalDrawable,
+    originalBackend: originalBackend,
+    nativeHandle: nativeHandle,
+    retiredHosts: retiredHosts
+  )
+}
+
+@MainActor
+private func replaceMacHost(
+  _ retiredHost: MacNativePiPHostView,
+  for player: Player,
+  recording retiredHosts: inout [MacWeakBox<MacNativePiPHostView>]
+) -> MacNativePiPHostView {
+  let successorHost = MacNativePiPHostView()
+  successorHost.attach(to: player)
+  retiredHost.detach()
+  retiredHosts.append(MacWeakBox(retiredHost))
+  return successorHost
 }
 #endif
 #endif

--- a/Tests/SwiftVLCTests/PiP/PixelBufferFormatDescriptionCacheTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferFormatDescriptionCacheTests.swift
@@ -1,0 +1,216 @@
+#if os(iOS) || os(macOS)
+@testable import SwiftVLC
+import AVFoundation
+import CoreMedia
+import CoreVideo
+import CustomDump
+import Synchronization
+import Testing
+
+extension Integration {
+  struct PixelBufferFormatDescriptionCacheTests {
+    @Test
+    func `Equivalent buffers reuse one exact format description`() throws {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      let firstBuffer = try makePixelBuffer(width: 16, height: 9)
+      let secondBuffer = try makePixelBuffer(width: 16, height: 9)
+      let generation = renderer.state.withLock { $0.renderGeneration }
+
+      let first = try #require(
+        renderer.formatDescription(for: firstBuffer, generation: generation)
+      )
+      let second = try #require(
+        renderer.formatDescription(for: secondBuffer, generation: generation)
+      )
+
+      #expect(first === second)
+      #expect(CMVideoFormatDescriptionMatchesImageBuffer(second, imageBuffer: secondBuffer))
+      expectNoDifference(
+        renderer.state.withLock { $0.formatDescriptionCreationCount },
+        UInt64(1)
+      )
+    }
+
+    @Test
+    func `Dimension and pixel format changes replace the cached description`() throws {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      let generation = renderer.state.withLock { $0.renderGeneration }
+      let originalBuffer = try makePixelBuffer(width: 16, height: 9)
+      let widerBuffer = try makePixelBuffer(width: 32, height: 9)
+      let argbBuffer = try makePixelBuffer(
+        width: 32,
+        height: 9,
+        pixelFormat: kCVPixelFormatType_32ARGB
+      )
+
+      let original = try #require(
+        renderer.formatDescription(for: originalBuffer, generation: generation)
+      )
+      #expect(!CMVideoFormatDescriptionMatchesImageBuffer(original, imageBuffer: widerBuffer))
+
+      let wider = try #require(
+        renderer.formatDescription(for: widerBuffer, generation: generation)
+      )
+      #expect(original !== wider)
+      #expect(CMVideoFormatDescriptionMatchesImageBuffer(wider, imageBuffer: widerBuffer))
+      expectNoDifference(CMVideoFormatDescriptionGetDimensions(wider).width, Int32(32))
+      expectNoDifference(CMVideoFormatDescriptionGetDimensions(wider).height, Int32(9))
+      #expect(!CMVideoFormatDescriptionMatchesImageBuffer(wider, imageBuffer: argbBuffer))
+
+      let argb = try #require(
+        renderer.formatDescription(for: argbBuffer, generation: generation)
+      )
+      #expect(wider !== argb)
+      #expect(CMVideoFormatDescriptionMatchesImageBuffer(argb, imageBuffer: argbBuffer))
+      expectNoDifference(CMFormatDescriptionGetMediaSubType(argb), kCVPixelFormatType_32ARGB)
+      expectNoDifference(
+        renderer.state.withLock { $0.formatDescriptionCreationCount },
+        UInt64(3)
+      )
+    }
+
+    @Test
+    func `Relevant attachment mutations replace stale descriptions`() throws {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      let buffer = try makePixelBuffer(width: 16, height: 9)
+      let generation = renderer.state.withLock { $0.renderGeneration }
+
+      CVBufferSetAttachment(
+        buffer,
+        kCVImageBufferColorPrimariesKey,
+        kCVImageBufferColorPrimaries_ITU_R_709_2,
+        .shouldPropagate
+      )
+      let rec709 = try #require(
+        renderer.formatDescription(for: buffer, generation: generation)
+      )
+
+      CVBufferSetAttachment(
+        buffer,
+        kCVImageBufferColorPrimariesKey,
+        kCVImageBufferColorPrimaries_P3_D65,
+        .shouldPropagate
+      )
+      #expect(!CMVideoFormatDescriptionMatchesImageBuffer(rec709, imageBuffer: buffer))
+      expectNoDifference(
+        sampleCreationStatus(buffer: buffer, description: rec709),
+        kCMSampleBufferError_InvalidMediaFormat
+      )
+
+      let displayP3 = try #require(
+        renderer.formatDescription(for: buffer, generation: generation)
+      )
+      #expect(rec709 !== displayP3)
+      #expect(CMVideoFormatDescriptionMatchesImageBuffer(displayP3, imageBuffer: buffer))
+      expectNoDifference(sampleCreationStatus(buffer: buffer, description: displayP3), noErr)
+
+      CVBufferRemoveAttachment(buffer, kCVImageBufferColorPrimariesKey)
+      #expect(!CMVideoFormatDescriptionMatchesImageBuffer(displayP3, imageBuffer: buffer))
+
+      let untagged = try #require(
+        renderer.formatDescription(for: buffer, generation: generation)
+      )
+      #expect(displayP3 !== untagged)
+      #expect(CMVideoFormatDescriptionMatchesImageBuffer(untagged, imageBuffer: buffer))
+      expectNoDifference(sampleCreationStatus(buffer: buffer, description: untagged), noErr)
+      expectNoDifference(
+        renderer.state.withLock { $0.formatDescriptionCreationCount },
+        UInt64(3)
+      )
+    }
+
+    @Test
+    func `A generation change clears the cache and stale work cannot evict its successor`() throws {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      let buffer = try makePixelBuffer(width: 16, height: 9)
+      let firstGeneration = renderer.state.withLock { $0.renderGeneration }
+      let first = try #require(
+        renderer.formatDescription(for: buffer, generation: firstGeneration)
+      )
+
+      renderer.setRenderSize(CMVideoDimensions(width: 16, height: 9))
+      let secondGeneration = renderer.state.withLock { $0.renderGeneration }
+      #expect(secondGeneration != firstGeneration)
+      #expect(renderer.state.withLock { $0.cachedFormatDescription } == nil)
+      #expect(renderer.formatDescription(for: buffer, generation: firstGeneration) == nil)
+
+      let second = try #require(
+        renderer.formatDescription(for: buffer, generation: secondGeneration)
+      )
+      #expect(first !== second)
+      #expect(CMVideoFormatDescriptionMatchesImageBuffer(second, imageBuffer: buffer))
+
+      // Simulate a delayed callback from the superseded generation after the
+      // successor has already populated its cache.
+      #expect(renderer.formatDescription(for: buffer, generation: firstGeneration) == nil)
+      let finalState = renderer.state.withLock { $0 }
+      #expect(finalState.cachedFormatDescription?.description === second)
+      expectNoDifference(finalState.cachedFormatDescription?.generation, secondGeneration)
+      expectNoDifference(finalState.formatDescriptionCreationCount, UInt64(2))
+    }
+
+    @Test
+    func `Ten thousand stable frames perform one description creation`() throws {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      let buffer = try makePixelBuffer(width: 1920, height: 1080)
+      let generation = renderer.state.withLock { $0.renderGeneration }
+      let first = try #require(
+        renderer.formatDescription(for: buffer, generation: generation)
+      )
+
+      var exactCacheHits = 0
+      for _ in 1..<10000
+        where renderer.formatDescription(for: buffer, generation: generation) === first {
+        exactCacheHits += 1
+      }
+
+      expectNoDifference(exactCacheHits, 9999)
+      expectNoDifference(
+        renderer.state.withLock { $0.formatDescriptionCreationCount },
+        UInt64(1)
+      )
+    }
+
+    private func makePixelBuffer(
+      width: Int,
+      height: Int,
+      pixelFormat: OSType = kCVPixelFormatType_32BGRA
+    )
+      throws -> CVPixelBuffer {
+      let attributes: [String: Any] = [
+        kCVPixelBufferIOSurfacePropertiesKey as String: [:] as [String: Any]
+      ]
+      var buffer: CVPixelBuffer?
+      let status = CVPixelBufferCreate(
+        kCFAllocatorDefault,
+        width,
+        height,
+        pixelFormat,
+        attributes as CFDictionary,
+        &buffer
+      )
+      expectNoDifference(status, kCVReturnSuccess)
+      return try #require(buffer)
+    }
+
+    private func sampleCreationStatus(
+      buffer: CVPixelBuffer,
+      description: CMVideoFormatDescription
+    ) -> OSStatus {
+      var timing = CMSampleTimingInfo(
+        duration: .invalid,
+        presentationTimeStamp: .zero,
+        decodeTimeStamp: .invalid
+      )
+      var sample: CMSampleBuffer?
+      return CMSampleBufferCreateReadyWithImageBuffer(
+        allocator: kCFAllocatorDefault,
+        imageBuffer: buffer,
+        formatDescription: description,
+        sampleTiming: &timing,
+        sampleBufferOut: &sample
+      )
+    }
+  }
+}
+#endif

--- a/Tests/SwiftVLCTests/PiP/PixelBufferGeometryTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferGeometryTests.swift
@@ -1,0 +1,218 @@
+#if os(iOS) || os(macOS)
+@testable import SwiftVLC
+import AVFoundation
+import CLibVLC
+import CoreVideo
+import Synchronization
+import Testing
+
+extension Integration {
+  struct PixelBufferGeometryTests {
+    private func geometry(
+      codedWidth: UInt32 = 736,
+      codedHeight: UInt32 = 496,
+      visibleWidth: UInt32 = 720,
+      visibleHeight: UInt32 = 480,
+      xOffset: UInt32 = 8,
+      yOffset: UInt32 = 4,
+      sarNumerator: UInt32 = 16,
+      sarDenominator: UInt32 = 15,
+      orientation: UInt32 = 0
+    ) -> swiftvlc_video_format_geometry_t {
+      var value = swiftvlc_video_format_geometry_t()
+      value.coded_width = codedWidth
+      value.coded_height = codedHeight
+      value.visible_width = visibleWidth
+      value.visible_height = visibleHeight
+      value.x_offset = xOffset
+      value.y_offset = yOffset
+      value.sar_num = sarNumerator
+      value.sar_den = sarDenominator
+      value.source_orientation = orientation
+      return value
+    }
+
+    @Test
+    func `C geometry ABI has the pinned fixed-width layout`() {
+      #expect(MemoryLayout<swiftvlc_video_format_geometry_t>.size == 36)
+      #expect(MemoryLayout<swiftvlc_video_format_geometry_t>.stride == 36)
+      #expect(MemoryLayout<swiftvlc_video_format_geometry_t>.alignment == 4)
+    }
+
+    @Test
+    func `asymmetric crop and 16 by 15 SAR produce exact square pixels`() {
+      let source = PixelBufferSourceGeometry(geometry())
+
+      #expect(source.isValid)
+      #expect(source.codedWidth == 736)
+      #expect(source.codedHeight == 496)
+      #expect(source.visibleWidth == 720)
+      #expect(source.visibleHeight == 480)
+      #expect(source.xOffset == 8)
+      #expect(source.yOffset == 4)
+      #expect(source.sarNumerator == 16)
+      #expect(source.sarDenominator == 15)
+      #expect(source.squarePixelDeliveryDimensions?.width == 768)
+      #expect(source.squarePixelDeliveryDimensions?.height == 480)
+    }
+
+    @Test(arguments: Array(UInt32(0)...UInt32(7)))
+    func `every libVLC orientation value is retained as diagnostic metadata`(
+      orientation: UInt32
+    ) {
+      let source = PixelBufferSourceGeometry(geometry(orientation: orientation))
+
+      #expect(source.isValid)
+      #expect(source.sourceOrientationRawValue == orientation)
+      #expect(source.squarePixelDeliveryDimensions?.width == 768)
+      #expect(source.squarePixelDeliveryDimensions?.height == 480)
+    }
+
+    @Test
+    func `reciprocal SAR expands height exactly`() {
+      let source = PixelBufferSourceGeometry(
+        geometry(sarNumerator: 15, sarDenominator: 16)
+      )
+
+      #expect(source.squarePixelDeliveryDimensions?.width == 720)
+      #expect(source.squarePixelDeliveryDimensions?.height == 512)
+    }
+
+    @Test
+    func `invalid crop orientation and inexact PAR fail closed`() {
+      let outOfBoundsCrop = PixelBufferSourceGeometry(
+        geometry(codedWidth: 727, visibleWidth: 720, xOffset: 8)
+      )
+      let unknownOrientation = PixelBufferSourceGeometry(geometry(orientation: 8))
+      let inexactPAR = PixelBufferSourceGeometry(
+        geometry(
+          codedWidth: 5,
+          codedHeight: 7,
+          visibleWidth: 5,
+          visibleHeight: 7,
+          xOffset: 0,
+          yOffset: 0,
+          sarNumerator: 3,
+          sarDenominator: 2
+        )
+      )
+
+      #expect(!outOfBoundsCrop.isValid)
+      #expect(outOfBoundsCrop.squarePixelDeliveryDimensions == nil)
+      #expect(!unknownOrientation.isValid)
+      #expect(unknownOrientation.squarePixelDeliveryDimensions == nil)
+      #expect(inexactPAR.isValid)
+      #expect(inexactPAR.squarePixelDeliveryDimensions == nil)
+    }
+
+    @Test
+    func `extended callback copies geometry and negotiates a per-vout pool`() throws {
+      let displayRenderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      let handleContext = PixelBufferRendererCallbackContext(renderer: displayRenderer)
+      let handleOpaque = Unmanaged.passRetained(handleContext).toOpaque()
+      defer {
+        Unmanaged<PixelBufferRendererCallbackContext>.fromOpaque(handleOpaque).release()
+      }
+
+      var opaque: UnsafeMutableRawPointer? = handleOpaque
+      var chroma = [CChar](repeating: 0, count: 4)
+      var source = geometry(orientation: 5)
+      var outputWidth: UInt32 = 1
+      var outputHeight: UInt32 = 1
+      var pitch: UInt32 = 0
+      var lines: UInt32 = 0
+
+      let success = withUnsafeMutablePointer(to: &opaque) { opaquePointer in
+        chroma.withUnsafeMutableBufferPointer { chromaBuffer in
+          withUnsafePointer(to: &source) { sourcePointer in
+            withUnsafeMutablePointer(to: &outputWidth) { widthPointer in
+              withUnsafeMutablePointer(to: &outputHeight) { heightPointer in
+                withUnsafeMutablePointer(to: &pitch) { pitchPointer in
+                  withUnsafeMutablePointer(to: &lines) { linesPointer in
+                    pixelBufferFormatCallbackEx(
+                      opaque: opaquePointer,
+                      chroma: chromaBuffer.baseAddress,
+                      sourceGeometry: sourcePointer,
+                      outputWidth: widthPointer,
+                      outputHeight: heightPointer,
+                      pitches: pitchPointer,
+                      lines: linesPointer
+                    )
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      let voutOpaque = try #require(opaque)
+      #expect(voutOpaque != handleOpaque)
+      defer { pixelBufferCleanupCallback(opaque: voutOpaque) }
+      let vout = try #require(pixelBufferVoutCallbackContext(from: voutOpaque))
+
+      #expect(success == pixelBufferRendererFormatSuccessCount)
+      #expect(String(bytes: chroma.map { UInt8(bitPattern: $0) }, encoding: .ascii) == "BGRA")
+      #expect(outputWidth == 768)
+      #expect(outputHeight == 480)
+      #expect(pitch >= outputWidth * 4)
+      #expect(lines == outputHeight)
+      #expect(vout.sourceGeometry == PixelBufferSourceGeometry(source))
+      #expect(vout.sourceGeometry.sourceOrientationRawValue == 5)
+      #expect(vout.decodeRenderer.state.withLock { $0.width } == 768)
+      #expect(vout.decodeRenderer.state.withLock { $0.height } == 480)
+    }
+
+    @Test
+    func `extended callback rejects malformed geometry without opening a vout`() {
+      let displayRenderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      let handleContext = PixelBufferRendererCallbackContext(renderer: displayRenderer)
+      let handleOpaque = Unmanaged.passRetained(handleContext).toOpaque()
+      defer {
+        Unmanaged<PixelBufferRendererCallbackContext>.fromOpaque(handleOpaque).release()
+      }
+
+      var opaque: UnsafeMutableRawPointer? = handleOpaque
+      var chroma = [CChar](repeating: 0x58, count: 4)
+      var source = geometry(codedWidth: 727, visibleWidth: 720, xOffset: 8)
+      var outputWidth: UInt32 = 111
+      var outputHeight: UInt32 = 222
+      var pitch: UInt32 = 333
+      var lines: UInt32 = 444
+
+      let success = withUnsafeMutablePointer(to: &opaque) { opaquePointer in
+        chroma.withUnsafeMutableBufferPointer { chromaBuffer in
+          withUnsafePointer(to: &source) { sourcePointer in
+            withUnsafeMutablePointer(to: &outputWidth) { widthPointer in
+              withUnsafeMutablePointer(to: &outputHeight) { heightPointer in
+                withUnsafeMutablePointer(to: &pitch) { pitchPointer in
+                  withUnsafeMutablePointer(to: &lines) { linesPointer in
+                    pixelBufferFormatCallbackEx(
+                      opaque: opaquePointer,
+                      chroma: chromaBuffer.baseAddress,
+                      sourceGeometry: sourcePointer,
+                      outputWidth: widthPointer,
+                      outputHeight: heightPointer,
+                      pitches: pitchPointer,
+                      lines: linesPointer
+                    )
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      #expect(success == 0)
+      #expect(opaque == handleOpaque)
+      #expect(outputWidth == 111)
+      #expect(outputHeight == 222)
+      #expect(pitch == 333)
+      #expect(lines == 444)
+      #expect(chroma.allSatisfy { $0 == 0x58 })
+      #expect(!handleContext.hasOpenVoutForTesting)
+    }
+  }
+}
+#endif

--- a/Tests/SwiftVLCTests/PiP/PixelBufferRendererCallbackTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferRendererCallbackTests.swift
@@ -32,6 +32,85 @@ extension Integration {
       Unmanaged.passRetained(PixelBufferRendererCallbackContext(renderer: renderer))
     }
 
+    /// Owns the handle-level callback retain plus every per-vout retain created
+    /// by a successful format callback. Tests can close vouts in arbitrary
+    /// order; any forgotten vout is still balanced before the handle retain.
+    private final class CallbackLease {
+      struct Vout {
+        let opaque: UnsafeMutableRawPointer
+        let context: PixelBufferRendererVoutCallbackContext
+        let buffers: FormatBuffers
+        let successCount: UInt32
+      }
+
+      let handleContext: PixelBufferRendererCallbackContext
+      let handleOpaque: UnsafeMutableRawPointer
+      private var openVoutOpaques: [UnsafeMutableRawPointer] = []
+
+      init(displayRenderer: PixelBufferRenderer) {
+        let handleContext = PixelBufferRendererCallbackContext(renderer: displayRenderer)
+        self.handleContext = handleContext
+        handleOpaque = Unmanaged.passRetained(handleContext).toOpaque()
+      }
+
+      deinit {
+        for opaque in openVoutOpaques {
+          pixelBufferCleanupCallback(opaque: opaque)
+        }
+        Unmanaged<PixelBufferRendererCallbackContext>.fromOpaque(handleOpaque).release()
+      }
+
+      func negotiate(width: UInt32, height: UInt32) throws -> Vout {
+        var opaqueSlot: UnsafeMutableRawPointer? = handleOpaque
+        var chroma = [CChar](repeating: 0, count: 4)
+        var negotiatedWidth = width
+        var negotiatedHeight = height
+        var pitch: UInt32 = 0
+        var lines: UInt32 = 0
+        let result = withUnsafeMutablePointer(to: &opaqueSlot) { opaquePointer in
+          chroma.withUnsafeMutableBufferPointer { chromaBuffer in
+            withUnsafeMutablePointer(to: &negotiatedWidth) { widthPointer in
+              withUnsafeMutablePointer(to: &negotiatedHeight) { heightPointer in
+                withUnsafeMutablePointer(to: &pitch) { pitchPointer in
+                  withUnsafeMutablePointer(to: &lines) { linesPointer in
+                    pixelBufferFormatCallback(
+                      opaque: opaquePointer,
+                      chroma: chromaBuffer.baseAddress,
+                      width: widthPointer,
+                      height: heightPointer,
+                      pitches: pitchPointer,
+                      lines: linesPointer
+                    )
+                  }
+                }
+              }
+            }
+          }
+        }
+        let voutOpaque = try #require(opaqueSlot)
+        let voutContext = try #require(pixelBufferVoutCallbackContext(from: voutOpaque))
+        openVoutOpaques.append(voutOpaque)
+        return Vout(
+          opaque: voutOpaque,
+          context: voutContext,
+          buffers: FormatBuffers(
+            chroma: chroma,
+            width: negotiatedWidth,
+            height: negotiatedHeight,
+            pitches: pitch,
+            lines: lines
+          ),
+          successCount: result
+        )
+      }
+
+      func close(_ vout: Vout) {
+        guard let index = openVoutOpaques.firstIndex(of: vout.opaque) else { return }
+        openVoutOpaques.remove(at: index)
+        pixelBufferCleanupCallback(opaque: vout.opaque)
+      }
+    }
+
     private func makeBGRAImageBuffer(
       width: Int,
       height: Int,
@@ -97,62 +176,137 @@ extension Integration {
       return result
     }
 
+    private func installUnlockedPicture(
+      _ buffer: CVPixelBuffer,
+      on vout: CallbackLease.Vout
+    )
+      throws -> UnsafeMutableRawPointer {
+      try #require(vout.context.installPendingPicture(buffer, isLocked: false))
+    }
+
     // MARK: - Format callback
 
     @Test
-    func `Format callback creates pool and updates state`() {
-      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
-      let retained = makeRetainedContext(renderer: renderer)
-      defer { retained.release() }
+    func `Format callback creates an isolated per-vout pool and opaque`() throws {
+      let displayRenderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      let lease = CallbackLease(displayRenderer: displayRenderer)
+      let vout = try lease.negotiate(width: 320, height: 240)
 
-      var opaqueSlot: UnsafeMutableRawPointer? = retained.toOpaque()
-      var buffers = FormatBuffers()
-
-      let result = withUnsafeMutablePointer(to: &opaqueSlot) { opaquePtr in
-        buffers.chroma.withUnsafeMutableBufferPointer { chromaBuf in
-          withUnsafeMutablePointer(to: &buffers.width) { widthPtr in
-            withUnsafeMutablePointer(to: &buffers.height) { heightPtr in
-              withUnsafeMutablePointer(to: &buffers.pitches) { pitchPtr in
-                withUnsafeMutablePointer(to: &buffers.lines) { linesPtr in
-                  pixelBufferFormatCallback(
-                    opaque: opaquePtr,
-                    chroma: chromaBuf.baseAddress,
-                    width: widthPtr,
-                    height: heightPtr,
-                    pitches: pitchPtr,
-                    lines: linesPtr
-                  )
-                }
-              }
-            }
-          }
-        }
-      }
-
-      #expect(result == 12)
+      #expect(vout.successCount == 1)
+      #expect(vout.opaque != lease.handleOpaque)
 
       // Chroma should be forced to BGRA.
       let chromaString = String(
-        bytes: buffers.chroma.map { UInt8(bitPattern: $0) },
+        bytes: vout.buffers.chroma.map { UInt8(bitPattern: $0) },
         encoding: .ascii
       )
       #expect(chromaString == "BGRA")
 
-      // Pool + dimensions should now be set in state.
-      let state = renderer.state.withLock { $0 }
+      // Pool + dimensions belong only to this vout, never the controller's
+      // display renderer shared by every output on the handle.
+      let state = vout.context.decodeRenderer.state.withLock { $0 }
       #expect(state.pool != nil)
       #expect(state.width == 320)
       #expect(state.height == 240)
+      #expect(displayRenderer.state.withLock { $0.pool } == nil)
 
       // Pitch must match actual CVPixelBufferGetBytesPerRow, not the
       // nominal width * 4 — libVLC relies on this exact alignment.
-      #expect(buffers.pitches >= 320 * 4)
-      #expect(buffers.lines == 240)
+      #expect(vout.buffers.pitches >= 320 * 4)
+      #expect(vout.buffers.lines == 240)
 
-      // Cleanup callback should release the pool.
-      pixelBufferCleanupCallback(opaque: retained.toOpaque())
-      let cleared = renderer.state.withLock { $0.pool }
+      lease.close(vout)
+      let cleared = vout.context.decodeRenderer.state.withLock { $0.pool }
       #expect(cleared == nil)
+      #expect(!lease.handleContext.hasOpenVoutForTesting)
+    }
+
+    /// Two vouts can overlap during track/input replacement. Their setup
+    /// callbacks start from the same handle opaque, but each must leave with
+    /// independent dimensions, pitch, pool, and callback storage. Closing A
+    /// must not invalidate B's next lock.
+    @Test
+    func `overlapping vouts keep independent pools through out-of-order cleanup`() throws {
+      let displayRenderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      let lease = CallbackLease(displayRenderer: displayRenderer)
+      let first = try lease.negotiate(width: 96, height: 54)
+      let second = try lease.negotiate(width: 321, height: 179)
+
+      #expect(first.opaque != second.opaque)
+      #expect(first.context !== second.context)
+      #expect(first.buffers.pitches != second.buffers.pitches)
+      #expect(lease.handleContext.hasOpenVoutForTesting)
+
+      let firstState = first.context.decodeRenderer.state.withLock {
+        ($0.pool, $0.width, $0.height)
+      }
+      let secondState = second.context.decodeRenderer.state.withLock {
+        ($0.pool, $0.width, $0.height)
+      }
+      let firstPool = try #require(firstState.0)
+      let secondPool = try #require(secondState.0)
+      #expect(firstState.1 == 96)
+      #expect(firstState.2 == 54)
+      #expect(secondState.1 == 321)
+      #expect(secondState.2 == 179)
+      #expect(
+        Unmanaged.passUnretained(firstPool).toOpaque()
+          != Unmanaged.passUnretained(secondPool).toOpaque()
+      )
+
+      var firstPlane: UnsafeMutableRawPointer?
+      let firstPicture = withUnsafeMutablePointer(to: &firstPlane) {
+        pixelBufferLockCallback(opaque: first.opaque, planes: $0)
+      }
+      let firstBuffer = try #require(
+        firstPicture.map {
+          Unmanaged<AnyObject>.fromOpaque($0).takeUnretainedValue() as! CVPixelBuffer
+        }
+      )
+      #expect(CVPixelBufferGetWidth(firstBuffer) == 96)
+      #expect(CVPixelBufferGetHeight(firstBuffer) == 54)
+      pixelBufferUnlockCallback(opaque: first.opaque, picture: firstPicture, planes: nil)
+      pixelBufferDisplayCallback(opaque: first.opaque, picture: firstPicture)
+
+      var secondPlane: UnsafeMutableRawPointer?
+      let secondPicture = withUnsafeMutablePointer(to: &secondPlane) {
+        pixelBufferLockCallback(opaque: second.opaque, planes: $0)
+      }
+      let secondBuffer = try #require(
+        secondPicture.map {
+          Unmanaged<AnyObject>.fromOpaque($0).takeUnretainedValue() as! CVPixelBuffer
+        }
+      )
+      #expect(CVPixelBufferGetWidth(secondBuffer) == 321)
+      #expect(CVPixelBufferGetHeight(secondBuffer) == 179)
+      pixelBufferUnlockCallback(opaque: second.opaque, picture: secondPicture, planes: nil)
+      pixelBufferDisplayCallback(opaque: second.opaque, picture: secondPicture)
+
+      lease.close(first)
+      #expect(first.context.decodeRenderer.state.withLock { $0.pool } == nil)
+      #expect(second.context.decodeRenderer.state.withLock { $0.pool } === secondPool)
+      #expect(lease.handleContext.hasOpenVoutForTesting)
+
+      var survivingPlane: UnsafeMutableRawPointer?
+      let survivingPicture = withUnsafeMutablePointer(to: &survivingPlane) {
+        pixelBufferLockCallback(opaque: second.opaque, planes: $0)
+      }
+      let survivingBuffer = try #require(
+        survivingPicture.map {
+          Unmanaged<AnyObject>.fromOpaque($0).takeUnretainedValue() as! CVPixelBuffer
+        }
+      )
+      #expect(CVPixelBufferGetWidth(survivingBuffer) == 321)
+      #expect(CVPixelBufferGetHeight(survivingBuffer) == 179)
+      pixelBufferUnlockCallback(
+        opaque: second.opaque,
+        picture: survivingPicture,
+        planes: nil
+      )
+      pixelBufferDisplayCallback(opaque: second.opaque, picture: survivingPicture)
+
+      lease.close(second)
+      #expect(!lease.handleContext.hasOpenVoutForTesting)
     }
 
     @Test
@@ -210,52 +364,175 @@ extension Integration {
     }
 
     @Test
-    func `Lock then unlock round trip after format`() {
+    func `Lock then unlock round trip after format`() throws {
       let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
-      let retained = makeRetainedContext(renderer: renderer)
-      defer { retained.release() }
-
-      // Prime the pool via format callback.
-      var opaqueSlot: UnsafeMutableRawPointer? = retained.toOpaque()
-      var buffers = FormatBuffers()
-      _ = withUnsafeMutablePointer(to: &opaqueSlot) { opaquePtr in
-        buffers.chroma.withUnsafeMutableBufferPointer { chromaBuf in
-          withUnsafeMutablePointer(to: &buffers.width) { w in
-            withUnsafeMutablePointer(to: &buffers.height) { h in
-              withUnsafeMutablePointer(to: &buffers.pitches) { p in
-                withUnsafeMutablePointer(to: &buffers.lines) { l in
-                  pixelBufferFormatCallback(
-                    opaque: opaquePtr,
-                    chroma: chromaBuf.baseAddress,
-                    width: w,
-                    height: h,
-                    pitches: p,
-                    lines: l
-                  )
-                }
-              }
-            }
-          }
-        }
-      }
+      let lease = CallbackLease(displayRenderer: renderer)
+      let vout = try lease.negotiate(width: 320, height: 240)
 
       // Lock → get a pixel buffer handle, base address written into plane.
       var plane: UnsafeMutableRawPointer?
       let handle = withUnsafeMutablePointer(to: &plane) { planePtr in
-        pixelBufferLockCallback(opaque: retained.toOpaque(), planes: planePtr)
+        pixelBufferLockCallback(opaque: vout.opaque, planes: planePtr)
       }
       #expect(plane != nil)
 
-      // Unlock must succeed regardless of opaque (it doesn't dereference it).
-      pixelBufferUnlockCallback(opaque: retained.toOpaque(), picture: handle, planes: nil)
+      // Unlock balances the base-address lock through the owning vout.
+      pixelBufferUnlockCallback(opaque: vout.opaque, picture: handle, planes: nil)
+      #expect(vout.context.hasPendingPictureForTesting)
 
-      // Balance the retain `pixelBufferLockCallback` performed internally.
-      if let h = handle {
-        Unmanaged<AnyObject>.fromOpaque(h).release()
+      lease.close(vout)
+      #expect(!vout.context.hasPendingPictureForTesting)
+    }
+
+    /// Pinned vmem suppresses display when its temporary picture allocation
+    /// fails. The vout context must therefore retain the successfully locked
+    /// Core Video buffer until cleanup, then drain it without relying on a
+    /// display callback that will never arrive.
+    @Test
+    func `Cleanup drains a picture whose native display was suppressed`() throws {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      let lease = CallbackLease(displayRenderer: renderer)
+      let vout = try lease.negotiate(width: 64, height: 36)
+
+      var plane: UnsafeMutableRawPointer?
+      let picture = withUnsafeMutablePointer(to: &plane) {
+        pixelBufferLockCallback(opaque: vout.opaque, planes: $0)
+      }
+      #expect(picture != nil)
+      #expect(plane != nil)
+      pixelBufferUnlockCallback(opaque: vout.opaque, picture: picture, planes: nil)
+      #expect(vout.context.hasPendingPictureForTesting)
+
+      // No display callback: this is the exact branch taken when patched
+      // vmem cannot allocate/copy its temporary picture.
+      lease.close(vout)
+      #expect(!vout.context.hasPendingPictureForTesting)
+    }
+
+    /// A failed subsequent lock has not superseded vmem's prior `pic_opaque`,
+    /// so it must leave that pending owner intact for eventual cleanup.
+    @Test
+    func `Failed lock preserves the undisplayed predecessor until cleanup`() throws {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      let lease = CallbackLease(displayRenderer: renderer)
+      let vout = try lease.negotiate(width: 64, height: 36)
+
+      var firstPlane: UnsafeMutableRawPointer?
+      let firstPicture = withUnsafeMutablePointer(to: &firstPlane) {
+        pixelBufferLockCallback(opaque: vout.opaque, planes: $0)
+      }
+      pixelBufferUnlockCallback(
+        opaque: vout.opaque,
+        picture: firstPicture,
+        planes: nil
+      )
+      #expect(vout.context.hasPendingPictureForTesting)
+
+      // Deterministically exercise the allocation-unavailable branch without
+      // depending on process-wide memory pressure.
+      vout.context.decodeRenderer.state.withLock { $0.pool = nil }
+      var failedPlane: UnsafeMutableRawPointer?
+      let failedPicture = withUnsafeMutablePointer(to: &failedPlane) {
+        pixelBufferLockCallback(opaque: vout.opaque, planes: $0)
+      }
+      #expect(failedPicture == nil)
+      #expect(failedPlane == nil)
+      #expect(vout.context.hasPendingPictureForTesting)
+
+      lease.close(vout)
+      #expect(!vout.context.hasPendingPictureForTesting)
+    }
+
+    @Test
+    func `Decode pool threshold leaves plane untouched and recovers after release`() throws {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      let lease = CallbackLease(displayRenderer: renderer)
+      let vout = try lease.negotiate(width: 64, height: 36)
+      defer { lease.close(vout) }
+      let pool = try #require(vout.context.decodeRenderer.state.withLock { $0.pool })
+      let threshold = pixelBufferRendererPoolAllocationThreshold(width: 64, height: 36)
+      expectNoDifference(threshold, 12)
+
+      var heldBuffers: [CVPixelBuffer] = []
+      for _ in 0..<threshold {
+        let allocation = pixelBufferRendererAllocatePixelBuffer(
+          from: pool,
+          width: 64,
+          height: 36
+        )
+        expectNoDifference(allocation.status, kCVReturnSuccess)
+        try heldBuffers.append(#require(allocation.buffer))
       }
 
-      // Clean up the pool.
-      pixelBufferCleanupCallback(opaque: retained.toOpaque())
+      let exhausted = pixelBufferRendererAllocatePixelBuffer(
+        from: pool,
+        width: 64,
+        height: 36
+      )
+      expectNoDifference(exhausted.status, kCVReturnWouldExceedAllocationThreshold)
+      #expect(exhausted.buffer == nil)
+
+      let sentinel = try #require(UnsafeMutableRawPointer(bitPattern: 0x1))
+      var failedPlane: UnsafeMutableRawPointer? = sentinel
+      let failedPicture = withUnsafeMutablePointer(to: &failedPlane) {
+        pixelBufferLockCallback(opaque: vout.opaque, planes: $0)
+      }
+      #expect(failedPicture == nil)
+      #expect(failedPlane == sentinel)
+      #expect(!vout.context.hasPendingPictureForTesting)
+
+      heldBuffers.removeLast()
+      var recoveredPlane: UnsafeMutableRawPointer? = sentinel
+      let recoveredPicture = try #require(withUnsafeMutablePointer(to: &recoveredPlane) {
+        pixelBufferLockCallback(opaque: vout.opaque, planes: $0)
+      })
+      #expect(recoveredPlane != sentinel)
+      pixelBufferUnlockCallback(
+        opaque: vout.opaque,
+        picture: recoveredPicture,
+        planes: nil
+      )
+      pixelBufferDisplayCallback(opaque: vout.opaque, picture: recoveredPicture)
+      #expect(!vout.context.hasPendingPictureForTesting)
+    }
+
+    /// Pinned vmem owns only one `pic_opaque`. A second successful lock means
+    /// an undisplayed predecessor can never arrive normally; replace it, then
+    /// reject a synthetic stale display without consuming the successor.
+    @Test
+    func `Repeated lock drains predecessor and stale display cannot consume successor`() throws {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      let lease = CallbackLease(displayRenderer: renderer)
+      let vout = try lease.negotiate(width: 64, height: 36)
+      defer { lease.close(vout) }
+
+      var firstPlane: UnsafeMutableRawPointer?
+      let firstPicture = try #require(withUnsafeMutablePointer(to: &firstPlane) {
+        pixelBufferLockCallback(opaque: vout.opaque, planes: $0)
+      })
+      pixelBufferUnlockCallback(
+        opaque: vout.opaque,
+        picture: firstPicture,
+        planes: nil
+      )
+
+      var secondPlane: UnsafeMutableRawPointer?
+      let secondPicture = try #require(withUnsafeMutablePointer(to: &secondPlane) {
+        pixelBufferLockCallback(opaque: vout.opaque, planes: $0)
+      })
+      #expect(firstPicture != secondPicture)
+      #expect(vout.context.hasPendingPictureForTesting)
+
+      pixelBufferDisplayCallback(opaque: vout.opaque, picture: firstPicture)
+      #expect(vout.context.hasPendingPictureForTesting)
+
+      pixelBufferUnlockCallback(
+        opaque: vout.opaque,
+        picture: secondPicture,
+        planes: nil
+      )
+      pixelBufferDisplayCallback(opaque: vout.opaque, picture: secondPicture)
+      #expect(!vout.context.hasPendingPictureForTesting)
     }
 
     @Test
@@ -273,7 +550,7 @@ extension Integration {
     }
 
     @Test
-    func `Retiring callback context without opened vout releases opaque retain`() throws {
+    func `Retiring callback context releases opaque only after native handle ends`() throws {
       weak var weakContext: PixelBufferRendererCallbackContext?
       weak var weakRenderer: PixelBufferRenderer?
 
@@ -285,12 +562,14 @@ extension Integration {
         weakContext = context
         weakRenderer = renderer
         let retained = Unmanaged.passRetained(context)
+        let opaque = retained.toOpaque()
         renderer = nil
 
-        context.requestRetirement(
-          opaque: retained.toOpaque(),
-          deferIfVoutMayBeOpening: false
-        )
+        context.requestRetirement()
+        #expect(weakContext != nil)
+        #expect(weakRenderer == nil)
+
+        context.nativePlayerHandleDidRelease(opaque: opaque)
       }
 
       #expect(weakContext == nil)
@@ -309,12 +588,11 @@ extension Integration {
         weakRenderer = renderer
         renderer = nil
         let retained = Unmanaged.passRetained(context)
+        let opaque = retained.toOpaque()
 
-        let result = context.withRenderer(opaque: retained.toOpaque()) { callbackRenderer in
-          context.requestRetirement(
-            opaque: retained.toOpaque(),
-            deferIfVoutMayBeOpening: false
-          )
+        let result = context.withRenderer(opaque: opaque) { callbackRenderer in
+          context.requestRetirement()
+          context.nativePlayerHandleDidRelease(opaque: opaque)
           #expect(weakRenderer != nil)
           _ = callbackRenderer
           return true
@@ -340,18 +618,16 @@ extension Integration {
         weakContext = context
         weakRenderer = renderer
         let retained = Unmanaged.passRetained(context)
+        let opaque = retained.toOpaque()
         renderer = nil
 
-        context.requestRetirement(
-          opaque: retained.toOpaque(),
-          deferIfVoutMayBeOpening: true
-        )
+        context.requestRetirement()
 
         #expect(weakContext != nil)
         #expect(weakRenderer == nil)
-        let result = context.withRenderer(opaque: retained.toOpaque()) { _ in true }
+        let result = context.withRenderer(opaque: opaque) { _ in true }
         #expect(result == nil)
-        #expect(context.releaseRetiredOpaqueRetainIfNoOpenVout(opaque: retained.toOpaque()))
+        context.nativePlayerHandleDidRelease(opaque: opaque)
       }
 
       #expect(weakContext == nil)
@@ -359,10 +635,11 @@ extension Integration {
     }
 
     @Test
-    func `Retired callback context keeps opaque alive until vout cleanup`() {
+    func `Retired callback context survives vout cleanup until native handle ends`() throws {
       weak var weakContext: PixelBufferRendererCallbackContext?
       weak var weakRenderer: PixelBufferRenderer?
-      var contextOpaque: UnsafeMutableRawPointer?
+      var handleOpaque: UnsafeMutableRawPointer?
+      var voutOpaque: UnsafeMutableRawPointer?
 
       do {
         let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
@@ -370,9 +647,9 @@ extension Integration {
         weakContext = context
         weakRenderer = renderer
         let retained = Unmanaged.passRetained(context)
-        contextOpaque = retained.toOpaque()
+        handleOpaque = retained.toOpaque()
 
-        var opaqueSlot: UnsafeMutableRawPointer? = contextOpaque
+        var opaqueSlot: UnsafeMutableRawPointer? = handleOpaque
         var buffers = FormatBuffers()
         let result = withUnsafeMutablePointer(to: &opaqueSlot) { opaquePtr in
           buffers.chroma.withUnsafeMutableBufferPointer { chromaBuf in
@@ -394,19 +671,23 @@ extension Integration {
             }
           }
         }
-        #expect(result == 12)
+        #expect(result == 1)
+        voutOpaque = opaqueSlot
+        #expect(voutOpaque != handleOpaque)
         #expect(context.hasOpenVoutForTesting)
 
-        context.requestRetirement(
-          opaque: retained.toOpaque(),
-          deferIfVoutMayBeOpening: false
-        )
+        context.requestRetirement()
       }
 
       #expect(weakContext != nil)
       #expect(weakRenderer == nil)
 
-      pixelBufferCleanupCallback(opaque: contextOpaque)
+      pixelBufferCleanupCallback(opaque: voutOpaque)
+
+      #expect(weakContext != nil)
+      #expect(weakRenderer == nil)
+
+      try weakContext?.nativePlayerHandleDidRelease(opaque: #require(handleOpaque))
 
       #expect(weakContext == nil)
       #expect(weakRenderer == nil)
@@ -427,16 +708,15 @@ extension Integration {
     func `Display callback enqueues a sample onto the display layer`() async throws {
       let displayLayer = AVSampleBufferDisplayLayer()
       let renderer = PixelBufferRenderer(displayLayer: displayLayer)
-      let retained = makeRetainedContext(renderer: renderer)
-      defer { retained.release() }
+      let lease = CallbackLease(displayRenderer: renderer)
+      let vout = try lease.negotiate(width: 2, height: 2)
+      defer { lease.close(vout) }
 
       let pb = try makeBGRAImageBuffer(width: 2, height: 2)
 
-      // The display callback expects a retained `AnyObject` pointer —
-      // matches the `passRetained(pb as AnyObject)` on the lock path.
-      let pictureHandle = Unmanaged.passRetained(pb as AnyObject).toOpaque()
+      let pictureHandle = try installUnlockedPicture(pb, on: vout)
 
-      pixelBufferDisplayCallback(opaque: retained.toOpaque(), picture: pictureHandle)
+      pixelBufferDisplayCallback(opaque: vout.opaque, picture: pictureHandle)
 
       // Give the renderer's async enqueue queue a moment to settle.
       try? await Task.sleep(for: .milliseconds(20))
@@ -447,14 +727,15 @@ extension Integration {
     func `Display callback does not mutate source frame bytes`() throws {
       let displayLayer = AVSampleBufferDisplayLayer()
       let renderer = PixelBufferRenderer(displayLayer: displayLayer)
-      let retained = makeRetainedContext(renderer: renderer)
-      defer { retained.release() }
+      let lease = CallbackLease(displayRenderer: renderer)
+      let vout = try lease.negotiate(width: 3, height: 2)
+      defer { lease.close(vout) }
 
       let pb = try makeBGRAImageBuffer(width: 3, height: 2, alpha: 37)
       let expectedAlphaBytes = try alphaBytes(in: pb)
 
-      let pictureHandle = Unmanaged.passRetained(pb as AnyObject).toOpaque()
-      pixelBufferDisplayCallback(opaque: retained.toOpaque(), picture: pictureHandle)
+      let pictureHandle = try installUnlockedPicture(pb, on: vout)
+      pixelBufferDisplayCallback(opaque: vout.opaque, picture: pictureHandle)
 
       try expectNoDifference(alphaBytes(in: pb), expectedAlphaBytes)
     }
@@ -464,8 +745,9 @@ extension Integration {
     func `Display callback uses configured timebase for presentation time`() throws {
       let displayLayer = AVSampleBufferDisplayLayer()
       let renderer = PixelBufferRenderer(displayLayer: displayLayer)
-      let retained = makeRetainedContext(renderer: renderer)
-      defer { retained.release() }
+      let lease = CallbackLease(displayRenderer: renderer)
+      let vout = try lease.negotiate(width: 2, height: 2)
+      defer { lease.close(vout) }
 
       let clock = CMClockGetHostTimeClock()
       var timebase: CMTimebase?
@@ -480,9 +762,9 @@ extension Integration {
       renderer.setTimebase(tb)
 
       let pb = try makeBGRAImageBuffer(width: 2, height: 2)
-      let pictureHandle = Unmanaged.passRetained(pb as AnyObject).toOpaque()
+      let pictureHandle = try installUnlockedPicture(pb, on: vout)
 
-      pixelBufferDisplayCallback(opaque: retained.toOpaque(), picture: pictureHandle)
+      pixelBufferDisplayCallback(opaque: vout.opaque, picture: pictureHandle)
     }
 
     /// A nil `opaque` guards-out early.
@@ -508,129 +790,131 @@ extension Integration {
     /// Drive the format callback and read back the negotiated pool's
     /// minimum buffer count via its attributes.
     private func formatCallbackPoolFloor(
-      renderer: PixelBufferRenderer,
-      opaque: UnsafeMutableRawPointer,
+      lease: CallbackLease,
       width: UInt32,
       height: UInt32
     )
-      throws -> (decodeHeadroom: UInt32, poolFloor: Int) {
-      var opaqueSlot: UnsafeMutableRawPointer? = opaque
-      var buffers = FormatBuffers()
-      buffers.width = width
-      buffers.height = height
-      let result = withUnsafeMutablePointer(to: &opaqueSlot) { opaquePtr in
-        buffers.chroma.withUnsafeMutableBufferPointer { chromaBuf in
-          withUnsafeMutablePointer(to: &buffers.width) { w in
-            withUnsafeMutablePointer(to: &buffers.height) { h in
-              withUnsafeMutablePointer(to: &buffers.pitches) { p in
-                withUnsafeMutablePointer(to: &buffers.lines) { l in
-                  pixelBufferFormatCallback(
-                    opaque: opaquePtr,
-                    chroma: chromaBuf.baseAddress,
-                    width: w,
-                    height: h,
-                    pitches: p,
-                    lines: l
-                  )
-                }
-              }
-            }
-          }
-        }
-      }
-      let pool = try #require(renderer.state.withLock { $0.pool })
+      throws -> (successCount: UInt32, poolFloor: Int) {
+      let vout = try lease.negotiate(width: width, height: height)
+      defer { lease.close(vout) }
+      let pool = try #require(vout.context.decodeRenderer.state.withLock { $0.pool })
       let attrs = try #require(CVPixelBufferPoolGetAttributes(pool) as? [String: Any])
       let minNumber = try #require(
         attrs[kCVPixelBufferPoolMinimumBufferCountKey as String] as? NSNumber
       )
-      return (result, minNumber.intValue)
+      return (vout.successCount, minNumber.intValue)
     }
 
     /// The resident pool floor is byte-budgeted: 4K drains down to a small
-    /// floor while the decode-headroom return value stays at the full
-    /// picture count; SD keeps the full floor.
+    /// floor while SD keeps the full recycled floor. The format return reports
+    /// the single allocation proven during negotiation, not decoder headroom.
     @Test
-    func `Pool floor is byte-budgeted while decode headroom is preserved`() throws {
+    func `Pool floor is byte-budgeted independently of format success count`() throws {
       let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
-      let retained = makeRetainedContext(renderer: renderer)
-      defer { retained.release() }
+      let lease = CallbackLease(displayRenderer: renderer)
 
       let uhd = try formatCallbackPoolFloor(
-        renderer: renderer,
-        opaque: retained.toOpaque(),
+        lease: lease,
         width: 3840,
         height: 2160
       )
-      #expect(uhd.decodeHeadroom == 12)
+      #expect(uhd.successCount == 1)
       #expect(uhd.poolFloor >= 3)
       #expect(uhd.poolFloor <= 4)
 
       let sd = try formatCallbackPoolFloor(
-        renderer: renderer,
-        opaque: retained.toOpaque(),
+        lease: lease,
         width: 320,
         height: 240
       )
-      #expect(sd.decodeHeadroom == 12)
+      #expect(sd.successCount == 1)
       #expect(sd.poolFloor == 12)
-
-      pixelBufferCleanupCallback(opaque: retained.toOpaque())
     }
 
-    /// Deferred retirement (the teardown path `PiPController.deinit` uses)
-    /// keeps both the context AND the renderer alive while a vout is open —
-    /// unlike `requestRetirement`, it does not drop the renderer, so a late
-    /// callback can still render. The vout cleanup callback performs the
-    /// balancing release.
+    /// Three 32 MiB BGRA buffers exactly fit the 96 MiB resident budget. One
+    /// pixel column beyond that deterministic boundary must switch the floor
+    /// to a single buffer instead of pinning three oversized frames.
     @Test
-    func `Deferred retirement keeps context and renderer alive until vout cleanup`() {
+    func `Pool floor drops to one immediately above the large-frame threshold`() throws {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      let lease = CallbackLease(displayRenderer: renderer)
+
+      let atBoundary = try formatCallbackPoolFloor(
+        lease: lease,
+        width: 4096,
+        height: 2048
+      )
+      #expect(atBoundary.successCount == 1)
+      #expect(atBoundary.poolFloor == 3)
+
+      let aboveBoundary = try formatCallbackPoolFloor(
+        lease: lease,
+        width: 4097,
+        height: 2048
+      )
+      #expect(aboveBoundary.successCount == 1)
+      #expect(aboveBoundary.poolFloor == 1)
+    }
+
+    /// Clearing the media-player callback variables does not update a vout
+    /// that is concurrently opening and may already have copied the opaque.
+    /// `voutOpen == false` therefore cannot prove that the opaque is safe to
+    /// release: the format callback may simply not have arrived yet.
+    @Test
+    func `Retired opaque remains callable until native handle lifetime ends`() throws {
       weak var weakContext: PixelBufferRendererCallbackContext?
-      weak var weakRenderer: PixelBufferRenderer?
-      var contextOpaque: UnsafeMutableRawPointer?
+      var opaque: UnsafeMutableRawPointer?
 
       do {
         let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
         let context = PixelBufferRendererCallbackContext(renderer: renderer)
         weakContext = context
-        weakRenderer = renderer
-        let retained = Unmanaged.passRetained(context)
-        contextOpaque = retained.toOpaque()
-
-        var opaqueSlot: UnsafeMutableRawPointer? = contextOpaque
-        var buffers = FormatBuffers()
-        _ = withUnsafeMutablePointer(to: &opaqueSlot) { opaquePtr in
-          buffers.chroma.withUnsafeMutableBufferPointer { chromaBuf in
-            withUnsafeMutablePointer(to: &buffers.width) { w in
-              withUnsafeMutablePointer(to: &buffers.height) { h in
-                withUnsafeMutablePointer(to: &buffers.pitches) { p in
-                  withUnsafeMutablePointer(to: &buffers.lines) { l in
-                    pixelBufferFormatCallback(
-                      opaque: opaquePtr,
-                      chroma: chromaBuf.baseAddress,
-                      width: w,
-                      height: h,
-                      pitches: p,
-                      lines: l
-                    )
-                  }
-                }
-              }
-            }
-          }
-        }
-        #expect(context.hasOpenVoutForTesting)
-
-        context.requestDeferredRetirement()
+        opaque = Unmanaged.passRetained(context).toOpaque()
+        context.requestRetirement()
       }
 
-      // Vout still open → context retained, and renderer NOT dropped.
       #expect(weakContext != nil)
-      #expect(weakRenderer != nil)
+      let handleOpaque = try #require(opaque)
+      var voutOpaque: UnsafeMutableRawPointer? = handleOpaque
+      var chroma = [CChar](repeating: 0, count: 4)
+      var width: UInt32 = 96
+      var height: UInt32 = 54
+      var pitch: UInt32 = 0
+      var lines: UInt32 = 0
+      let result = withUnsafeMutablePointer(to: &voutOpaque) { opaquePointer in
+        chroma.withUnsafeMutableBufferPointer { chromaBuffer in
+          pixelBufferFormatCallback(
+            opaque: opaquePointer,
+            chroma: chromaBuffer.baseAddress,
+            width: &width,
+            height: &height,
+            pitches: &pitch,
+            lines: &lines
+          )
+        }
+      }
+      #expect(result == 1)
+      let negotiatedOpaque = try #require(voutOpaque)
+      #expect(negotiatedOpaque != handleOpaque)
 
-      pixelBufferCleanupCallback(opaque: contextOpaque)
+      var plane: UnsafeMutableRawPointer?
+      let lateLock = withUnsafeMutablePointer(to: &plane) {
+        pixelBufferLockCallback(opaque: negotiatedOpaque, planes: $0)
+      }
+      #expect(lateLock != nil)
+      #expect(plane != nil)
+      pixelBufferUnlockCallback(
+        opaque: negotiatedOpaque,
+        picture: lateLock,
+        planes: nil
+      )
+      pixelBufferDisplayCallback(opaque: negotiatedOpaque, picture: lateLock)
+      pixelBufferCleanupCallback(opaque: negotiatedOpaque)
+      #expect(weakContext != nil)
+
+      weakContext?.nativePlayerHandleDidRelease(opaque: handleOpaque)
 
       #expect(weakContext == nil)
-      #expect(weakRenderer == nil)
     }
   }
 }

--- a/Tests/SwiftVLCTests/PiP/PixelBufferRendererEnqueueTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferRendererEnqueueTests.swift
@@ -1,0 +1,460 @@
+#if os(iOS) || os(macOS)
+@testable import SwiftVLC
+import AVFoundation
+import CoreMedia
+import CoreVideo
+import CustomDump
+import Foundation
+import Synchronization
+import Testing
+
+extension Integration {
+  struct PixelBufferRendererEnqueueTests {
+    @Test
+    func `Blocked queue retains only the latest pending frame`() throws {
+      let queue = DispatchQueue(label: "org.swiftvlc.tests.enqueue-blocked")
+      let blocker = QueueBlocker(queue: queue)
+      defer { blocker.release() }
+      #expect(blocker.waitUntilStarted() == .success)
+
+      let layer = AVSampleBufferDisplayLayer()
+      let probe = DisplayLayerProbe()
+      let renderer = PixelBufferRenderer(
+        displayLayer: layer,
+        enqueueQueue: queue,
+        displayLayerAPI: probe.api
+      )
+      let generation = renderer.state.withLock { $0.renderGeneration }
+
+      var weakBuffers: [WeakPixelBuffer] = []
+      for index in 0..<100 {
+        try weakBuffers.append(
+          submitFrame(
+            index: index,
+            renderer: renderer,
+            generation: generation,
+            layer: layer
+          )
+        )
+      }
+
+      expectNoDifference(
+        renderer.enqueueSnapshotForTesting,
+        PixelBufferEnqueueSnapshot(
+          pendingCount: 1,
+          isDrainScheduled: true,
+          scheduledDrainCount: 1,
+          drainedSampleCount: 0,
+          replacementCount: 99
+        )
+      )
+      #expect(weakBuffers.dropLast().allSatisfy { $0.value == nil })
+      #expect(weakBuffers.last?.value != nil)
+
+      blocker.release()
+      #expect(probe.waitForDelivery() == .success)
+      #expect(waitUntilIdle(queue) == .success)
+
+      expectNoDifference(probe.snapshot.enqueuedPresentationValues, [99])
+      expectNoDifference(
+        renderer.enqueueSnapshotForTesting,
+        PixelBufferEnqueueSnapshot(
+          pendingCount: 0,
+          isDrainScheduled: false,
+          scheduledDrainCount: 1,
+          drainedSampleCount: 1,
+          replacementCount: 99
+        )
+      )
+      #expect(weakBuffers.allSatisfy { $0.value == nil })
+    }
+
+    @Test
+    func `Slow delivery retains one processing frame and one latest pending frame`() throws {
+      let queue = DispatchQueue(label: "org.swiftvlc.tests.enqueue-slow")
+      let layer = AVSampleBufferDisplayLayer()
+      let probe = DisplayLayerProbe(blockFirstEnqueue: true)
+      let renderer = PixelBufferRenderer(
+        displayLayer: layer,
+        enqueueQueue: queue,
+        displayLayerAPI: probe.api
+      )
+      let generation = renderer.state.withLock { $0.renderGeneration }
+
+      var weakBuffers = try [
+        submitFrame(
+          index: 0,
+          renderer: renderer,
+          generation: generation,
+          layer: layer
+        )
+      ]
+      #expect(probe.waitForEnqueueEntry() == .success)
+
+      for index in 1..<100 {
+        try weakBuffers.append(
+          submitFrame(
+            index: index,
+            renderer: renderer,
+            generation: generation,
+            layer: layer
+          )
+        )
+      }
+
+      expectNoDifference(
+        renderer.enqueueSnapshotForTesting,
+        PixelBufferEnqueueSnapshot(
+          pendingCount: 1,
+          isDrainScheduled: true,
+          scheduledDrainCount: 1,
+          drainedSampleCount: 1,
+          replacementCount: 98
+        )
+      )
+      #expect(weakBuffers[0].value != nil)
+      #expect(weakBuffers[1..<99].allSatisfy { $0.value == nil })
+      #expect(weakBuffers[99].value != nil)
+
+      probe.releaseBlockedEnqueue()
+      #expect(probe.waitForDelivery() == .success)
+      #expect(probe.waitForDelivery() == .success)
+      #expect(waitUntilIdle(queue) == .success)
+
+      expectNoDifference(probe.snapshot.enqueuedPresentationValues, [0, 99])
+      expectNoDifference(
+        renderer.enqueueSnapshotForTesting,
+        PixelBufferEnqueueSnapshot(
+          pendingCount: 0,
+          isDrainScheduled: false,
+          scheduledDrainCount: 1,
+          drainedSampleCount: 2,
+          replacementCount: 98
+        )
+      )
+      #expect(weakBuffers.allSatisfy { $0.value == nil })
+    }
+
+    @Test
+    func `Stale generation and layer drop clears the gate for a successor`() throws {
+      let queue = DispatchQueue(label: "org.swiftvlc.tests.enqueue-stale")
+      let blocker = QueueBlocker(queue: queue)
+      defer { blocker.release() }
+      #expect(blocker.waitUntilStarted() == .success)
+
+      let oldLayer = AVSampleBufferDisplayLayer()
+      let newLayer = AVSampleBufferDisplayLayer()
+      let probe = DisplayLayerProbe()
+      let renderer = PixelBufferRenderer(
+        displayLayer: oldLayer,
+        enqueueQueue: queue,
+        displayLayerAPI: probe.api
+      )
+      let staleGeneration = renderer.state.withLock { $0.renderGeneration }
+      _ = try submitFrame(
+        index: 1,
+        renderer: renderer,
+        generation: staleGeneration,
+        layer: oldLayer
+      )
+
+      renderer.setRenderSize(CMVideoDimensions(width: 16, height: 9))
+      renderer.setDisplayLayer(newLayer)
+      let currentGeneration = renderer.state.withLock { $0.renderGeneration }
+
+      blocker.release()
+      #expect(waitUntilIdle(queue) == .success)
+      expectNoDifference(probe.snapshot.enqueuedPresentationValues, [])
+      #expect(!renderer.enqueueSnapshotForTesting.isDrainScheduled)
+
+      _ = try submitFrame(
+        index: 2,
+        renderer: renderer,
+        generation: currentGeneration,
+        layer: newLayer
+      )
+      #expect(probe.waitForDelivery() == .success)
+      #expect(waitUntilIdle(queue) == .success)
+
+      expectNoDifference(probe.snapshot.enqueuedPresentationValues, [2])
+      expectNoDifference(
+        renderer.enqueueSnapshotForTesting,
+        PixelBufferEnqueueSnapshot(
+          pendingCount: 0,
+          isDrainScheduled: false,
+          scheduledDrainCount: 2,
+          drainedSampleCount: 2,
+          replacementCount: 0
+        )
+      )
+    }
+
+    @Test
+    func `Backpressure drop clears the gate and a later ready frame delivers`() throws {
+      let queue = DispatchQueue(label: "org.swiftvlc.tests.enqueue-backpressure")
+      let layer = AVSampleBufferDisplayLayer()
+      let probe = DisplayLayerProbe(isReady: false)
+      let renderer = PixelBufferRenderer(
+        displayLayer: layer,
+        enqueueQueue: queue,
+        displayLayerAPI: probe.api
+      )
+      let generation = renderer.state.withLock { $0.renderGeneration }
+
+      _ = try submitFrame(
+        index: 1,
+        renderer: renderer,
+        generation: generation,
+        layer: layer
+      )
+      #expect(probe.waitForReadinessCheck() == .success)
+      #expect(waitUntilIdle(queue) == .success)
+      expectNoDifference(probe.snapshot.enqueuedPresentationValues, [])
+      #expect(!renderer.enqueueSnapshotForTesting.isDrainScheduled)
+
+      probe.setReady(true)
+      _ = try submitFrame(
+        index: 2,
+        renderer: renderer,
+        generation: generation,
+        layer: layer
+      )
+      #expect(probe.waitForDelivery() == .success)
+      #expect(waitUntilIdle(queue) == .success)
+
+      expectNoDifference(probe.snapshot.enqueuedPresentationValues, [2])
+      expectNoDifference(renderer.enqueueSnapshotForTesting.scheduledDrainCount, UInt64(2))
+    }
+
+    @Test
+    func `Required flush does not strand the pending gate`() throws {
+      let queue = DispatchQueue(label: "org.swiftvlc.tests.enqueue-flush")
+      let layer = AVSampleBufferDisplayLayer()
+      let probe = DisplayLayerProbe(requiresFlush: true)
+      let renderer = PixelBufferRenderer(
+        displayLayer: layer,
+        enqueueQueue: queue,
+        displayLayerAPI: probe.api
+      )
+      let generation = renderer.state.withLock { $0.renderGeneration }
+
+      _ = try submitFrame(
+        index: 7,
+        renderer: renderer,
+        generation: generation,
+        layer: layer
+      )
+      #expect(probe.waitForDelivery() == .success)
+      #expect(waitUntilIdle(queue) == .success)
+
+      expectNoDifference(probe.snapshot.flushCount, 1)
+      expectNoDifference(probe.snapshot.enqueuedPresentationValues, [7])
+      #expect(!renderer.enqueueSnapshotForTesting.isDrainScheduled)
+    }
+
+    private func submitFrame(
+      index: Int,
+      renderer: PixelBufferRenderer,
+      generation: UInt64,
+      layer: AVSampleBufferDisplayLayer
+    )
+      throws -> WeakPixelBuffer {
+      try autoreleasepool {
+        let buffer = try makePixelBuffer()
+        let weakBuffer = WeakPixelBuffer(buffer)
+        let description = try makeFormatDescription(for: buffer)
+        var timing = CMSampleTimingInfo(
+          duration: CMTime(value: 1, timescale: 30),
+          presentationTimeStamp: CMTime(value: CMTimeValue(index), timescale: 1),
+          decodeTimeStamp: .invalid
+        )
+        var sample: CMSampleBuffer?
+        let status = CMSampleBufferCreateReadyWithImageBuffer(
+          allocator: kCFAllocatorDefault,
+          imageBuffer: buffer,
+          formatDescription: description,
+          sampleTiming: &timing,
+          sampleBufferOut: &sample
+        )
+        expectNoDifference(status, noErr)
+        try renderer.enqueue(
+          #require(sample),
+          generation: generation,
+          on: layer
+        )
+        return weakBuffer
+      }
+    }
+
+    private func makePixelBuffer() throws -> CVPixelBuffer {
+      var buffer: CVPixelBuffer?
+      let status = CVPixelBufferCreate(
+        kCFAllocatorDefault,
+        2,
+        2,
+        kCVPixelFormatType_32BGRA,
+        nil,
+        &buffer
+      )
+      expectNoDifference(status, kCVReturnSuccess)
+      return try #require(buffer)
+    }
+
+    private func makeFormatDescription(
+      for buffer: CVPixelBuffer
+    )
+      throws -> CMVideoFormatDescription {
+      var description: CMVideoFormatDescription?
+      let status = CMVideoFormatDescriptionCreateForImageBuffer(
+        allocator: kCFAllocatorDefault,
+        imageBuffer: buffer,
+        formatDescriptionOut: &description
+      )
+      expectNoDifference(status, noErr)
+      return try #require(description)
+    }
+
+    private func waitUntilIdle(_ queue: DispatchQueue) -> DispatchTimeoutResult {
+      let completed = DispatchSemaphore(value: 0)
+      queue.async { completed.signal() }
+      return completed.wait(timeout: .now() + 5)
+    }
+  }
+}
+
+private final class WeakPixelBuffer {
+  weak var value: CVPixelBuffer?
+
+  init(_ value: CVPixelBuffer) {
+    self.value = value
+  }
+}
+
+private final class QueueBlocker: @unchecked Sendable {
+  private let started = DispatchSemaphore(value: 0)
+  private let releaseSemaphore = DispatchSemaphore(value: 0)
+  private let wasReleased = Mutex(false)
+
+  init(queue: DispatchQueue) {
+    queue.async { [started, releaseSemaphore] in
+      started.signal()
+      releaseSemaphore.wait()
+    }
+  }
+
+  func waitUntilStarted() -> DispatchTimeoutResult {
+    started.wait(timeout: .now() + 5)
+  }
+
+  func release() {
+    let shouldSignal = wasReleased.withLock { wasReleased -> Bool in
+      guard !wasReleased else { return false }
+      wasReleased = true
+      return true
+    }
+    if shouldSignal {
+      releaseSemaphore.signal()
+    }
+  }
+}
+
+private final class DisplayLayerProbe: @unchecked Sendable {
+  struct Snapshot: Equatable {
+    let flushCount: Int
+    let enqueuedPresentationValues: [CMTimeValue]
+  }
+
+  private struct State: @unchecked Sendable {
+    var status: AVQueuedSampleBufferRenderingStatus = .rendering
+    var requiresFlush: Bool
+    var isReady: Bool
+    var shouldBlockNextEnqueue: Bool
+    var flushCount = 0
+    var enqueuedPresentationValues: [CMTimeValue] = []
+  }
+
+  private let state: Mutex<State>
+  private let enqueueEntry = DispatchSemaphore(value: 0)
+  private let releaseEnqueue = DispatchSemaphore(value: 0)
+  private let delivery = DispatchSemaphore(value: 0)
+  private let readinessCheck = DispatchSemaphore(value: 0)
+
+  init(
+    requiresFlush: Bool = false,
+    isReady: Bool = true,
+    blockFirstEnqueue: Bool = false
+  ) {
+    state = Mutex(
+      State(
+        requiresFlush: requiresFlush,
+        isReady: isReady,
+        shouldBlockNextEnqueue: blockFirstEnqueue
+      )
+    )
+  }
+
+  var api: PixelBufferDisplayLayerAPI {
+    PixelBufferDisplayLayerAPI(
+      status: { [self] _ in state.withLock { $0.status } },
+      requiresFlush: { [self] _ in state.withLock { $0.requiresFlush } },
+      flush: { [self] _ in
+        state.withLock {
+          $0.flushCount += 1
+          $0.requiresFlush = false
+        }
+      },
+      isReadyForMoreMediaData: { [self] _ in
+        let result = state.withLock { $0.isReady }
+        readinessCheck.signal()
+        return result
+      },
+      enqueue: { [self] _, sample in
+        let shouldBlock = state.withLock { state -> Bool in
+          guard state.shouldBlockNextEnqueue else { return false }
+          state.shouldBlockNextEnqueue = false
+          return true
+        }
+        enqueueEntry.signal()
+        if shouldBlock {
+          releaseEnqueue.wait()
+        }
+        state.withLock {
+          $0.enqueuedPresentationValues.append(
+            CMSampleBufferGetPresentationTimeStamp(sample).value
+          )
+        }
+        delivery.signal()
+      }
+    )
+  }
+
+  var snapshot: Snapshot {
+    state.withLock {
+      Snapshot(
+        flushCount: $0.flushCount,
+        enqueuedPresentationValues: $0.enqueuedPresentationValues
+      )
+    }
+  }
+
+  func setReady(_ isReady: Bool) {
+    state.withLock { $0.isReady = isReady }
+  }
+
+  func waitForEnqueueEntry() -> DispatchTimeoutResult {
+    enqueueEntry.wait(timeout: .now() + 5)
+  }
+
+  func releaseBlockedEnqueue() {
+    releaseEnqueue.signal()
+  }
+
+  func waitForDelivery() -> DispatchTimeoutResult {
+    delivery.wait(timeout: .now() + 5)
+  }
+
+  func waitForReadinessCheck() -> DispatchTimeoutResult {
+    readinessCheck.wait(timeout: .now() + 5)
+  }
+}
+#endif

--- a/Tests/SwiftVLCTests/PiP/PixelBufferRendererTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferRendererTests.swift
@@ -3,6 +3,7 @@
 import AVFoundation
 import CoreMedia
 import CoreVideo
+import CustomDump
 import Synchronization
 import Testing
 
@@ -249,6 +250,39 @@ extension Integration {
     }
 
     @Test
+    func `Scaling resources stay unallocated for passthrough frames`() throws {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      let sourceBuffer = try makeBGRAImageBuffer(width: 16, height: 16)
+
+      #expect(renderer.state.withLock { $0.scalingResources } == nil)
+
+      let unsetOutput = try #require(renderer.outputPixelBuffer(from: sourceBuffer)?.buffer)
+      #expect(unsetOutput === sourceBuffer)
+      #expect(renderer.state.withLock { $0.scalingResources } == nil)
+
+      renderer.setRenderSize(CMVideoDimensions(width: 16, height: 16))
+      let matchingOutput = try #require(renderer.outputPixelBuffer(from: sourceBuffer)?.buffer)
+      #expect(matchingOutput === sourceBuffer)
+      #expect(renderer.state.withLock { $0.scalingResources } == nil)
+    }
+
+    @Test
+    func `Scaling resources are created once and reused across resizes`() throws {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      let sourceBuffer = try makeBGRAImageBuffer(width: 16, height: 16)
+
+      renderer.setRenderSize(CMVideoDimensions(width: 8, height: 8))
+      _ = try #require(renderer.outputPixelBuffer(from: sourceBuffer))
+      let firstResources = try #require(renderer.state.withLock { $0.scalingResources })
+
+      renderer.setRenderSize(CMVideoDimensions(width: 4, height: 4))
+      _ = try #require(renderer.outputPixelBuffer(from: sourceBuffer))
+      let secondResources = try #require(renderer.state.withLock { $0.scalingResources })
+
+      #expect(firstResources === secondResources)
+    }
+
+    @Test
     func `repeated scaling reuses the render pool for unchanged dimensions`() throws {
       let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
       renderer.setRenderSize(CMVideoDimensions(width: 8, height: 8))
@@ -262,6 +296,27 @@ extension Integration {
 
       #expect(firstPool != nil)
       #expect(firstPool === secondPool)
+    }
+
+    @Test
+    func `Render pool threshold fails closed and recovers after a buffer returns`() throws {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      renderer.setRenderSize(CMVideoDimensions(width: 8, height: 8))
+      let sourceBuffer = try makeBGRAImageBuffer(width: 16, height: 16)
+      let threshold = pixelBufferRendererPoolAllocationThreshold(width: 8, height: 8)
+      expectNoDifference(threshold, 12)
+
+      var heldBuffers: [CVPixelBuffer] = []
+      for _ in 0..<threshold {
+        try heldBuffers.append(
+          #require(renderer.outputPixelBuffer(from: sourceBuffer)?.buffer)
+        )
+      }
+
+      #expect(renderer.outputPixelBuffer(from: sourceBuffer) == nil)
+
+      heldBuffers.removeLast()
+      #expect(renderer.outputPixelBuffer(from: sourceBuffer) != nil)
     }
 
     @Test

--- a/Tests/SwiftVLCTests/Player/EventBridgeConcurrencyTests.swift
+++ b/Tests/SwiftVLCTests/Player/EventBridgeConcurrencyTests.swift
@@ -50,7 +50,9 @@ extension Integration {
       let converged = await withTaskGroup(of: Bool.self) { group in
         group.addTask { @Sendable in
           while !Task.isCancelled {
-            if counts.withLock({ $0.allSatisfy { $0 >= 1 } }) { return true }
+            if counts.withLock({ $0.allSatisfy { $0 >= 1 } }) {
+              return true
+            }
             try? await Task.sleep(for: .milliseconds(5))
           }
           return false

--- a/Tests/SwiftVLCTests/Player/EventBridgeDeepTests.swift
+++ b/Tests/SwiftVLCTests/Player/EventBridgeDeepTests.swift
@@ -84,7 +84,9 @@ extension Integration {
             counts[key, default: 0] += 1
             return counts.values.reduce(0, +)
           }
-          if total >= 10 { break }
+          if total >= 10 {
+            break
+          }
         }
       }
 
@@ -122,7 +124,9 @@ extension Integration {
             $0.append(event)
             return $0.count
           }
-          if count >= 3 { break }
+          if count >= 3 {
+            break
+          }
         }
       }
 

--- a/Tests/SwiftVLCTests/Player/EventBridgeFinalTests.swift
+++ b/Tests/SwiftVLCTests/Player/EventBridgeFinalTests.swift
@@ -74,7 +74,9 @@ extension Integration {
         for await event in stream {
           if case .mediaChanged = event {
             let c = mediaChangedCount.withLock { $0 += 1; return $0 }
-            if c >= 2 { break }
+            if c >= 2 {
+              break
+            }
           }
         }
       }
@@ -237,7 +239,9 @@ extension Integration {
           if case .tracksChanged = event {
             let c = tracksCount.withLock { $0 += 1; return $0 }
             // ESAdded fires for each track (audio + video), so we expect multiple
-            if c >= 2 { break }
+            if c >= 2 {
+              break
+            }
           }
         }
       }
@@ -287,7 +291,9 @@ extension Integration {
               && receivedMedia.withLock { $0 }
               && receivedTime.withLock { $0 }
               && receivedLength.withLock { $0 }
-          if allCore { break }
+          if allCore {
+            break
+          }
         }
       }
 

--- a/Tests/SwiftVLCTests/Player/EventBridgeStressTests.swift
+++ b/Tests/SwiftVLCTests/Player/EventBridgeStressTests.swift
@@ -16,7 +16,9 @@ extension Integration {
         Task.detached { @Sendable in
           for await _ in streams[i] {
             let c = counts.withLock { $0[i] += 1; return $0[i] }
-            if c >= 3 { break }
+            if c >= 3 {
+              break
+            }
           }
         }
       }
@@ -123,7 +125,9 @@ extension Integration {
       let fastTask = Task.detached { @Sendable in
         for await _ in fastStream {
           let c = fastCount.withLock { $0 += 1; return $0 }
-          if c >= 5 { break }
+          if c >= 5 {
+            break
+          }
         }
       }
 
@@ -132,7 +136,9 @@ extension Integration {
           // Simulate slow processing
           try? await Task.sleep(for: .milliseconds(200))
           let c = slowCount.withLock { $0 += 1; return $0 }
-          if c >= 2 { break }
+          if c >= 2 {
+            break
+          }
         }
       }
 
@@ -199,7 +205,9 @@ extension Integration {
               && (receivedTracks.withLock { $0 } || receivedMedia.withLock { $0 })
               && receivedBuffering.withLock { $0 }
 
-          if allReceived { break }
+          if allReceived {
+            break
+          }
         }
       }
 
@@ -253,7 +261,9 @@ extension Integration {
             }
             return $0.count >= 3
           }
-          if shouldBreak { break }
+          if shouldBreak {
+            break
+          }
         }
       }
       let task2 = Task.detached { @Sendable in
@@ -266,7 +276,9 @@ extension Integration {
             }
             return $0.count >= 3
           }
-          if shouldBreak { break }
+          if shouldBreak {
+            break
+          }
         }
       }
 
@@ -301,7 +313,9 @@ extension Integration {
         for await event in stream {
           if case .mediaChanged = event {
             let c = mediaChangedCount.withLock { $0 += 1; return $0 }
-            if c >= 2 { break }
+            if c >= 2 {
+              break
+            }
           }
         }
       }

--- a/Tests/SwiftVLCTests/Player/EventBridgeTests.swift
+++ b/Tests/SwiftVLCTests/Player/EventBridgeTests.swift
@@ -51,13 +51,17 @@ extension Integration {
       let t1 = Task.detached { @Sendable in
         for await _ in stream1 {
           let c = count1.withLock { $0 += 1; return $0 }
-          if c >= 2 { break }
+          if c >= 2 {
+            break
+          }
         }
       }
       let t2 = Task.detached { @Sendable in
         for await _ in stream2 {
           let c = count2.withLock { $0 += 1; return $0 }
-          if c >= 2 { break }
+          if c >= 2 {
+            break
+          }
         }
       }
 
@@ -112,7 +116,9 @@ extension Integration {
               $0.append(state)
               return state == .stopped || $0.count >= 8
             }
-            if shouldBreak { break }
+            if shouldBreak {
+              break
+            }
           }
         }
       }
@@ -143,7 +149,9 @@ extension Integration {
           case .positionChanged: receivedPosition.withLock { $0 = true }
           default: break
           }
-          if receivedTime.withLock({ $0 }) && receivedPosition.withLock({ $0 }) { break }
+          if receivedTime.withLock({ $0 }) && receivedPosition.withLock({ $0 }) {
+            break
+          }
         }
       }
 
@@ -191,7 +199,9 @@ extension Integration {
           case .pausableChanged: receivedPausable.withLock { $0 = true }
           default: break
           }
-          if receivedSeekable.withLock({ $0 }) && receivedPausable.withLock({ $0 }) { break }
+          if receivedSeekable.withLock({ $0 }) && receivedPausable.withLock({ $0 }) {
+            break
+          }
         }
       }
 
@@ -218,7 +228,9 @@ extension Integration {
           case .unmuted: receivedUnmuted.withLock { $0 = true }
           default: break
           }
-          if receivedMuted.withLock({ $0 }) && receivedUnmuted.withLock({ $0 }) { break }
+          if receivedMuted.withLock({ $0 }) && receivedUnmuted.withLock({ $0 }) {
+            break
+          }
         }
       }
 
@@ -296,7 +308,9 @@ extension Integration {
           case .mediaChanged: receivedMediaChanged.withLock { $0 = true }
           default: break
           }
-          if receivedTracksChanged.withLock({ $0 }) || receivedMediaChanged.withLock({ $0 }) { break }
+          if receivedTracksChanged.withLock({ $0 }) || receivedMediaChanged.withLock({ $0 }) {
+            break
+          }
         }
       }
 

--- a/Tests/SwiftVLCTests/Player/PlaybackEndCoordinatorTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlaybackEndCoordinatorTests.swift
@@ -120,8 +120,12 @@ extension Logic {
     )
     func `Full decision table`(libraryStop: Bool, error: Bool, suppressed: Bool) {
       let coordinator = PlaybackEndCoordinator()
-      if libraryStop { coordinator.markLibraryStop() }
-      if error { coordinator.markError() }
+      if libraryStop {
+        coordinator.markLibraryStop()
+      }
+      if error {
+        coordinator.markError()
+      }
       coordinator.setSuppressed(suppressed)
 
       let expected = !libraryStop && !error && !suppressed

--- a/Tests/SwiftVLCTests/Player/PlayerCarryOverTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerCarryOverTests.swift
@@ -293,6 +293,8 @@ extension Integration {
       let player = Player(instance: instance)
       let listPlayer = MediaListPlayer(instance: instance)
       listPlayer.mediaPlayer = player
+      let oldLifetime = player.nativeHandleLifetime
+      #expect(oldLifetime.nativeOwnerCount == 2)
 
       try forceHandleSwap(on: player)
 
@@ -302,6 +304,14 @@ extension Integration {
       #expect(
         bound == player.pointer,
         "list player still bound to the released handle"
+      )
+      #expect(
+        oldLifetime.nativeOwnerCount <= 1,
+        "list-player lease remained on the replaced handle after synchronous rebind"
+      )
+      #expect(
+        player.nativeHandleLifetime.nativeOwnerCount == 2,
+        "replacement handle is missing its counted list-player owner"
       )
     }
   }

--- a/Tests/SwiftVLCTests/Player/PlayerDeepCoverageTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerDeepCoverageTests.swift
@@ -251,8 +251,12 @@ extension Integration {
       try player.play(Media(url: TestMedia.twosecURL))
       var sawBuffering = false
       for _ in 0..<40 {
-        if case .buffering = player.state { sawBuffering = true; break }
-        if player.state == .playing { break }
+        if case .buffering = player.state {
+          sawBuffering = true; break
+        }
+        if player.state == .playing {
+          break
+        }
         try await Task.sleep(for: .milliseconds(25))
       }
       _ = sawBuffering

--- a/Tests/SwiftVLCTests/Player/PlayerEndReachedTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerEndReachedTests.swift
@@ -6,14 +6,22 @@ import Testing
 /// Indices of `.endReached` deliveries in a collected raw sequence.
 private func endReachedIndices(in events: [PlayerEvent]) -> [Int] {
   events.indices.filter { index in
-    if case .endReached = events[index] { true } else { false }
+    if case .endReached = events[index] {
+      true
+    } else {
+      false
+    }
   }
 }
 
 /// Index of the first `.stateChanged(.stopped)` in a collected raw sequence.
 private func firstStoppedIndex(in events: [PlayerEvent]) -> Int? {
   events.firstIndex { event in
-    if case .stateChanged(.stopped) = event { true } else { false }
+    if case .stateChanged(.stopped) = event {
+      true
+    } else {
+      false
+    }
   }
 }
 

--- a/Tests/SwiftVLCTests/Player/PlayerEventSequenceTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerEventSequenceTests.swift
@@ -175,7 +175,9 @@ private func collectStableLifecycleEvents(
           if collected.last != line {
             collected.append(line)
           }
-          if predicate(collected) { break }
+          if predicate(collected) {
+            break
+          }
         }
         return collected.joined(separator: "\n")
       }

--- a/Tests/SwiftVLCTests/Player/PlayerEventStreamPolicyTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerEventStreamPolicyTests.swift
@@ -106,7 +106,9 @@ extension Integration {
       let bridge = player.eventBridge
       let source = Player.sourceIdentifier(for: player.pointer)
       let stream = player.events(policy: .unbounded, filter: { event in
-        if case .timeChanged = event { return false }
+        if case .timeChanged = event {
+          return false
+        }
         return true
       })
 
@@ -242,7 +244,9 @@ extension Integration {
     func `Subscription filter keeps the firehose out`() async throws {
       let player = Player(instance: TestInstance.makePlayback())
       let stream = player.events(policy: .unbounded, filter: { event in
-        if case .stateChanged = event { return true }
+        if case .stateChanged = event {
+          return true
+        }
         return false
       })
 
@@ -268,7 +272,9 @@ extension Integration {
         await poll(until: {
           received.withLock { events in
             events.contains { event in
-              if case .stateChanged(.stopped) = event { return true }
+              if case .stateChanged(.stopped) = event {
+                return true
+              }
               return false
             }
           }

--- a/Tests/SwiftVLCTests/Player/PlayerFinalCoverageTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerFinalCoverageTests.swift
@@ -214,8 +214,12 @@ extension Integration {
       try player.play(Media(url: TestMedia.twosecURL))
       // Rapidly poll for opening/buffering
       for _ in 0..<100 {
-        if player.state == .opening { _ = player.isActive; break }
-        if player.state == .playing { break }
+        if player.state == .opening {
+          _ = player.isActive; break
+        }
+        if player.state == .playing {
+          break
+        }
         try await Task.sleep(for: .milliseconds(10))
       }
       player.stop()

--- a/Tests/SwiftVLCTests/Player/PlayerNativeLifecycleTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerNativeLifecycleTests.swift
@@ -1,6 +1,7 @@
 @testable import SwiftVLC
 import CLibVLC
 import Foundation
+import Synchronization
 import Testing
 
 extension Integration {
@@ -59,6 +60,96 @@ extension Integration {
       #expect(player.state == .idle)
     }
 
+    /// `shutdown()` clears `pauseTransition` before offloading native teardown.
+    /// The decision to resume must therefore be captured while `.pausing` is
+    /// still visible, even when libVLC has not published `.paused` yet.
+    @Test
+    func `pending native pause requires resume before teardown`() {
+      let player = Player(instance: TestInstance.shared)
+      player.pauseTransition = .pausing
+
+      #expect(player.nativePlaybackState != .paused)
+      #expect(player.shouldResumeNativePlayerBeforeStop)
+
+      player.pauseTransition = nil
+      #expect(player.shouldResumeNativePlayerBeforeStop == false)
+    }
+
+    @Test
+    func `Native handle release waits for every counted native owner`() throws {
+      let pointer = try #require(OpaquePointer(bitPattern: 0x51A2_ED00))
+      let lifetime = NativePlayerHandleLifetime(pointer: pointer)
+      let listPlayerLease = lifetime.acquireNativeOwnerLease()
+      let actionCount = Mutex(0)
+      weak var retainedProbe: NSObject?
+
+      do {
+        let probe = NSObject()
+        retainedProbe = probe
+        lifetime.retainUntilReleased([probe])
+      }
+      lifetime.whenReleased {
+        actionCount.withLock { $0 += 1 }
+      }
+
+      lifetime.initialOwnerDidRelease()
+
+      #expect(lifetime.nativeOwnerCount == 1)
+      #expect(!lifetime.isReleased)
+      #expect(actionCount.withLock { $0 } == 0)
+      #expect(retainedProbe != nil)
+
+      listPlayerLease.endAfterNativeOwnerRelease()
+
+      #expect(lifetime.nativeOwnerCount == 0)
+      #expect(lifetime.isReleased)
+      #expect(actionCount.withLock { $0 } == 1)
+      #expect(retainedProbe == nil)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `Native lifetime hands final retained-object release to the main thread`() async throws {
+      let pointer = try #require(OpaquePointer(bitPattern: 0x51A2_ED01))
+      let lifetime = NativePlayerHandleLifetime(pointer: pointer)
+      let additionalOwner = lifetime.acquireNativeOwnerLease()
+      let deinitWasOnMainThread = Mutex<Bool?>(nil)
+      weak var retainedProbe: DeinitThreadProbe?
+
+      do {
+        let probe = DeinitThreadProbe {
+          deinitWasOnMainThread.withLock { $0 = Thread.isMainThread }
+        }
+        retainedProbe = probe
+        lifetime.retainUntilReleased([probe])
+      }
+
+      await withCheckedContinuation { continuation in
+        DispatchQueue.global(qos: .utility).async {
+          lifetime.initialOwnerDidRelease()
+          continuation.resume()
+        }
+      }
+      #expect(lifetime.nativeOwnerCount == 1)
+      #expect(retainedProbe != nil)
+
+      await withCheckedContinuation { continuation in
+        DispatchQueue.global(qos: .utility).async {
+          additionalOwner.endAfterNativeOwnerRelease()
+          continuation.resume()
+        }
+      }
+      try #require(
+        await poll(timeout: .seconds(10)) {
+          deinitWasOnMainThread.withLock { $0 != nil }
+        },
+        "Waiting for: main-thread retained-object release"
+      )
+
+      #expect(lifetime.isReleased)
+      #expect(retainedProbe == nil)
+      #expect(deinitWasOnMainThread.withLock { $0 } == true)
+    }
+
     @Test
     func `direct drawable attachment and clearing maintain ownership`() {
       let player = Player(instance: TestInstance.shared)
@@ -75,6 +166,217 @@ extension Integration {
       player.clearDrawable(ifCurrent: drawable)
       #expect(player.drawable == nil)
       #expect(!player.isDrawableOwner(drawable))
+    }
+
+    /// libVLC reads `drawable-nsobject` asynchronously. Once a handle has
+    /// started, clearing the variable cannot prove that a vout which already
+    /// copied the raw pointer has finished retaining or messaging it. Keep the
+    /// outgoing drawable alive until that exact native handle is released.
+    @Test
+    func `detaching drawable from a list-owned handle retains it until full native release`() async {
+      let player = Player(instance: TestInstance.shared)
+      let listPlayer = MediaListPlayer(instance: TestInstance.shared)
+      listPlayer.mediaPlayer = player
+      let lifetime = player.nativeHandleLifetime
+      weak var weakDrawable: NSObject?
+
+      do {
+        let drawable = NSObject()
+        weakDrawable = drawable
+        player.setDrawable(drawable)
+        // Deterministically model the state set immediately after a successful
+        // libvlc_media_player_play call without opening a real CI video output.
+        player.nativePlayerHasStartedPlayback = true
+        player.setDrawable(nil)
+        player.setDrawable(drawable)
+        player.setDrawable(nil)
+        #expect(player.retainedDrawablesUntilNativePlayerRelease.count == 1)
+      }
+
+      #expect(weakDrawable != nil)
+      await player.shutdown()
+      #expect(lifetime.isReleased)
+      #expect(listPlayer.mediaPlayer == nil)
+      #expect(weakDrawable == nil)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `Coupled list-player and player deinit keep drawable until both native releases finish`() async throws {
+      let instance = TestInstance.makeAudioOnly()
+      var player: Player? = Player(instance: instance)
+      var listPlayer: MediaListPlayer? = MediaListPlayer(instance: instance)
+      let lifetime = try #require(player?.nativeHandleLifetime)
+      weak let weakPlayer = player
+      weak var weakDrawable: NSObject?
+
+      do {
+        let drawable = NSObject()
+        weakDrawable = drawable
+        player?.setDrawable(drawable)
+        player?.nativePlayerHasStartedPlayback = true
+        player?.setDrawable(nil)
+      }
+      listPlayer?.mediaPlayer = player
+      #expect(lifetime.nativeOwnerCount == 2)
+      #expect(weakDrawable != nil)
+
+      listPlayer = nil
+      player = nil
+
+      try #require(
+        await poll(timeout: .seconds(10)) { lifetime.isReleased },
+        "Waiting for: list-player and player native releases"
+      )
+      #expect(lifetime.nativeOwnerCount == 0)
+      #expect(weakPlayer == nil)
+      #expect(weakDrawable == nil)
+    }
+
+    /// A replacement handle and its predecessor tear down on independent
+    /// utility-queue jobs. Holding a real extra native retain keeps the
+    /// predecessor alive after the successor has fully shut down, proving the
+    /// drawable is leased by the predecessor's lifetime rather than merely by
+    /// the current `Player.drawable` property.
+    @Test(.timeLimit(.minutes(1)))
+    func `Replacement retains current drawable until the outgoing native handle releases`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let oldPointer = player.pointer
+      let oldLifetime = player.nativeHandleLifetime
+      let oldLease = oldLifetime.acquireNativeOwnerLease()
+      _ = libvlc_media_player_retain(oldPointer)
+      var oldLeaseDidEnd = false
+      defer {
+        if !oldLeaseDidEnd {
+          libvlc_media_player_release(oldPointer)
+          oldLease.endAfterNativeOwnerRelease()
+        }
+      }
+      weak var weakDrawable: NSObject?
+
+      do {
+        let drawable = NSObject()
+        weakDrawable = drawable
+        player.setDrawable(drawable)
+        // Deterministically model an old vout that copied the drawable without
+        // requiring a window server or timing-sensitive decoder in CI.
+        player.nativePlayerHasStartedPlayback = true
+
+        try player.replaceNativePlayerForDrawablePlayback(target: drawable)
+        player.setDrawable(nil)
+      }
+
+      await player.shutdown()
+      try #require(
+        await poll(timeout: .seconds(10)) { oldLifetime.nativeOwnerCount == 1 },
+        "Waiting for: outgoing Swift owner release"
+      )
+      #expect(weakDrawable != nil)
+
+      libvlc_media_player_release(oldPointer)
+      oldLease.endAfterNativeOwnerRelease()
+      oldLeaseDidEnd = true
+
+      #expect(oldLifetime.isReleased)
+      #expect(weakDrawable == nil)
+    }
+
+    /// Each outgoing generation owns only its own drawable lease. Three rapid
+    /// replacements are then released in a deliberately different order to
+    /// prove that no global/current-handle retain accidentally makes the test
+    /// pass through FIFO queue timing.
+    @Test(.timeLimit(.minutes(1)))
+    func `Rapid replacements release drawable leases in exact native handle order`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+
+      let drawable0 = StrongReferenceBox(NSObject())
+      weak let weakDrawable0 = drawable0.value
+      try player.setDrawable(requireValue(in: drawable0))
+      player.nativePlayerHasStartedPlayback = true
+      let pointer0 = player.pointer
+      let lifetime0 = player.nativeHandleLifetime
+      let lease0 = lifetime0.acquireNativeOwnerLease()
+      _ = libvlc_media_player_retain(pointer0)
+      var lease0DidEnd = false
+      defer {
+        if !lease0DidEnd {
+          libvlc_media_player_release(pointer0)
+          lease0.endAfterNativeOwnerRelease()
+        }
+      }
+      try player.replaceNativePlayerForDrawablePlayback(target: drawable0.value)
+
+      let drawable1 = StrongReferenceBox(NSObject())
+      weak let weakDrawable1 = drawable1.value
+      try player.setDrawable(requireValue(in: drawable1))
+      drawable0.value = nil
+      player.nativePlayerHasStartedPlayback = true
+      let pointer1 = player.pointer
+      let lifetime1 = player.nativeHandleLifetime
+      let lease1 = lifetime1.acquireNativeOwnerLease()
+      _ = libvlc_media_player_retain(pointer1)
+      var lease1DidEnd = false
+      defer {
+        if !lease1DidEnd {
+          libvlc_media_player_release(pointer1)
+          lease1.endAfterNativeOwnerRelease()
+        }
+      }
+      try player.replaceNativePlayerForDrawablePlayback(target: drawable1.value)
+
+      let drawable2 = StrongReferenceBox(NSObject())
+      weak let weakDrawable2 = drawable2.value
+      try player.setDrawable(requireValue(in: drawable2))
+      drawable1.value = nil
+      player.nativePlayerHasStartedPlayback = true
+      let pointer2 = player.pointer
+      let lifetime2 = player.nativeHandleLifetime
+      let lease2 = lifetime2.acquireNativeOwnerLease()
+      _ = libvlc_media_player_retain(pointer2)
+      var lease2DidEnd = false
+      defer {
+        if !lease2DidEnd {
+          libvlc_media_player_release(pointer2)
+          lease2.endAfterNativeOwnerRelease()
+        }
+      }
+      try player.replaceNativePlayerForDrawablePlayback(target: drawable2.value)
+
+      player.setDrawable(nil)
+      drawable2.value = nil
+      await player.shutdown()
+      try #require(
+        await poll(timeout: .seconds(10)) {
+          lifetime0.nativeOwnerCount == 1
+            && lifetime1.nativeOwnerCount == 1
+            && lifetime2.nativeOwnerCount == 1
+        },
+        "Waiting for: all outgoing Swift owner releases"
+      )
+      #expect(weakDrawable0 != nil)
+      #expect(weakDrawable1 != nil)
+      #expect(weakDrawable2 != nil)
+
+      // Finish H1 before H0: only H1's drawable may disappear.
+      libvlc_media_player_release(pointer1)
+      lease1.endAfterNativeOwnerRelease()
+      lease1DidEnd = true
+      #expect(lifetime1.isReleased)
+      #expect(weakDrawable0 != nil)
+      #expect(weakDrawable1 == nil)
+      #expect(weakDrawable2 != nil)
+
+      libvlc_media_player_release(pointer0)
+      lease0.endAfterNativeOwnerRelease()
+      lease0DidEnd = true
+      #expect(lifetime0.isReleased)
+      #expect(weakDrawable0 == nil)
+      #expect(weakDrawable2 != nil)
+
+      libvlc_media_player_release(pointer2)
+      lease2.endAfterNativeOwnerRelease()
+      lease2DidEnd = true
+      #expect(lifetime2.isReleased)
+      #expect(weakDrawable2 == nil)
     }
 
     @Test
@@ -135,4 +437,31 @@ extension Integration {
       #expect(player.currentMedia == nil)
     }
   }
+}
+
+private final class DeinitThreadProbe: @unchecked Sendable {
+  private let onDeinit: @Sendable () -> Void
+
+  init(onDeinit: @escaping @Sendable () -> Void) {
+    self.onDeinit = onDeinit
+  }
+
+  deinit {
+    onDeinit()
+  }
+}
+
+private final class StrongReferenceBox<Value: AnyObject> {
+  var value: Value?
+
+  init(_ value: Value) {
+    self.value = value
+  }
+}
+
+private func requireValue<Value: AnyObject>(
+  in box: StrongReferenceBox<Value>
+)
+  throws -> Value {
+  try #require(box.value)
 }

--- a/Tests/SwiftVLCTests/Playlist/MediaListPlayerRebuildTests.swift
+++ b/Tests/SwiftVLCTests/Playlist/MediaListPlayerRebuildTests.swift
@@ -1,4 +1,5 @@
 @testable import SwiftVLC
+import CLibVLC
 import Foundation
 import Testing
 
@@ -47,6 +48,205 @@ extension Integration {
       #expect(listPlayer.mediaList == nil)
       #expect(listPlayer.mediaPlayer === player, "Player must survive the rebuild")
       #expect(listPlayer.playbackMode == .repeat)
+    }
+
+    /// Root-cause proof at the pinned C API boundary: two native list players
+    /// retain the same media-player pointer, and stopping either list player
+    /// sends `stop_async` to that shared handle. The Swift regression below
+    /// proves a retiring wrapper no longer makes this call after its successor
+    /// adopts the handle.
+    @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
+    func `Pinned libVLC stop on either list wrapper disrupts their shared player`() async throws {
+      let instance = TestInstance.makePlayback()
+      let player = Player(instance: instance)
+      defer { withExtendedLifetime(player) {} }
+      let oldWrapper = try #require(libvlc_media_list_player_new(instance.pointer))
+      let successor = try #require(libvlc_media_list_player_new(instance.pointer))
+      defer {
+        libvlc_media_list_player_stop_async(successor)
+        libvlc_media_list_player_stop_async(oldWrapper)
+        libvlc_media_list_player_release(successor)
+        libvlc_media_list_player_release(oldWrapper)
+      }
+      libvlc_media_list_player_set_media_player(oldWrapper, player.pointer)
+      libvlc_media_list_player_set_media_player(successor, player.pointer)
+      let list = MediaList()
+      try list.append(Media(url: TestMedia.sparseURL))
+      libvlc_media_list_player_set_media_list(oldWrapper, list.pointer)
+      libvlc_media_list_player_play(oldWrapper)
+      try #require(
+        await poll { player.nativePlaybackState == .playing },
+        "Waiting for: shared native player starts"
+      )
+
+      let terminalTransition = subscribeAndAwaitTerminalStop(on: player)
+      libvlc_media_list_player_stop_async(oldWrapper)
+
+      try await requireReached(
+        terminalTransition,
+        "Pinned libVLC emitted no stopping transition for the shared handle"
+      )
+    }
+
+    /// Rebuilding only the list wrapper must not stop the shared native
+    /// media-player handle. This is the handle an active PiP session also
+    /// observes, so an old list wrapper stopping it tears down PiP playback.
+    @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
+    func `Clearing mediaList while playing preserves the shared player`() async throws {
+      let instance = TestInstance.makePlayback()
+      let listPlayer = MediaListPlayer(instance: instance)
+      let player = Player(instance: instance)
+      let list = MediaList()
+      try list.append(Media(url: TestMedia.sparseURL))
+      listPlayer.mediaPlayer = player
+      listPlayer.mediaList = list
+      listPlayer.play()
+      defer { listPlayer.stop() }
+      let retiringWrapper = try #require(libvlc_media_list_player_retain(listPlayer.pointer))
+      defer {
+        libvlc_media_list_player_stop_async(retiringWrapper)
+        libvlc_media_list_player_release(retiringWrapper)
+      }
+
+      try #require(
+        await poll(until: { player.nativePlaybackState == .playing }),
+        "Waiting for: shared player reaches playing"
+      )
+
+      listPlayer.mediaList = nil
+
+      // Keep the retired wrapper alive past its queued Swift release and prove
+      // it was synchronously severed from the shared player. This closes the
+      // list-end race: even if its old playlist callback advances now, it can
+      // only drive the independent neutral player.
+      let retiredBinding = try #require(
+        libvlc_media_list_player_get_media_player(retiringWrapper)
+      )
+      defer { libvlc_media_player_release(retiredBinding) }
+      let successorBinding = try #require(
+        libvlc_media_list_player_get_media_player(listPlayer.pointer)
+      )
+      defer { libvlc_media_player_release(successorBinding) }
+      #expect(retiredBinding != player.pointer)
+      #expect(successorBinding == player.pointer)
+      let sharedMediaBeforeRetiredControl = try #require(
+        libvlc_media_player_get_media(player.pointer)
+      )
+      defer { libvlc_media_release(sharedMediaBeforeRetiredControl) }
+      libvlc_media_list_player_play(retiringWrapper)
+      let sharedMediaAfterRetiredControl = try #require(
+        libvlc_media_player_get_media(player.pointer)
+      )
+      defer { libvlc_media_release(sharedMediaAfterRetiredControl) }
+      #expect(sharedMediaAfterRetiredControl == sharedMediaBeforeRetiredControl)
+
+      let oldWrapperStoppedSharedPlayer = try await poll(
+        timeout: .seconds(2),
+        until: { player.nativePlaybackState == .stopped }
+      )
+      #expect(
+        oldWrapperStoppedSharedPlayer == false,
+        "retired list wrapper stopped the shared player adopted by its replacement"
+      )
+      #expect(listPlayer.isPlaying)
+    }
+
+    @Test
+    func `Rebuild transfers counted ownership before returning`() {
+      let instance = TestInstance.makeAudioOnly()
+      let listPlayer = MediaListPlayer(instance: instance)
+      let player = Player(instance: instance)
+      let lifetime = player.nativeHandleLifetime
+      let list = MediaList()
+
+      listPlayer.mediaPlayer = player
+      #expect(lifetime.nativeOwnerCount == 2)
+      listPlayer.mediaList = list
+      listPlayer.mediaList = nil
+
+      // The retiring wrapper itself releases off-main, but its binding to the
+      // shared player is synchronously replaced with a neutral player.
+      #expect(lifetime.nativeOwnerCount == 2)
+      #expect(!lifetime.isReleased)
+
+      listPlayer.mediaPlayer = nil
+      #expect(lifetime.nativeOwnerCount == 1)
+      #expect(!lifetime.isReleased)
+    }
+
+    @Test
+    func `Attaching a player to a second list transfers sole live ownership`() {
+      let instance = TestInstance.makeAudioOnly()
+      let player = Player(instance: instance)
+      let first = MediaListPlayer(instance: instance)
+      let second = MediaListPlayer(instance: instance)
+      let lifetime = player.nativeHandleLifetime
+
+      first.mediaPlayer = player
+      second.mediaPlayer = player
+
+      #expect(first.mediaPlayer == nil)
+      #expect(second.mediaPlayer === player)
+      #expect(player.attachedMediaListPlayer === second)
+      #expect(lifetime.nativeOwnerCount == 2)
+    }
+
+    @Test(.tags(.async, .media), .enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
+    func `Transferring an actively playing shared player does not stop it`() async throws {
+      let instance = TestInstance.makePlayback()
+      let player = Player(instance: instance)
+      let first = MediaListPlayer(instance: instance)
+      let second = MediaListPlayer(instance: instance)
+      let list = MediaList()
+      try list.append(Media(url: TestMedia.sparseURL))
+      first.mediaPlayer = player
+      first.mediaList = list
+      first.play()
+      defer { second.stop() }
+      let retiringFirstWrapper = try #require(libvlc_media_list_player_retain(first.pointer))
+      defer {
+        libvlc_media_list_player_stop_async(retiringFirstWrapper)
+        libvlc_media_list_player_release(retiringFirstWrapper)
+      }
+      try #require(
+        await poll { player.nativePlaybackState == .playing },
+        "Waiting for: first list starts the shared player"
+      )
+
+      second.mediaPlayer = player
+
+      let retiredBinding = try #require(
+        libvlc_media_list_player_get_media_player(retiringFirstWrapper)
+      )
+      defer { libvlc_media_player_release(retiredBinding) }
+      #expect(retiredBinding != player.pointer)
+
+      let retiredOwnerStoppedSharedPlayer = try await poll(
+        timeout: .seconds(2),
+        until: { player.nativePlaybackState == .stopped }
+      )
+      #expect(!retiredOwnerStoppedSharedPlayer)
+      #expect(first.mediaPlayer == nil)
+      #expect(second.mediaPlayer === player)
+      #expect(player.attachedMediaListPlayer === second)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `List-player deinit ends its counted native owner after release`() async throws {
+      let instance = TestInstance.makeAudioOnly()
+      let player = Player(instance: instance)
+      let lifetime = player.nativeHandleLifetime
+      var listPlayer: MediaListPlayer? = MediaListPlayer(instance: instance)
+      listPlayer?.mediaPlayer = player
+      #expect(lifetime.nativeOwnerCount == 2)
+
+      listPlayer = nil
+
+      try #require(
+        await poll { lifetime.nativeOwnerCount == 1 },
+        "Waiting for: deinitialized list player's native release"
+      )
+      #expect(!lifetime.isReleased)
     }
 
     /// After a rebuild, re-attaching a mediaPlayer / mediaList must

--- a/Tests/SwiftVLCTests/Support/AwaitEvent.swift
+++ b/Tests/SwiftVLCTests/Support/AwaitEvent.swift
@@ -57,7 +57,9 @@ func subscribeAndAwait(
     await withTaskGroup(of: Bool.self) { group in
       group.addTask {
         for await event in stream {
-          if case .stateChanged(let s) = event, s == state { return true }
+          if case .stateChanged(let s) = event, s == state {
+            return true
+          }
         }
         return false
       }

--- a/Tests/SwiftVLCTests/Support/Poll.swift
+++ b/Tests/SwiftVLCTests/Support/Poll.swift
@@ -11,7 +11,9 @@ func poll(
   async throws -> Bool {
   let deadline = ContinuousClock.now + timeout
   while !condition() {
-    if ContinuousClock.now >= deadline { return false }
+    if ContinuousClock.now >= deadline {
+      return false
+    }
     try await Task.sleep(for: interval)
   }
   return true

--- a/Tests/SwiftVLCTests/Support/StringSnapshot.swift
+++ b/Tests/SwiftVLCTests/Support/StringSnapshot.swift
@@ -79,7 +79,9 @@ func renderUnifiedDiff(expected: String, actual: String) -> String {
 private func longestCommonSubsequence(_ a: [String], _ b: [String]) -> [String] {
   let m = a.count
   let n = b.count
-  if m == 0 || n == 0 { return [] }
+  if m == 0 || n == 0 {
+    return []
+  }
   var dp = Array(repeating: Array(repeating: 0, count: n + 1), count: m + 1)
   for i in 1...m {
     for j in 1...n {

--- a/Tests/SwiftVLCTests/Video/AspectRatioReadbackTests.swift
+++ b/Tests/SwiftVLCTests/Video/AspectRatioReadbackTests.swift
@@ -45,8 +45,35 @@ extension Integration {
       #expect(displayFit(player) == libvlc_video_fit_larger)
     }
 
+    @Test
+    func `ratio after fill forces the aspect and resets the fit`() {
+      let player = Player(instance: TestInstance.shared)
+      player.aspectRatio = .fill
+      player.aspectRatio = .ratio(16, 9)
+      #expect(aspectString(player) == "16:9")
+      #expect(displayFit(player) == libvlc_video_fit_smaller)
+    }
+
+    @Test
+    func `fill after ratio clears the aspect and requests the larger fit`() {
+      let player = Player(instance: TestInstance.shared)
+      player.aspectRatio = .ratio(4, 3)
+      player.aspectRatio = .fill
+      #expect(aspectString(player) == nil)
+      #expect(displayFit(player) == libvlc_video_fit_larger)
+    }
+
+    @Test
+    func `default after ratio clears the aspect and restores the smaller fit`() {
+      let player = Player(instance: TestInstance.shared)
+      player.aspectRatio = .ratio(4, 3)
+      player.aspectRatio = .default
+      #expect(aspectString(player) == nil)
+      #expect(displayFit(player) == libvlc_video_fit_smaller)
+    }
+
     /// The aspect mode must reapply to the replacement handle so a stop/play
-    /// or recast keeps `.fill` covering rather than reverting to letterbox.
+    /// or recast keeps the setting rather than reverting.
     @Test
     func `fill survives a native handle swap`() throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
@@ -57,6 +84,18 @@ extension Integration {
       try player.prepareDrawableForPlayback()
       try #require(player.pointer != old, "swap did not replace the native handle")
       #expect(displayFit(player) == libvlc_video_fit_larger)
+    }
+
+    @Test
+    func `ratio survives a native handle swap`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player.aspectRatio = .ratio(16, 9)
+      let old = player.pointer
+      player.setDrawable(NSObject())
+      player.stop()
+      try player.prepareDrawableForPlayback()
+      try #require(player.pointer != old, "swap did not replace the native handle")
+      #expect(aspectString(player) == "16:9")
     }
   }
 }

--- a/Tests/SwiftVLCTests/Video/AspectRatioReadbackTests.swift
+++ b/Tests/SwiftVLCTests/Video/AspectRatioReadbackTests.swift
@@ -1,0 +1,47 @@
+@testable import SwiftVLC
+import CLibVLC
+import Testing
+
+/// Characterizes the libVLC video-configuration state each `AspectRatio` case
+/// drives, read back through `libvlc_video_get_aspect_ratio` and
+/// `libvlc_video_get_display_fit`. These are API-level readbacks — they prove
+/// which knobs the wrapper sets, not what the vout renders (the sample-buffer
+/// display honors the source SAR, not the fit variable). On-screen geometry is
+/// covered by `scripts/aspect-harness`.
+extension Integration {
+  @Suite(.tags(.mainActor))
+  @MainActor struct AspectRatioReadbackTests {
+    private func aspectString(_ player: Player) -> String? {
+      guard let c = libvlc_video_get_aspect_ratio(player.pointer) else { return nil }
+      defer { libvlc_free(c) }
+      let s = String(cString: c)
+      return s.isEmpty ? nil : s
+    }
+
+    private func displayFit(_ player: Player) -> libvlc_video_fit_mode_t {
+      libvlc_video_get_display_fit(player.pointer)
+    }
+
+    @Test
+    func `default sets no forced aspect and the smaller fit`() {
+      let player = Player(instance: TestInstance.shared)
+      player.aspectRatio = .default
+      #expect(aspectString(player) == nil)
+      #expect(displayFit(player) == libvlc_video_fit_smaller)
+    }
+
+    @Test
+    func `ratio sets the forced aspect string`() {
+      let player = Player(instance: TestInstance.shared)
+      player.aspectRatio = .ratio(16, 9)
+      #expect(aspectString(player) == "16:9")
+    }
+
+    @Test
+    func `fill requests the larger fit`() {
+      let player = Player(instance: TestInstance.shared)
+      player.aspectRatio = .fill
+      #expect(displayFit(player) == libvlc_video_fit_larger)
+    }
+  }
+}

--- a/Tests/SwiftVLCTests/Video/AspectRatioReadbackTests.swift
+++ b/Tests/SwiftVLCTests/Video/AspectRatioReadbackTests.swift
@@ -1,5 +1,6 @@
 @testable import SwiftVLC
 import CLibVLC
+import Foundation
 import Testing
 
 /// Characterizes the libVLC video-configuration state each `AspectRatio` case
@@ -41,6 +42,20 @@ extension Integration {
     func `fill requests the larger fit`() {
       let player = Player(instance: TestInstance.shared)
       player.aspectRatio = .fill
+      #expect(displayFit(player) == libvlc_video_fit_larger)
+    }
+
+    /// The aspect mode must reapply to the replacement handle so a stop/play
+    /// or recast keeps `.fill` covering rather than reverting to letterbox.
+    @Test
+    func `fill survives a native handle swap`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player.aspectRatio = .fill
+      let old = player.pointer
+      player.setDrawable(NSObject())
+      player.stop()
+      try player.prepareDrawableForPlayback()
+      try #require(player.pointer != old, "swap did not replace the native handle")
       #expect(displayFit(player) == libvlc_video_fit_larger)
     }
   }

--- a/scripts/aspect-harness/BASELINE.md
+++ b/scripts/aspect-harness/BASELINE.md
@@ -1,0 +1,18 @@
+# Aspect harness baseline — pre-fix
+
+Measured on the v0.10.0 binary, iPhone 17 Pro simulator / iOS 26.5, with the
+2.40:1 (`testsrc2` 1920×800) fixture in `AspectRatioCase` (16:9 surface,
+1110×625 px @3x). `surface_ar` 1.776; the source DAR is 2.40.
+
+| option | picture (px) | picture_ar | corrected target | status |
+|--------|--------------|-----------|------------------|--------|
+| default | 1110×463 | 2.40 | 2.40 (letterbox) | correct |
+| fill    | 1110×463 | 2.40 | ~1.78 (cover) | **A1** — identical to default |
+| 16:9    | 1110×463 | 2.40 | 1.78 | **A2** — unchanged |
+| 4:3     | 834×347  | 2.40 | 1.33 | **A2** — 2.40 fit *inside* an 833×625 4:3 box |
+| 1:1     | 625×261  | 2.40 | 1.00 | **A2** — 2.40 fit *inside* a 625×625 1:1 box |
+| 21:9    | 1110×463 | 2.40 | 2.33 | **A2** — unchanged (near-degenerate vs source DAR) |
+
+`assert.py` exits non-zero against this baseline. A1: `.fill` never covers
+(the sample-buffer vout ignores `display_fit`). A2: `.ratio(w,h)` letterboxes
+the native picture inside a w:h region instead of forcing display aspect.

--- a/scripts/aspect-harness/README.md
+++ b/scripts/aspect-harness/README.md
@@ -1,0 +1,31 @@
+# Aspect-ratio visual harness
+
+Measures the rendered video rectangle for every `AspectRatio` option by driving
+the iOS-simulator Showcase `AspectRatioCase`, so `.fill` (cover) and
+`.ratio(w,h)` (forced display aspect) are verified against real pixels rather
+than only the libVLC API state. Complements the headless getter-readback
+characterization tests in `Tests/SwiftVLCTests/Video/`.
+
+## Why a 2.40:1 fixture
+`AspectRatioCase` renders into a 16:9 surface. With 16:9 content, `.default`,
+`.fill` and `.ratio(16,9)` are pixel-identical even when correct, so the harness
+plays a 2.40:1 clip whose aspect differs from the surface; letterbox, cover and
+forced-aspect then produce distinct bounding boxes.
+
+## Run
+```sh
+# tools (one-time): fb-idb + Pillow in venvs, idb_companion on PATH
+idb_companion --udid <SIM_UDID> &
+./scripts/aspect-harness/make-fixture.sh /tmp/aspect-240.mp4
+# build+install Showcase iOS on the sim first (xcodebuild -scheme iOS ...)
+./scripts/aspect-harness/sweep.sh <SIM_UDID> /tmp/aspect-240.mp4 | tee /tmp/sweep.txt
+./scripts/aspect-harness/assert.py < /tmp/sweep.txt   # exit 0 = fixed, non-zero = A1/A2 present
+```
+
+`measure.py <shot.png> <band_y0_px> <band_y1_px>` reports the surface and
+picture bounding boxes (center-cross scan; band isolates the surface between the
+About row and the play/pause control). Coordinates are @3x screenshot pixels.
+
+## Baseline (pre-fix, v0.10.0 binary, iPhone 17 Pro / iOS 26.5)
+See `BASELINE.md` — `.fill` and every `.ratio` collapse to the 2.40 letterboxed
+box, which is what the fixes correct.

--- a/scripts/aspect-harness/assert.py
+++ b/scripts/aspect-harness/assert.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Reads `sweep.sh` output (lines "<opt> <json>") and asserts the corrected
+aspect geometry: .fill covers the surface, and .ratio(w,h) forces the picture
+to the requested display aspect. Exits non-zero with a report if any case is
+wrong (the failing state on a binary without the A1/A2 fixes)."""
+import sys, json
+
+TARGET = {  # picture aspect each option must produce in a 16:9 (1.778) surface
+    "fill": ("cover", None),   # picture aspect ~= surface aspect (full cover)
+    "r169": ("ar", 16 / 9),
+    "r43":  ("ar", 4 / 3),
+    "r11":  ("ar", 1.0),
+}
+TOL = 0.06
+
+rows = {}
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    opt, _, blob = line.partition(" ")
+    rows[opt] = json.loads(blob)
+
+ok = True
+default_ar = rows.get("default", {}).get("picture_ar")
+print(f"default picture_ar={default_ar} (source DAR, letterboxed) surface_ar={rows.get('default',{}).get('surface_ar')}")
+for opt, (kind, want) in TARGET.items():
+    row = rows.get(opt)
+    if not row or row.get("picture_ar") is None:
+        print(f"FAIL {opt}: no measurement"); ok = False; continue
+    got = row["picture_ar"]; surf = row["surface_ar"]
+    target = surf if kind == "cover" else want
+    passed = abs(got - target) <= TOL
+    if kind == "cover":
+        # also reject the letterboxed-equals-default state explicitly
+        passed = passed and abs(got - (default_ar or 0)) > TOL
+    print(f"{'PASS' if passed else 'FAIL'} {opt}: picture_ar={got} target~{round(target,3)}")
+    ok = ok and passed
+
+sys.exit(0 if ok else 1)

--- a/scripts/aspect-harness/assert.py
+++ b/scripts/aspect-harness/assert.py
@@ -2,14 +2,16 @@
 """Reads `sweep.sh` output (lines "<opt> <json>") and asserts the corrected
 aspect geometry: .fill covers the surface, and .ratio(w,h) forces the picture
 to the requested display aspect. Exits non-zero with a report if any case is
-wrong (the failing state on a binary without the A1/A2 fixes)."""
+wrong (the failing state on a binary without the aspect cover/stretch fixes)."""
 import sys, json
 
-TARGET = {  # picture aspect each option must produce in a 16:9 (1.778) surface
-    "fill": ("cover", None),   # picture aspect ~= surface aspect (full cover)
+SURFACE_AR = 16 / 9
+TARGET = {  # picture aspect each option must produce in a 16:9 surface
+    "fill": ("cover", SURFACE_AR),   # picture aspect ~= surface aspect (full cover)
     "r169": ("ar", 16 / 9),
     "r43":  ("ar", 4 / 3),
     "r11":  ("ar", 1.0),
+    "r219": ("ar", 21 / 9),
 }
 TOL = 0.06
 
@@ -28,8 +30,8 @@ for opt, (kind, want) in TARGET.items():
     row = rows.get(opt)
     if not row or row.get("picture_ar") is None:
         print(f"FAIL {opt}: no measurement"); ok = False; continue
-    got = row["picture_ar"]; surf = row["surface_ar"]
-    target = surf if kind == "cover" else want
+    got = row["picture_ar"]
+    target = want
     passed = abs(got - target) <= TOL
     if kind == "cover":
         # also reject the letterboxed-equals-default state explicitly

--- a/scripts/aspect-harness/make-fixture.sh
+++ b/scripts/aspect-harness/make-fixture.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Generates the 2.40:1 (1920x800) test clip the aspect harness drives through
+# AspectRatioCase. Content aspect must differ from the 16:9 video surface so
+# letterbox vs cover vs forced-aspect are all distinguishable. testsrc2 fills
+# the frame edge-to-edge with saturated colour bars (clean non-black content).
+set -euo pipefail
+OUT="${1:-/tmp/aspect-240.mp4}"
+ffmpeg -y -f lavfi -i "testsrc2=size=1920x800:rate=15:duration=60" \
+  -pix_fmt yuv420p -c:v libx264 -t 60 "$OUT"
+echo "wrote $OUT"

--- a/scripts/aspect-harness/measure.py
+++ b/scripts/aspect-harness/measure.py
@@ -1,0 +1,48 @@
+import sys, json
+from PIL import Image
+
+# SURFACE = non-light-gray bbox in the band. PICTURE = extent of non-black content
+# along the surface's center column (vertical) and center row (horizontal). Center
+# cross avoids rounded-corner anti-aliasing. Robust to centered letterbox/pillarbox.
+path = sys.argv[1]; y0 = int(sys.argv[2]); y1 = int(sys.argv[3])
+im = Image.open(path).convert("RGB"); W, H = im.size; px = im.load()
+def lightgray(r,g,b): return r>228 and g>228 and b>228
+def black(r,g,b):     return max(r,g,b) < 40
+
+# surface bbox = non-light-gray within band
+bx0,by0,bx1,by1 = W,y1,0,y0; found=False
+for y in range(max(0,y0),min(H,y1)):
+    for x in range(W):
+        if not lightgray(*px[x,y]):
+            found=True
+            bx0=min(bx0,x); bx1=max(bx1,x); by0=min(by0,y); by1=max(by1,y)
+surface=(bx0,by0,bx1-bx0+1,by1-by0+1) if found else None
+
+def content_run_v(xs, ytop, ybot):
+    top,bot=None,None
+    for y in range(ytop,ybot+1):
+        if any(not black(*px[x,y]) and not lightgray(*px[x,y]) for x in xs):
+            if top is None: top=y
+            bot=y
+    return top,bot
+def content_run_h(ys, xl, xr):
+    left,right=None,None
+    for x in range(xl,xr+1):
+        if any(not black(*px[x,y]) and not lightgray(*px[x,y]) for y in ys):
+            if left is None: left=x
+            right=x
+    return left,right
+
+picture=None
+if surface:
+    sx,sy,sw,sh=surface
+    cx=sx+sw//2; cy=sy+sh//2
+    xs=[cx-8,cx,cx+8]; ys=[cy-8,cy,cy+8]
+    top,bot=content_run_v(xs, sy, sy+sh-1)
+    left,right=content_run_h(ys, sx, sx+sw-1)
+    if None not in (top,bot,left,right):
+        picture=(left,top,right-left+1,bot-top+1)
+
+def ar(r): return round(r[2]/r[3],3) if r and r[3] else None
+print(json.dumps({"surface":surface,"surface_ar":ar(surface),
+                  "picture":picture,"picture_ar":ar(picture)}))

--- a/scripts/aspect-harness/sweep.sh
+++ b/scripts/aspect-harness/sweep.sh
@@ -15,17 +15,38 @@ PY="${PY:-/tmp/axvenv/bin/python}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 BUNDLE=com.swiftvlc.showcase.ios
 PICKER_X=201; PICKER_Y=587
+PLAY_X=201; PLAY_Y=492
 mkdir -p "$OUT"
 optY() { case "$1" in
   default) echo 366;; fill) echo 408;; r169) echo 450;;
   r43) echo 492;; r11) echo 534;; r219) echo 576;; esac; }
 xcrun simctl terminate "$UDID" "$BUNDLE" 2>/dev/null || true
 xcrun simctl launch "$UDID" "$BUNDLE" \
-  -UITestMode 1 -UITestRoute AspectRatio -UITestFixtureURL "$FIXTURE" >/dev/null
-sleep 5
+  -UITestMode 1 -UITestRoute AspectRatio -UITestFixtureURL "$FIXTURE" \
+  >/tmp/aspect-harness-launch.out 2>/tmp/aspect-harness-launch.err &
+launch_pid=$!
+for _ in $(seq 1 30); do
+  if "$IDB" ui describe-all --udid "$UDID" 2>/dev/null | grep -q 'Ratio,'; then
+    break
+  fi
+  sleep 0.5
+done
+if kill -0 "$launch_pid" 2>/dev/null; then
+  kill "$launch_pid" 2>/dev/null || true
+  wait "$launch_pid" 2>/dev/null || true
+else
+  wait "$launch_pid" 2>/dev/null || true
+fi
+sleep 4
 for opt in default fill r169 r43 r11 r219; do
   "$IDB" ui tap --udid "$UDID" $PICKER_X $PICKER_Y >/dev/null 2>&1; sleep 1
-  "$IDB" ui tap --udid "$UDID" 245 "$(optY "$opt")" >/dev/null 2>&1; sleep 2
+  "$IDB" ui tap --udid "$UDID" 245 "$(optY "$opt")" >/dev/null 2>&1; sleep 1
+  if "$IDB" ui describe-all --udid "$UDID" | grep -q '"AXLabel":"Play"'; then
+    "$IDB" ui tap --udid "$UDID" $PLAY_X $PLAY_Y >/dev/null 2>&1
+    sleep 4
+  else
+    sleep 2
+  fi
   xcrun simctl io "$UDID" screenshot "$OUT/$opt.png" >/dev/null 2>&1
   printf '%s ' "$opt"
   "$PY" "$HERE/measure.py" "$OUT/$opt.png" 666 1396

--- a/scripts/aspect-harness/sweep.sh
+++ b/scripts/aspect-harness/sweep.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Drives Showcase AspectRatioCase through every aspect option on a booted iOS
+# simulator and prints one JSON measurement line per option. Prerequisites:
+#   - Showcase iOS installed on the target sim (bundle com.swiftvlc.showcase.ios)
+#   - idb_companion running for the UDID; fb-idb + Pillow venvs (see README)
+#   - the fixture from make-fixture.sh
+# The PopUpButton menu coordinates are layout-stable for this screen; re-derive
+# with `idb ui describe-all` if the Showcase layout changes.
+set -euo pipefail
+UDID="${1:?usage: sweep.sh <udid> [fixture] [outdir]}"
+FIXTURE="${2:-/tmp/aspect-240.mp4}"
+OUT="${3:-/tmp/aspect-sweep}"
+IDB="${IDB:-/tmp/idbvenv/bin/idb}"
+PY="${PY:-/tmp/axvenv/bin/python}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+BUNDLE=com.swiftvlc.showcase.ios
+PICKER_X=201; PICKER_Y=587
+mkdir -p "$OUT"
+optY() { case "$1" in
+  default) echo 366;; fill) echo 408;; r169) echo 450;;
+  r43) echo 492;; r11) echo 534;; r219) echo 576;; esac; }
+xcrun simctl terminate "$UDID" "$BUNDLE" 2>/dev/null || true
+xcrun simctl launch "$UDID" "$BUNDLE" \
+  -UITestMode 1 -UITestRoute AspectRatio -UITestFixtureURL "$FIXTURE" >/dev/null
+sleep 5
+for opt in default fill r169 r43 r11 r219; do
+  "$IDB" ui tap --udid "$UDID" $PICKER_X $PICKER_Y >/dev/null 2>&1; sleep 1
+  "$IDB" ui tap --udid "$UDID" 245 "$(optY "$opt")" >/dev/null 2>&1; sleep 2
+  xcrun simctl io "$UDID" screenshot "$OUT/$opt.png" >/dev/null 2>&1
+  printf '%s ' "$opt"
+  "$PY" "$HERE/measure.py" "$OUT/$opt.png" 666 1396
+done

--- a/scripts/build-libvlc.sh
+++ b/scripts/build-libvlc.sh
@@ -19,17 +19,16 @@
 
 set -e
 
-# --- Error trap for better failure reporting ---
-trap 'error "Build failed at line $LINENO (exit code $?)"' ERR
-
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 BUILD_DIR="${SCRIPT_DIR}/.build-libvlc"
 OUTPUT_DIR="${REPO_ROOT}/Vendor"
 VLC_REPO="https://code.videolan.org/videolan/vlc.git"
 VLC_BRANCH="master"
-# Pin to a known-good commit for reproducible builds (same as VLCKit)
-# Update this hash when upgrading libVLC
+# Pin to a known-good commit for reproducible builds. This intentionally does
+# not track VLCKit's moving pin: newer libVLC revisions changed libvlc_time_t
+# from milliseconds to microseconds and require a coordinated wrapper migration.
+# Update this hash only as part of an audited libVLC API upgrade.
 VLC_HASH="c833c4be0"
 
 # Directory containing source patches applied to the VLC checkout before
@@ -67,8 +66,15 @@ if [ -z "$MAKEFLAGS" ]; then
 fi
 
 # --- Terminal color support ---
-# Guard tput calls for non-terminal contexts (CI runners, piped output)
-if [ -t 1 ] && command -v tput >/dev/null 2>&1 && tput colors >/dev/null 2>&1; then
+# Guard tput calls for non-terminal and colorless contexts. `TERM=dumb`
+# reports `tput colors` as -1 with a successful exit status, while `setaf`
+# still fails; checking the numeric capability prevents the ERR trap from
+# masking the real build before logging has even initialized.
+TPUT_COLORS=0
+if [ -t 1 ] && command -v tput >/dev/null 2>&1; then
+    TPUT_COLORS=$(tput colors 2>/dev/null || echo 0)
+fi
+if [ "${TPUT_COLORS}" -ge 8 ] 2>/dev/null; then
     COLOR_GREEN=$(tput setaf 2)
     COLOR_RED=$(tput setaf 1)
     COLOR_YELLOW=$(tput setaf 3)
@@ -100,6 +106,11 @@ error() {
     echo "[${COLOR_RED}error${COLOR_RESET}] [$(elapsed)] $1" >&2
     exit 1
 }
+
+# --- Error trap for better failure reporting ---
+# Install only after `error` and its formatting dependencies are defined so a
+# startup failure cannot be replaced by `error: command not found`.
+trap 'error "Build failed at line $LINENO (exit code $?)"' ERR
 
 # --- Prerequisite validation ---
 # Maps a missing command to the Homebrew formula that provides it.
@@ -619,11 +630,12 @@ if [ ! -d "vlc" ]; then
     cd ..
 else
     cd vlc
-    # Only reset if HEAD isn't already at the pinned commit. An unconditional
-    # `git reset --hard` wipes our in-tree patches every run, forcing every
-    # downstream patch function to re-apply and all per-platform build dirs
-    # to rebuild. VideoLAN's GitLab also doesn't allow fetching by raw SHA,
-    # so skip the fetch unless the commit is missing locally.
+    # Only reset the whole checkout if HEAD isn't already at the pinned commit.
+    # Step 1b verifies the exact ordered patch result and restores only
+    # mismatching patch-owned paths, preserving source mtimes, unrelated
+    # generated build-system changes, and per-platform build directories.
+    # VideoLAN's GitLab also doesn't allow fetching by raw SHA, so skip the
+    # fetch unless the commit is missing locally.
     CURRENT_HEAD=$(git rev-parse --verify HEAD 2>/dev/null || echo "")
     TARGET_SHA=$(git rev-parse --verify "${VLC_HASH}^{commit}" 2>/dev/null || echo "")
     if [ -z "$TARGET_SHA" ]; then
@@ -642,21 +654,133 @@ fi
 
 VLC_SRC="${BUILD_DIR}/vlc"
 
+# Resolve the requested revision to a full commit ID before applying any
+# uncommitted source patches. This keeps build logs auditable even when VLC_HASH
+# is abbreviated or overridden with --hash.
+TARGET_SHA=$(git -C "${VLC_SRC}" rev-parse --verify "${VLC_HASH}^{commit}")
+SOURCE_SHA=$(git -C "${VLC_SRC}" rev-parse --verify HEAD)
+if [ "${SOURCE_SHA}" != "${TARGET_SHA}" ]; then
+    error "VLC source revision mismatch: expected ${TARGET_SHA}, found ${SOURCE_SHA}"
+fi
+info "VLC source provenance: ${SOURCE_SHA}"
+
 # --- Step 1b: Apply patches ---
 if [ -n "${PATCHES_DIR}" ] && [ -d "${PATCHES_DIR}" ]; then
     info "Applying patches from ${PATCHES_DIR}..."
     cd "${VLC_SRC}"
+
+    # Ordered patches can intentionally overlap (0003 refines code introduced
+    # by 0002), which makes a per-patch reverse-check ambiguous on a subsequent
+    # run. Build the expected final tree in a temporary Git index first. If the
+    # working files already match that exact ordered result, leave them and their
+    # mtimes untouched so an incremental invocation remains incremental. Only a
+    # mismatch restores patch-owned paths to the pinned base and reapplies the
+    # complete series. Build directories and unrelated source changes remain
+    # intact.
+    patch_files=()
+    patch_paths=()
     for patch in "${PATCHES_DIR}"/*.patch; do
         if [ -f "$patch" ]; then
-            patch_name=$(basename "$patch")
-            if git apply --check "$patch" 2>/dev/null; then
-                git apply "$patch"
-                info "  Applied: ${patch_name}"
-            else
-                info "  Skipped (already applied or conflicts): ${patch_name}"
-            fi
+            patch_files+=("$patch")
+            patch_numstat=$(git apply --numstat "$patch") \
+                || error "Could not parse patch metadata: $(basename "$patch")"
+            while IFS=$'\t' read -r _added _deleted patch_path; do
+                [ -n "$patch_path" ] || continue
+                case "$patch_path" in
+                    /*|..|../*|*/..|*/../*) error "Unsafe path in patch $(basename "$patch"): ${patch_path}" ;;
+                esac
+                already_listed=no
+                for existing_path in "${patch_paths[@]}"; do
+                    if [ "$existing_path" = "$patch_path" ]; then
+                        already_listed=yes
+                        break
+                    fi
+                done
+                if [ "$already_listed" = no ]; then
+                    patch_paths+=("$patch_path")
+                fi
+            done <<< "$patch_numstat"
         fi
     done
+
+    expected_index=$(mktemp "${TMPDIR:-/tmp}/swiftvlc-patches.XXXXXX")
+    rm -f -- "$expected_index"
+    if ! GIT_INDEX_FILE="$expected_index" git read-tree HEAD; then
+        rm -f -- "$expected_index" "$expected_index.lock"
+        error "Could not create the expected patch-series index"
+    fi
+    for patch in "${patch_files[@]}"; do
+        if ! GIT_INDEX_FILE="$expected_index" git apply --cached "$patch"; then
+            rm -f -- "$expected_index" "$expected_index.lock"
+            error "Ordered patch series does not apply to ${SOURCE_SHA}: $(basename "$patch")"
+        fi
+    done
+
+    patch_series_matches=yes
+    for patch_path in "${patch_paths[@]}"; do
+        expected_entry=$(GIT_INDEX_FILE="$expected_index" git ls-files -s -- "$patch_path")
+        if [ -z "$expected_entry" ]; then
+            if [ -e "$patch_path" ] || [ -L "$patch_path" ]; then
+                patch_series_matches=no
+                break
+            fi
+            continue
+        fi
+
+        expected_metadata=${expected_entry%%$'\t'*}
+        read -r expected_mode expected_blob _stage <<< "$expected_metadata"
+        if [ ! -e "$patch_path" ] && [ ! -L "$patch_path" ]; then
+            patch_series_matches=no
+            break
+        fi
+        current_blob=$(git hash-object -- "$patch_path")
+        if [ "$current_blob" != "$expected_blob" ]; then
+            patch_series_matches=no
+            break
+        fi
+        case "$expected_mode" in
+            100644) [ ! -x "$patch_path" ] || patch_series_matches=no ;;
+            100755) [ -x "$patch_path" ] || patch_series_matches=no ;;
+            120000) [ -L "$patch_path" ] || patch_series_matches=no ;;
+        esac
+        [ "$patch_series_matches" = yes ] || break
+    done
+    rm -f -- "$expected_index" "$expected_index.lock"
+
+    if [ "$patch_series_matches" = yes ]; then
+        for patch in "${patch_files[@]}"; do
+            patch_name=$(basename "$patch")
+            patch_sha=$(shasum -a 256 "$patch" | awk '{print $1}')
+            info "  Verified in applied series: ${patch_name} (sha256 ${patch_sha})"
+        done
+    else
+        for patch_path in "${patch_paths[@]}"; do
+            if git cat-file -e "HEAD:${patch_path}" 2>/dev/null; then
+                git checkout HEAD -- "$patch_path"
+            else
+                rm -f -- "$patch_path"
+            fi
+        done
+        info "  Restored ${#patch_paths[@]} patch-owned source path(s) to ${SOURCE_SHA}"
+
+        for patch in "${patch_files[@]}"; do
+            patch_name=$(basename "$patch")
+            patch_sha=$(shasum -a 256 "$patch" | awk '{print $1}')
+            if git apply --check "$patch" 2>/dev/null; then
+                git apply "$patch"
+                if ! git apply --reverse --check "$patch" 2>/dev/null; then
+                    error "Patch verification failed after apply: ${patch_name}"
+                fi
+                info "  Applied: ${patch_name} (sha256 ${patch_sha})"
+            elif git apply --reverse --check "$patch" 2>/dev/null; then
+                info "  Already applied: ${patch_name} (sha256 ${patch_sha})"
+            else
+                warn "Patch is neither applicable nor already applied: ${patch_name}"
+                git apply --check "$patch" 2>&1 || true
+                error "Refusing to build with a conflicted or partially applied patch: ${patch_name}"
+            fi
+        done
+    fi
     cd "${BUILD_DIR}"
 fi
 
@@ -894,10 +1018,9 @@ patch_vlc_xros_deployment_target
 
 patch_vlc_deployment_targets() {
     local BUILD_CONF="${VLC_SRC}/extras/package/apple/build.conf"
+    local deployment_result
 
-    info "Patching VLC deployment targets to match SwiftVLC's supported minimums..."
-
-    python3 - "$BUILD_CONF" \
+    deployment_result=$(python3 - "$BUILD_CONF" \
         "$SWIFTVLC_MIN_MACOS" \
         "$SWIFTVLC_MIN_IOS" \
         "$SWIFTVLC_MIN_TVOS" \
@@ -910,6 +1033,7 @@ build_conf_path, macos, ios, tvos, catalyst, visionos = sys.argv[1:]
 
 with open(build_conf_path, 'r') as f:
     content = f.read()
+original = content
 
 replacements = {
     r'^export VLC_DEPLOYMENT_TARGET_MACOSX=.*$': f'export VLC_DEPLOYMENT_TARGET_MACOSX="{macos}"',
@@ -931,13 +1055,22 @@ if re.search(r'^export VLC_DEPLOYMENT_TARGET_CATALYST=.*$', content, flags=re.MU
         flags=re.MULTILINE
     )
 
-with open(build_conf_path, 'w') as f:
-    f.write(content)
-
-print('Deployment targets patched successfully')
+if content == original:
+    print('unchanged')
+else:
+    with open(build_conf_path, 'w') as f:
+        f.write(content)
+    print('changed')
 PYEOF
+    )
 
-    info "VLC deployment targets patched"
+    if [ "$deployment_result" = "changed" ]; then
+        info "VLC deployment targets patched to SwiftVLC minimums"
+    elif [ "$deployment_result" = "unchanged" ]; then
+        info "VLC deployment targets already match SwiftVLC minimums"
+    else
+        error "Unexpected deployment-target patch result: ${deployment_result}"
+    fi
 }
 
 patch_vlc_deployment_targets

--- a/scripts/patches/0002-samplebufferdisplay-aspect.patch
+++ b/scripts/patches/0002-samplebufferdisplay-aspect.patch
@@ -1,0 +1,64 @@
+diff --git a/modules/video_output/apple/VLCSampleBufferDisplay.m b/modules/video_output/apple/VLCSampleBufferDisplay.m
+index f13a4f4f8a..d26f365703 100644
+--- a/modules/video_output/apple/VLCSampleBufferDisplay.m
++++ b/modules/video_output/apple/VLCSampleBufferDisplay.m
+@@ -140,7 +140,7 @@ typedef NS_ENUM(NSUInteger, VLCSampleBufferPixelFlip) {
+             kCVPixelBufferMetalCompatibilityKey,
+ #if TARGET_OS_OSX
+             kCVPixelBufferOpenGLCompatibilityKey,
+-#elif !defined(TARGET_OS_VISION) || !TARGET_OS_VISION
++#elif (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION) && !TARGET_OS_MACCATALYST
+             kCVPixelBufferOpenGLESCompatibilityKey,
+ #endif
+         };
+@@ -151,7 +151,7 @@ typedef NS_ENUM(NSUInteger, VLCSampleBufferPixelFlip) {
+             (__bridge CFNumberRef)(@(dstHeight)),
+             (__bridge CFDictionaryRef)@{},
+             kCFBooleanTrue,
+-#if !defined(TARGET_OS_VISION) || !TARGET_OS_VISION
++#if (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION) && !TARGET_OS_MACCATALYST
+             kCFBooleanTrue
+ #endif
+         };
+@@ -660,6 +660,17 @@ shouldInheritContentsScale:(CGFloat)newScale
+     - (instancetype)initWithVoutDisplay:(vout_display_t *)vd;
+ @end
+ 
++/* The sample-buffer layer fits its enqueued frames by gravity, not by the
++ * core-computed place rectangle, so the display fitting mode is mapped to a
++ * gravity: the larger ("fit outside") mode covers and crops, every other mode
++ * preserves aspect inside the surface. */
++static AVLayerVideoGravity VLCGravityForDisplayCfg(const vout_display_cfg_t *cfg)
++{
++    if (cfg->display.fitting == VLC_VIDEO_FIT_LARGER)
++        return AVLayerVideoGravityResizeAspectFill;
++    return AVLayerVideoGravityResizeAspect;
++}
++
+ @implementation VLCSampleBufferDisplay
+ 
+ - (id<VLCPixelBufferRotationContext>)rotationContext
+@@ -742,6 +753,7 @@ shouldInheritContentsScale:(CGFloat)newScale
+         @synchronized(sys.displayLayer) {
+             sys.displayLayer = displayView.displayLayer;
+         }
++        sys.displayLayer.videoGravity = VLCGravityForDisplayCfg(sys.vd->cfg);
+         [sys preparePictureInPicture];
+     });
+ }
+@@ -1055,7 +1067,15 @@ static int Control (vout_display_t *vd, int query)
+         case VOUT_DISPLAY_CHANGE_SOURCE_ASPECT:
+         case VOUT_DISPLAY_CHANGE_SOURCE_CROP:
+         case VOUT_DISPLAY_CHANGE_SOURCE_PLACE:
++        {
++            AVLayerVideoGravity gravity = VLCGravityForDisplayCfg(vd->cfg);
++            dispatch_async(dispatch_get_main_queue(), ^{
++                @synchronized(sys.displayLayer) {
++                    sys.displayLayer.videoGravity = gravity;
++                }
++            });
+             break;
++        }
+         default:
+             msg_Err (vd, "Unhandled request %d", query);
+             return VLC_EGENERIC;

--- a/scripts/patches/0002-samplebufferdisplay-aspect.patch
+++ b/scripts/patches/0002-samplebufferdisplay-aspect.patch
@@ -1,5 +1,5 @@
 diff --git a/modules/video_output/apple/VLCSampleBufferDisplay.m b/modules/video_output/apple/VLCSampleBufferDisplay.m
-index f13a4f4f8a..96a55172f7 100644
+index f13a4f4f8a..567a03a7b1 100644
 --- a/modules/video_output/apple/VLCSampleBufferDisplay.m
 +++ b/modules/video_output/apple/VLCSampleBufferDisplay.m
 @@ -140,7 +140,7 @@ typedef NS_ENUM(NSUInteger, VLCSampleBufferPixelFlip) {
@@ -20,7 +20,7 @@ index f13a4f4f8a..96a55172f7 100644
              kCFBooleanTrue
  #endif
          };
-@@ -660,8 +660,50 @@ shouldInheritContentsScale:(CGFloat)newScale
+@@ -660,8 +660,59 @@ shouldInheritContentsScale:(CGFloat)newScale
      - (instancetype)initWithVoutDisplay:(vout_display_t *)vd;
  @end
  
@@ -37,41 +37,50 @@ index f13a4f4f8a..96a55172f7 100644
 +
  @implementation VLCSampleBufferDisplay
  
-+/* A forced display aspect (libvlc_video_set_aspect_ratio) reaches the layer as
-+ * a place rectangle at the requested aspect, but the layer fits the source
-+ * inside it instead of filling it. Stretch the placed content to the box by
-+ * scaling the deficient axis so the displayed picture takes the requested
-+ * shape. The fill (cover) path keeps its identity transform. */
++/* A forced display aspect (libvlc_video_set_aspect_ratio) reaches the vout as a
++ * target place rectangle, but AVSampleBufferDisplayLayer still fits the natural
++ * pixel shape. Scale the natural aspect-fit box into VLC's computed place box so
++ * forced ratios visibly stretch while the default path remains identity. The
++ * fill (cover) path keeps its identity transform and uses layer gravity. */
 +- (void)applyAspectStretch
 +{
-+    VLCSampleBufferDisplayView *view = self.displayView;
-+    if (!view)
++    AVSampleBufferDisplayLayer *layer = self.displayLayer;
++    if (!layer)
 +        return;
 +    const vout_display_place_t *p = self.vd->place;
-+    const double rawW = self.vd->source->i_visible_width;
-+    const double rawH = self.vd->source->i_visible_height;
++    const video_format_t *source = self.vd->source;
++    const vout_display_cfg_t *cfg = self.vd->cfg;
 +    CGAffineTransform t = CGAffineTransformIdentity;
-+    if (p->width > 0 && p->height > 0 && rawW > 0 && rawH > 0
-+        && self.vd->cfg->display.fitting != VLC_VIDEO_FIT_LARGER)
++    if (source && cfg && p->width > 0 && p->height > 0
++        && cfg->display.width > 0 && cfg->display.height > 0
++        && source->i_visible_width > 0 && source->i_visible_height > 0
++        && cfg->display.fitting != VLC_VIDEO_FIT_LARGER)
 +    {
-+        const double rawAR = rawW / rawH;
-+        const double placeAR = (double)p->width / (double)p->height;
-+        if (placeAR < rawAR)
-+            t = CGAffineTransformMakeScale(1.0, rawAR / placeAR);
-+        else if (placeAR > rawAR)
-+            t = CGAffineTransformMakeScale(placeAR / rawAR, 1.0);
++        const double displayW = (double)cfg->display.width;
++        const double displayH = (double)cfg->display.height;
++        const double naturalAR =
++            (double)source->i_visible_width / (double)source->i_visible_height;
++        const double displayAR = displayW / displayH;
++        double naturalW;
++        double naturalH;
++        if (naturalAR > displayAR) {
++            naturalW = displayW;
++            naturalH = displayW / naturalAR;
++        } else {
++            naturalW = displayH * naturalAR;
++            naturalH = displayH;
++        }
++        if (naturalW > 0.0 && naturalH > 0.0)
++            t = CGAffineTransformMakeScale((double)p->width / naturalW,
++                                           (double)p->height / naturalH);
 +    }
-+#if TARGET_OS_OSX
-+    view.layer.affineTransform = t;
-+#else
-+    view.transform = t;
-+#endif
++    layer.affineTransform = t;
 +}
 +
  - (id<VLCPixelBufferRotationContext>)rotationContext
  {
      if (_rotationContext)
-@@ -742,6 +784,8 @@ shouldInheritContentsScale:(CGFloat)newScale
+@@ -742,6 +793,8 @@ shouldInheritContentsScale:(CGFloat)newScale
          @synchronized(sys.displayLayer) {
              sys.displayLayer = displayView.displayLayer;
          }
@@ -80,7 +89,7 @@ index f13a4f4f8a..96a55172f7 100644
          [sys preparePictureInPicture];
      });
  }
-@@ -1055,7 +1099,16 @@ static int Control (vout_display_t *vd, int query)
+@@ -1055,7 +1108,16 @@ static int Control (vout_display_t *vd, int query)
          case VOUT_DISPLAY_CHANGE_SOURCE_ASPECT:
          case VOUT_DISPLAY_CHANGE_SOURCE_CROP:
          case VOUT_DISPLAY_CHANGE_SOURCE_PLACE:

--- a/scripts/patches/0002-samplebufferdisplay-aspect.patch
+++ b/scripts/patches/0002-samplebufferdisplay-aspect.patch
@@ -1,5 +1,5 @@
 diff --git a/modules/video_output/apple/VLCSampleBufferDisplay.m b/modules/video_output/apple/VLCSampleBufferDisplay.m
-index f13a4f4f8a..d26f365703 100644
+index f13a4f4f8a..96a55172f7 100644
 --- a/modules/video_output/apple/VLCSampleBufferDisplay.m
 +++ b/modules/video_output/apple/VLCSampleBufferDisplay.m
 @@ -140,7 +140,7 @@ typedef NS_ENUM(NSUInteger, VLCSampleBufferPixelFlip) {
@@ -20,7 +20,7 @@ index f13a4f4f8a..d26f365703 100644
              kCFBooleanTrue
  #endif
          };
-@@ -660,6 +660,17 @@ shouldInheritContentsScale:(CGFloat)newScale
+@@ -660,8 +660,50 @@ shouldInheritContentsScale:(CGFloat)newScale
      - (instancetype)initWithVoutDisplay:(vout_display_t *)vd;
  @end
  
@@ -37,16 +37,50 @@ index f13a4f4f8a..d26f365703 100644
 +
  @implementation VLCSampleBufferDisplay
  
++/* A forced display aspect (libvlc_video_set_aspect_ratio) reaches the layer as
++ * a place rectangle at the requested aspect, but the layer fits the source
++ * inside it instead of filling it. Stretch the placed content to the box by
++ * scaling the deficient axis so the displayed picture takes the requested
++ * shape. The fill (cover) path keeps its identity transform. */
++- (void)applyAspectStretch
++{
++    VLCSampleBufferDisplayView *view = self.displayView;
++    if (!view)
++        return;
++    const vout_display_place_t *p = self.vd->place;
++    const double rawW = self.vd->source->i_visible_width;
++    const double rawH = self.vd->source->i_visible_height;
++    CGAffineTransform t = CGAffineTransformIdentity;
++    if (p->width > 0 && p->height > 0 && rawW > 0 && rawH > 0
++        && self.vd->cfg->display.fitting != VLC_VIDEO_FIT_LARGER)
++    {
++        const double rawAR = rawW / rawH;
++        const double placeAR = (double)p->width / (double)p->height;
++        if (placeAR < rawAR)
++            t = CGAffineTransformMakeScale(1.0, rawAR / placeAR);
++        else if (placeAR > rawAR)
++            t = CGAffineTransformMakeScale(placeAR / rawAR, 1.0);
++    }
++#if TARGET_OS_OSX
++    view.layer.affineTransform = t;
++#else
++    view.transform = t;
++#endif
++}
++
  - (id<VLCPixelBufferRotationContext>)rotationContext
-@@ -742,6 +753,7 @@ shouldInheritContentsScale:(CGFloat)newScale
+ {
+     if (_rotationContext)
+@@ -742,6 +784,8 @@ shouldInheritContentsScale:(CGFloat)newScale
          @synchronized(sys.displayLayer) {
              sys.displayLayer = displayView.displayLayer;
          }
 +        sys.displayLayer.videoGravity = VLCGravityForDisplayCfg(sys.vd->cfg);
++        [sys applyAspectStretch];
          [sys preparePictureInPicture];
      });
  }
-@@ -1055,7 +1067,15 @@ static int Control (vout_display_t *vd, int query)
+@@ -1055,7 +1099,16 @@ static int Control (vout_display_t *vd, int query)
          case VOUT_DISPLAY_CHANGE_SOURCE_ASPECT:
          case VOUT_DISPLAY_CHANGE_SOURCE_CROP:
          case VOUT_DISPLAY_CHANGE_SOURCE_PLACE:
@@ -56,6 +90,7 @@ index f13a4f4f8a..d26f365703 100644
 +                @synchronized(sys.displayLayer) {
 +                    sys.displayLayer.videoGravity = gravity;
 +                }
++                [sys applyAspectStretch];
 +            });
              break;
 +        }

--- a/scripts/patches/0003-samplebufferdisplay-lifetime-placement.patch
+++ b/scripts/patches/0003-samplebufferdisplay-lifetime-placement.patch
@@ -1,0 +1,193 @@
+# Backports VideoLAN VLC commits da8b3130c0, af61becb6c, 82803f4e26,
+# and 1729b74116 onto SwiftVLC's pinned c833c4be0 source.
+# Adapted to c833's Control callback and the preceding SwiftVLC aspect patch.
+diff --git a/modules/video_output/apple/VLCSampleBufferDisplay.m b/modules/video_output/apple/VLCSampleBufferDisplay.m
+index 567a03a..2d90143 100644
+--- a/modules/video_output/apple/VLCSampleBufferDisplay.m
++++ b/modules/video_output/apple/VLCSampleBufferDisplay.m
+@@ -563,23 +563,20 @@ - (void)drawRect:(CGRect)dirtyRect {
+ #pragma mark -
+ 
+ @interface VLCSampleBufferDisplayView: VLCView <CALayerDelegate>
+-@property (nonatomic, readonly) vout_display_t *vd;
+-- (instancetype)initWithVoutDisplay:(vout_display_t *)vd;
+ - (AVSampleBufferDisplayLayer *)displayLayer;
+ @end
+ 
+ @implementation VLCSampleBufferDisplayView
+ 
+-- (instancetype)initWithVoutDisplay:(vout_display_t *)vd {
++- (instancetype)init {
+     self = [super init];
+     if (!self)
+         return nil;
+-    _vd = vd;
+ #if TARGET_OS_OSX
+-    self.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
++    self.autoresizingMask = NSViewNotSizable;
+     self.wantsLayer = YES;
+ #else
+-    self.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
++    self.autoresizingMask = UIViewAutoresizingNone;
+ #endif
+     return self;
+ }
+@@ -642,7 +639,6 @@ - (BOOL)acceptsFirstResponder
+ @interface VLCSampleBufferDisplay: NSObject
+ {
+     @public
+-    vout_display_place_t place;
+     filter_t *converter;
+ }
+     @property (nonatomic, readonly, weak) VLCView *window;
+@@ -658,6 +654,7 @@ @interface VLCSampleBufferDisplay: NSObject
+     - (instancetype)init NS_UNAVAILABLE;
+     + (instancetype)new NS_UNAVAILABLE;
+     - (instancetype)initWithVoutDisplay:(vout_display_t *)vd;
++    - (void)placeVideo:(vout_display_place_t)newPlace;
+ @end
+ 
+ /* The sample-buffer layer fits its enqueued frames by gravity, not by the
+@@ -671,29 +668,28 @@ static AVLayerVideoGravity VLCGravityForDisplayCfg(const vout_display_cfg_t *cfg
+     return AVLayerVideoGravityResizeAspect;
+ }
+ 
+-@implementation VLCSampleBufferDisplay
+-
+ /* A forced display aspect (libvlc_video_set_aspect_ratio) reaches the vout as a
+  * target place rectangle, but AVSampleBufferDisplayLayer still fits the natural
+  * pixel shape. Scale the natural aspect-fit box into VLC's computed place box so
+  * forced ratios visibly stretch while the default path remains identity. The
+- * fill (cover) path keeps its identity transform and uses layer gravity. */
+-- (void)applyAspectStretch
++ * fill (cover) path keeps its identity transform and uses layer gravity.
++ *
++ * Compute the transform on the vout thread. A vout_display_t must never be
++ * retained or dereferenced by the asynchronous main-queue presentation block. */
++static CGAffineTransform VLCAspectStretchForDisplay(const vout_display_t *vd)
+ {
+-    AVSampleBufferDisplayLayer *layer = self.displayLayer;
+-    if (!layer)
+-        return;
+-    const vout_display_place_t *p = self.vd->place;
+-    const video_format_t *source = self.vd->source;
+-    const vout_display_cfg_t *cfg = self.vd->cfg;
++    const vout_display_place_t *p = vd->place;
++    const video_format_t *source = vd->source;
++    const vout_display_cfg_t *cfg = vd->cfg;
+     CGAffineTransform t = CGAffineTransformIdentity;
+     if (source && cfg && p->width > 0 && p->height > 0
+-        && cfg->display.width > 0 && cfg->display.height > 0
+         && source->i_visible_width > 0 && source->i_visible_height > 0
+         && cfg->display.fitting != VLC_VIDEO_FIT_LARGER)
+     {
+-        const double displayW = (double)cfg->display.width;
+-        const double displayH = (double)cfg->display.height;
++        /* The display view is placed in p, so calculate the natural aspect-fit
++         * box in that coordinate space before stretching it to the full box. */
++        const double displayW = (double)p->width;
++        const double displayH = (double)p->height;
+         const double naturalAR =
+             (double)source->i_visible_width / (double)source->i_visible_height;
+         const double displayAR = displayW / displayH;
+@@ -710,9 +706,11 @@ - (void)applyAspectStretch
+             t = CGAffineTransformMakeScale((double)p->width / naturalW,
+                                            (double)p->height / naturalH);
+     }
+-    layer.affineTransform = t;
++    return t;
+ }
+ 
++@implementation VLCSampleBufferDisplay
++
+ - (id<VLCPixelBufferRotationContext>)rotationContext
+ {
+     if (_rotationContext)
+@@ -763,6 +761,23 @@ - (void)preparePictureInPicture {
+     }
+ }
+ 
++- (CGRect)frameForPlace:(const vout_display_place_t *)place
++{
++    VLCView *window = self.window;
++    CGRect frame = CGRectMake(place->x, place->y, place->width, place->height);
++#if TARGET_OS_OSX
++    frame = [window convertRectFromBacking:frame];
++    frame.origin.y = window.bounds.size.height - frame.origin.y - frame.size.height;
++#else
++    CGFloat scale = window.contentScaleFactor;
++    frame.origin.x /= scale;
++    frame.origin.y /= scale;
++    frame.size.width /= scale;
++    frame.size.height /= scale;
++#endif
++    return frame;
++}
++
+ - (void)prepareDisplay {
+     @synchronized(_displayLayer) {
+         if (_displayLayer)
+@@ -770,6 +785,9 @@ - (void)prepareDisplay {
+     }
+ 
+     VLCSampleBufferDisplay *sys = self;
++    vout_display_place_t place = *_vd->place;
++    AVLayerVideoGravity gravity = VLCGravityForDisplayCfg(_vd->cfg);
++    CGAffineTransform aspectStretch = VLCAspectStretchForDisplay(_vd);
+     dispatch_async(dispatch_get_main_queue(), ^{
+         if (sys.displayView)
+             return;
+@@ -778,27 +796,29 @@ - (void)prepareDisplay {
+         VLCSampleBufferSubpictureView *spuView;
+         VLCView *window = sys.window;
+ 
+-        displayView =
+-            [[VLCSampleBufferDisplayView alloc] initWithVoutDisplay:sys.vd];
++        displayView = [[VLCSampleBufferDisplayView alloc] init];
+         spuView = [VLCSampleBufferSubpictureView new];
+         [window addSubview:displayView];
+         [window addSubview:spuView];
+-        [displayView setFrame:[window bounds]];
++        displayView.frame = [sys frameForPlace:&place];
+         [spuView setFrame:[window bounds]];
+ 
+-        sys->place = *sys.vd->place;
+-
+         sys.displayView = displayView;
+         sys.spuView = spuView;
+         @synchronized(sys.displayLayer) {
+             sys.displayLayer = displayView.displayLayer;
+         }
+-        sys.displayLayer.videoGravity = VLCGravityForDisplayCfg(sys.vd->cfg);
+-        [sys applyAspectStretch];
++        sys.displayLayer.videoGravity = gravity;
++        sys.displayLayer.affineTransform = aspectStretch;
+         [sys preparePictureInPicture];
+     });
+ }
+ 
++- (void)placeVideo:(vout_display_place_t)newPlace
++{
++    self.displayView.frame = [self frameForPlace:&newPlace];
++}
++
+ - (void)close {
+     VLCSampleBufferDisplay *sys = self;
+     dispatch_async(dispatch_get_main_queue(), ^{
+@@ -1109,12 +1129,15 @@ static int Control (vout_display_t *vd, int query)
+         case VOUT_DISPLAY_CHANGE_SOURCE_CROP:
+         case VOUT_DISPLAY_CHANGE_SOURCE_PLACE:
+         {
++            vout_display_place_t newPlace = *vd->place;
+             AVLayerVideoGravity gravity = VLCGravityForDisplayCfg(vd->cfg);
++            CGAffineTransform aspectStretch = VLCAspectStretchForDisplay(vd);
+             dispatch_async(dispatch_get_main_queue(), ^{
++                [sys placeVideo:newPlace];
+                 @synchronized(sys.displayLayer) {
+                     sys.displayLayer.videoGravity = gravity;
++                    sys.displayLayer.affineTransform = aspectStretch;
+                 }
+-                [sys applyAspectStretch];
+             });
+             break;
+         }

--- a/scripts/patches/0004-samplebuffer-pip-safety-geometry.patch
+++ b/scripts/patches/0004-samplebuffer-pip-safety-geometry.patch
@@ -1,0 +1,2568 @@
+diff --git a/include/meson.build b/include/meson.build
+index a28298687a..7f7b951758 100644
+--- a/include/meson.build
++++ b/include/meson.build
+@@ -9,6 +9,7 @@ install_headers(
+     'vlc/libvlc_media_list.h',
+     'vlc/libvlc_media_list_player.h',
+     'vlc/libvlc_media_player.h',
++    'vlc/swiftvlc_vmem.h',
+     'vlc/libvlc_media_track.h',
+     'vlc/libvlc_picture.h',
+     'vlc/libvlc_renderer_discoverer.h',
+diff --git a/include/vlc/libvlc_media_player.h b/include/vlc/libvlc_media_player.h
+index 7e28aeda59..c8e6b0fc45 100644
+--- a/include/vlc/libvlc_media_player.h
++++ b/include/vlc/libvlc_media_player.h
+@@ -29,6 +29,7 @@
+ 
+ /* Definitions of enum properties for video */
+ #include "libvlc_video.h"
++#include "swiftvlc_vmem.h"
+ 
+ # ifdef __cplusplus
+ extern "C" {
+@@ -258,6 +259,37 @@ LIBVLC_API void libvlc_media_player_set_media( libvlc_media_player_t *p_mi,
+  */
+ LIBVLC_API libvlc_media_t * libvlc_media_player_get_media( libvlc_media_player_t *p_mi );
+ 
++/**
++ * Atomic retained-media and playback-length snapshot.
++ *
++ * Both fields are captured while holding the media player's internal player
++ * lock, so the media identity cannot change between the retained reference and
++ * its associated playback length. The caller owns one reference to @a media
++ * on success and must release it with libvlc_media_release().
++ *
++ * \param p_mi the media player
++ * \param[out] snapshot destination for the retained media and length
++ * \retval true a media was captured; both output fields are initialized
++ * \retval false no media is associated; both output fields are initialized
++ */
++typedef struct swiftvlc_media_player_media_length_snapshot_t
++{
++    libvlc_media_t *media;
++    libvlc_time_t length;
++} swiftvlc_media_player_media_length_snapshot_t;
++
++/**
++ * Version of SwiftVLC's additive pinned-libVLC extensions.
++ *
++ * Version 1 provides the geometry-aware vmem callback and atomic retained
++ * media/length snapshot.
++ */
++LIBVLC_API unsigned swiftvlc_libvlc_pip_extensions_version( void );
++
++LIBVLC_API bool swiftvlc_libvlc_media_player_get_media_length_snapshot(
++    libvlc_media_player_t *p_mi,
++    swiftvlc_media_player_media_length_snapshot_t *snapshot );
++
+ /**
+  * Get the Event Manager from which the media player send event.
+  *
+@@ -447,6 +479,31 @@ typedef unsigned (*libvlc_video_format_cb)(void **opaque, char *chroma,
+                                            unsigned *pitches,
+                                            unsigned *lines);
+ 
++/**
++ * Atomic source geometry supplied to @ref swiftvlc_video_format_ex_cb.
++ *
++ * The size, crop and sample-aspect fields describe one post-rotation
++ * video_format_ApplyRotation() snapshot. @a source_orientation records the
++ * original pre-rotation source orientation for diagnostics only.
++ */
++/**
++ * Extended callback to configure custom-memory picture buffers.
++ *
++ * Unlike @ref libvlc_video_format_cb, @a source_geometry preserves the exact
++ * coded, visible, crop, sample-aspect and original-orientation state seen by
++ * the vmem output. @a output_width and @a output_height select the delivered
++ * full-visible, zero-offset surface. The extended vmem path accepts only an
++ * exact square-pixel output aspect; an incompatible result fails setup.
++ *
++ * \param[in,out] opaque callback private pointer
++ * \param[in,out] chroma four-byte video format identifier
++ * \param[in] source_geometry atomic post-rotation source geometry
++ * \param[in,out] output_width delivered full-visible width
++ * \param[in,out] output_height delivered full-visible height
++ * \param[out] pitches scanline pitches for every plane
++ * \param[out] lines scanline counts for every plane
++ * \return a positive setup success count, or zero on failure
++ */
+ /**
+  * Callback prototype to configure picture buffers format.
+  *
+@@ -535,6 +592,23 @@ void libvlc_video_set_format_callbacks( libvlc_media_player_t *mp,
+                                         libvlc_video_format_cb setup,
+                                         libvlc_video_cleanup_cb cleanup );
+ 
++/**
++ * Set the additive extended decoded-video format callback.
++ *
++ * This is mutually exclusive with libvlc_video_set_format_callbacks(). Calling
++ * either setter clears the other setup callback. Legacy callback semantics are
++ * otherwise unchanged.
++ *
++ * \param mp the media player
++ * \param setup extended setup callback, or NULL to clear it
++ * \param cleanup callback to release setup resources, or NULL
++ */
++LIBVLC_API
++void swiftvlc_libvlc_video_set_format_callbacks_ex(
++    libvlc_media_player_t *mp,
++    swiftvlc_video_format_ex_cb setup,
++    libvlc_video_cleanup_cb cleanup );
++
+ 
+ typedef struct libvlc_video_setup_device_cfg_t
+ {
+diff --git a/include/vlc/swiftvlc_vmem.h b/include/vlc/swiftvlc_vmem.h
+new file mode 100644
+index 0000000000..1e141bf17b
+--- /dev/null
++++ b/include/vlc/swiftvlc_vmem.h
+@@ -0,0 +1,69 @@
++/*****************************************************************************
++ * swiftvlc_vmem.h: SwiftVLC geometry-aware vmem callback ABI
++ *****************************************************************************
++ * This header intentionally depends only on fixed-width C types so the vmem
++ * core module can consume the ABI without importing LibVLC's public API.
++ *****************************************************************************/
++
++#ifndef VLC_SWIFTVLC_VMEM_H
++#define VLC_SWIFTVLC_VMEM_H 1
++
++#include <stddef.h>
++#include <stdint.h>
++
++/**
++ * One atomic post-rotation source-geometry snapshot.
++ *
++ * source_orientation is the numeric value of libvlc_video_orient_t before
++ * rotation was applied. It is fixed-width here so this ABI is independent of
++ * compiler enum representation.
++ */
++typedef struct swiftvlc_video_format_geometry_t
++{
++    uint32_t coded_width;
++    uint32_t coded_height;
++    uint32_t visible_width;
++    uint32_t visible_height;
++    uint32_t x_offset;
++    uint32_t y_offset;
++    uint32_t sar_num;
++    uint32_t sar_den;
++    uint32_t source_orientation;
++} swiftvlc_video_format_geometry_t;
++
++/** Geometry-aware custom-memory format callback. */
++typedef unsigned (*swiftvlc_video_format_ex_cb)(
++    void **opaque, char *chroma,
++    const swiftvlc_video_format_geometry_t *source_geometry,
++    unsigned *output_width, unsigned *output_height,
++    unsigned *pitches, unsigned *lines);
++
++#if defined(__cplusplus)
++# define SWIFTVLC_VMEM_STATIC_ASSERT(condition, message) \
++    static_assert(condition, message)
++#else
++# define SWIFTVLC_VMEM_STATIC_ASSERT(condition, message) \
++    _Static_assert(condition, message)
++#endif
++
++SWIFTVLC_VMEM_STATIC_ASSERT(sizeof(swiftvlc_video_format_geometry_t) == 36,
++    "SwiftVLC vmem geometry ABI size changed");
++SWIFTVLC_VMEM_STATIC_ASSERT(
++    offsetof(swiftvlc_video_format_geometry_t, coded_width) == 0,
++    "SwiftVLC vmem coded_width offset changed");
++SWIFTVLC_VMEM_STATIC_ASSERT(
++    offsetof(swiftvlc_video_format_geometry_t, visible_width) == 8,
++    "SwiftVLC vmem visible_width offset changed");
++SWIFTVLC_VMEM_STATIC_ASSERT(
++    offsetof(swiftvlc_video_format_geometry_t, x_offset) == 16,
++    "SwiftVLC vmem x_offset offset changed");
++SWIFTVLC_VMEM_STATIC_ASSERT(
++    offsetof(swiftvlc_video_format_geometry_t, sar_num) == 24,
++    "SwiftVLC vmem sar_num offset changed");
++SWIFTVLC_VMEM_STATIC_ASSERT(
++    offsetof(swiftvlc_video_format_geometry_t, source_orientation) == 32,
++    "SwiftVLC vmem source_orientation offset changed");
++
++#undef SWIFTVLC_VMEM_STATIC_ASSERT
++
++#endif /* VLC_SWIFTVLC_VMEM_H */
+diff --git a/lib/Makefile.am b/lib/Makefile.am
+index 4fe7af932f..ed985db86b 100644
+--- a/lib/Makefile.am
++++ b/lib/Makefile.am
+@@ -21,6 +21,7 @@ pkginclude_HEADERS = \
+ 	../include/vlc/libvlc_picture.h \
+ 	../include/vlc/libvlc_version.h \
+ 	../include/vlc/libvlc_video.h \
++	../include/vlc/swiftvlc_vmem.h \
+ 	../include/vlc/vlc.h
+ 
+ lib_LTLIBRARIES = libvlc.la
+diff --git a/lib/libvlc.sym b/lib/libvlc.sym
+index f92df6b013..d2d1374b80 100644
+--- a/lib/libvlc.sym
++++ b/lib/libvlc.sym
+@@ -137,6 +137,8 @@ libvlc_media_player_get_full_title_descriptions
+ libvlc_media_player_get_hwnd
+ libvlc_media_player_get_length
+ libvlc_media_player_get_media
++swiftvlc_libvlc_media_player_get_media_length_snapshot
++swiftvlc_libvlc_pip_extensions_version
+ libvlc_media_player_get_nsobject
+ libvlc_media_player_get_position
+ libvlc_media_player_get_rate
+@@ -264,6 +266,7 @@ libvlc_video_set_display_fit
+ libvlc_video_set_deinterlace
+ libvlc_video_set_format
+ libvlc_video_set_format_callbacks
++swiftvlc_libvlc_video_set_format_callbacks_ex
+ libvlc_video_set_output_callbacks
+ libvlc_video_set_key_input
+ libvlc_video_set_logo_int
+diff --git a/lib/media_player.c b/lib/media_player.c
+index 73c0b54d71..2fe615d2e4 100644
+--- a/lib/media_player.c
++++ b/lib/media_player.c
+@@ -654,6 +654,7 @@ libvlc_media_player_new( libvlc_instance_t *instance )
+     var_Create (mp, "vmem-display", VLC_VAR_ADDRESS);
+     var_Create (mp, "vmem-data", VLC_VAR_ADDRESS);
+     var_Create (mp, "vmem-setup", VLC_VAR_ADDRESS);
++    var_Create (mp, "vmem-setup-ex", VLC_VAR_ADDRESS);
+     var_Create (mp, "vmem-cleanup", VLC_VAR_ADDRESS);
+     var_Create (mp, "vmem-chroma", VLC_VAR_STRING);
+     var_Create (mp, "vmem-width", VLC_VAR_INTEGER);
+@@ -967,6 +968,35 @@ libvlc_media_player_get_media( libvlc_media_player_t *p_mi )
+     return p_m;
+ }
+ 
++unsigned swiftvlc_libvlc_pip_extensions_version( void )
++{
++    return 1;
++}
++
++bool
++swiftvlc_libvlc_media_player_get_media_length_snapshot(
++    libvlc_media_player_t *p_mi,
++    swiftvlc_media_player_media_length_snapshot_t *snapshot )
++{
++    if (snapshot == NULL)
++        return false;
++
++    vlc_player_t *player = p_mi->player;
++    vlc_player_Lock(player);
++
++    libvlc_media_t *media = p_mi->p_md;
++    if (media != NULL)
++        libvlc_media_retain(media);
++
++    snapshot->media = media;
++    snapshot->length = media != NULL
++        ? libvlc_time_from_vlc_tick(vlc_player_GetLength(player))
++        : -1;
++
++    vlc_player_Unlock(player);
++    return media != NULL;
++}
++
+ /**************************************************************************
+  * Get the event Manager.
+  **************************************************************************/
+@@ -1090,6 +1120,17 @@ void libvlc_video_set_format_callbacks( libvlc_media_player_t *mp,
+                                         libvlc_video_cleanup_cb cleanup )
+ {
+     var_SetAddress( mp, "vmem-setup", setup );
++    var_SetAddress( mp, "vmem-setup-ex", NULL );
++    var_SetAddress( mp, "vmem-cleanup", cleanup );
++}
++
++void swiftvlc_libvlc_video_set_format_callbacks_ex(
++    libvlc_media_player_t *mp,
++    swiftvlc_video_format_ex_cb setup,
++    libvlc_video_cleanup_cb cleanup )
++{
++    var_SetAddress( mp, "vmem-setup", NULL );
++    var_SetAddress( mp, "vmem-setup-ex", setup );
+     var_SetAddress( mp, "vmem-cleanup", cleanup );
+ }
+ 
+diff --git a/modules/video_output/Makefile.am b/modules/video_output/Makefile.am
+index 62808377ed..bca97ac800 100644
+--- a/modules/video_output/Makefile.am
++++ b/modules/video_output/Makefile.am
+@@ -81,7 +81,10 @@ endif
+ 
+ if HAVE_DARWIN
+ if !HAVE_WATCHOS
+-libsamplebufferdisplay_plugin_la_SOURCES = video_output/apple/VLCSampleBufferDisplay.m codec/vt_utils.c codec/vt_utils.h
++libsamplebufferdisplay_plugin_la_SOURCES = \
++	video_output/apple/VLCSampleBufferDisplay.m \
++	video_output/apple/VLCSampleBufferGeometry.h \
++	codec/vt_utils.c codec/vt_utils.h
+ libsamplebufferdisplay_plugin_la_OBJCFLAGS = $(AM_OBJCFLAGS) -fobjc-arc
+ if HAVE_OSX
+ libsamplebufferdisplay_plugin_la_LDFLAGS = $(AM_LDFLAGS) -rpath '$(voutdir)' \
+@@ -422,3 +425,14 @@ vout_LTLIBRARIES += \
+ 	libwextern_plugin.la \
+ 	libvgl_plugin.la \
+ 	libyuv_plugin.la
++
++# libtool 2.5+ cannot infer the tag for .m compiles; force CC.
++libcaeagl_ios_plugin_la_LIBTOOLFLAGS = --tag=CC
++libcaopengllayer_plugin_la_LIBTOOLFLAGS = --tag=CC
++libcvpx_gl_plugin_la_LIBTOOLFLAGS = --tag=CC
++libglinterop_cvpx_plugin_la_LIBTOOLFLAGS = --tag=CC
++libpictureinpicturecontroller_plugin_la_LIBTOOLFLAGS = --tag=CC
++libsamplebufferdisplay_plugin_la_LIBTOOLFLAGS = --tag=CC
++libuiview_window_plugin_la_LIBTOOLFLAGS = --tag=CC
++libvout_macosx_plugin_la_LIBTOOLFLAGS = --tag=CC
++libwindow_macosx_plugin_la_LIBTOOLFLAGS = --tag=CC
+diff --git a/modules/video_output/apple/VLCPictureInPictureController.m b/modules/video_output/apple/VLCPictureInPictureController.m
+index ff3b7f9985..3926844c81 100644
+--- a/modules/video_output/apple/VLCPictureInPictureController.m
++++ b/modules/video_output/apple/VLCPictureInPictureController.m
+@@ -33,7 +33,9 @@
+ #import <TargetConditionals.h>
+ #import <Foundation/Foundation.h>
+ #import <AVKit/AVKit.h>
++#include <math.h>
+ #import <AVFoundation/AVFoundation.h>
++#import <stdatomic.h>
+ #import "VLCDrawable.h"
+ 
+ #include "vlc_pip_controller.h"
+@@ -42,15 +44,21 @@
+ @interface VLCPictureInPictureController: NSObject
+     <AVPictureInPictureSampleBufferPlaybackDelegate, 
+      AVPictureInPictureControllerDelegate,
+-     VLCPictureInPictureWindowControlling>
++     VLCPictureInPictureWindowControlling> {
++    atomic_bool _closed;
++    BOOL _observingPictureInPicturePossible;
++    id<VLCPictureInPictureMediaControlling> _mediaController;
++    void (^_pictureInPictureReady)(id<VLCPictureInPictureWindowControlling>);
++    BOOL _canStartAutomaticallyFromInline;
++    AVSampleBufferDisplayLayer *_displayLayer;
++}
+ 
+ @property (nonatomic, readonly) NSObject *avPipController;
+-@property (nonatomic, readonly) pip_controller_t *pipcontroller;
+-@property (nonatomic, readonly, weak) id<VLCPictureInPictureDrawable> drawable;
+ @property (nonatomic) void(^stateChangeEventHandler)(BOOL isStarted);
+ 
+ - (instancetype)initWithPipController:(pip_controller_t *)pipcontroller;
+ - (void)invalidatePlaybackState;
++- (void)close;
+ 
+ @end
+ 
+@@ -60,25 +68,36 @@ - (instancetype)initWithPipController:(pip_controller_t *)pipcontroller {
+     self = [super init];
+     if (!self)
+         return nil;
+-    _pipcontroller = pipcontroller;
++    atomic_init(&_closed, false);
+ 
+-    id drawable = (__bridge id)var_InheritAddress (pipcontroller, "drawable-nsobject");
++    id<VLCPictureInPictureDrawable> drawable =
++        (__bridge id)var_InheritAddress (pipcontroller, "drawable-nsobject");
+     
+     if (![drawable conformsToProtocol:@protocol(VLCPictureInPictureDrawable)])
+         return nil;
+     
+-    _drawable = drawable;
++    _mediaController = drawable.mediaController;
++    _pictureInPictureReady = [drawable.pictureInPictureReady copy];
++    if ([drawable respondsToSelector:@selector(canStartPictureInPictureAutomaticallyFromInline)])
++        _canStartAutomaticallyFromInline =
++            [drawable canStartPictureInPictureAutomaticallyFromInline];
++    else
++        _canStartAutomaticallyFromInline = YES;
+ 
+     return self;
+ }
+ 
+ - (void)prepare:(AVSampleBufferDisplayLayer *)layer {
+-    if (![AVPictureInPictureController isPictureInPictureSupported]) {
+-        msg_Err(_pipcontroller, "Picture In Picture isn't supported");
++    NSAssert([NSThread isMainThread], @"PiP preparation must run on the main thread");
++    if (atomic_load_explicit(&_closed, memory_order_acquire))
++        return;
++    if (![AVPictureInPictureController isPictureInPictureSupported])
++        return;
++    if (_avPipController != nil)
+         return;
+-    }
+         
+     assert(layer);
++    _displayLayer = layer;
+     AVPictureInPictureControllerContentSource *avPipSource;
+     avPipSource = [
+         [AVPictureInPictureControllerContentSource alloc]
+@@ -89,20 +108,11 @@ - (void)prepare:(AVSampleBufferDisplayLayer *)layer {
+         [AVPictureInPictureController alloc]
+             initWithContentSource:avPipSource
+     ];
+-    void *mediaController = (__bridge void*)_drawable.mediaController;
+-    BOOL isMediaSeekable = (BOOL)_pipcontroller->media_cbs->is_media_seekable(mediaController);
+-    avPipController.requiresLinearPlayback = !isMediaSeekable;
++    avPipController.requiresLinearPlayback = ![_mediaController isMediaSeekable];
+     avPipController.delegate = self;
+ #if TARGET_OS_IOS
+-    // Check if the drawable implements the new method to Controls whether PiP 
+-    // can start automatically when video enters inline mode
+-    if ([_drawable respondsToSelector:@selector(canStartPictureInPictureAutomaticallyFromInline)]) {
+-        avPipController.canStartPictureInPictureAutomaticallyFromInline = 
+-            [_drawable canStartPictureInPictureAutomaticallyFromInline];
+-    } else {
+-        // Use default value if method not implemented
+-        avPipController.canStartPictureInPictureAutomaticallyFromInline = YES;
+-    }
++    avPipController.canStartPictureInPictureAutomaticallyFromInline =
++        _canStartAutomaticallyFromInline;
+ #endif
+     _avPipController = avPipController;
+ 
+@@ -111,29 +121,43 @@ - (void)prepare:(AVSampleBufferDisplayLayer *)layer {
+                        forKeyPath:@"isPictureInPicturePossible"
+                           options:NSKeyValueObservingOptionInitial|NSKeyValueObservingOptionNew
+                           context:NULL];
++    _observingPictureInPicturePossible = YES;
+ 
+-    _drawable.pictureInPictureReady(self);
++    if (!atomic_load_explicit(&_closed, memory_order_acquire) && _pictureInPictureReady)
++        _pictureInPictureReady(self);
+ }
+ 
+ - (void)close {
+-    AVPictureInPictureController *avPipController =
+-        (AVPictureInPictureController *)_avPipController;
+-    NSObject *observer = self;
+-    dispatch_async(dispatch_get_main_queue(),^{
++    if (atomic_exchange_explicit(&_closed, true, memory_order_acq_rel))
++        return;
++
++    dispatch_block_t cleanup = ^{
++        AVPictureInPictureController *avPipController =
++            (AVPictureInPictureController *)self->_avPipController;
++        if (avPipController.isPictureInPictureActive)
++            [avPipController stopPictureInPicture];
++        if (self->_observingPictureInPicturePossible) {
++            [avPipController removeObserver:self
++                                 forKeyPath:@"isPictureInPicturePossible"];
++            self->_observingPictureInPicturePossible = NO;
++        }
++        avPipController.delegate = nil;
+         avPipController.contentSource = nil;
+-        [avPipController removeObserver:observer forKeyPath:@"isPictureInPicturePossible"];
+-    });
+-    _avPipController = nil;
++        self.stateChangeEventHandler = nil;
++        self->_avPipController = nil;
++    };
++
++    if ([NSThread isMainThread])
++        cleanup();
++    else
++        dispatch_async(dispatch_get_main_queue(), cleanup);
+ }
+ 
+ - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object
+                         change:(NSDictionary<NSKeyValueChangeKey,id> *)change
+                        context:(void *)context {
+-    if (object==_avPipController) {
+-        if ([keyPath isEqualToString:@"isPictureInPicturePossible"]) {
+-            msg_Dbg(_pipcontroller, "isPictureInPicturePossible:%d", [change[NSKeyValueChangeNewKey] boolValue]);
+-        }
+-    } else {
++    if (object != _avPipController ||
++        ![keyPath isEqualToString:@"isPictureInPicturePossible"]) {
+         [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+     }
+ }
+@@ -147,49 +171,81 @@ - (void)pictureInPictureController:(AVPictureInPictureController *)pictureInPict
+ 
+ - (void)pictureInPictureController:(AVPictureInPictureController *)pictureInPictureController
+                         setPlaying:(BOOL)playing {
+-    assert(_pipcontroller->media_cbs);
+-    void *mediaController = (__bridge void*)_drawable.mediaController;
+-    bool isPlaying = _pipcontroller->media_cbs->is_media_playing(mediaController);
++    if (atomic_load_explicit(&_closed, memory_order_acquire))
++        return;
++    id<VLCPictureInPictureMediaControlling> mediaController = _mediaController;
++    if (!mediaController)
++        return;
++    BOOL isPlaying = mediaController.isMediaPlaying;
+     if(isPlaying && !playing)
+-        _pipcontroller->media_cbs->pause(mediaController);    
++        [mediaController pause];
+     if(!isPlaying && playing)
+-        _pipcontroller->media_cbs->play(mediaController);
++        [mediaController play];
+ }
+ 
+ - (void)pictureInPictureController:(AVPictureInPictureController *)pictureInPictureController
+                     skipByInterval:(CMTime)skipInterval
+                  completionHandler:(void (^)(void))completionHandler {
+-    assert(_pipcontroller->media_cbs);
++    if (atomic_load_explicit(&_closed, memory_order_acquire)) {
++        completionHandler();
++        return;
++    }
++    id<VLCPictureInPictureMediaControlling> mediaController = _mediaController;
++    if (!mediaController) {
++        completionHandler();
++        return;
++    }
++    if (!CMTIME_IS_NUMERIC(skipInterval)) {
++        completionHandler();
++        return;
++    }
+     Float64 time_sec = CMTimeGetSeconds(skipInterval);
+-    
+-    void *mediaController = (__bridge void*)_drawable.mediaController;
+-    int64_t offset = time_sec * 1e3;
+-    _pipcontroller->media_cbs->seek_by(offset, completionHandler, mediaController);
++    if (!isfinite(time_sec)) {
++        completionHandler();
++        return;
++    }
++    int64_t offset;
++    if (time_sec >= (Float64)INT64_MAX / 1e3)
++        offset = INT64_MAX;
++    else if (time_sec <= (Float64)INT64_MIN / 1e3)
++        offset = INT64_MIN;
++    else
++        offset = (int64_t)(time_sec * 1e3);
++    [mediaController seekBy:offset completion:completionHandler];
+ }
+ 
+ - (BOOL)pictureInPictureControllerIsPlaybackPaused:(AVPictureInPictureController *)pictureInPictureController {
+-    assert(_pipcontroller->media_cbs);
+-    void *mediaController = (__bridge void*)_drawable.mediaController;
+-    return ! _pipcontroller->media_cbs->is_media_playing(mediaController);
++    if (atomic_load_explicit(&_closed, memory_order_acquire))
++        return YES;
++    id<VLCPictureInPictureMediaControlling> mediaController = _mediaController;
++    return mediaController ? !mediaController.isMediaPlaying : YES;
+ }
+ 
+ - (CMTimeRange)pictureInPictureControllerTimeRangeForPlayback:(AVPictureInPictureController *)pictureInPictureController {
+-    assert(_pipcontroller->media_cbs);
+-    //TODO: Handle media duration
+-    void *mediaController = (__bridge void*)_drawable.mediaController;
+-    const CMTimeRange live = CMTimeRangeMake(kCMTimeNegativeInfinity, kCMTimePositiveInfinity);
+-    
+-    int64_t length = _pipcontroller->media_cbs->media_length(mediaController);
+-    if (length == VLC_TICK_INVALID)
++    if (atomic_load_explicit(&_closed, memory_order_acquire))
++        return kCMTimeRangeInvalid;
++    id<VLCPictureInPictureMediaControlling> mediaController = _mediaController;
++    if (!mediaController)
++        return kCMTimeRangeInvalid;
++    const CMTimeRange live = CMTimeRangeMake(kCMTimeZero, kCMTimePositiveInfinity);
++
++    int64_t length = mediaController.mediaLength;
++    if (length <= 0)
+         return live;
+ 
+-    int64_t time = _pipcontroller->media_cbs->media_time(mediaController);
+-
+-    CFTimeInterval ca_now = CACurrentMediaTime();
+-    CFTimeInterval time_sec = ((Float64)time) * 1e-3;
+-    CFTimeInterval start = ca_now - time_sec;
+-    CFTimeInterval duration = ((Float64)length) * 1e-3;
+-    return CMTimeRangeMake(CMTimeMakeWithSeconds(start, 1000000), CMTimeMakeWithSeconds(duration, 1000000));
++    int64_t time = mediaController.mediaTime;
++    if (time < 0)
++        time = 0;
++    else if (time >= length)
++        time = length - 1;
++
++    CMTime current =
++        CMTimebaseGetTime(_displayLayer.sampleBufferRenderer.timebase);
++    if (!CMTIME_IS_NUMERIC(current))
++        current = CMClockGetTime(CMClockGetHostTimeClock());
++    CMTime start = CMTimeSubtract(current, CMTimeMake(time, 1000));
++    CMTime duration = CMTimeMake(length, 1000);
++    return CMTimeRangeMake(start, duration);
+ }
+ 
+ - (BOOL)pictureInPictureControllerShouldProhibitBackgroundAudioPlayback:(AVPictureInPictureController *)pictureInPictureController {
+@@ -204,34 +260,41 @@ - (void)pictureInPictureControllerWillStartPictureInPicture:(AVPictureInPictureC
+      * pictureInPictureControllerTimeRangeForPlayback: isn't automatically
+      * called each time PiP is activated
+      */
+-    [self invalidatePlaybackState];
++    if (!atomic_load_explicit(&_closed, memory_order_acquire))
++        [self invalidatePlaybackState];
+ }
+ 
+ - (void)pictureInPictureControllerDidStartPictureInPicture:(AVPictureInPictureController *)pictureInPictureController {
+-    if (_stateChangeEventHandler)
++    if (!atomic_load_explicit(&_closed, memory_order_acquire) && _stateChangeEventHandler)
+         _stateChangeEventHandler(YES);
+ }
+ 
+ - (void)pictureInPictureControllerDidStopPictureInPicture:(AVPictureInPictureController *)pictureInPictureController {
+-    if(_stateChangeEventHandler)
++    if (!atomic_load_explicit(&_closed, memory_order_acquire) && _stateChangeEventHandler)
+         _stateChangeEventHandler(NO);
+ }
+ 
+ #pragma mark - VLCDisplayPictureInPictureControlling
+ 
+ - (void)startPictureInPicture {
++    if (atomic_load_explicit(&_closed, memory_order_acquire))
++        return;
+     AVPictureInPictureController *avPipController =
+         (AVPictureInPictureController *)_avPipController;
+     [avPipController startPictureInPicture];
+ }
+ 
+ - (void)stopPictureInPicture {
++    if (atomic_load_explicit(&_closed, memory_order_acquire))
++        return;
+     AVPictureInPictureController *avPipController =
+         (AVPictureInPictureController *)_avPipController;
+     [avPipController stopPictureInPicture];
+ }
+ 
+ - (void)invalidatePlaybackState {
++    if (atomic_load_explicit(&_closed, memory_order_acquire))
++        return;
+     AVPictureInPictureController *avPipController =
+         (AVPictureInPictureController *)_avPipController;
+     [avPipController invalidatePlaybackState];
+@@ -239,58 +302,28 @@ - (void)invalidatePlaybackState {
+ 
+ @end
+ 
+-static void SetDisplayLayer( pip_controller_t *pipcontroller, void *layer) {
++static void *HoldPresentationContext(pip_controller_t *pipcontroller) {
++    if (pipcontroller->p_sys == NULL)
++        return NULL;
++    id context = (__bridge id)pipcontroller->p_sys;
++    return (__bridge_retained void *)context;
++}
++
++static void SetDisplayLayerOnContext(void *opaque, void *layer) {
+     if (@available(macOS 12.0, iOS 15.0, tvos 15.0, *)) {
+-        VLCPictureInPictureController *sys = 
+-            (__bridge VLCPictureInPictureController*)pipcontroller->p_sys;
+-        
++        VLCPictureInPictureController *sys =
++            (__bridge VLCPictureInPictureController *)opaque;
+         AVSampleBufferDisplayLayer *displayLayer =
+             (__bridge AVSampleBufferDisplayLayer *)layer;
+-        
+         [sys prepare:displayLayer];
+     }
+ }
+ 
+-static void PipControllerMediaPlay(void *opaque) {
+-    id<VLCPictureInPictureMediaControlling> mediaController;
+-    mediaController = (__bridge id<VLCPictureInPictureMediaControlling>)opaque;
+-    [mediaController play];
+-}
+-
+-static void PipControllerMediaPause(void *opaque) {
+-    id<VLCPictureInPictureMediaControlling> mediaController;
+-    mediaController = (__bridge id<VLCPictureInPictureMediaControlling>)opaque;
+-    [mediaController pause];
+-}
+-
+-static void PipControllerMediaSeekBy(vlc_tick_t time, dispatch_block_t completion, void *opaque) {
+-    id<VLCPictureInPictureMediaControlling> mediaController;
+-    mediaController = (__bridge id<VLCPictureInPictureMediaControlling>)opaque;
+-    [mediaController seekBy:time completion:completion];
+-}
+-
+-static vlc_tick_t PipControllerMediaGetLength(void *opaque) {
+-    id<VLCPictureInPictureMediaControlling> mediaController;
+-    mediaController = (__bridge id<VLCPictureInPictureMediaControlling>)opaque;
+-    return [mediaController mediaLength];
+-}
+-
+-static vlc_tick_t PipControllerMediaGetTime(void *opaque) {
+-    id<VLCPictureInPictureMediaControlling> mediaController;
+-    mediaController = (__bridge id<VLCPictureInPictureMediaControlling>)opaque;
+-    return [mediaController mediaTime];
+-}
+-
+-static bool PipControllerMediaIsSeekable(void *opaque) {
+-    id<VLCPictureInPictureMediaControlling> mediaController;
+-    mediaController = (__bridge id<VLCPictureInPictureMediaControlling>)opaque;
+-    return (bool)[mediaController isMediaSeekable];
+-}
+-
+-static bool PipControllerMediaIsPlaying(void *opaque) {
+-    id<VLCPictureInPictureMediaControlling> mediaController;
+-    mediaController = (__bridge id<VLCPictureInPictureMediaControlling>)opaque;
+-    return [mediaController isMediaPlaying];
++static void ReleasePresentationContext(void *opaque) {
++    if (opaque != NULL) {
++        id context = (__bridge_transfer id)opaque;
++        (void)context;
++    }
+ }
+ 
+ static int CloseController( pip_controller_t *pipcontroller )
+@@ -298,6 +331,7 @@ static int CloseController( pip_controller_t *pipcontroller )
+     if (@available(macOS 12.0, iOS 15.0, tvos 15.0, *)) {
+         VLCPictureInPictureController *sys = 
+             (__bridge_transfer VLCPictureInPictureController*)pipcontroller->p_sys;
++        pipcontroller->p_sys = NULL;
+ 
+         [sys close];
+     }
+@@ -308,24 +342,14 @@ static int CloseController( pip_controller_t *pipcontroller )
+ static int OpenController( pip_controller_t *pipcontroller )
+ {
+     static const struct pip_controller_operations ops = {
+-        SetDisplayLayer, 
+-        CloseController
++        .hold_presentation_context = HoldPresentationContext,
++        .set_display_layer_on_context = SetDisplayLayerOnContext,
++        .release_presentation_context = ReleasePresentationContext,
++        .close = CloseController,
+     };
+ 
+     pipcontroller->ops = &ops;
+ 
+-    static const struct pip_controller_media_callbacks cbs = {
+-        PipControllerMediaPlay,
+-        PipControllerMediaPause,
+-        PipControllerMediaSeekBy,
+-        PipControllerMediaGetLength,
+-        PipControllerMediaGetTime,
+-        PipControllerMediaIsSeekable,
+-        PipControllerMediaIsPlaying
+-    };
+-    
+-    pipcontroller->media_cbs = &cbs;
+-
+     if (@available(macOS 12.0, iOS 15.0, tvos 15.0, *)) {
+         VLCPictureInPictureController *sys = 
+         [[VLCPictureInPictureController alloc] 
+diff --git a/modules/video_output/apple/VLCSampleBufferDisplay.m b/modules/video_output/apple/VLCSampleBufferDisplay.m
+index 2d90143261..ebe5a3be95 100644
+--- a/modules/video_output/apple/VLCSampleBufferDisplay.m
++++ b/modules/video_output/apple/VLCSampleBufferDisplay.m
+@@ -33,6 +33,8 @@
+ #include <vlc_atomic.h>
+ #include <vlc_modules.h>
+ 
++#include <limits.h>
++
+ #import "VLCDrawable.h"
+ 
+ #import <AVFoundation/AVFoundation.h>
+@@ -40,6 +42,7 @@
+ 
+ #include "../../codec/vt_utils.h"
+ #include "vlc_pip_controller.h"
++#include "VLCSampleBufferGeometry.h"
+ 
+ #import <VideoToolbox/VideoToolbox.h>
+ 
+@@ -70,7 +73,8 @@ typedef NS_ENUM(NSUInteger, VLCSampleBufferPixelFlip) {
+ 
+ @interface VLCRotatedPixelBufferProvider : NSObject
+ - (CVPixelBufferRef)provideFromBuffer:(CVPixelBufferRef)pixelBuffer
+-                             rotation:(VLCSampleBufferPixelRotation)rotation;
++                          outputWidth:(size_t)outputWidth
++                         outputHeight:(size_t)outputHeight;
+ @end
+ 
+ @implementation VLCRotatedPixelBufferProvider
+@@ -78,40 +82,40 @@ @implementation VLCRotatedPixelBufferProvider
+     CVPixelBufferPoolRef _rotationPool;
+ }
+ 
+-- (BOOL)_validateRotationPoolWithBuffer:(CVPixelBufferRef)pixelBuffer
+-                               rotation:(VLCSampleBufferPixelRotation)rotation
++- (BOOL)_validatePoolWithBuffer:(CVPixelBufferRef)pixelBuffer
++                     outputWidth:(size_t)outputWidth
++                    outputHeight:(size_t)outputHeight
+ {
+     if (!_rotationPool)
+         return NO;
+ 
+-    uint32_t poolWidth, poolHeigth, bufferWidth, bufferHeight;
+-
+-    bufferWidth = (uint32_t)CVPixelBufferGetWidth(pixelBuffer);
+-    bufferHeight = (uint32_t)CVPixelBufferGetHeight(pixelBuffer);
+-    if (rotation == kVLCSampleBufferPixelRotation_90CW || rotation == kVLCSampleBufferPixelRotation_90CCW)
+-    {
+-        uint32_t swap = bufferWidth;
+-        bufferWidth = bufferHeight;
+-        bufferHeight = swap;
+-    }
+-
+     CFDictionaryRef poolAttr = CVPixelBufferPoolGetPixelBufferAttributes(_rotationPool);
+     if (!poolAttr) {
+         return NO;
+     }
+     CFTypeRef value;
++    int64_t poolValue;
+     value = CFDictionaryGetValue(poolAttr, kCVPixelBufferWidthKey);
+     if (!value || CFGetTypeID(value) != CFNumberGetTypeID()
+-        || !CFNumberGetValue(value, kCFNumberIntType, &poolWidth)
+-        || poolWidth != bufferWidth)
++        || !CFNumberGetValue(value, kCFNumberSInt64Type, &poolValue)
++        || poolValue < 0 || (uint64_t)poolValue != outputWidth)
+     {
+         return NO;
+     }
+ 
+     value = CFDictionaryGetValue(poolAttr, kCVPixelBufferHeightKey);
+     if (!value || CFGetTypeID(value) != CFNumberGetTypeID()
+-        || !CFNumberGetValue(value, kCFNumberIntType, &poolHeigth)
+-        || poolHeigth != bufferHeight)
++        || !CFNumberGetValue(value, kCFNumberSInt64Type, &poolValue)
++        || poolValue < 0 || (uint64_t)poolValue != outputHeight)
++    {
++        return NO;
++    }
++
++    value = CFDictionaryGetValue(poolAttr, kCVPixelBufferPixelFormatTypeKey);
++    if (!value || CFGetTypeID(value) != CFNumberGetTypeID()
++        || !CFNumberGetValue(value, kCFNumberSInt64Type, &poolValue)
++        || poolValue < 0
++        || (OSType)poolValue != CVPixelBufferGetPixelFormatType(pixelBuffer))
+     {
+         return NO;
+     }
+@@ -120,18 +124,21 @@ - (BOOL)_validateRotationPoolWithBuffer:(CVPixelBufferRef)pixelBuffer
+ }
+ 
+ - (CVPixelBufferRef)provideFromBuffer:(CVPixelBufferRef)pixelBuffer
+-                             rotation:(VLCSampleBufferPixelRotation)rotation
++                          outputWidth:(size_t)outputWidth
++                         outputHeight:(size_t)outputHeight
+ {
+-    if (![self _validateRotationPoolWithBuffer:pixelBuffer rotation:rotation])
++    if (outputWidth == 0 || outputHeight == 0 ||
++        outputWidth > INT64_MAX || outputHeight > INT64_MAX)
++        return NULL;
++
++    if (![self _validatePoolWithBuffer:pixelBuffer
++                            outputWidth:outputWidth
++                           outputHeight:outputHeight]) {
+         CVPixelBufferPoolRelease(_rotationPool);
++        _rotationPool = NULL;
++    }
+ 
+     if (!_rotationPool) {
+-        bool rotated = rotation == kVLCSampleBufferPixelRotation_90CW || rotation == kVLCSampleBufferPixelRotation_90CCW;
+-        uint32_t srcWidth = CVPixelBufferGetWidth(pixelBuffer);
+-        uint32_t srcHeight = CVPixelBufferGetHeight(pixelBuffer);
+-        uint32_t dstWidth = rotated ? srcHeight : srcWidth;
+-        uint32_t dstHeight = rotated ? srcWidth : srcHeight;
+-
+         CFTypeRef keys[] = {
+             kCVPixelBufferPixelFormatTypeKey,
+             kCVPixelBufferWidthKey,
+@@ -147,8 +154,8 @@ - (CVPixelBufferRef)provideFromBuffer:(CVPixelBufferRef)pixelBuffer
+ 
+         CFTypeRef values[] = {
+             (__bridge CFNumberRef)(@(CVPixelBufferGetPixelFormatType(pixelBuffer))),
+-            (__bridge CFNumberRef)(@(dstWidth)),
+-            (__bridge CFNumberRef)(@(dstHeight)),
++            (__bridge CFNumberRef)(@(outputWidth)),
++            (__bridge CFNumberRef)(@(outputHeight)),
+             (__bridge CFDictionaryRef)@{},
+             kCFBooleanTrue,
+ #if (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION) && !TARGET_OS_MACCATALYST
+@@ -171,16 +178,6 @@ - (CVPixelBufferRef)provideFromBuffer:(CVPixelBufferRef)pixelBuffer
+     if (status != noErr) {
+         return NULL;
+     }
+-    CFDictionaryRef attachments;
+-    if (@available(iOS 15.0, tvOS 15.0, macOS 12.0, *)) {
+-        attachments = CVBufferCopyAttachments(pixelBuffer, kCVAttachmentMode_ShouldPropagate);
+-    } else {
+-        attachments = CVBufferGetAttachments(pixelBuffer, kCVAttachmentMode_ShouldPropagate);
+-    }
+-    CVBufferSetAttachments(rotated, attachments, kCVAttachmentMode_ShouldPropagate);
+-    if (@available(iOS 15.0, tvOS 15.0, macOS 12.0, *)) {
+-        CFRelease(attachments);
+-    }
+     return rotated;
+ }
+ 
+@@ -190,6 +187,113 @@ - (void)dealloc
+ }
+ @end
+ 
++#pragma mark - VLCPixelBufferCropContext
++
++@interface VLCPixelBufferCropContext : NSObject
++- (CVPixelBufferRef)crop:(CVPixelBufferRef)pixelBuffer
++                    rect:(vlc_samplebuffer_crop)crop;
++@end
++
++@implementation VLCPixelBufferCropContext
++{
++    VLCRotatedPixelBufferProvider *_bufferProvider;
++    VTPixelTransferSessionRef _transferSession;
++}
++
++- (instancetype)init
++{
++    self = [super init];
++    if (!self)
++        return nil;
++
++    OSStatus status = VTPixelTransferSessionCreate(NULL, &_transferSession);
++    if (status != noErr)
++        return nil;
++
++    status = VTSessionSetProperty(_transferSession,
++                                  kVTPixelTransferPropertyKey_ScalingMode,
++                                  kVTScalingMode_CropSourceToCleanAperture);
++    if (status == noErr)
++        status = VTSessionSetProperty(
++            _transferSession, kVTPixelTransferPropertyKey_RealTime,
++            kCFBooleanTrue);
++    if (status != noErr)
++    {
++        VTPixelTransferSessionInvalidate(_transferSession);
++        CFRelease(_transferSession);
++        _transferSession = NULL;
++        return nil;
++    }
++
++    _bufferProvider = [VLCRotatedPixelBufferProvider new];
++    return self;
++}
++
++- (CVPixelBufferRef)crop:(CVPixelBufferRef)pixelBuffer
++                    rect:(vlc_samplebuffer_crop)crop
++{
++    if (_transferSession == NULL)
++        return NULL;
++
++    CVPixelBufferRef cropped =
++        [_bufferProvider provideFromBuffer:pixelBuffer
++                               outputWidth:crop.width
++                              outputHeight:crop.height];
++    if (cropped == NULL)
++        return NULL;
++
++    size_t sourceWidth = CVPixelBufferGetWidth(pixelBuffer);
++    size_t sourceHeight = CVPixelBufferGetHeight(pixelBuffer);
++    NSDictionary *cleanAperture = @{
++        (__bridge NSString *)kCVImageBufferCleanApertureWidthKey:
++            @(crop.width),
++        (__bridge NSString *)kCVImageBufferCleanApertureHeightKey:
++            @(crop.height),
++        (__bridge NSString *)kCVImageBufferCleanApertureHorizontalOffsetKey:
++            @((double)crop.x + (double)crop.width / 2.0 -
++              (double)sourceWidth / 2.0),
++        (__bridge NSString *)kCVImageBufferCleanApertureVerticalOffsetKey:
++            @((double)crop.y + (double)crop.height / 2.0 -
++              (double)sourceHeight / 2.0),
++    };
++
++    CVAttachmentMode previousMode = kCVAttachmentMode_ShouldPropagate;
++    CFTypeRef previousAperture =
++        CVBufferCopyAttachment(pixelBuffer, kCVImageBufferCleanApertureKey,
++                               &previousMode);
++    CVBufferSetAttachment(pixelBuffer, kCVImageBufferCleanApertureKey,
++                          (__bridge CFDictionaryRef)cleanAperture,
++                          kCVAttachmentMode_ShouldPropagate);
++    OSStatus status = VTPixelTransferSessionTransferImage(
++        _transferSession, pixelBuffer, cropped);
++    CVBufferRemoveAttachment(pixelBuffer, kCVImageBufferCleanApertureKey);
++    if (previousAperture != NULL)
++    {
++        CVBufferSetAttachment(pixelBuffer, kCVImageBufferCleanApertureKey,
++                              previousAperture, previousMode);
++        CFRelease(previousAperture);
++    }
++
++    if (status != noErr)
++    {
++        CVPixelBufferRelease(cropped);
++        return NULL;
++    }
++
++    return cropped;
++}
++
++- (void)dealloc
++{
++    if (_transferSession != NULL)
++    {
++        VTPixelTransferSessionInvalidate(_transferSession);
++        CFRelease(_transferSession);
++    }
++}
++
++@end
++
+ #pragma mark - VLCPixelBufferRotationContext
+ 
+ @protocol VLCPixelBufferRotationContext
+@@ -210,6 +314,8 @@ @implementation VLCPixelBufferRotationContextVT
+ {
+     VLCRotatedPixelBufferProvider *_bufferProvider;
+     VTPixelRotationSessionRef _rotationSession;
++    BOOL _rotationValid;
++    BOOL _flipValid;
+ }
+ 
+ @synthesize rotation = _rotation, flip = _flip;
+@@ -222,6 +328,8 @@ - (instancetype)init
+             OSStatus status = VTPixelRotationSessionCreate(NULL, &_rotationSession);
+             if (status != noErr)
+                 return nil;
++            _rotationValid = YES;
++            _flipValid = YES;
+         } else {
+             return nil;
+         }
+@@ -230,40 +338,67 @@ - (instancetype)init
+ }
+ 
+ - (void)setRotation:(VLCSampleBufferPixelRotation)rotation {
+-    if (_rotation == rotation)
++    if (_rotation == rotation && _rotationValid)
+         return;
+-    _rotation = rotation;
++    OSStatus status;
+     switch (rotation) {
+         case kVLCSampleBufferPixelRotation_90CW:
+-            VTSessionSetProperty(_rotationSession, kVTPixelRotationPropertyKey_Rotation, kVTRotation_CW90);
++            status = VTSessionSetProperty(_rotationSession,
++                                          kVTPixelRotationPropertyKey_Rotation,
++                                          kVTRotation_CW90);
+             break;
+         case kVLCSampleBufferPixelRotation_180:
+-            VTSessionSetProperty(_rotationSession, kVTPixelRotationPropertyKey_Rotation, kVTRotation_180);
++            status = VTSessionSetProperty(_rotationSession,
++                                          kVTPixelRotationPropertyKey_Rotation,
++                                          kVTRotation_180);
+             break;
+         case kVLCSampleBufferPixelRotation_90CCW:
+-            VTSessionSetProperty(_rotationSession, kVTPixelRotationPropertyKey_Rotation, kVTRotation_CCW90);
++            status = VTSessionSetProperty(_rotationSession,
++                                          kVTPixelRotationPropertyKey_Rotation,
++                                          kVTRotation_CCW90);
+             break;
+         case kVLCSampleBufferPixelRotation_0:
+         default:
+-            VTSessionSetProperty(_rotationSession, kVTPixelRotationPropertyKey_Rotation, kVTRotation_0);
++            status = VTSessionSetProperty(_rotationSession,
++                                          kVTPixelRotationPropertyKey_Rotation,
++                                          kVTRotation_0);
+             break;
+     }
++    _rotationValid = status == noErr;
++    if (_rotationValid)
++        _rotation = rotation;
+ }
+ 
+ - (void)setFlip:(VLCSampleBufferPixelFlip)flip {
+-    if (_flip == flip)
++    if (_flip == flip && _flipValid)
+         return;
+-    _flip = flip;
+-    VTSessionSetProperty(_rotationSession, kVTPixelRotationPropertyKey_FlipHorizontalOrientation, flip & kVLCSampleBufferPixelFlip_H ? kCFBooleanTrue : kCFBooleanFalse);
+-    VTSessionSetProperty(_rotationSession, kVTPixelRotationPropertyKey_FlipVerticalOrientation, flip & kVLCSampleBufferPixelFlip_V ? kCFBooleanTrue : kCFBooleanFalse);
++    OSStatus horizontalStatus = VTSessionSetProperty(
++        _rotationSession, kVTPixelRotationPropertyKey_FlipHorizontalOrientation,
++        flip & kVLCSampleBufferPixelFlip_H ? kCFBooleanTrue : kCFBooleanFalse);
++    OSStatus verticalStatus = VTSessionSetProperty(
++        _rotationSession, kVTPixelRotationPropertyKey_FlipVerticalOrientation,
++        flip & kVLCSampleBufferPixelFlip_V ? kCFBooleanTrue : kCFBooleanFalse);
++    _flipValid = horizontalStatus == noErr && verticalStatus == noErr;
++    if (_flipValid)
++        _flip = flip;
+ }
+ 
+ - (CVPixelBufferRef)rotate:(CVPixelBufferRef)pixelBuffer {
++    if (!_rotationValid || !_flipValid)
++        return NULL;
++
+     if (!_bufferProvider)
+         _bufferProvider = [VLCRotatedPixelBufferProvider new];
+ 
++    bool swapsAxes =
++        _rotation == kVLCSampleBufferPixelRotation_90CW ||
++        _rotation == kVLCSampleBufferPixelRotation_90CCW;
++    size_t sourceWidth = CVPixelBufferGetWidth(pixelBuffer);
++    size_t sourceHeight = CVPixelBufferGetHeight(pixelBuffer);
+     CVPixelBufferRef rotated;
+-    rotated = [_bufferProvider provideFromBuffer:pixelBuffer rotation:_rotation];
++    rotated = [_bufferProvider provideFromBuffer:pixelBuffer
++                                     outputWidth:swapsAxes ? sourceHeight : sourceWidth
++                                    outputHeight:swapsAxes ? sourceWidth : sourceHeight];
+     if (!rotated)
+         return NULL;
+ 
+@@ -288,124 +423,14 @@ - (void)dealloc
+ 
+ #endif // IS_VT_ROTATION_API_AVAILABLE
+ 
+-#pragma mark - VLCPixelBufferRotationContextCI
+-
+-@interface VLCPixelBufferRotationContextCI : NSObject <VLCPixelBufferRotationContext>
+-
+-@end
+-
+-@implementation VLCPixelBufferRotationContextCI
+-{
+-    VLCRotatedPixelBufferProvider *_bufferProvider;
+-    CIContext *_rotationContext;
+-    CGImagePropertyOrientation _orientation;
+-}
+-
+-@synthesize rotation = _rotation, flip = _flip;
+-
+-- (instancetype)init
+-{
+-    self = [super init];
+-    if (self) {
+-        _rotationContext = [[CIContext alloc] initWithOptions:nil];
+-        if (!_rotationContext)
+-            return nil;
+-    }
+-    return self;
+-}
+-
+-- (void)_updateOrientation {
+-    switch (_rotation) {
+-        case kVLCSampleBufferPixelRotation_90CW:
+-        {
+-            if (_flip == kVLCSampleBufferPixelFlip_None)
+-                _orientation = kCGImagePropertyOrientationRight;
+-            if (_flip == kVLCSampleBufferPixelFlip_H)
+-                _orientation = kCGImagePropertyOrientationLeftMirrored;
+-            if (_flip == kVLCSampleBufferPixelFlip_V)
+-                _orientation = kCGImagePropertyOrientationRightMirrored;
+-            if (_flip == (kVLCSampleBufferPixelFlip_H | kVLCSampleBufferPixelFlip_V))
+-                _orientation = kCGImagePropertyOrientationLeft;
+-            break;
+-        }
+-        case kVLCSampleBufferPixelRotation_180:
+-        {
+-            if (_flip == kVLCSampleBufferPixelFlip_None)
+-                _orientation = kCGImagePropertyOrientationDown;
+-            if (_flip == kVLCSampleBufferPixelFlip_H)
+-                _orientation = kCGImagePropertyOrientationDownMirrored;
+-            if (_flip == kVLCSampleBufferPixelFlip_V)
+-                _orientation = kCGImagePropertyOrientationUpMirrored;
+-            if (_flip == (kVLCSampleBufferPixelFlip_H | kVLCSampleBufferPixelFlip_V))
+-                _orientation = kCGImagePropertyOrientationUp;
+-            break;
+-        }
+-        case kVLCSampleBufferPixelRotation_90CCW:
+-        {
+-            if (_flip == kVLCSampleBufferPixelFlip_None)
+-                _orientation = kCGImagePropertyOrientationLeft;
+-            if (_flip == kVLCSampleBufferPixelFlip_H)
+-                _orientation = kCGImagePropertyOrientationRightMirrored;
+-            if (_flip == kVLCSampleBufferPixelFlip_V)
+-                _orientation = kCGImagePropertyOrientationLeftMirrored;
+-            if (_flip == (kVLCSampleBufferPixelFlip_H | kVLCSampleBufferPixelFlip_V))
+-                _orientation = kCGImagePropertyOrientationRight;
+-            break;
+-        }
+-        case kVLCSampleBufferPixelRotation_0:
+-        default:
+-        {
+-            if (_flip == kVLCSampleBufferPixelFlip_None)
+-                _orientation = kCGImagePropertyOrientationUp;
+-            if (_flip == kVLCSampleBufferPixelFlip_H)
+-                _orientation = kCGImagePropertyOrientationUpMirrored;
+-            if (_flip == kVLCSampleBufferPixelFlip_V)
+-                _orientation = kCGImagePropertyOrientationDownMirrored;
+-            if (_flip == (kVLCSampleBufferPixelFlip_H | kVLCSampleBufferPixelFlip_V))
+-                _orientation = kCGImagePropertyOrientationDown;
+-            break;
+-        }
+-    }
+-}
+-
+-- (void)setRotation:(VLCSampleBufferPixelRotation)rotation {
+-    if (_rotation == rotation)
+-        return;
+-    _rotation = rotation;
+-    [self _updateOrientation];
+-}
+-
+-- (void)setFlip:(VLCSampleBufferPixelFlip)flip {
+-    if (_flip == flip)
+-        return;
+-    _flip = flip;
+-    [self _updateOrientation];
+-}
+-
+-- (CVPixelBufferRef)rotate:(CVPixelBufferRef)pixelBuffer {
+-    if (!_bufferProvider)
+-        _bufferProvider = [VLCRotatedPixelBufferProvider new];
+-
+-    CVPixelBufferRef rotated;
+-    rotated = [_bufferProvider provideFromBuffer:pixelBuffer rotation:_rotation];
+-    if (!rotated)
+-        return NULL;
+-
+-    CIImage *image = [[CIImage alloc] initWithCVPixelBuffer:pixelBuffer];
+-    image = [image imageByApplyingOrientation:_orientation];
+-    [_rotationContext render:image toCVPixelBuffer:rotated];
+-
+-    return rotated;
+-}
+-
+-@end
+-
+ static vlc_decoder_device * CVPXHoldDecoderDevice(vlc_object_t *o, void *sys)
+ {
+     VLC_UNUSED(o);
+     vout_display_t *vd = sys;
+     vlc_decoder_device *device =
+         vlc_decoder_device_Create(VLC_OBJECT(vd), vd->cfg->window);
++    if (device == NULL)
++        return NULL;
+     static const struct vlc_decoder_device_operations ops =
+     {
+         NULL,
+@@ -465,30 +490,75 @@ static void DeleteCVPXConverter( filter_t * p_converter )
+ static void DeletePipController( pip_controller_t * pipcontroller );
+ 
+ #pragma mark -
+-@class VLCSampleBufferSubpicture, VLCSampleBufferDisplay;
++@class VLCSampleBufferSubpicture;
+ 
+ @interface VLCSampleBufferSubpictureRegion: NSObject
+-@property (nonatomic, weak) VLCSampleBufferSubpicture *subpicture;
+-@property (nonatomic) CGRect backingFrame;
+-@property (nonatomic) CGImageRef image;
+-@property (nonatomic) CGFloat    alpha;
++{
++    CGRect _backingFrame;
++    CGImageRef _image;
++    CGFloat _alpha;
++}
++@property (nonatomic, readonly) CGRect backingFrame;
++@property (nonatomic, readonly) CGImageRef image;
++@property (nonatomic, readonly) CGFloat alpha;
++- (instancetype)initWithBackingFrame:(CGRect)backingFrame
++                                image:(CGImageRef)image
++                                alpha:(CGFloat)alpha;
+ @end
+ 
+ @implementation VLCSampleBufferSubpictureRegion
++@synthesize backingFrame = _backingFrame;
++@synthesize image = _image;
++@synthesize alpha = _alpha;
++
++- (instancetype)initWithBackingFrame:(CGRect)backingFrame
++                                image:(CGImageRef)image
++                                alpha:(CGFloat)alpha
++{
++    self = [super init];
++    if (!self)
++        return nil;
++
++    _backingFrame = backingFrame;
++    _image = CGImageRetain(image);
++    _alpha = alpha;
++    return self;
++}
++
+ - (void)dealloc {
+-    CGImageRelease(_image);
++    if (_image != NULL)
++        CGImageRelease(_image);
+ }
+ @end
+ 
+ #pragma mark -
+ 
+ @interface VLCSampleBufferSubpicture: NSObject
+-@property (nonatomic, weak) VLCSampleBufferDisplay *sys;
+-@property (nonatomic) NSArray<VLCSampleBufferSubpictureRegion *> *regions;
+-@property (nonatomic) int64_t order;
++{
++    NSArray<VLCSampleBufferSubpictureRegion *> *_regions;
++    int64_t _order;
++}
++@property (nonatomic, copy, readonly) NSArray<VLCSampleBufferSubpictureRegion *> *regions;
++@property (nonatomic, readonly) int64_t order;
++- (instancetype)initWithOrder:(int64_t)order
++                       regions:(NSArray<VLCSampleBufferSubpictureRegion *> *)regions;
+ @end
+ 
+ @implementation VLCSampleBufferSubpicture
++@synthesize regions = _regions;
++@synthesize order = _order;
++
++- (instancetype)initWithOrder:(int64_t)order
++                       regions:(NSArray<VLCSampleBufferSubpictureRegion *> *)regions
++{
++    self = [super init];
++    if (!self)
++        return nil;
++
++    _order = order;
++    _regions = [regions copy];
++    return self;
++}
+ 
+ @end
+ 
+@@ -640,14 +710,24 @@ @interface VLCSampleBufferDisplay: NSObject
+ {
+     @public
+     filter_t *converter;
++    atomic_uint geometryFailureCount;
++    CMSampleBufferRef pendingSampleBuffer;
+ }
+     @property (nonatomic, readonly, weak) VLCView *window;
+     @property (nonatomic, readonly) vout_display_t *vd;
++    @property (nonatomic) VLCView *displayClipView;
+     @property (nonatomic) VLCSampleBufferDisplayView *displayView;
+     @property (nonatomic) AVSampleBufferDisplayLayer *displayLayer;
++    @property (nonatomic, readonly) NSObject *displayLayerLock;
++    @property (nonatomic) BOOL displayClosed;
++    @property (nonatomic) BOOL displayPreparationScheduled;
+     @property (nonatomic) VLCSampleBufferSubpictureView *spuView;
+-    @property (nonatomic) VLCSampleBufferSubpicture *subpicture;
++    /* Producer-thread-only reference to the last immutable subtitle snapshot.
++     * Main-queue drawing receives the exact triggering snapshot through its
++     * block capture and never reads this mutable publication slot. */
++    @property (nonatomic, strong) VLCSampleBufferSubpicture *subpicture;
+     @property (nonatomic) id<VLCPixelBufferRotationContext> rotationContext;
++    @property (nonatomic) VLCPixelBufferCropContext *cropContext;
+ 
+     @property (nonatomic, readonly) pip_controller_t *pipcontroller;
+ 
+@@ -657,57 +737,11 @@ - (instancetype)initWithVoutDisplay:(vout_display_t *)vd;
+     - (void)placeVideo:(vout_display_place_t)newPlace;
+ @end
+ 
+-/* The sample-buffer layer fits its enqueued frames by gravity, not by the
+- * core-computed place rectangle, so the display fitting mode is mapped to a
+- * gravity: the larger ("fit outside") mode covers and crops, every other mode
+- * preserves aspect inside the surface. */
+-static AVLayerVideoGravity VLCGravityForDisplayCfg(const vout_display_cfg_t *cfg)
+-{
+-    if (cfg->display.fitting == VLC_VIDEO_FIT_LARGER)
+-        return AVLayerVideoGravityResizeAspectFill;
+-    return AVLayerVideoGravityResizeAspect;
+-}
+-
+-/* A forced display aspect (libvlc_video_set_aspect_ratio) reaches the vout as a
+- * target place rectangle, but AVSampleBufferDisplayLayer still fits the natural
+- * pixel shape. Scale the natural aspect-fit box into VLC's computed place box so
+- * forced ratios visibly stretch while the default path remains identity. The
+- * fill (cover) path keeps its identity transform and uses layer gravity.
+- *
+- * Compute the transform on the vout thread. A vout_display_t must never be
+- * retained or dereferenced by the asynchronous main-queue presentation block. */
+-static CGAffineTransform VLCAspectStretchForDisplay(const vout_display_t *vd)
+-{
+-    const vout_display_place_t *p = vd->place;
+-    const video_format_t *source = vd->source;
+-    const vout_display_cfg_t *cfg = vd->cfg;
+-    CGAffineTransform t = CGAffineTransformIdentity;
+-    if (source && cfg && p->width > 0 && p->height > 0
+-        && source->i_visible_width > 0 && source->i_visible_height > 0
+-        && cfg->display.fitting != VLC_VIDEO_FIT_LARGER)
+-    {
+-        /* The display view is placed in p, so calculate the natural aspect-fit
+-         * box in that coordinate space before stretching it to the full box. */
+-        const double displayW = (double)p->width;
+-        const double displayH = (double)p->height;
+-        const double naturalAR =
+-            (double)source->i_visible_width / (double)source->i_visible_height;
+-        const double displayAR = displayW / displayH;
+-        double naturalW;
+-        double naturalH;
+-        if (naturalAR > displayAR) {
+-            naturalW = displayW;
+-            naturalH = displayW / naturalAR;
+-        } else {
+-            naturalW = displayH * naturalAR;
+-            naturalH = displayH;
+-        }
+-        if (naturalW > 0.0 && naturalH > 0.0)
+-            t = CGAffineTransformMakeScale((double)p->width / naturalW,
+-                                           (double)p->height / naturalH);
+-    }
+-    return t;
+-}
++/* VLC core already computes the final video rectangle in `vd->place`,
++ * including fitting, alignment, source SAR, rotation and forced DAR. Resize
++ * the sample to that one authoritative rectangle instead of interpreting its
++ * aspect a second time in AVSampleBufferDisplayLayer. The host clips an
++ * oversized place rectangle for cover/width/height fitting modes. */
+ 
+ @implementation VLCSampleBufferDisplay
+ 
+@@ -719,11 +753,16 @@ @implementation VLCSampleBufferDisplay
+     if (@available(iOS 16.0, tvOS 16.0, macOS 13.0, *))
+         _rotationContext = [VLCPixelBufferRotationContextVT new];
+ #endif
+-    if (!_rotationContext)
+-        _rotationContext = [VLCPixelBufferRotationContextCI new];
+     return _rotationContext;
+ }
+ 
++- (VLCPixelBufferCropContext *)cropContext
++{
++    if (!_cropContext)
++        _cropContext = [VLCPixelBufferCropContext new];
++    return _cropContext;
++}
++
+ 
+ - (instancetype)initWithVoutDisplay:(vout_display_t *)vd
+ {
+@@ -741,35 +780,30 @@ - (instancetype)initWithVoutDisplay:(vout_display_t *)vd
+     }
+ 
+     _window = window;
++    _displayLayerLock = [NSObject new];
+ 
+     _pipcontroller = CreatePipController(vd, (__bridge void *)self);
+ 
+     _vd = vd;
++    atomic_init(&geometryFailureCount, 0);
+ 
+     return self;
+ }
+ 
+-- (void)preparePictureInPicture {
+-    if ( !_pipcontroller)
+-        return;
+-
+-    if ( _pipcontroller->ops->set_display_layer ) {
+-        _pipcontroller->ops->set_display_layer(
+-            _pipcontroller,
+-            (__bridge void*)_displayView.displayLayer
+-        );
+-    }
+-}
+-
+ - (CGRect)frameForPlace:(const vout_display_place_t *)place
+ {
+     VLCView *window = self.window;
++    if (window == nil)
++        return CGRectZero;
++
+     CGRect frame = CGRectMake(place->x, place->y, place->width, place->height);
+ #if TARGET_OS_OSX
+     frame = [window convertRectFromBacking:frame];
+     frame.origin.y = window.bounds.size.height - frame.origin.y - frame.size.height;
+ #else
+     CGFloat scale = window.contentScaleFactor;
++    if (scale <= 0.0)
++        scale = 1.0;
+     frame.origin.x /= scale;
+     frame.origin.y /= scale;
+     frame.size.width /= scale;
+@@ -779,38 +813,94 @@ - (CGRect)frameForPlace:(const vout_display_place_t *)place
+ }
+ 
+ - (void)prepareDisplay {
+-    @synchronized(_displayLayer) {
+-        if (_displayLayer)
++    @synchronized(_displayLayerLock) {
++        if (_displayClosed || _displayLayer || _displayPreparationScheduled)
+             return;
++        _displayPreparationScheduled = YES;
+     }
+ 
+     VLCSampleBufferDisplay *sys = self;
+     vout_display_place_t place = *_vd->place;
+-    AVLayerVideoGravity gravity = VLCGravityForDisplayCfg(_vd->cfg);
+-    CGAffineTransform aspectStretch = VLCAspectStretchForDisplay(_vd);
++    void *presentationContext = NULL;
++    void (*preparePresentationContext)(void *, void *) = NULL;
++    void (*releasePresentationContext)(void *) = NULL;
++    if (_pipcontroller != NULL &&
++        _pipcontroller->ops->hold_presentation_context != NULL &&
++        _pipcontroller->ops->set_display_layer_on_context != NULL &&
++        _pipcontroller->ops->release_presentation_context != NULL) {
++        presentationContext =
++            _pipcontroller->ops->hold_presentation_context(_pipcontroller);
++        preparePresentationContext =
++            _pipcontroller->ops->set_display_layer_on_context;
++        releasePresentationContext =
++            _pipcontroller->ops->release_presentation_context;
++    }
+     dispatch_async(dispatch_get_main_queue(), ^{
+-        if (sys.displayView)
+-            return;
+-
+-        VLCSampleBufferDisplayView *displayView;
+-        VLCSampleBufferSubpictureView *spuView;
+-        VLCView *window = sys.window;
+-
+-        displayView = [[VLCSampleBufferDisplayView alloc] init];
+-        spuView = [VLCSampleBufferSubpictureView new];
+-        [window addSubview:displayView];
+-        [window addSubview:spuView];
+-        displayView.frame = [sys frameForPlace:&place];
+-        [spuView setFrame:[window bounds]];
+-
+-        sys.displayView = displayView;
+-        sys.spuView = spuView;
+-        @synchronized(sys.displayLayer) {
+-            sys.displayLayer = displayView.displayLayer;
++        @try {
++            if (sys.displayView)
++                return;
++
++            VLCSampleBufferDisplayView *displayView;
++            VLCView *displayClipView;
++            VLCSampleBufferSubpictureView *spuView;
++            VLCView *window = sys.window;
++
++            displayClipView = [VLCView new];
++            displayView = [[VLCSampleBufferDisplayView alloc] init];
++            spuView = [VLCSampleBufferSubpictureView new];
++#if TARGET_OS_OSX
++            displayClipView.wantsLayer = YES;
++            displayClipView.layer.masksToBounds = YES;
++            displayClipView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
++#else
++            displayClipView.clipsToBounds = YES;
++            displayClipView.autoresizingMask =
++                UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
++#endif
++            AVSampleBufferDisplayLayer *displayLayer = displayView.displayLayer;
++            displayLayer.videoGravity = AVLayerVideoGravityResize;
++            @synchronized(sys.displayLayerLock) {
++                if (sys.displayClosed)
++                    return;
++                displayClipView.frame = window.bounds;
++                [window addSubview:displayClipView];
++                [displayClipView addSubview:displayView];
++                [window addSubview:spuView];
++                displayView.frame = [sys frameForPlace:&place];
++                [spuView setFrame:[window bounds]];
++
++                sys.displayClipView = displayClipView;
++                sys.displayView = displayView;
++                sys.spuView = spuView;
++                sys.displayLayer = displayLayer;
++                if (sys->pendingSampleBuffer != NULL)
++                {
++                    AVSampleBufferVideoRenderer *renderer =
++                        displayLayer.sampleBufferRenderer;
++                    if (renderer.requiresFlushToResumeDecoding ||
++                        renderer.status ==
++                            AVQueuedSampleBufferRenderingStatusFailed)
++                        [renderer flush];
++                    /* AVQueuedSampleBufferRendering explicitly permits enqueue
++                     * while not ready. This is exactly one bounded startup
++                     * sample, never an unbounded producer queue. */
++                    [renderer enqueueSampleBuffer:sys->pendingSampleBuffer];
++                    CFRelease(sys->pendingSampleBuffer);
++                    sys->pendingSampleBuffer = NULL;
++                }
++            }
++            if (presentationContext != NULL)
++                preparePresentationContext(
++                    presentationContext,
++                    (__bridge void *)displayLayer
++                );
++        } @finally {
++            @synchronized(sys.displayLayerLock) {
++                sys.displayPreparationScheduled = NO;
++            }
++            if (presentationContext != NULL)
++                releasePresentationContext(presentationContext);
+         }
+-        sys.displayLayer.videoGravity = gravity;
+-        sys.displayLayer.affineTransform = aspectStretch;
+-        [sys preparePictureInPicture];
+     });
+ }
+ 
+@@ -821,8 +911,17 @@ - (void)placeVideo:(vout_display_place_t)newPlace
+ 
+ - (void)close {
+     VLCSampleBufferDisplay *sys = self;
++    @synchronized(_displayLayerLock) {
++        _displayClosed = YES;
++        _displayLayer = nil;
++        if (pendingSampleBuffer != NULL)
++        {
++            CFRelease(pendingSampleBuffer);
++            pendingSampleBuffer = NULL;
++        }
++    }
+     dispatch_async(dispatch_get_main_queue(), ^{
+-        [sys.displayView removeFromSuperview];
++        [sys.displayClipView removeFromSuperview];
+         [sys.spuView removeFromSuperview];
+     });
+     DeletePipController(_pipcontroller);
+@@ -844,11 +943,76 @@ static void Close(vout_display_t *vd)
+     [sys close];
+ }
+ 
++static vlc_samplebuffer_geometry
++SampleBufferGeometryFromFormat(const video_format_t *format)
++{
++    return (vlc_samplebuffer_geometry) {
++        .width = format->i_width,
++        .height = format->i_height,
++        .x_offset = format->i_x_offset,
++        .y_offset = format->i_y_offset,
++        .visible_width = format->i_visible_width,
++        .visible_height = format->i_visible_height,
++        .sar_num = format->i_sar_num,
++        .sar_den = format->i_sar_den,
++    };
++}
++
++static void ReportGeometryFailure(vout_display_t *vd,
++                                  VLCSampleBufferDisplay *sys,
++                                  const char *reason)
++{
++    unsigned occurrence = atomic_fetch_add_explicit(
++        &sys->geometryFailureCount, 1, memory_order_relaxed) + 1;
++    if (occurrence <= 4 || (occurrence & (occurrence - 1)) == 0)
++        msg_Warn(vd, "Dropping sample-buffer frame: %s (occurrence %u)",
++                 reason, occurrence);
++}
++
+ static void RenderPicture(vout_display_t *vd, picture_t *pic, vlc_tick_t date) {
+     VLCSampleBufferDisplay *sys;
+     sys = (__bridge VLCSampleBufferDisplay*)vd->sys;
+ 
+-    switch (vd->fmt->orientation) {
++    video_orientation_t orientation = vd->fmt->orientation;
++    vlc_samplebuffer_geometry sourceGeometry =
++        SampleBufferGeometryFromFormat(vd->source);
++
++    /* Avoid conversion/crop/rotation work when an installed renderer cannot
++     * accept a frame. A missing layer is different: retain the latest fully
++     * constructed sample below so a one-frame or paused source is not lost
++     * while main installs the view asynchronously. */
++    BOOL layerWasMissingAtStart = NO;
++    @synchronized(sys.displayLayerLock) {
++        if (sys.displayClosed)
++            return;
++        AVSampleBufferDisplayLayer *displayLayer = sys.displayLayer;
++        if (displayLayer == nil)
++            layerWasMissingAtStart = YES;
++        else
++        {
++            AVSampleBufferVideoRenderer *renderer =
++                displayLayer.sampleBufferRenderer;
++            if (renderer.requiresFlushToResumeDecoding ||
++                renderer.status == AVQueuedSampleBufferRenderingStatusFailed)
++            {
++                NSError *error = renderer.error;
++                msg_Warn(vd, "Flushing failed sample-buffer renderer%s%s",
++                         error ? ": " : "",
++                         error ? error.description.UTF8String : "");
++                [renderer flush];
++            }
++            if (sys->pendingSampleBuffer != NULL)
++            {
++                [renderer enqueueSampleBuffer:sys->pendingSampleBuffer];
++                CFRelease(sys->pendingSampleBuffer);
++                sys->pendingSampleBuffer = NULL;
++            }
++            if (!renderer.isReadyForMoreMediaData)
++                return;
++        }
++    }
++
++    switch (orientation) {
+     case ORIENT_HFLIPPED:
+         sys.rotationContext.flip = kVLCSampleBufferPixelFlip_H;
+         sys.rotationContext.rotation = kVLCSampleBufferPixelRotation_0;
+@@ -870,32 +1034,32 @@ static void RenderPicture(vout_display_t *vd, picture_t *pic, vlc_tick_t date) {
+         sys.rotationContext.rotation = kVLCSampleBufferPixelRotation_90CCW;
+         break;
+     case ORIENT_TRANSPOSED:
+-        sys.rotationContext.flip = kVLCSampleBufferPixelFlip_V;
++        sys.rotationContext.flip = kVLCSampleBufferPixelFlip_H;
+         sys.rotationContext.rotation = kVLCSampleBufferPixelRotation_90CW;
+         break;
+     case ORIENT_ANTI_TRANSPOSED:
+-        sys.rotationContext.flip = kVLCSampleBufferPixelFlip_H;
++        sys.rotationContext.flip = kVLCSampleBufferPixelFlip_V;
+         sys.rotationContext.rotation = kVLCSampleBufferPixelRotation_90CW;
++        break;
+     case ORIENT_NORMAL:
+     default:
+         sys.rotationContext = nil;
+         break;
+     }
+ 
+-    @synchronized(sys.displayLayer) {
+-        if (sys.displayLayer == nil)
+-            return;
+-    }
+-
+     picture_Hold(pic);
+ 
+     picture_t *dst = pic;
+-    if (sys->converter) {
++    if (sys->converter)
+         dst = sys->converter->ops->filter_video(sys->converter, pic);
+-    }
++    if (dst == NULL)
++        return;
+ 
++    vlc_samplebuffer_geometry deliveredGeometry =
++        SampleBufferGeometryFromFormat(&dst->format);
+     CVPixelBufferRef pixelBuffer = cvpxpic_get_ref(dst);
+-    CVPixelBufferRetain(pixelBuffer);
++    if (pixelBuffer != NULL)
++        CVPixelBufferRetain(pixelBuffer);
+     picture_Release(dst);
+ 
+     if (pixelBuffer == NULL) {
+@@ -903,33 +1067,102 @@ static void RenderPicture(vout_display_t *vd, picture_t *pic, vlc_tick_t date) {
+         return;
+     }
+ 
+-    if (vd->fmt->orientation != ORIENT_NORMAL) {
++    CFDictionaryRef sourceAttachments =
++        CVBufferCopyAttachments(pixelBuffer, kCVAttachmentMode_ShouldPropagate);
++    vlc_samplebuffer_crop crop;
++    size_t pixelWidth = CVPixelBufferGetWidth(pixelBuffer);
++    size_t pixelHeight = CVPixelBufferGetHeight(pixelBuffer);
++    if (!vlc_samplebuffer_map_crop(&sourceGeometry, &deliveredGeometry,
++                                   pixelWidth, pixelHeight, &crop))
++    {
++        if (sourceAttachments != NULL)
++            CFRelease(sourceAttachments);
++        CVPixelBufferRelease(pixelBuffer);
++        ReportGeometryFailure(vd, sys, "source crop cannot be mapped exactly");
++        return;
++    }
++
++    if (crop.x != 0 || crop.y != 0 || crop.width != pixelWidth ||
++        crop.height != pixelHeight)
++    {
++        CVPixelBufferRef cropped = [sys.cropContext crop:pixelBuffer rect:crop];
++        if (cropped == NULL)
++        {
++            if (sourceAttachments != NULL)
++                CFRelease(sourceAttachments);
++            CVPixelBufferRelease(pixelBuffer);
++            ReportGeometryFailure(vd, sys, "VideoToolbox crop failed");
++            return;
++        }
++        CVPixelBufferRelease(pixelBuffer);
++        pixelBuffer = cropped;
++    }
++
++    if (orientation != ORIENT_NORMAL) {
+         CVPixelBufferRef rotated = [sys.rotationContext rotate:pixelBuffer];
+-        if (rotated) {
++        if (rotated == NULL) {
++            if (sourceAttachments != NULL)
++                CFRelease(sourceAttachments);
+             CVPixelBufferRelease(pixelBuffer);
+-            pixelBuffer = rotated;
++            ReportGeometryFailure(vd, sys, "pixel rotation failed");
++            return;
+         }
++        CVPixelBufferRelease(pixelBuffer);
++        pixelBuffer = rotated;
+     }
+ 
+-    id aspectRatio = @{
++    if (sourceAttachments != NULL)
++    {
++        CVBufferSetAttachments(pixelBuffer, sourceAttachments,
++                               kCVAttachmentMode_ShouldPropagate);
++        CFRelease(sourceAttachments);
++    }
++
++    pixelWidth = CVPixelBufferGetWidth(pixelBuffer);
++    pixelHeight = CVPixelBufferGetHeight(pixelBuffer);
++    uint64_t horizontalSpacing;
++    uint64_t verticalSpacing;
++    if (!vlc_samplebuffer_pixel_aspect(
++            &sourceGeometry, ORIENT_IS_SWAP(orientation), &horizontalSpacing,
++            &verticalSpacing))
++    {
++        CVPixelBufferRelease(pixelBuffer);
++        ReportGeometryFailure(vd, sys, "pixel aspect ratio is invalid");
++        return;
++    }
++
++    NSDictionary *aspectRatio = @{
+         (__bridge NSString*)kCVImageBufferPixelAspectRatioHorizontalSpacingKey:
+-            @(vd->source->i_sar_num),
++            @(horizontalSpacing),
+         (__bridge NSString*)kCVImageBufferPixelAspectRatioVerticalSpacingKey:
+-            @(vd->source->i_sar_den)
++            @(verticalSpacing)
++    };
++    NSDictionary *cleanAperture = @{
++        (__bridge NSString *)kCVImageBufferCleanApertureWidthKey:
++            @(pixelWidth),
++        (__bridge NSString *)kCVImageBufferCleanApertureHeightKey:
++            @(pixelHeight),
++        (__bridge NSString *)kCVImageBufferCleanApertureHorizontalOffsetKey:
++            @0,
++        (__bridge NSString *)kCVImageBufferCleanApertureVerticalOffsetKey:
++            @0,
+     };
+ 
+-    CVBufferSetAttachment(
+-        pixelBuffer,
+-        kCVImageBufferPixelAspectRatioKey,
+-        (__bridge CFDictionaryRef)aspectRatio,
+-        kCVAttachmentMode_ShouldPropagate
+-    );
++    /* Keep image-buffer attachments consistent with the format description
++     * while the renderer retains the asynchronous sample. Decoder buffers are
++     * not recycled until that sample releases its CVPixelBuffer. */
++    CVBufferSetAttachment(pixelBuffer, kCVImageBufferPixelAspectRatioKey,
++                          (__bridge CFDictionaryRef)aspectRatio,
++                          kCVAttachmentMode_ShouldPropagate);
++    CVBufferSetAttachment(pixelBuffer, kCVImageBufferCleanApertureKey,
++                          (__bridge CFDictionaryRef)cleanAperture,
++                          kCVAttachmentMode_ShouldPropagate);
+ 
+     CMSampleBufferRef sampleBuffer = NULL;
+     CMVideoFormatDescriptionRef formatDesc = NULL;
+     OSStatus err = CMVideoFormatDescriptionCreateForImageBuffer(kCFAllocatorDefault, pixelBuffer, &formatDesc);
+     if (err != noErr) {
+-        msg_Err(vd, "Image buffer format desciption creation failed!");
++        msg_Err(vd, "Image buffer format description creation failed!");
+         CVPixelBufferRelease(pixelBuffer);
+         return;
+     }
+@@ -953,11 +1186,41 @@ static void RenderPicture(vout_display_t *vd, picture_t *pic, vlc_tick_t date) {
+         return;
+     }
+ 
+-    @synchronized(sys.displayLayer) {
+-        [sys.displayLayer enqueueSampleBuffer:sampleBuffer];
++    @synchronized(sys.displayLayerLock) {
++        AVSampleBufferDisplayLayer *displayLayer = sys.displayLayer;
++        if (displayLayer == nil)
++        {
++            if (!sys.displayClosed)
++            {
++                if (sys->pendingSampleBuffer != NULL)
++                    CFRelease(sys->pendingSampleBuffer);
++                sys->pendingSampleBuffer = sampleBuffer;
++                sampleBuffer = NULL;
++            }
++        }
++        else
++        {
++            AVSampleBufferVideoRenderer *renderer =
++                displayLayer.sampleBufferRenderer;
++            if (renderer.requiresFlushToResumeDecoding ||
++                renderer.status == AVQueuedSampleBufferRenderingStatusFailed)
++            {
++                NSError *error = renderer.error;
++                msg_Warn(vd, "Flushing failed sample-buffer renderer%s%s",
++                         error ? ": " : "",
++                         error ? error.description.UTF8String : "");
++                [renderer flush];
++            }
++            /* A frame built while the layer was absent is the one bounded
++             * startup sample. AVFoundation documents this enqueue as safe
++             * even if readiness changed before installation completed. */
++            if (renderer.isReadyForMoreMediaData || layerWasMissingAtStart)
++                [renderer enqueueSampleBuffer:sampleBuffer];
++        }
+     }
+ 
+-    CFRelease(sampleBuffer);
++    if (sampleBuffer != NULL)
++        CFRelease(sampleBuffer);
+ }
+ 
+ static CGRect RegionBackingFrame(unsigned display_height,
+@@ -974,59 +1237,128 @@ static CGRect RegionBackingFrame(unsigned display_height,
+     );
+ }
+ 
+-static void UpdateSubpictureRegions(vout_display_t *vd,
+-                                    const vlc_render_subpicture *subpicture)
++static VLCSampleBufferSubpicture *
++CreateSubpictureSnapshot(vout_display_t *vd,
++                         const vlc_render_subpicture *subpicture)
+ {
+-    VLCSampleBufferDisplay *sys;
+-    sys = (__bridge VLCSampleBufferDisplay*)vd->sys;
+-
+-    if (sys.subpicture == nil || subpicture == NULL)
+-        return;
++    if (subpicture == NULL)
++        return nil;
+ 
+-    NSMutableArray *regions = [NSMutableArray new];
++    NSMutableArray<VLCSampleBufferSubpictureRegion *> *regions =
++        [NSMutableArray new];
+     CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();
++    if (space == NULL)
++        return nil;
++
++    bool success = true;
+     const struct subpicture_region_rendered *r;
+     vlc_vector_foreach(r, &subpicture->regions) {
+-        CFIndex length = r->p_picture->format.i_height * r->p_picture->p->i_pitch;
+-        const size_t pixels_offset =
+-                r->p_picture->format.i_y_offset * r->p_picture->p->i_pitch +
+-                r->p_picture->format.i_x_offset * r->p_picture->p->i_pixel_pitch;
++        int picturePitch = r->p_picture->p->i_pitch;
++        int picturePixelPitch = r->p_picture->p->i_pixel_pitch;
++        if (r->p_picture->p->p_pixels == NULL || picturePitch <= 0 ||
++            picturePixelPitch <= 0)
++        {
++            success = false;
++            break;
++        }
++
++        size_t pitch = (size_t)picturePitch;
++        size_t height = r->p_picture->format.i_height;
++        if (height != 0 && pitch > SIZE_MAX / height)
++        {
++            success = false;
++            break;
++        }
++
++        size_t length = height * pitch;
++        size_t yOffset = r->p_picture->format.i_y_offset;
++        size_t xOffset = r->p_picture->format.i_x_offset;
++        size_t pixelPitch = (size_t)picturePixelPitch;
++        if ((yOffset != 0 && pitch > SIZE_MAX / yOffset) ||
++            (xOffset != 0 && pixelPitch > SIZE_MAX / xOffset))
++        {
++            success = false;
++            break;
++        }
+ 
++        size_t yBytes = yOffset * pitch;
++        size_t xBytes = xOffset * pixelPitch;
++        if (xBytes > SIZE_MAX - yBytes || yBytes + xBytes > length ||
++            length - (yBytes + xBytes) > LONG_MAX)
++        {
++            success = false;
++            break;
++        }
++
++        size_t pixelsOffset = yBytes + xBytes;
+         CFDataRef data = CFDataCreate(
+-            NULL,
+-            r->p_picture->p->p_pixels + pixels_offset,
+-            length - pixels_offset);
++            NULL, r->p_picture->p->p_pixels + pixelsOffset,
++            (CFIndex)(length - pixelsOffset));
++        if (data == NULL)
++        {
++            success = false;
++            break;
++        }
++
+         CGDataProviderRef provider = CGDataProviderCreateWithCFData(data);
++        if (provider == NULL)
++        {
++            CFRelease(data);
++            success = false;
++            break;
++        }
++
+         CGImageRef image = CGImageCreate(
+-            r->p_picture->format.i_visible_width, r->p_picture->format.i_visible_height,
+-            8, 32, r->p_picture->p->i_pitch,
+-            space, kCGBitmapByteOrderDefault | kCGImageAlphaFirst,
+-            provider, NULL, true, kCGRenderingIntentDefault
+-            );
+-        VLCSampleBufferSubpictureRegion *region;
+-        region = [VLCSampleBufferSubpictureRegion new];
+-        region.subpicture = sys.subpicture;
+-        region.image = image;
+-        region.alpha = r->i_alpha / 255.f;
+-
+-        region.backingFrame = RegionBackingFrame(vd->cfg->display.height, r);
+-        [regions addObject:region];
++            r->p_picture->format.i_visible_width,
++            r->p_picture->format.i_visible_height,
++            8, 32, pitch, space,
++            kCGBitmapByteOrderDefault | kCGImageAlphaFirst,
++            provider, NULL, true, kCGRenderingIntentDefault);
+         CGDataProviderRelease(provider);
+         CFRelease(data);
++        if (image == NULL)
++        {
++            success = false;
++            break;
++        }
++
++        VLCSampleBufferSubpictureRegion *region =
++            [[VLCSampleBufferSubpictureRegion alloc]
++                initWithBackingFrame:
++                    RegionBackingFrame(vd->cfg->display.height, r)
++                image:image
++                alpha:r->i_alpha / 255.f];
++        CGImageRelease(image);
++        if (region == nil)
++        {
++            success = false;
++            break;
++        }
++        [regions addObject:region];
+     }
+     CGColorSpaceRelease(space);
+ 
+-    sys.subpicture.regions = regions;
++    if (!success)
++        return nil;
++
++    return [[VLCSampleBufferSubpicture alloc]
++        initWithOrder:subpicture->i_order
++        regions:regions];
+ }
+ 
+-static bool IsSubpictureDrawNeeded(vout_display_t *vd, const vlc_render_subpicture *subpicture)
++static bool UpdateSubpictureSnapshot(
++    vout_display_t *vd, const vlc_render_subpicture *subpicture,
++    VLCSampleBufferSubpicture * __strong *triggeringSnapshot)
+ {
+     VLCSampleBufferDisplay *sys;
+     sys = (__bridge VLCSampleBufferDisplay*)vd->sys;
++    *triggeringSnapshot = nil;
++
++    VLCSampleBufferSubpicture *current = sys.subpicture;
+ 
+     if (subpicture == NULL)
+     {
+-        if (sys.subpicture == nil)
++        if (current == nil)
+             return false;
+         sys.subpicture = nil;
+         /* Need to draw one last time in order to clear the current subpicture */
+@@ -1036,25 +1368,15 @@ static bool IsSubpictureDrawNeeded(vout_display_t *vd, const vlc_render_subpictu
+     size_t count = subpicture->regions.size;
+     const struct subpicture_region_rendered *r;
+ 
+-    if (!sys.subpicture || subpicture->i_order != sys.subpicture.order)
+-    {
+-        /* Subpicture content is different */
+-        sys.subpicture = [VLCSampleBufferSubpicture new];
+-        sys.subpicture.sys = sys;
+-        sys.subpicture.order = subpicture->i_order;
+-        UpdateSubpictureRegions(vd, subpicture);
+-        return true;
+-    }
+-
+-    bool draw = false;
++    bool draw = current == nil || subpicture->i_order != current.order;
+ 
+-    if (count == sys.subpicture.regions.count)
++    if (!draw && count == current.regions.count)
+     {
+         size_t i = 0;
+         vlc_vector_foreach(r, &subpicture->regions)
+         {
+             VLCSampleBufferSubpictureRegion *region =
+-                sys.subpicture.regions[i++];
++                current.regions[i++];
+ 
+             CGRect newRegion = RegionBackingFrame(vd->cfg->display.height, r);
+ 
+@@ -1066,7 +1388,7 @@ static bool IsSubpictureDrawNeeded(vout_display_t *vd, const vlc_render_subpictu
+             }
+         }
+     }
+-    else
++    else if (!draw)
+     {
+         /* Subpicture region count is different */
+         draw = true;
+@@ -1075,23 +1397,39 @@ static bool IsSubpictureDrawNeeded(vout_display_t *vd, const vlc_render_subpictu
+     if (!draw)
+         return false;
+ 
+-    /* Store the current subpicture regions in order to compare then later.
+-     */
++    /* Build a complete replacement before publishing it. No object reachable
++     * from a published snapshot is mutated afterward. */
++    VLCSampleBufferSubpicture *snapshot =
++        CreateSubpictureSnapshot(vd, subpicture);
++    if (snapshot == nil)
++    {
++        msg_Err(vd, "Failed to create immutable subpicture snapshot");
++        if (current == nil)
++            return false;
++        /* Do not leave stale subtitles visible after a failed replacement. */
++        sys.subpicture = nil;
++        return true;
++    }
+ 
+-    UpdateSubpictureRegions(vd, subpicture);
++    sys.subpicture = snapshot;
++    *triggeringSnapshot = snapshot;
+     return true;
+ }
+ 
+ static void RenderSubpicture(vout_display_t *vd, const vlc_render_subpicture *spu)
+ {
+-    if (!IsSubpictureDrawNeeded(vd, spu))
++    VLCSampleBufferSubpicture *snapshot = nil;
++    if (!UpdateSubpictureSnapshot(vd, spu, &snapshot))
+         return;
+ 
+     VLCSampleBufferDisplay *sys;
+     sys = (__bridge VLCSampleBufferDisplay*)vd->sys;
++    VLCSampleBufferSubpicture *const triggeringSnapshot = snapshot;
+ 
+     dispatch_async(dispatch_get_main_queue(), ^{
+-        [sys.spuView drawSubpicture:sys.subpicture];
++        /* The block retains the exact snapshot that triggered this draw. It
++         * never re-reads the producer's replaceable publication slot. */
++        [sys.spuView drawSubpicture:triggeringSnapshot];
+     });
+ }
+ 
+@@ -1115,6 +1453,8 @@ static void Prepare (vout_display_t *vd, picture_t *pic,
+ 
+ static void Display(vout_display_t *vd, picture_t *pic)
+ {
++    VLC_UNUSED(vd);
++    VLC_UNUSED(pic);
+     // kept as the core is not properly pacing the calls to Prepare without this callback
+ }
+ 
+@@ -1130,14 +1470,8 @@ static int Control (vout_display_t *vd, int query)
+         case VOUT_DISPLAY_CHANGE_SOURCE_PLACE:
+         {
+             vout_display_place_t newPlace = *vd->place;
+-            AVLayerVideoGravity gravity = VLCGravityForDisplayCfg(vd->cfg);
+-            CGAffineTransform aspectStretch = VLCAspectStretchForDisplay(vd);
+             dispatch_async(dispatch_get_main_queue(), ^{
+                 [sys placeVideo:newPlace];
+-                @synchronized(sys.displayLayer) {
+-                    sys.displayLayer.videoGravity = gravity;
+-                    sys.displayLayer.affineTransform = aspectStretch;
+-                }
+             });
+             break;
+         }
+@@ -1151,7 +1485,10 @@ static int Control (vout_display_t *vd, int query)
+ 
+ static pip_controller_t * CreatePipController( vout_display_t *vd, void *cbs_opaque )
+ {
++    VLC_UNUSED(cbs_opaque);
+     pip_controller_t *pip_controller = vlc_object_create(vd, sizeof(pip_controller_t));
++    if (pip_controller == NULL)
++        return NULL;
+ 
+     module_t **mods;
+     ssize_t total = vlc_module_match("pictureinpicture", NULL, false, &mods, NULL);
+diff --git a/modules/video_output/apple/VLCSampleBufferGeometry.h b/modules/video_output/apple/VLCSampleBufferGeometry.h
+new file mode 100644
+index 0000000000..f23417c2ea
+--- /dev/null
++++ b/modules/video_output/apple/VLCSampleBufferGeometry.h
+@@ -0,0 +1,134 @@
++/*****************************************************************************
++ * VLCSampleBufferGeometry.h: exact sample-buffer crop and aspect helpers
++ *****************************************************************************
++ * Copyright (C) 2026 VLC authors and VideoLAN
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *****************************************************************************
++ * This header intentionally depends only on the C standard library so that
++ * the integer geometry can be exercised outside Apple frameworks.
++ *****************************************************************************/
++
++#ifndef VLC_SAMPLE_BUFFER_GEOMETRY_H
++#define VLC_SAMPLE_BUFFER_GEOMETRY_H
++
++#include <stdbool.h>
++#include <stddef.h>
++#include <stdint.h>
++
++typedef struct
++{
++    uint32_t width;
++    uint32_t height;
++    uint32_t x_offset;
++    uint32_t y_offset;
++    uint32_t visible_width;
++    uint32_t visible_height;
++    uint32_t sar_num;
++    uint32_t sar_den;
++} vlc_samplebuffer_geometry;
++
++typedef struct
++{
++    size_t x;
++    size_t y;
++    size_t width;
++    size_t height;
++} vlc_samplebuffer_crop;
++
++/* Maps VLC's current source crop into the physical CVPixelBuffer. The
++ * delivered geometry describes both its coded and visible baselines. VLC's
++ * VideoToolbox decoder can return a coded/aligned buffer while software CVPX
++ * conversion returns a visible-only buffer, so those two identities are
++ * handled explicitly. Any other relationship is ambiguous and rejected. */
++static inline bool
++vlc_samplebuffer_map_crop(const vlc_samplebuffer_geometry *source,
++                          const vlc_samplebuffer_geometry *delivered,
++                          size_t buffer_width, size_t buffer_height,
++                          vlc_samplebuffer_crop *crop)
++{
++    if (source == NULL || delivered == NULL || crop == NULL ||
++        source->width == 0 || source->height == 0 ||
++        delivered->width == 0 || delivered->height == 0 ||
++        source->visible_width == 0 || source->visible_height == 0 ||
++        delivered->visible_width == 0 || delivered->visible_height == 0 ||
++        buffer_width == 0 || buffer_height == 0)
++        return false;
++
++    uint64_t delivered_right =
++        (uint64_t)delivered->x_offset + delivered->visible_width;
++    uint64_t delivered_bottom =
++        (uint64_t)delivered->y_offset + delivered->visible_height;
++    uint64_t source_right =
++        (uint64_t)source->x_offset + source->visible_width;
++    uint64_t source_bottom =
++        (uint64_t)source->y_offset + source->visible_height;
++
++    if (delivered_right > delivered->width ||
++        delivered_bottom > delivered->height ||
++        source_right > source->width || source_bottom > source->height ||
++        source->width != delivered->width ||
++        source->height != delivered->height)
++        return false;
++
++    if (source->x_offset < delivered->x_offset ||
++        source->y_offset < delivered->y_offset ||
++        source_right > delivered_right || source_bottom > delivered_bottom)
++        return false;
++
++    if (buffer_width == delivered->width &&
++        buffer_height == delivered->height)
++    {
++        crop->x = source->x_offset;
++        crop->y = source->y_offset;
++    }
++    else if (buffer_width == delivered->visible_width &&
++             buffer_height == delivered->visible_height)
++    {
++        crop->x = source->x_offset - delivered->x_offset;
++        crop->y = source->y_offset - delivered->y_offset;
++    }
++    else
++        return false;
++
++    crop->width = source->visible_width;
++    crop->height = source->visible_height;
++    if (crop->width > buffer_width || crop->height > buffer_height ||
++        crop->x > buffer_width - crop->width ||
++        crop->y > buffer_height - crop->height)
++        return false;
++
++    return true;
++}
++
++/* Crop output is exactly source.visible dimensions, so its pixel aspect is
++ * VLC's source SAR. A physical 90° transform swaps the axes and reciprocates
++ * that ratio. */
++static inline bool
++vlc_samplebuffer_pixel_aspect(const vlc_samplebuffer_geometry *source,
++                              bool swaps_axes, uint64_t *horizontal_spacing,
++                              uint64_t *vertical_spacing)
++{
++    if (source == NULL || horizontal_spacing == NULL ||
++        vertical_spacing == NULL || source->visible_width == 0 ||
++        source->visible_height == 0 || source->sar_num == 0 ||
++        source->sar_den == 0)
++        return false;
++
++    if (swaps_axes)
++    {
++        *horizontal_spacing = source->sar_den;
++        *vertical_spacing = source->sar_num;
++    }
++    else
++    {
++        *horizontal_spacing = source->sar_num;
++        *vertical_spacing = source->sar_den;
++    }
++    return true;
++}
++
++#endif /* VLC_SAMPLE_BUFFER_GEOMETRY_H */
+diff --git a/modules/video_output/apple/VLCVideoUIView.m b/modules/video_output/apple/VLCVideoUIView.m
+index 8f5d1d08e0..2c9e55b9e0 100644
+--- a/modules/video_output/apple/VLCVideoUIView.m
++++ b/modules/video_output/apple/VLCVideoUIView.m
+@@ -137,10 +137,20 @@ - (id)initWithWindow:(vlc_window_t *)wnd
+     }
+ 
+     CGSize size = self.viewContainerBounds.size;
+-    _width = size.width;
+-    _height = size.height;
++    CGFloat scaleFactor = 1.0;
++    if ([_viewContainer respondsToSelector:@selector(contentScaleFactor)])
++        scaleFactor = [(UIView *)_viewContainer contentScaleFactor];
++#if !defined(TARGET_OS_VISION) || !TARGET_OS_VISION
++    if (scaleFactor <= 0.0)
++        scaleFactor = [UIScreen mainScreen].scale;
++#endif
++    if (scaleFactor <= 0.0)
++        scaleFactor = 1.0;
++    self.contentScaleFactor = scaleFactor;
++    _width = size.width * scaleFactor;
++    _height = size.height * scaleFactor;
+     [self reportEvent:^{
+-        vlc_window_ReportSize(_wnd, size.width, size.height);
++        vlc_window_ReportSize(_wnd, _width, _height);
+     }];
+ 
+     return self;
+diff --git a/modules/video_output/apple/vlc_pip_controller.h b/modules/video_output/apple/vlc_pip_controller.h
+index d92226c647..96c6ad0b3a 100644
+--- a/modules/video_output/apple/vlc_pip_controller.h
++++ b/modules/video_output/apple/vlc_pip_controller.h
+@@ -32,20 +32,14 @@
+ typedef struct pip_controller_t pip_controller_t;
+ 
+ struct pip_controller_operations {
+-    void (*set_display_layer)(pip_controller_t *, void *);
++    /* Hold an implementation-owned presentation context across asynchronous
++     * UI work. The context, unlike pip_controller_t, may outlive vout close. */
++    void *(*hold_presentation_context)(pip_controller_t *);
++    void (*set_display_layer_on_context)(void *, void *);
++    void (*release_presentation_context)(void *);
+     int (*close)(pip_controller_t *);
+ };
+ 
+-struct pip_controller_media_callbacks {
+-    void (*play)(void* opaque);
+-    void (*pause)(void* opaque);
+-    void (*seek_by)(vlc_tick_t time, dispatch_block_t completion, void *opaque);
+-    vlc_tick_t (*media_length)(void* opaque);
+-    vlc_tick_t (*media_time)(void* opaque);
+-    bool (*is_media_seekable)(void* opaque);
+-    bool (*is_media_playing)(void* opaque);
+-};
+-
+ struct pip_controller_t
+ {
+     struct vlc_object_t obj;
+@@ -53,7 +47,6 @@ struct pip_controller_t
+     void               *p_sys;
+ 
+     const struct pip_controller_operations *ops;
+-    const struct pip_controller_media_callbacks *media_cbs;
+ };
+ 
+-#endif // VLC_PIP_CONTROLLER_H
+\ No newline at end of file
++#endif // VLC_PIP_CONTROLLER_H
+diff --git a/modules/video_output/vmem.c b/modules/video_output/vmem.c
+index fbf2921ac7..b85c256fd5 100644
+--- a/modules/video_output/vmem.c
++++ b/modules/video_output/vmem.c
+@@ -34,6 +34,7 @@
+ #include <vlc_common.h>
+ #include <vlc_plugin.h>
+ #include <vlc_vout_display.h>
++#include <vlc/swiftvlc_vmem.h>
+ 
+ /*****************************************************************************
+  * Module descriptor
+@@ -89,6 +90,8 @@ typedef struct vout_display_sys_t {
+     void (*unlock)(void *sys, void *id, void *const *plane);
+     void (*display)(void *sys, void *id);
+     void (*cleanup)(void *sys);
++    bool picture_ready;
++    bool extended_format;
+ 
+     unsigned pitches[PICTURE_PLANE_MAX];
+     unsigned lines[PICTURE_PLANE_MAX];
+@@ -97,6 +100,39 @@ typedef struct vout_display_sys_t {
+ typedef unsigned (*vlc_format_cb)(void **, char *, unsigned *, unsigned *,
+                                   unsigned *, unsigned *);
+ 
++static bool GeometryIsValid(const swiftvlc_video_format_geometry_t *geometry)
++{
++    return geometry->coded_width > 0 && geometry->coded_height > 0 &&
++           geometry->visible_width > 0 && geometry->visible_height > 0 &&
++           geometry->x_offset <= geometry->coded_width &&
++           geometry->visible_width <= geometry->coded_width - geometry->x_offset &&
++           geometry->y_offset <= geometry->coded_height &&
++           geometry->visible_height <= geometry->coded_height - geometry->y_offset &&
++           geometry->sar_num > 0 && geometry->sar_den > 0;
++}
++
++static bool HasExactSquarePixelAspect(
++    const swiftvlc_video_format_geometry_t *geometry,
++    unsigned output_width, unsigned output_height)
++{
++    if (output_width == 0 || output_height == 0)
++        return false;
++
++    unsigned source_num, source_den;
++    if (!vlc_ureduce(&source_num, &source_den,
++                     (uint64_t)geometry->visible_width * geometry->sar_num,
++                     (uint64_t)geometry->visible_height * geometry->sar_den,
++                     0))
++        return false;
++
++    unsigned output_num, output_den;
++    if (!vlc_ureduce(&output_num, &output_den,
++                     output_width, output_height, 0))
++        return false;
++
++    return source_num == output_num && source_den == output_den;
++}
++
+ static void           Prepare(vout_display_t *, picture_t *, const struct vlc_render_subpicture *, vlc_tick_t);
+ static void           Display(vout_display_t *, picture_t *);
+ static int            Control(vout_display_t *, int);
+@@ -122,6 +158,8 @@ static int Open(vout_display_t *vd,
+ 
+     /* Get the callbacks */
+     vlc_format_cb setup = var_InheritAddress(vd, "vmem-setup");
++    swiftvlc_video_format_ex_cb setup_ex =
++        var_InheritAddress(vd, "vmem-setup-ex");
+ 
+     sys->lock = var_InheritAddress(vd, "vmem-lock");
+     if (sys->lock == NULL) {
+@@ -133,12 +171,61 @@ static int Open(vout_display_t *vd,
+     sys->display = var_InheritAddress(vd, "vmem-display");
+     sys->cleanup = var_InheritAddress(vd, "vmem-cleanup");
+     sys->opaque = var_InheritAddress(vd, "vmem-data");
++    sys->picture_ready = false;
++    sys->extended_format = setup_ex != NULL;
+ 
+     /* Define the video format */
+     video_format_t fmt;
+     video_format_ApplyRotation(&fmt, vd->source);
+ 
+-    if (setup != NULL) {
++    if (setup_ex != NULL) {
++        char chroma[5];
++        memcpy(chroma, &fmt.i_chroma, 4);
++        chroma[4] = '\0';
++        memset(sys->pitches, 0, sizeof(sys->pitches));
++        memset(sys->lines, 0, sizeof(sys->lines));
++
++        const swiftvlc_video_format_geometry_t geometry = {
++            .coded_width = fmt.i_width,
++            .coded_height = fmt.i_height,
++            .visible_width = fmt.i_visible_width,
++            .visible_height = fmt.i_visible_height,
++            .x_offset = fmt.i_x_offset,
++            .y_offset = fmt.i_y_offset,
++            .sar_num = fmt.i_sar_num,
++            .sar_den = fmt.i_sar_den,
++            .source_orientation = (uint32_t)vd->source->orientation,
++        };
++        if (!GeometryIsValid(&geometry)) {
++            msg_Err(vd, "invalid extended vmem source geometry");
++            free(sys);
++            return VLC_EGENERIC;
++        }
++
++        unsigned output_width = geometry.visible_width;
++        unsigned output_height = geometry.visible_height;
++        if (setup_ex(&sys->opaque, chroma, &geometry,
++                     &output_width, &output_height,
++                     sys->pitches, sys->lines) == 0) {
++            msg_Err(vd, "extended video format setup failure");
++            free(sys);
++            return VLC_EGENERIC;
++        }
++        if (!HasExactSquarePixelAspect(&geometry,
++                                       output_width, output_height)) {
++            msg_Err(vd, "extended vmem output does not preserve exact aspect");
++            if (sys->cleanup != NULL)
++                sys->cleanup(sys->opaque);
++            free(sys);
++            return VLC_EGENERIC;
++        }
++
++        fmt.i_chroma = vlc_fourcc_GetCodecFromString(VIDEO_ES, chroma);
++        fmt.i_width = output_width;
++        fmt.i_height = output_height;
++        fmt.i_sar_num = 1;
++        fmt.i_sar_den = 1;
++    } else if (setup != NULL) {
+         char chroma[5];
+ 
+         memcpy(chroma, &fmt.i_chroma, 4);
+@@ -215,19 +302,30 @@ static void Prepare(vout_display_t *vd, picture_t *pic,
+     VLC_UNUSED(date);
+     vout_display_sys_t *sys = vd->sys;
+     picture_resource_t rsc = { .p_sys = NULL };
+-    void *planes[PICTURE_PLANE_MAX];
++    void *planes[PICTURE_PLANE_MAX] = { NULL };
+ 
++    sys->picture_ready = false;
+     sys->pic_opaque = sys->lock(sys->opaque, planes);
+ 
+     picture_t *locked = picture_NewFromResource(vd->fmt, &rsc);
+     if (likely(locked != NULL)) {
+-        for (unsigned i = 0; i < PICTURE_PLANE_MAX; i++) {
++        bool valid = true;
++        for (int i = 0; i < locked->i_planes; i++) {
++            if (planes[i] == NULL) {
++                valid = false;
++                break;
++            }
++        }
++        for (int i = 0; valid && i < locked->i_planes; i++) {
+             locked->p[i].p_pixels = planes[i];
+             locked->p[i].i_lines  = sys->lines[i];
+             locked->p[i].i_pitch  = sys->pitches[i];
+         }
+ 
+-        picture_CopyPixels(locked, pic);
++        if (valid) {
++            picture_CopyPixels(locked, pic);
++            sys->picture_ready = true;
++        }
+         picture_Release(locked);
+     }
+ 
+@@ -242,17 +340,19 @@ static void Display(vout_display_t *vd, picture_t *pic)
+     vout_display_sys_t *sys = vd->sys;
+     VLC_UNUSED(pic);
+ 
+-    if (sys->display != NULL)
++    if (sys->picture_ready && sys->display != NULL)
+         sys->display(sys->opaque, sys->pic_opaque);
++    sys->picture_ready = false;
+ }
+ 
+ static int Control(vout_display_t *vd, int query)
+ {
+-    (void) vd;
++    vout_display_sys_t *sys = vd->sys;
+ 
+     switch (query) {
+         case VOUT_DISPLAY_CHANGE_SOURCE_ASPECT:
+         case VOUT_DISPLAY_CHANGE_SOURCE_CROP:
++            return sys->extended_format ? VLC_EGENERIC : VLC_SUCCESS;
+         case VOUT_DISPLAY_CHANGE_SOURCE_PLACE:
+             return VLC_SUCCESS;
+     }


### PR DESCRIPTION
## Summary

Lands the v0.10.1 Picture in Picture and video-aspect work on top of v0.10.0. It adds two iOS PiP routes, the per-handle lifetime machinery that keeps libVLC's custom-memory callbacks safe across teardown and media-list ownership, and the aspect/codec fixes staged as A1–A5.

## iOS Picture in Picture

- **`PiPVideoView` (native drawable).** Attaches a drawable proxy to the player and drives libVLC's bundled iOS sample-buffer video output, which creates and owns the `AVPictureInPictureController`. SwiftVLC receives the native window controller back for start/stop, possibility, activity, playback invalidation, and linear-playback policy. This view never hosts `PiPController.layer`.
- **Direct `PiPController` (vmem).** Instantiating `PiPController` directly installs public vmem callbacks and exposes a SwiftVLC-owned `AVSampleBufferDisplayLayer`: `CVPixelBuffer → CMSampleBuffer → layer`, enqueued on a dedicated serial queue. The direct renderer requests 8-bit BGRA and is SDR (its optional resize uses a device-RGB Core Image target).
- **macOS** keeps the `PrivateMacOSPiP` SPI native-drawable backend unchanged.

## Callback lifetime safety

libVLC copies vmem function pointers and their opaque value when a video output opens, so clearing the media-player callback variables does not revoke a copy already in flight. `NativePlayerHandleLifetime` ties each retained opaque to one exact `libvlc_media_player_t`:

- Owners are counted — the player's own ownership plus each `MediaListPlayer` binding lease.
- A native-handle replacement creates a fresh slot and permanently retires the old one.
- The handle opaque is released only after the final counted native release returns **and** every in-flight callback has drained. No timeout or transient `vout` observation is treated as proof of safety.

## New C ABI

- `swiftvlc_vmem.h` — geometry-aware custom-memory format callback carrying an atomic post-rotation source geometry (coded/visible size, crop, sample aspect, orientation).
- Atomic media/length snapshot shim so the playback delegate reads media identity and length under one internal lock.

## Playback range & invalidation policy

AVKit range invalidation and `requiresLinearPlayback` are driven from media/length/seekability **event payloads** rather than observable mirrors, because `Player` and `PiPController` subscribe independently and either may observe an event first. Unknown duration is treated as valid live/indefinite content.

## Module structure

`PixelBufferRenderer` is split into `+Enqueue`, `+FormatCallback`, `+FormatDescription`, `+Geometry`, `+Pool`; `PiPController` into `+AudioSession`, `+PlaybackState`, and a `BindingPublication` helper.

## Aspect & codec fixes (A1–A5)

- `.fill` covers the surface and `.ratio(w,h)` stretches to the forced display aspect in the sample-buffer vout.
- `Track.codecString`, rebuffer hysteresis, and subtitle policy.
- A measuring harness with vout readbacks pins the aspect behavior.

## Fixes surfaced during review

- Removed a duplicated `NativePlayerHandleLease` declaration (invalid redeclaration).
- `perform` now runs only on the terminal native release; a media-list lease ending before the player's own ownership no longer trips the release precondition.
- Filled out doc coverage on the new C ABI, corrected misattached Doxygen on the media-length snapshot shim, and tidied transitional comments.

## Lint / formatting

- `swiftlint --strict` and `swiftformat --lint --strict` pass. Fixes: a failable `Track.codecString` decode (`String(validating:as:)`) and `file_length` opt-outs on the two large PiP files.
- CI's brew swiftformat had drifted 0.61 → 0.62.1 (new rules such as `wrapIfStatementBodies`), which flagged files repo-wide — including on `main`. This PR normalizes the whole tree to 0.62.1, so ~39 of the touched files are formatting-only.

## Testing

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` — clean (0 warnings).
- `CI=true swift test --no-parallel` — **1600 tests / 131 suites pass** (~29s; headless video-output and playback-race suites self-skip per the CI mirror).
- iOS/tvOS-simulator slices and the sanitizer jobs run in repo CI. PiP is force-disabled in the simulator, so PiP acceptance is device-only.

## Notes

- Ships the libVLC build patches (`0003`, `0004`) that the pinned binary depends on. The one-off PiP proof/benchmark harnesses under `scripts/` are intentionally excluded from this PR.
