### PR TITLE
Prepare SwiftVLC 1.0.0

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,7 +81,7 @@ flowchart TB
 
 | Component | Choice | Why |
 |---|---|---|
-| **Language** | Swift 6.3+ | Strict concurrency, typed throws, `@Observable`, upcoming feature flags |
+| **Language** | Swift 6.3+ with Xcode 26.4+ | Strict concurrency, typed throws, `@Observable`, upcoming feature flags |
 | **C Bindings** | libVLC 4.0 C API | Direct access, no Objective-C overhead |
 | **State** | `@Observable` / `@MainActor` | Automatic SwiftUI integration, thread safety |
 | **Events** | `AsyncStream<PlayerEvent>` | Native structured concurrency, multi-consumer |
@@ -89,7 +89,7 @@ flowchart TB
 | **PiP** | iOS `PiPVideoView`: native drawable; direct controller: vmem → `AVSampleBufferDisplayLayer`; macOS view: native drawable behind SPI | Public iOS PiP, a public direct sample-buffer route, plus explicit private-API macOS opt-in |
 | **Thread Safety** | `Mutex<T>`, `Sendable`, `nonisolated(unsafe)` | Compile-time data race prevention |
 | **Testing** | Swift Testing framework | Modern `@Test`, `#expect`, tags, traits |
-| **Platforms** | iOS 18+, macOS 15+, tvOS 18+, visionOS 2+, Mac Catalyst | Unified SwiftUI minimum |
+| **Platforms** | iOS 18+, macOS 15+, tvOS 18+, visionOS 2+, Mac Catalyst 18+ | Unified SwiftUI minimum |
 
 ---
 
@@ -122,7 +122,7 @@ The central observable type that drives all playback.
 | `Player+Audio.swift` | `extension Player` | Audio-output device selection, role, mix mode, stereo mode. |
 | `Player+Chapters.swift` | `extension Player` | Title/chapter navigation, DVD menu actions. |
 | `Player+ABLoop.swift` | `extension Player` | A-B loop state plus checked time/position mutations. |
-| `Player+Programs.swift` | `extension Player` | DVB/MPEG-TS program selection and scrambled-state polling. |
+| `Player+Programs.swift` | `extension Player` | DVB/MPEG-TS program selection, renderer targeting, mid-playback `recast(to:)`, and scrambled-state polling. |
 | `Player+Recording.swift` | `extension Player` | Snapshot capture and recording start/stop. |
 | `Player+Overlays.swift` | `extension Player` | Scoped `withMarquee`/`withLogo`/`withAdjustments` accessors for the `~Copyable ~Escapable` overlay types. |
 | `Player+Typed.swift` | `extension Player` | Typed read-only accessors for raw `position`/`volume`/`rate`/`subtitleTextScale`, plus explicit checked mutation methods such as `setPlaybackRate(_:)`. |
@@ -151,7 +151,7 @@ player.subtitleTracks     // [Track]
 
 // Playback observations
 player.position           // Double (0.0–1.0), read-only
-player.volume             // Float (0.0–1.25), read-only requested volume shadow
+player.volume             // Float (0.0–2.0), read-only requested volume shadow
 player.rate               // Float (current libVLC rate), read-only
 player.audioDelay         // Duration, read-only
 player.subtitleDelay      // Duration, read-only
@@ -656,9 +656,9 @@ iOS device with the `audio` background mode enabled.
 
 ## Error Handling
 
-### Typed Throws
+### Typed Library Errors
 
-All throwing operations use `throws(VLCError)`:
+Operations that introduce a SwiftVLC failure use `throws(VLCError)`:
 
 ```swift
 func play() throws(VLCError) {
@@ -672,6 +672,10 @@ func parse(timeout: Duration) async throws(VLCError) -> Metadata {
   throw .parseTimeout
 }
 ```
+
+Scoped closure APIs such as `withAdjustments`, `withMarquee`, `withLogo`,
+and `MediaList.withLocked` use `rethrows`. They introduce no library
+failure and propagate an error thrown by the caller's closure unchanged.
 
 ### Error Cases
 
@@ -795,7 +799,7 @@ The Showcase apps follow the same split: published states pin `SwiftVLC` by exac
 ```mermaid
 flowchart LR
     BUILD["build-libvlc.sh --all"] --> XCF["Vendor/libvlc.xcframework<br/>(unstripped)"]
-    XCF --> RELEASE["release.sh vX.Y.Z"]
+    XCF --> RELEASE["release.sh X.Y.Z"]
     RELEASE --> VERIFY["Verify all required slices present"]
     VERIFY --> STRIP["strip -S"]
     STRIP --> ZIP["ditto -c -k"]
@@ -810,12 +814,18 @@ flowchart LR
 
 Preflight refuses releases from non-`main` branches, uncommitted changes in `Package.swift` or the Showcase project, pre-existing local or remote tags, and unauthenticated `gh`. If a pre-commit rewrite or post-write sanity check fails, the script restores `Package.swift` and the Showcase project before exiting. The tag is pushed before `main`, so if GitHub Release creation fails, `origin/main` still points at the previous good release; finish the release or delete the tag before retrying. A post-write regex guard verifies that the rewritten `Package.swift` still contains the `CLibVLC` target, catching a malformed replacement before the tag is cut.
 
+After publishing a tag, verify that Swift Package Index has completed its
+asynchronous documentation build and that the unversioned documentation URL
+resolves to the new release rather than the preceding tag.
+
 ### CI/CD
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
 | `test.yml` | Push to `main` / PR | Lints sources, builds all Showcase schemes, runs package tests with coverage, and checks public API doc coverage. |
 | `sanitize.yml` | Push to `main`, selected PR paths, weekly schedule | Runs race, stress, memory, and lifecycle tests under Thread Sanitizer and Address Sanitizer. |
+| `fixtures.yml` | Push to `main` / selected PR paths | Builds the layered dynamic-host fixtures and verifies that applications load exactly one copy of libVLC. |
+| `vendor-manifest.yml` | Push to `main` / binary-manifest PR paths | Verifies every xcframework slice against its checked-in archive-member manifest. |
 | `claude.yml` | Issue comment / PR mention | Claude Code bot integration. |
 
 ---
@@ -862,12 +872,15 @@ SwiftVLC/
 │   ├── release.sh                        # Cut a versioned release and advance main
 │   ├── fix-duplicate-symbols.sh          # Localize duplicate json symbols
 │   ├── ci-use-released-xcframework.sh    # CI: point Package.swift at latest release
-│   └── ci-run-with-timeouts.py           # CI: wall-clock + idle test timeouts
+│   ├── ci-run-with-timeouts.py           # CI: wall-clock + idle test timeouts
+│   └── patches/                           # Ordered VLC source patches applied by the build
 │
 ├── .github/workflows/
-│   ├── test.yml                   # CI test runner
-│   ├── sanitize.yml               # Sanitizer test runner
-│   └── claude.yml                 # Claude Code bot integration
+│   ├── test.yml                    # CI test runner
+│   ├── sanitize.yml                # Sanitizer test runner
+│   ├── fixtures.yml                # Layered-consumer single-copy gate
+│   ├── vendor-manifest.yml         # XCFramework archive-member gate
+│   └── claude.yml                  # Claude Code bot integration
 │
 ├── Package.swift                  # SPM manifest (Swift 6.3+)
 ├── .swiftlint.yml                # Lint configuration

--- a/Package.swift
+++ b/Package.swift
@@ -16,11 +16,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3")
   ],
   targets: [
-    .binaryTarget(
-      name: "libvlc",
-      url: "https://github.com/harflabs/SwiftVLC/releases/download/v0.10.1/libvlc.xcframework.zip",
-      checksum: "b3a318c3068e2567c5533f6da5c79f4ac10c16cc60b8b8402e52e8ec3c9f3c03"
-    ),
+    .binaryTarget(name: "libvlc", path: "Vendor/libvlc.xcframework"),
     .target(
       name: "CLibVLC",
       dependencies: ["libvlc"],

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ VideoLAN's Apple wrapper, [VLCKit](https://code.videolan.org/videolan/VLCKit), i
 | **State management** | `@Observable`, drives SwiftUI directly | KVO, `NSNotificationCenter`, and delegates |
 | **Concurrency** | `@MainActor`, `Sendable`, `async/await` | Manual thread dispatch, no isolation |
 | **Video rendering** | `VideoView(player)` | App-supplied view setup plus drawable configuration |
-| **Errors** | `throws(VLCError)`, typed and exhaustive | `NSError` codes |
+| **Errors** | Library failures use `throws(VLCError)`, typed and exhaustive | `NSError` codes |
 | **Events** | `AsyncStream<PlayerEvent>` with multiple consumers | `NSNotificationCenter` |
 | **libVLC generation** | 4.0 | 3.x stable line; 4.0 alpha packages exist |
 | **SwiftUI PiP** | iOS via libVLC's native AVKit-backed drawable path; macOS private backend is SPI opt-in | App-supplied integration |
@@ -43,7 +43,7 @@ VideoLAN's Apple wrapper, [VLCKit](https://code.videolan.org/videolan/VLCKit), i
 
 - `@Observable` player: state, current time, duration, tracks, and volume drive SwiftUI directly.
 - `VideoView(player)` handles the rendering lifecycle in a single SwiftUI view.
-- Typed errors via `throws(VLCError)` instead of error codes.
+- Library failures use typed `throws(VLCError)` instead of error codes.
 - Asynchronous media parsing: `try await media.parse()` with cancellation support.
 - 10-band equalizer with libVLC's built-in presets.
 - A-B looping, playback rate control, and subtitle and audio delay.
@@ -55,7 +55,7 @@ VideoLAN's Apple wrapper, [VLCKit](https://code.videolan.org/videolan/VLCKit), i
 
 ## Requirements
 
-- Swift 6.3+ / Xcode 26+
+- Swift 6.3+ / Xcode 26.4+
 - iOS 18+ / macOS 15+ / tvOS 18+ / visionOS 2+ / Mac Catalyst 18+
 
 ## Installation
@@ -72,7 +72,7 @@ current release. The version string lives on the
 [releases page](https://github.com/harflabs/SwiftVLC/releases).
 
 ```swift
-.package(url: "https://github.com/harflabs/SwiftVLC.git", from: "x.y.z")
+.package(url: "https://github.com/harflabs/SwiftVLC.git", from: "1.0.0")
 ```
 
 The pre-built libVLC xcframework downloads automatically via SPM. It's a large binary (multi-GB unstripped; the release zip is a few hundred MB).
@@ -135,7 +135,9 @@ for await event in player.events {
 
 ## Documentation
 
-Full API reference is hosted on Swift Package Index:
+The API reference for the latest published release is hosted on Swift Package
+Index. The unversioned link follows the most recent tag that the service has
+finished building:
 **[swiftpackageindex.com/harflabs/swiftvlc/documentation](https://swiftpackageindex.com/harflabs/swiftvlc/documentation)**
 
 ## Showcase Apps
@@ -146,6 +148,22 @@ The `Showcase/` directory contains separate folders, targets, and schemes for ea
 - **macOS.** Native macOS app target with the same showcase coverage, adapted into sidebar-driven Mac UI.
 - **tvOS.** Native tvOS showcase app target with TV-focused focus navigation and Siri Remote controls.
 - **visionOS.** Native visionOS app target with a focused simple playback showcase.
+
+Every showcase target accepts an app-wide test stream URL. The override is
+kept in memory for the current app session, redacted to its scheme, host, and a
+hidden path in the UI, and used by showcases that otherwise load bundled or
+public sample media. HTTP, HTTPS, HLS, RTSP, UDP, and other URL schemes
+supported by VLC are accepted.
+
+- **iOS and Mac Catalyst:** open **Set App-Wide Stream URL** in the **Test Stream** section on the first screen.
+- **macOS:** use **Test Stream** in the toolbar or **Test Stream URL** in the sidebar's **Configuration** section.
+- **tvOS:** select **Set App-Wide Stream URL** on the first screen and enter the URL with the on-screen keyboard or a paired device.
+- **visionOS:** use the **Test Stream** button beside the simple playback controls.
+
+The development showcase targets allow arbitrary network loads so user-entered
+HTTP hosts work with libVLC. This broad App Transport Security exception is for
+the Showcase apps only. Applications embedding SwiftVLC should define the
+narrowest transport policy appropriate for their own media sources.
 
 Showcase UI tests live under `Showcase/UITests/`. `iOSUITests` covers
 the broad showcase flows, `macOSUITests` covers native macOS PiP, and
@@ -210,9 +228,10 @@ Expect a full `--all` build to take tens of minutes on Apple Silicon. The script
 
 > `*-only` flags **replace** the xcframework; any slices already in `Vendor/` are lost.
 
-### Source patches
+### Build adjustments and source patches
 
-VLC master requires a few local patches for SwiftVLC's supported Apple toolchains. The script applies them in-tree on every invocation, idempotently:
+VLC master requires several build adjustments for SwiftVLC's supported Apple
+toolchains. The script applies them in-tree on every invocation, idempotently:
 
 1. **Mac Catalyst.** Teaches VLC's build system the `macabi` target triple and guards OpenGLES-only code paths.
 2. **visionOS deployment target.** Adds the `xros` target triple so object files are stamped with visionOS 2.0 instead of the installed SDK version.
@@ -220,6 +239,15 @@ VLC master requires a few local patches for SwiftVLC's supported Apple toolchain
 4. **libtool 2.5 OBJC tag.** Adds `_LIBTOOLFLAGS = --tag=CC` to the `Makefile.am` files that contain `.m` sources. Older libtool versions inferred the tag; 2.5 refuses.
 5. **Rust contribs disabled.** VLC's contribs pin `cargo-c 0.9.29`, which pulls `time 0.3.31` and fails type inference under the supported Rust toolchain. The only Rust contrib on Apple is `rav1e` (AV1 *encoder*); `dav1d` handles decoding.
 6. **`dup3` / `pipe2`.** Forced unavailable via autoconf cache vars. iOS Simulator SDK 26 exports these Linux-only syscalls from libSystem, fooling configure into using them.
+
+The script also applies these checked-in VLC source patches in order:
+
+1. **[Chromecast hardening](scripts/patches/0001-chromecast-hardening.patch).** Enables the supported subtitle burn-in path and rejects unreachable receivers cleanly instead of routing playback into a dead cast session.
+2. **[Sample-buffer aspect handling](scripts/patches/0002-samplebufferdisplay-aspect.patch).** Maps VLC fitting modes to the correct layer gravity and avoids OpenGLES-only configuration on Mac Catalyst.
+3. **[Sample-buffer lifetime and placement](scripts/patches/0003-samplebufferdisplay-lifetime-placement.patch).** Backports upstream fixes that detach the display view from the vout lifetime and keep native placement updates consistent.
+4. **[PiP safety and geometry](scripts/patches/0004-samplebuffer-pip-safety-geometry.patch).** Adds the retained media snapshots and pixel-buffer bridge used to keep asynchronous PiP frame delivery and geometry safe.
+5. **[UPnP initialization teardown](scripts/patches/0005-upnp-init-failure-teardown.patch).** Balances cleanup only for initialization stages that completed, preventing a failed UPnP startup from hanging during teardown.
+6. **[MP4 roll seek point](scripts/patches/0006-mp4-roll-seek-point.patch).** Keeps AAC decoder preroll metadata from resetting an MP4 seek to the start of the stream.
 
 `git reset --hard` only runs when HEAD is not at `VLC_HASH`, so the patches and per-platform build dirs survive repeated runs.
 
@@ -245,6 +273,11 @@ What `release.sh` does:
 8. Pushes `main` to the same commit, so `main` always references the latest published xcframework and Showcase package version.
 
 Preflight refuses non-`main` branches, uncommitted changes in `Package.swift` or the Showcase project, pre-existing local or remote tags, and unauthenticated `gh`. If a pre-commit rewrite fails, the script restores `Package.swift` and the Showcase project before exiting. If the tag push succeeds but a later step fails, `origin/main` is still untouched; finish the GitHub Release (or delete the tag) before retrying.
+
+After publication, verify that Swift Package Index has finished building the
+tagged API reference and that the unversioned documentation link above resolves
+to `1.0.0`. Its documentation build is asynchronous and may temporarily serve
+the previous release while the new tag is queued.
 
 ## Architecture
 

--- a/Showcase/Shared/AccessibilityID.swift
+++ b/Showcase/Shared/AccessibilityID.swift
@@ -14,6 +14,16 @@ enum AccessibilityID {
     }
   }
 
+  enum TestStream {
+    static let settingsLink = "testStream.settings"
+    static let urlField = "testStream.url"
+    static let pasteButton = "testStream.paste"
+    static let applyButton = "testStream.apply"
+    static let clearButton = "testStream.clear"
+    static let currentValue = "testStream.current"
+    static let validationError = "testStream.validationError"
+  }
+
   enum MusicPlayer {
     static let playPauseButton = "music.playPause"
     static let currentTime = "music.currentTime"

--- a/Showcase/Shared/TestStreamURL.swift
+++ b/Showcase/Shared/TestStreamURL.swift
@@ -1,11 +1,14 @@
 import Foundation
 import SwiftUI
+import Synchronization
 
 enum TestStreamURL {
-  static let defaultsKey = "ShowcaseTestStreamURL"
+  static let revisionDefaultsKey = "ShowcaseTestStreamRevision"
+  private static let legacyDefaultsKey = "ShowcaseTestStreamURL"
+  private static let storage = Mutex(Storage())
 
   static var storedString: String {
-    UserDefaults.standard.string(forKey: defaultsKey) ?? ""
+    storage.withLock { $0.value }
   }
 
   static var overrideURL: URL? {
@@ -16,6 +19,37 @@ enum TestStreamURL {
     LaunchArguments.fixtureURLValue ?? overrideURL ?? fallback()
   }
 
+  static func startSession() {
+    let isFirstStart = storage.withLock { storage -> Bool in
+      guard !storage.didStart else { return false }
+      storage.didStart = true
+      storage.value = ""
+      return true
+    }
+    guard isFirstStart else { return }
+    UserDefaults.standard.removeObject(forKey: legacyDefaultsKey)
+    UserDefaults.standard.removeObject(forKey: revisionDefaultsKey)
+  }
+
+  static func store(_ value: String) {
+    storage.withLock { $0.value = value }
+    publishChange()
+  }
+
+  static func clear() {
+    storage.withLock { $0.value = "" }
+    publishChange()
+  }
+
+  static func displayString(for url: URL) -> String {
+    guard let scheme = url.scheme else { return "Configured stream" }
+    guard let host = url.host, !host.isEmpty else { return "\(scheme.uppercased()) stream" }
+    let displayHost = host.contains(":") ? "[\(host)]" : host
+    let port = url.port.map { ":\($0)" } ?? ""
+    let path = url.path.isEmpty || url.path == "/" ? "" : "/…"
+    return "\(scheme)://\(displayHost)\(port)\(path)"
+  }
+
   static func validatedURL(from value: String) -> (url: URL, string: String)? {
     let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
     guard
@@ -24,6 +58,15 @@ enum TestStreamURL {
       !scheme.isEmpty
     else { return nil }
     return (url, trimmed)
+  }
+
+  private static func publishChange() {
+    UserDefaults.standard.set(UUID().uuidString, forKey: revisionDefaultsKey)
+  }
+
+  private struct Storage: Sendable {
+    var value = ""
+    var didStart = false
   }
 }
 
@@ -65,12 +108,12 @@ struct TestStreamSettingsView: View {
       } header: {
         Text("Stream URL")
       } footer: {
-        Text("The override is used throughout this Showcase for bundled media and public test streams. HTTP, HLS, RTSP, UDP, and other VLC-supported URL schemes are accepted.")
+        Text("The override is used throughout this Showcase and kept only until the app closes. HTTP, HLS, RTSP, UDP, and other VLC-supported URL schemes are accepted.")
       }
 
       Section("Current Source") {
         if let url = TestStreamURL.overrideURL {
-          LabeledContent("Override", value: url.absoluteString)
+          LabeledContent("Override", value: TestStreamURL.displayString(for: url))
             .accessibilityIdentifier(AccessibilityID.TestStream.currentValue)
         } else {
           LabeledContent("Source", value: "Default showcase media")
@@ -104,12 +147,12 @@ struct TestStreamSettingsView: View {
       validationError = "Enter a complete URL that includes a scheme."
       return
     }
-    UserDefaults.standard.set(validated.string, forKey: TestStreamURL.defaultsKey)
+    TestStreamURL.store(validated.string)
     dismiss()
   }
 
   private func useDefaultsButtonTapped() {
-    UserDefaults.standard.removeObject(forKey: TestStreamURL.defaultsKey)
+    TestStreamURL.clear()
     dismiss()
   }
 }

--- a/Showcase/Shared/TestStreamURL.swift
+++ b/Showcase/Shared/TestStreamURL.swift
@@ -1,0 +1,115 @@
+import Foundation
+import SwiftUI
+
+enum TestStreamURL {
+  static let defaultsKey = "ShowcaseTestStreamURL"
+
+  static var storedString: String {
+    UserDefaults.standard.string(forKey: defaultsKey) ?? ""
+  }
+
+  static var overrideURL: URL? {
+    validatedURL(from: storedString)?.url
+  }
+
+  static func resolve(fallback: @autoclosure () -> URL) -> URL {
+    LaunchArguments.fixtureURLValue ?? overrideURL ?? fallback()
+  }
+
+  static func validatedURL(from value: String) -> (url: URL, string: String)? {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard
+      let url = URL(string: trimmed),
+      let scheme = url.scheme,
+      !scheme.isEmpty
+    else { return nil }
+    return (url, trimmed)
+  }
+}
+
+struct TestStreamSettingsView: View {
+  @Environment(\.dismiss) private var dismiss
+  @State private var draftURL: String
+  @State private var validationError: String?
+
+  init() {
+    _draftURL = State(initialValue: TestStreamURL.storedString)
+  }
+
+  var body: some View {
+    Form {
+      Section {
+        HStack {
+          TextField("https://example.com/live.m3u8", text: $draftURL)
+            .font(.body.monospaced())
+            .accessibilityIdentifier(AccessibilityID.TestStream.urlField)
+
+          #if os(iOS) || os(macOS) || os(visionOS)
+          PasteButton(payloadType: String.self) { values in
+            guard let value = values.first else { return }
+            draftURL = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            validationError = nil
+          }
+          .labelStyle(.iconOnly)
+          .accessibilityLabel("Paste URL")
+          .accessibilityIdentifier(AccessibilityID.TestStream.pasteButton)
+          #endif
+        }
+
+        if let validationError {
+          Label(validationError, systemImage: "exclamationmark.triangle.fill")
+            .font(.footnote)
+            .foregroundStyle(.red)
+            .accessibilityIdentifier(AccessibilityID.TestStream.validationError)
+        }
+      } header: {
+        Text("Stream URL")
+      } footer: {
+        Text("The override is used throughout this Showcase for bundled media and public test streams. HTTP, HLS, RTSP, UDP, and other VLC-supported URL schemes are accepted.")
+      }
+
+      Section("Current Source") {
+        if let url = TestStreamURL.overrideURL {
+          LabeledContent("Override", value: url.absoluteString)
+            .accessibilityIdentifier(AccessibilityID.TestStream.currentValue)
+        } else {
+          LabeledContent("Source", value: "Default showcase media")
+            .accessibilityIdentifier(AccessibilityID.TestStream.currentValue)
+        }
+
+        if TestStreamURL.overrideURL != nil {
+          Button("Use Default Showcase Media", role: .destructive) {
+            useDefaultsButtonTapped()
+          }
+          .accessibilityIdentifier(AccessibilityID.TestStream.clearButton)
+        }
+      }
+    }
+    .navigationTitle("Test Stream")
+    .toolbar {
+      ToolbarItem(placement: .cancellationAction) {
+        Button("Cancel", role: .cancel) { dismiss() }
+      }
+
+      ToolbarItem(placement: .confirmationAction) {
+        Button("Use Stream") { useStreamButtonTapped() }
+          .disabled(draftURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+          .accessibilityIdentifier(AccessibilityID.TestStream.applyButton)
+      }
+    }
+  }
+
+  private func useStreamButtonTapped() {
+    guard let validated = TestStreamURL.validatedURL(from: draftURL) else {
+      validationError = "Enter a complete URL that includes a scheme."
+      return
+    }
+    UserDefaults.standard.set(validated.string, forKey: TestStreamURL.defaultsKey)
+    dismiss()
+  }
+
+  private func useDefaultsButtonTapped() {
+    UserDefaults.standard.removeObject(forKey: TestStreamURL.defaultsKey)
+    dismiss()
+  }
+}

--- a/Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj
+++ b/Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj
@@ -55,13 +55,34 @@
 			);
 			target = B5000001 /* iOS */;
 		};
+		C10000000000000000000001 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = B5000002 /* macOS */;
+		};
+		C10000000000000000000002 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = B5000003 /* tvOS */;
+		};
+		C10000000000000000000003 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = B5000004 /* visionOS */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		B4000002 /* iOS */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (07E764A82F965C6100828E69 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = iOS; sourceTree = "<group>"; };
-		B4000004 /* macOS */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = macOS; sourceTree = "<group>"; };
-		B4000005 /* tvOS */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = tvOS; sourceTree = "<group>"; };
-		B4000006 /* visionOS */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = visionOS; sourceTree = "<group>"; };
+		B4000004 /* macOS */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (C10000000000000000000001 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = macOS; sourceTree = "<group>"; };
+		B4000005 /* tvOS */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (C10000000000000000000002 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = tvOS; sourceTree = "<group>"; };
+		B4000006 /* visionOS */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (C10000000000000000000003 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = visionOS; sourceTree = "<group>"; };
 		B4000010 /* Shared */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Shared; sourceTree = "<group>"; };
 		B4000011 /* iOS */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = iOS; sourceTree = "<group>"; };
 		B4000013 /* macOS */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = macOS; sourceTree = "<group>"; };
@@ -339,7 +360,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 2600;
-				LastUpgradeCheck = 2640;
+				LastUpgradeCheck = 2660;
 				TargetAttributes = {
 					B5000010 = {
 						TestTargetID = B5000001;
@@ -363,7 +384,7 @@
 			mainGroup = B4000001;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				BA000001 /* XCRemoteSwiftPackageReference "SwiftVLC" */,
+				BA000001 /* XCLocalSwiftPackageReference ".." */,
 			);
 			productRefGroup = B4000003 /* Products */;
 			projectDirPath = "";
@@ -718,6 +739,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = macOS/Info.plist;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.swiftvlc.showcase.macos;
@@ -738,6 +760,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = macOS/Info.plist;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.swiftvlc.showcase.macos;
@@ -756,6 +779,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = tvOS/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				MARKETING_VERSION = 1.0;
@@ -777,6 +801,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = tvOS/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				MARKETING_VERSION = 1.0;
@@ -799,6 +824,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = visionOS/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				MARKETING_VERSION = 1.0;
@@ -821,6 +847,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = visionOS/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				MARKETING_VERSION = 1.0;
@@ -993,21 +1020,17 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		BA000001 /* XCRemoteSwiftPackageReference "SwiftVLC" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/harflabs/SwiftVLC";
-			requirement = {
-				kind = exactVersion;
-				version = 0.10.1;
-			};
+/* Begin XCLocalSwiftPackageReference section */
+		BA000001 /* XCLocalSwiftPackageReference ".." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ..;
 		};
-/* End XCRemoteSwiftPackageReference section */
+/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		B8000001 /* SwiftVLC */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BA000001 /* XCRemoteSwiftPackageReference "SwiftVLC" */;
+			package = BA000001 /* XCLocalSwiftPackageReference ".." */;
 			productName = SwiftVLC;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Showcase/SwiftVLCShowcase.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
+++ b/Showcase/SwiftVLCShowcase.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2640"
+   LastUpgradeVersion = "2660"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Showcase/SwiftVLCShowcase.xcodeproj/xcshareddata/xcschemes/macOS.xcscheme
+++ b/Showcase/SwiftVLCShowcase.xcodeproj/xcshareddata/xcschemes/macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2640"
+   LastUpgradeVersion = "2660"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Showcase/SwiftVLCShowcase.xcodeproj/xcshareddata/xcschemes/tvOS.xcscheme
+++ b/Showcase/SwiftVLCShowcase.xcodeproj/xcshareddata/xcschemes/tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2640"
+   LastUpgradeVersion = "2660"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Showcase/SwiftVLCShowcase.xcodeproj/xcshareddata/xcschemes/visionOS.xcscheme
+++ b/Showcase/SwiftVLCShowcase.xcodeproj/xcshareddata/xcschemes/visionOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2640"
+   LastUpgradeVersion = "2660"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Showcase/UITests/iOS/Tests/TestStreamSettingsUITests.swift
+++ b/Showcase/UITests/iOS/Tests/TestStreamSettingsUITests.swift
@@ -1,7 +1,7 @@
 import XCTest
 
 final class TestStreamSettingsUITests: ShowcaseIOSTestCase {
-  func test_streamURLPersistsAndCanBeCleared() {
+  func test_streamURLStaysInSessionAndCanBeCleared() {
     launchAtRoot()
     openSettings()
 
@@ -32,6 +32,26 @@ final class TestStreamSettingsUITests: ShowcaseIOSTestCase {
     XCTAssertTrue(
       app.buttons[AccessibilityID.TestStream.settingsLink].waitForExistence(timeout: 5)
     )
+
+    openSettings()
+    XCTAssertNotEqual(
+      app.textFields[AccessibilityID.TestStream.urlField].value as? String,
+      streamURL
+    )
+
+    let urlFieldAfterClear = app.textFields[AccessibilityID.TestStream.urlField]
+    urlFieldAfterClear.tap()
+    urlFieldAfterClear.typeText(streamURL)
+    app.buttons[AccessibilityID.TestStream.applyButton].tap()
+
+    app.terminate()
+    app.launch()
+    openSettings()
+    XCTAssertNotEqual(
+      app.textFields[AccessibilityID.TestStream.urlField].value as? String,
+      streamURL
+    )
+    XCTAssertFalse(app.buttons[AccessibilityID.TestStream.clearButton].exists)
   }
 
   private func openSettings() {

--- a/Showcase/UITests/iOS/Tests/TestStreamSettingsUITests.swift
+++ b/Showcase/UITests/iOS/Tests/TestStreamSettingsUITests.swift
@@ -1,0 +1,45 @@
+import XCTest
+
+final class TestStreamSettingsUITests: ShowcaseIOSTestCase {
+  func test_streamURLPersistsAndCanBeCleared() {
+    launchAtRoot()
+    openSettings()
+
+    let clearButton = app.buttons[AccessibilityID.TestStream.clearButton]
+    if clearButton.exists {
+      clearButton.tap()
+      openSettings()
+    }
+
+    let streamURL = "http://example.com/live/test.m3u8"
+    let urlField = app.textFields[AccessibilityID.TestStream.urlField]
+    XCTAssertTrue(urlField.waitForExistence(timeout: 5))
+    urlField.tap()
+    urlField.typeText(streamURL)
+
+    let applyButton = app.buttons[AccessibilityID.TestStream.applyButton]
+    XCTAssertTrue(applyButton.isEnabled)
+    applyButton.tap()
+
+    openSettings()
+    XCTAssertEqual(
+      app.textFields[AccessibilityID.TestStream.urlField].value as? String,
+      streamURL
+    )
+
+    XCTAssertTrue(clearButton.waitForExistence(timeout: 5))
+    clearButton.tap()
+    XCTAssertTrue(
+      app.buttons[AccessibilityID.TestStream.settingsLink].waitForExistence(timeout: 5)
+    )
+  }
+
+  private func openSettings() {
+    let settingsLink = app.buttons[AccessibilityID.TestStream.settingsLink]
+    XCTAssertTrue(settingsLink.waitForExistence(timeout: 5))
+    settingsLink.tap()
+    XCTAssertTrue(
+      app.textFields[AccessibilityID.TestStream.urlField].waitForExistence(timeout: 5)
+    )
+  }
+}

--- a/Showcase/UITests/macOS/PiPUITests.swift
+++ b/Showcase/UITests/macOS/PiPUITests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import AVKit
 import XCTest
 
@@ -18,7 +19,7 @@ private enum MacDeinterlaceAccessibilityID {
 
 @MainActor
 final class MacOSPiPUITests: XCTestCase {
-  func test_startPiPButtonStartsPiPWhenSystemSupportsPiP() throws {
+  func test_closingPiPRestoresInlineVideo() throws {
     guard AVPictureInPictureController.isPictureInPictureSupported() else {
       throw XCTSkip("macOS Picture in Picture is not supported in this environment.")
     }
@@ -26,14 +27,17 @@ final class MacOSPiPUITests: XCTestCase {
     let app = XCUIApplication()
     app.launchArguments += [
       "-UITestMode", "YES",
-      "-UITestRoute", "PiP",
-      "-UITestFixtureURL", Self.fixtureURL.path
+      "-UITestRoute", "PiP"
     ]
     app.launch()
     defer { app.terminate() }
 
     let toggleButton = app.buttons["macos.pip.toggle"]
     XCTAssertTrue(toggleButton.waitForExistence(timeout: 10), "Start PiP button never appeared.")
+
+    let videoSurface = app.descendants(matching: .any)["macos.pip.video"]
+    XCTAssertTrue(videoSurface.waitForExistence(timeout: 10), "Inline video surface never appeared.")
+    waitForRenderedVideo(in: videoSurface, timeout: 15)
 
     let enabled = NSPredicate(format: "isEnabled == true")
     expectation(for: enabled, evaluatedWith: toggleButton)
@@ -43,17 +47,84 @@ final class MacOSPiPUITests: XCTestCase {
 
     let activeValue = app.staticTexts["macos.pip.active.value"]
     XCTAssertTrue(activeValue.waitForExistence(timeout: 5), "PiP active status never appeared.")
+    waitForText(activeValue, equals: "Yes", timeout: 10)
 
-    let active = NSPredicate(format: "label == %@", "Yes")
-    expectation(for: active, evaluatedWith: activeValue)
-    waitForExpectations(timeout: 10)
+    app.activate()
+    toggleButton.click()
+
+    waitForText(activeValue, equals: "No", timeout: 10)
+    waitForRenderedVideo(in: videoSurface, timeout: 15)
   }
 
-  private static var fixtureURL: URL {
-    URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .appendingPathComponent("iOS/Fixtures/test.mp4")
+  private func waitForText(
+    _ element: XCUIElement,
+    equals expected: String,
+    timeout: TimeInterval,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    let predicate = NSPredicate { _, _ in self.accessibleText(of: element) == expected }
+    let exp = expectation(for: predicate, evaluatedWith: NSObject())
+    if XCTWaiter.wait(for: [exp], timeout: timeout) != .completed {
+      XCTFail(
+        "Expected text '\(expected)' but found '\(accessibleText(of: element))' after \(timeout)s",
+        file: file,
+        line: line
+      )
+    }
+  }
+
+  private func accessibleText(of element: XCUIElement) -> String {
+    if let value = element.value as? String, !value.isEmpty {
+      return value
+    }
+    return element.label
+  }
+
+  private func waitForRenderedVideo(
+    in element: XCUIElement,
+    timeout: TimeInterval,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    let deadline = Date().addingTimeInterval(timeout)
+    repeat {
+      if renderedPixelRatio(in: element) >= 0.02 {
+        return
+      }
+      RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+    } while Date() < deadline
+
+    XCTFail("Video surface remained black after \(timeout)s", file: file, line: line)
+  }
+
+  private func renderedPixelRatio(in element: XCUIElement) -> Double {
+    let image = element.screenshot().image
+    guard
+      let data = image.tiffRepresentation,
+      let bitmap = NSBitmapImageRep(data: data),
+      bitmap.pixelsWide > 0,
+      bitmap.pixelsHigh > 0
+    else { return 0 }
+
+    let insetX = max(bitmap.pixelsWide / 12, 1)
+    let insetY = max(bitmap.pixelsHigh / 12, 1)
+    let stepX = max((bitmap.pixelsWide - insetX * 2) / 48, 1)
+    let stepY = max((bitmap.pixelsHigh - insetY * 2) / 27, 1)
+    var rendered = 0
+    var samples = 0
+
+    for y in stride(from: insetY, to: bitmap.pixelsHigh - insetY, by: stepY) {
+      for x in stride(from: insetX, to: bitmap.pixelsWide - insetX, by: stepX) {
+        guard let color = bitmap.colorAt(x: x, y: y)?.usingColorSpace(.deviceRGB) else { continue }
+        samples += 1
+        if max(color.redComponent, color.greenComponent, color.blueComponent) > 0.12 {
+          rendered += 1
+        }
+      }
+    }
+
+    return samples == 0 ? 0 : Double(rendered) / Double(samples)
   }
 }
 

--- a/Showcase/UITests/macOS/PiPUITests.swift
+++ b/Showcase/UITests/macOS/PiPUITests.swift
@@ -27,7 +27,8 @@ final class MacOSPiPUITests: XCTestCase {
     let app = XCUIApplication()
     app.launchArguments += [
       "-UITestMode", "YES",
-      "-UITestRoute", "PiP"
+      "-UITestRoute", "PiP",
+      "-UITestFixtureURL", Self.fixtureURL.path
     ]
     app.launch()
     defer { app.terminate() }
@@ -54,6 +55,13 @@ final class MacOSPiPUITests: XCTestCase {
 
     waitForText(activeValue, equals: "No", timeout: 10)
     waitForRenderedVideo(in: videoSurface, timeout: 15)
+  }
+
+  private static var fixtureURL: URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("iOS/Fixtures/test.mp4")
   }
 
   private func waitForText(

--- a/Showcase/iOS/Apps/MusicPlayer/MusicPlayerApp.swift
+++ b/Showcase/iOS/Apps/MusicPlayer/MusicPlayerApp.swift
@@ -13,11 +13,13 @@ struct MusicPlayerApp: View {
     return Self.defaultLibrary
   }
 
-  private static let defaultLibrary: [Song] = [
-    Song(id: "showcase-reel", title: "Showcase Reel", artist: "SwiftVLC", url: TestMedia.demo),
-    Song(id: "big-buck-bunny", title: "Big Buck Bunny", artist: "Blender Foundation", url: TestMedia.bigBuckBunny),
-    Song(id: "hls-test-stream", title: "HLS test stream", artist: "Mux", url: TestMedia.hls)
-  ]
+  private static var defaultLibrary: [Song] {
+    [
+      Song(id: "showcase-reel", title: "Showcase Reel", artist: "SwiftVLC", url: TestMedia.demo),
+      Song(id: "big-buck-bunny", title: "Big Buck Bunny", artist: "Blender Foundation", url: TestMedia.bigBuckBunny),
+      Song(id: "hls-test-stream", title: "HLS test stream", artist: "Mux", url: TestMedia.hls)
+    ]
+  }
 
   var body: some View {
     List(library) { song in

--- a/Showcase/iOS/Info.plist
+++ b/Showcase/iOS/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<!-- Required by this development showcase's arbitrary user-entered HTTP streams.
+	     NSAllowsArbitraryLoadsForMedia only applies to AVFoundation, not libVLC. -->
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/Showcase/iOS/Internal/RootView.swift
+++ b/Showcase/iOS/Internal/RootView.swift
@@ -14,6 +14,20 @@ struct RootView: View {
 
   private var rootForm: some View {
     Form {
+      Section("Test Stream") {
+        NavigationLink {
+          TestStreamSettingsView()
+        } label: {
+          Label("Set App-Wide Stream URL", systemImage: "link")
+        }
+        .accessibilityIdentifier(AccessibilityID.TestStream.settingsLink)
+
+        Text(TestStreamURL.overrideURL?.absoluteString ?? "Using default showcase media")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .lineLimit(2)
+      }
+
       Section("Validation Harness") {
         NavigationLink("Device validation") { HarnessHome() }
       }

--- a/Showcase/iOS/Internal/RootView.swift
+++ b/Showcase/iOS/Internal/RootView.swift
@@ -22,7 +22,7 @@ struct RootView: View {
         }
         .accessibilityIdentifier(AccessibilityID.TestStream.settingsLink)
 
-        Text(TestStreamURL.overrideURL?.absoluteString ?? "Using default showcase media")
+        Text(TestStreamURL.overrideURL.map { TestStreamURL.displayString(for: $0) } ?? "Using default showcase media")
           .font(.caption)
           .foregroundStyle(.secondary)
           .lineLimit(2)

--- a/Showcase/iOS/Internal/TestMedia.swift
+++ b/Showcase/iOS/Internal/TestMedia.swift
@@ -23,13 +23,10 @@ enum TestMedia {
   /// in normal use. The override is a single file shared by every showcase
   /// that needs media — the test asserts behavior, not source-specific quirks.
   private static func fixtureOverrideOr(remote: String) -> URL {
-    LaunchArguments.fixtureURLValue ?? URL(string: remote)!
+    TestStreamURL.resolve(fallback: URL(string: remote)!)
   }
 
   private static func fixtureOverrideOr(bundled name: String, withExtension ext: String) -> URL {
-    if let override = LaunchArguments.fixtureURLValue {
-      return override
-    }
-    return Bundle.main.url(forResource: name, withExtension: ext)!
+    TestStreamURL.resolve(fallback: Bundle.main.url(forResource: name, withExtension: ext)!)
   }
 }

--- a/Showcase/iOS/ShowcaseApp.swift
+++ b/Showcase/iOS/ShowcaseApp.swift
@@ -4,6 +4,8 @@ import SwiftVLC
 
 @main
 struct ShowcaseApp: App {
+  @AppStorage(TestStreamURL.defaultsKey) private var testStreamURL = ""
+
   init() {
     VLCInstance.prewarmShared()
     try? AVAudioSession.sharedInstance().setCategory(.playback)
@@ -15,6 +17,7 @@ struct ShowcaseApp: App {
   var body: some Scene {
     WindowGroup {
       RootView()
+        .id(testStreamURL)
         .tint(.orange)
     }
   }

--- a/Showcase/iOS/ShowcaseApp.swift
+++ b/Showcase/iOS/ShowcaseApp.swift
@@ -4,9 +4,10 @@ import SwiftVLC
 
 @main
 struct ShowcaseApp: App {
-  @AppStorage(TestStreamURL.defaultsKey) private var testStreamURL = ""
+  @AppStorage(TestStreamURL.revisionDefaultsKey) private var testStreamRevision = ""
 
   init() {
+    TestStreamURL.startSession()
     VLCInstance.prewarmShared()
     try? AVAudioSession.sharedInstance().setCategory(.playback)
     try? AVAudioSession.sharedInstance().setActive(true)
@@ -17,7 +18,7 @@ struct ShowcaseApp: App {
   var body: some Scene {
     WindowGroup {
       RootView()
-        .id(testStreamURL)
+        .id(testStreamRevision)
         .tint(.orange)
     }
   }

--- a/Showcase/iOS/ValidationHarness/HarnessHome.swift
+++ b/Showcase/iOS/ValidationHarness/HarnessHome.swift
@@ -53,6 +53,9 @@ struct HarnessHome: View {
     Section {
       if let config {
         LabeledContent("Loaded from", value: config.source.label)
+        if let overrideURL = TestStreamURL.overrideURL {
+          LabeledContent("Override", value: TestStreamURL.displayString(for: overrideURL))
+        }
         let missing = config.streams.missingKeys
         if missing.isEmpty {
           LabeledContent("Streams", value: "all \(HarnessStreams.Key.allCases.count) configured")

--- a/Showcase/iOS/ValidationHarness/HarnessStreams.swift
+++ b/Showcase/iOS/ValidationHarness/HarnessStreams.swift
@@ -29,22 +29,52 @@ struct HarnessStreams {
   enum Source {
     case bundle
     case documents
+    case appOverride
 
     var label: String {
       switch self {
       case .bundle: "bundled streams.local.json"
       case .documents: "Documents/streams.local.json"
+      case .appOverride: "app-wide test stream"
       }
     }
   }
 
-  let liveTS: URL?
-  let hlsLive: URL?
-  let vod: URL?
-  let catchup: URL?
-  let subtitled: URL?
-  let adaptive: URL?
-  let audioOnly: URL?
+  private let configuredLiveTS: URL?
+  private let configuredHLSLive: URL?
+  private let configuredVOD: URL?
+  private let configuredCatchup: URL?
+  private let configuredSubtitled: URL?
+  private let configuredAdaptive: URL?
+  private let configuredAudioOnly: URL?
+
+  var liveTS: URL? {
+    TestStreamURL.overrideURL ?? configuredLiveTS
+  }
+
+  var hlsLive: URL? {
+    TestStreamURL.overrideURL ?? configuredHLSLive
+  }
+
+  var vod: URL? {
+    TestStreamURL.overrideURL ?? configuredVOD
+  }
+
+  var catchup: URL? {
+    TestStreamURL.overrideURL ?? configuredCatchup
+  }
+
+  var subtitled: URL? {
+    TestStreamURL.overrideURL ?? configuredSubtitled
+  }
+
+  var adaptive: URL? {
+    TestStreamURL.overrideURL ?? configuredAdaptive
+  }
+
+  var audioOnly: URL? {
+    TestStreamURL.overrideURL ?? configuredAudioOnly
+  }
 
   func url(for key: Key) -> URL? {
     switch key {
@@ -72,13 +102,13 @@ struct HarnessStreams {
 extension HarnessStreams: Decodable {
   init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: Key.self)
-    liveTS = Self.url(in: container, for: .liveTS)
-    hlsLive = Self.url(in: container, for: .hlsLive)
-    vod = Self.url(in: container, for: .vod)
-    catchup = Self.url(in: container, for: .catchup)
-    subtitled = Self.url(in: container, for: .subtitled)
-    adaptive = Self.url(in: container, for: .adaptive)
-    audioOnly = Self.url(in: container, for: .audioOnly)
+    configuredLiveTS = Self.url(in: container, for: .liveTS)
+    configuredHLSLive = Self.url(in: container, for: .hlsLive)
+    configuredVOD = Self.url(in: container, for: .vod)
+    configuredCatchup = Self.url(in: container, for: .catchup)
+    configuredSubtitled = Self.url(in: container, for: .subtitled)
+    configuredAdaptive = Self.url(in: container, for: .adaptive)
+    configuredAudioOnly = Self.url(in: container, for: .audioOnly)
   }
 
   private static func url(in container: KeyedDecodingContainer<Key>, for key: Key) -> URL? {
@@ -108,7 +138,21 @@ extension HarnessStreams {
       return (streams, .documents)
     }
 
+    if TestStreamURL.overrideURL != nil {
+      return (HarnessStreams(), .appOverride)
+    }
+
     return nil
+  }
+
+  private init() {
+    configuredLiveTS = nil
+    configuredHLSLive = nil
+    configuredVOD = nil
+    configuredCatchup = nil
+    configuredSubtitled = nil
+    configuredAdaptive = nil
+    configuredAudioOnly = nil
   }
 
   private static func decode(contentsOf url: URL) -> HarnessStreams? {

--- a/Showcase/macOS/Apps/MusicPlayer/MacMusicPlayerApp.swift
+++ b/Showcase/macOS/Apps/MusicPlayer/MacMusicPlayerApp.swift
@@ -15,7 +15,10 @@ struct MacMusicPlayerApp: View {
     return Self.defaultSongs
   }
 
-  private static let defaultSongs = Song.all
+  private static var defaultSongs: [Song] {
+    Song.all
+  }
+
   private static let audioOnlyInstance = try! VLCInstance(arguments: VLCInstance.defaultArguments + ["--no-video"])
 
   var body: some View {
@@ -109,9 +112,19 @@ private struct Song: Identifiable, Hashable {
   let artist: String
   let url: URL
 
-  static let demo = Song(id: "demo", title: "Demo reel", artist: "Bundled sample", url: MacTestMedia.demo)
-  static let bunny = Song(id: "bunny", title: "Big Buck Bunny", artist: "Blender Foundation", url: MacTestMedia.bigBuckBunny)
-  static let hls = Song(id: "hls", title: "HLS Stream", artist: "Mux test stream", url: MacTestMedia.hls)
+  static var demo: Song {
+    Song(id: "demo", title: "Demo reel", artist: "Bundled sample", url: MacTestMedia.demo)
+  }
 
-  static let all = [demo, bunny, hls]
+  static var bunny: Song {
+    Song(id: "bunny", title: "Big Buck Bunny", artist: "Blender Foundation", url: MacTestMedia.bigBuckBunny)
+  }
+
+  static var hls: Song {
+    Song(id: "hls", title: "HLS Stream", artist: "Mux test stream", url: MacTestMedia.hls)
+  }
+
+  static var all: [Song] {
+    [demo, bunny, hls]
+  }
 }

--- a/Showcase/macOS/Apps/VideoPlayer/MacVideoPlayerApp.swift
+++ b/Showcase/macOS/Apps/VideoPlayer/MacVideoPlayerApp.swift
@@ -56,26 +56,34 @@ private struct Source: Identifiable, Hashable {
   let subtitle: String
   let url: URL
 
-  static let demo = Source(
-    id: "demo",
-    title: "Demo reel",
-    subtitle: "Bundled file with tracks, chapters, subtitles, and metadata",
-    url: MacTestMedia.demo
-  )
+  static var demo: Source {
+    Source(
+      id: "demo",
+      title: "Demo reel",
+      subtitle: "Bundled file with tracks, chapters, subtitles, and metadata",
+      url: MacTestMedia.demo
+    )
+  }
 
-  static let bigBuckBunny = Source(
-    id: "big-buck-bunny",
-    title: "Big Buck Bunny",
-    subtitle: "Remote MP4 with 5.1 audio",
-    url: MacTestMedia.bigBuckBunny
-  )
+  static var bigBuckBunny: Source {
+    Source(
+      id: "big-buck-bunny",
+      title: "Big Buck Bunny",
+      subtitle: "Remote MP4 with 5.1 audio",
+      url: MacTestMedia.bigBuckBunny
+    )
+  }
 
-  static let hls = Source(
-    id: "hls",
-    title: "Live HLS stream",
-    subtitle: "Public adaptive-bitrate test stream",
-    url: MacTestMedia.hls
-  )
+  static var hls: Source {
+    Source(
+      id: "hls",
+      title: "Live HLS stream",
+      subtitle: "Public adaptive-bitrate test stream",
+      url: MacTestMedia.hls
+    )
+  }
 
-  static let all = [demo, bigBuckBunny, hls]
+  static var all: [Source] {
+    [demo, bigBuckBunny, hls]
+  }
 }

--- a/Showcase/macOS/CaseStudies/01-Foundation-Lifecycle.swift
+++ b/Showcase/macOS/CaseStudies/01-Foundation-Lifecycle.swift
@@ -66,8 +66,19 @@ private struct Source: Identifiable, Hashable {
   let title: String
   let url: URL
 
-  static let demo = Source(id: "demo", title: "Demo", url: MacTestMedia.demo)
-  static let movie = Source(id: "movie", title: "Remote MP4", url: MacTestMedia.bigBuckBunny)
-  static let stream = Source(id: "stream", title: "HLS", url: MacTestMedia.hls)
-  static let all = [demo, movie, stream]
+  static var demo: Source {
+    Source(id: "demo", title: "Demo", url: MacTestMedia.demo)
+  }
+
+  static var movie: Source {
+    Source(id: "movie", title: "Remote MP4", url: MacTestMedia.bigBuckBunny)
+  }
+
+  static var stream: Source {
+    Source(id: "stream", title: "HLS", url: MacTestMedia.hls)
+  }
+
+  static var all: [Source] {
+    [demo, movie, stream]
+  }
 }

--- a/Showcase/macOS/CaseStudies/06-Advanced-PiP.swift
+++ b/Showcase/macOS/CaseStudies/06-Advanced-PiP.swift
@@ -15,6 +15,9 @@ struct MacPiPCase: View {
         PiPVideoView(player, controller: $controller)
           .aspectRatio(16 / 9, contentMode: .fit)
           .background(.black, in: .rect(cornerRadius: 8))
+          .accessibilityElement(children: .ignore)
+          .accessibilityLabel("Video")
+          .accessibilityIdentifier("macos.pip.video")
           .overlay {
             RoundedRectangle(cornerRadius: 8)
               .stroke(Color.secondary.opacity(0.25))

--- a/Showcase/macOS/CaseStudies/06-Advanced-StreamingHLS.swift
+++ b/Showcase/macOS/CaseStudies/06-Advanced-StreamingHLS.swift
@@ -14,7 +14,7 @@ struct MacStreamingHLSCase: View {
         MacVideoPanel(player: player)
         MacPlaybackControls(player: player)
         MacSection(title: "Stream") {
-          Text(MacTestMedia.hls.absoluteString)
+          Text(TestStreamURL.displayString(for: MacTestMedia.hls))
             .font(.caption)
             .foregroundStyle(.secondary)
             .textSelection(.enabled)

--- a/Showcase/macOS/CaseStudies/07-Playlist-Queue.swift
+++ b/Showcase/macOS/CaseStudies/07-Playlist-Queue.swift
@@ -88,8 +88,19 @@ private struct Source: Identifiable, Hashable {
   let title: String
   let url: URL
 
-  static let demo = Source(id: "demo", title: "Demo reel", url: MacTestMedia.demo)
-  static let bunny = Source(id: "bunny", title: "Big Buck Bunny", url: MacTestMedia.bigBuckBunny)
-  static let hls = Source(id: "hls", title: "HLS stream", url: MacTestMedia.hls)
-  static let all = [demo, bunny, hls]
+  static var demo: Source {
+    Source(id: "demo", title: "Demo reel", url: MacTestMedia.demo)
+  }
+
+  static var bunny: Source {
+    Source(id: "bunny", title: "Big Buck Bunny", url: MacTestMedia.bigBuckBunny)
+  }
+
+  static var hls: Source {
+    Source(id: "hls", title: "HLS stream", url: MacTestMedia.hls)
+  }
+
+  static var all: [Source] {
+    [demo, bunny, hls]
+  }
 }

--- a/Showcase/macOS/Info.plist
+++ b/Showcase/macOS/Info.plist
@@ -7,15 +7,7 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>audio</string>
-	</array>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>Connects to test streams and discovers media receivers on your local network.</string>
-	<key>NSBonjourServices</key>
-	<array>
-		<string>_googlecast._tcp</string>
-	</array>
+	<string>Connects to test streams and media servers on your local network.</string>
 </dict>
 </plist>

--- a/Showcase/macOS/Info.plist
+++ b/Showcase/macOS/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<!-- Required by this development showcase's arbitrary user-entered HTTP streams.
+	     NSAllowsArbitraryLoadsForMedia only applies to AVFoundation, not libVLC. -->
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/Showcase/macOS/Internal/MacShowcaseRootView.swift
+++ b/Showcase/macOS/Internal/MacShowcaseRootView.swift
@@ -19,7 +19,7 @@ struct MacShowcaseRootView: View {
           }
           .accessibilityIdentifier(AccessibilityID.TestStream.settingsLink)
 
-          Text(TestStreamURL.overrideURL?.absoluteString ?? "Using default showcase media")
+          Text(TestStreamURL.overrideURL.map { TestStreamURL.displayString(for: $0) } ?? "Using default showcase media")
             .font(.caption)
             .foregroundStyle(.secondary)
             .lineLimit(2)

--- a/Showcase/macOS/Internal/MacShowcaseRootView.swift
+++ b/Showcase/macOS/Internal/MacShowcaseRootView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct MacShowcaseRootView: View {
   @State private var selection: MacShowcase?
+  @State private var isShowingTestStreamSettings = false
 
   init() {
     _selection = State(initialValue: MacShowcase.initialSelection)
@@ -10,6 +11,20 @@ struct MacShowcaseRootView: View {
   var body: some View {
     NavigationSplitView {
       List(selection: $selection) {
+        Section("Configuration") {
+          Button {
+            isShowingTestStreamSettings = true
+          } label: {
+            Label("Test Stream URL", systemImage: "link")
+          }
+          .accessibilityIdentifier(AccessibilityID.TestStream.settingsLink)
+
+          Text(TestStreamURL.overrideURL?.absoluteString ?? "Using default showcase media")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .lineLimit(2)
+        }
+
         ForEach(MacShowcaseSection.allCases) { section in
           Section(section.title) {
             ForEach(section.showcases) { showcase in
@@ -24,6 +39,22 @@ struct MacShowcaseRootView: View {
     } detail: {
       MacShowcaseDetail(showcase: selection ?? .simplePlayback)
         .navigationTitle((selection ?? .simplePlayback).title)
+    }
+    .toolbar {
+      ToolbarItem(placement: .primaryAction) {
+        Button {
+          isShowingTestStreamSettings = true
+        } label: {
+          Label("Test Stream", systemImage: "link")
+        }
+        .help("Configure the app-wide test stream URL")
+      }
+    }
+    .sheet(isPresented: $isShowingTestStreamSettings) {
+      NavigationStack {
+        TestStreamSettingsView()
+      }
+      .frame(minWidth: 560, minHeight: 360)
     }
   }
 }

--- a/Showcase/macOS/Internal/MacTestMedia.swift
+++ b/Showcase/macOS/Internal/MacTestMedia.swift
@@ -14,22 +14,16 @@ enum MacTestMedia {
   }
 
   private static func fixtureOverrideOr(remote: String) -> URL {
-    if let override = LaunchArguments.fixtureURLValue {
-      return override
-    }
     guard let url = URL(string: remote) else {
       preconditionFailure("Invalid remote media URL: \(remote)")
     }
-    return url
+    return TestStreamURL.resolve(fallback: url)
   }
 
   private static func fixtureOverrideOr(bundled name: String, withExtension ext: String) -> URL {
-    if let override = LaunchArguments.fixtureURLValue {
-      return override
-    }
     guard let url = Bundle.main.url(forResource: name, withExtension: ext) else {
       preconditionFailure("Missing bundled media resource: \(name).\(ext)")
     }
-    return url
+    return TestStreamURL.resolve(fallback: url)
   }
 }

--- a/Showcase/macOS/ShowcaseApp.swift
+++ b/Showcase/macOS/ShowcaseApp.swift
@@ -3,9 +3,10 @@ import SwiftUI
 
 @main
 struct MacOSShowcaseApp: App {
-  @AppStorage(TestStreamURL.defaultsKey) private var testStreamURL = ""
+  @AppStorage(TestStreamURL.revisionDefaultsKey) private var testStreamRevision = ""
 
   init() {
+    TestStreamURL.startSession()
     // The macOS Showcase is a local demo app, not App Store sample code.
     // Opt into SwiftVLC's private macOS PiP backend so the PiP case can run.
     PiPController.allowsPrivateMacOSAPI = true
@@ -14,7 +15,7 @@ struct MacOSShowcaseApp: App {
   var body: some Scene {
     WindowGroup {
       MacShowcaseRootView()
-        .id(testStreamURL)
+        .id(testStreamRevision)
         .frame(minWidth: 980, minHeight: 660)
     }
     .windowResizability(.contentMinSize)

--- a/Showcase/macOS/ShowcaseApp.swift
+++ b/Showcase/macOS/ShowcaseApp.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 @main
 struct MacOSShowcaseApp: App {
+  @AppStorage(TestStreamURL.defaultsKey) private var testStreamURL = ""
+
   init() {
     // The macOS Showcase is a local demo app, not App Store sample code.
     // Opt into SwiftVLC's private macOS PiP backend so the PiP case can run.
@@ -12,6 +14,7 @@ struct MacOSShowcaseApp: App {
   var body: some Scene {
     WindowGroup {
       MacShowcaseRootView()
+        .id(testStreamURL)
         .frame(minWidth: 980, minHeight: 660)
     }
     .windowResizability(.contentMinSize)

--- a/Showcase/tvOS/Apps/MusicPlayer/TVMusicPlayerApp.swift
+++ b/Showcase/tvOS/Apps/MusicPlayer/TVMusicPlayerApp.swift
@@ -90,9 +90,19 @@ private struct Song: Identifiable, Hashable {
   let artist: String
   let url: URL
 
-  static let demo = Song(id: "demo", title: "Demo reel", artist: "Bundled sample", url: TVTestMedia.demo)
-  static let bunny = Song(id: "bunny", title: "Big Buck Bunny", artist: "Blender Foundation", url: TVTestMedia.bigBuckBunny)
-  static let hls = Song(id: "hls", title: "HLS Stream", artist: "Mux test stream", url: TVTestMedia.hls)
+  static var demo: Song {
+    Song(id: "demo", title: "Demo reel", artist: "Bundled sample", url: TVTestMedia.demo)
+  }
 
-  static let all = [demo, bunny, hls]
+  static var bunny: Song {
+    Song(id: "bunny", title: "Big Buck Bunny", artist: "Blender Foundation", url: TVTestMedia.bigBuckBunny)
+  }
+
+  static var hls: Song {
+    Song(id: "hls", title: "HLS Stream", artist: "Mux test stream", url: TVTestMedia.hls)
+  }
+
+  static var all: [Song] {
+    [demo, bunny, hls]
+  }
 }

--- a/Showcase/tvOS/Apps/VideoPlayer/TVVideoPlayerApp.swift
+++ b/Showcase/tvOS/Apps/VideoPlayer/TVVideoPlayerApp.swift
@@ -57,26 +57,34 @@ private struct Source: Identifiable, Hashable {
   let subtitle: String
   let url: URL
 
-  static let demo = Source(
-    id: "demo",
-    title: "Demo reel",
-    subtitle: "Bundled file with tracks, chapters, subtitles, and metadata",
-    url: TVTestMedia.demo
-  )
+  static var demo: Source {
+    Source(
+      id: "demo",
+      title: "Demo reel",
+      subtitle: "Bundled file with tracks, chapters, subtitles, and metadata",
+      url: TVTestMedia.demo
+    )
+  }
 
-  static let bigBuckBunny = Source(
-    id: "big-buck-bunny",
-    title: "Big Buck Bunny",
-    subtitle: "Remote MP4 with 5.1 audio",
-    url: TVTestMedia.bigBuckBunny
-  )
+  static var bigBuckBunny: Source {
+    Source(
+      id: "big-buck-bunny",
+      title: "Big Buck Bunny",
+      subtitle: "Remote MP4 with 5.1 audio",
+      url: TVTestMedia.bigBuckBunny
+    )
+  }
 
-  static let hls = Source(
-    id: "hls",
-    title: "Live HLS stream",
-    subtitle: "Public adaptive-bitrate test stream",
-    url: TVTestMedia.hls
-  )
+  static var hls: Source {
+    Source(
+      id: "hls",
+      title: "Live HLS stream",
+      subtitle: "Public adaptive-bitrate test stream",
+      url: TVTestMedia.hls
+    )
+  }
 
-  static let all = [demo, bigBuckBunny, hls]
+  static var all: [Source] {
+    [demo, bigBuckBunny, hls]
+  }
 }

--- a/Showcase/tvOS/CaseStudies/01-Foundation-Lifecycle.swift
+++ b/Showcase/tvOS/CaseStudies/01-Foundation-Lifecycle.swift
@@ -70,8 +70,19 @@ private struct Source: Identifiable, Hashable {
   let title: String
   let url: URL
 
-  static let demo = Source(id: "demo", title: "Demo", url: TVTestMedia.demo)
-  static let movie = Source(id: "movie", title: "Remote MP4", url: TVTestMedia.bigBuckBunny)
-  static let stream = Source(id: "stream", title: "HLS", url: TVTestMedia.hls)
-  static let all = [demo, movie, stream]
+  static var demo: Source {
+    Source(id: "demo", title: "Demo", url: TVTestMedia.demo)
+  }
+
+  static var movie: Source {
+    Source(id: "movie", title: "Remote MP4", url: TVTestMedia.bigBuckBunny)
+  }
+
+  static var stream: Source {
+    Source(id: "stream", title: "HLS", url: TVTestMedia.hls)
+  }
+
+  static var all: [Source] {
+    [demo, movie, stream]
+  }
 }

--- a/Showcase/tvOS/CaseStudies/06-Advanced-StreamingHLS.swift
+++ b/Showcase/tvOS/CaseStudies/06-Advanced-StreamingHLS.swift
@@ -14,7 +14,7 @@ struct TVStreamingHLSCase: View {
         TVVideoPanel(player: player)
         TVPlaybackControls(player: player)
         TVSection(title: "Stream", isFocusable: true) {
-          Text(TVTestMedia.hls.absoluteString)
+          Text(TestStreamURL.displayString(for: TVTestMedia.hls))
             .font(.caption)
             .foregroundStyle(.secondary)
         }

--- a/Showcase/tvOS/CaseStudies/07-Playlist-Queue.swift
+++ b/Showcase/tvOS/CaseStudies/07-Playlist-Queue.swift
@@ -99,8 +99,19 @@ private struct Source: Identifiable, Hashable {
   let title: String
   let url: URL
 
-  static let demo = Source(id: "demo", title: "Demo reel", url: TVTestMedia.demo)
-  static let bunny = Source(id: "bunny", title: "Big Buck Bunny", url: TVTestMedia.bigBuckBunny)
-  static let hls = Source(id: "hls", title: "HLS stream", url: TVTestMedia.hls)
-  static let all = [demo, bunny, hls]
+  static var demo: Source {
+    Source(id: "demo", title: "Demo reel", url: TVTestMedia.demo)
+  }
+
+  static var bunny: Source {
+    Source(id: "bunny", title: "Big Buck Bunny", url: TVTestMedia.bigBuckBunny)
+  }
+
+  static var hls: Source {
+    Source(id: "hls", title: "HLS stream", url: TVTestMedia.hls)
+  }
+
+  static var all: [Source] {
+    [demo, bunny, hls]
+  }
 }

--- a/Showcase/tvOS/Info.plist
+++ b/Showcase/tvOS/Info.plist
@@ -7,15 +7,7 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>audio</string>
-	</array>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>Connects to test streams and discovers media receivers on your local network.</string>
-	<key>NSBonjourServices</key>
-	<array>
-		<string>_googlecast._tcp</string>
-	</array>
+	<string>Connects to test streams and media servers on your local network.</string>
 </dict>
 </plist>

--- a/Showcase/tvOS/Info.plist
+++ b/Showcase/tvOS/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<!-- Required by this development showcase's arbitrary user-entered HTTP streams.
+	     NSAllowsArbitraryLoadsForMedia only applies to AVFoundation, not libVLC. -->
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/Showcase/tvOS/Internal/TVShowcaseRootView.swift
+++ b/Showcase/tvOS/Internal/TVShowcaseRootView.swift
@@ -61,6 +61,14 @@ struct TVShowcaseRootView: View {
         .foregroundStyle(.secondary)
         .fixedSize(horizontal: false, vertical: true)
         .frame(maxWidth: 980, alignment: .leading)
+
+      NavigationLink {
+        TestStreamSettingsView()
+      } label: {
+        Label("Set App-Wide Stream URL", systemImage: "link")
+      }
+      .buttonStyle(.bordered)
+      .accessibilityIdentifier(AccessibilityID.TestStream.settingsLink)
     }
   }
 }

--- a/Showcase/tvOS/Internal/TVTestMedia.swift
+++ b/Showcase/tvOS/Internal/TVTestMedia.swift
@@ -18,20 +18,14 @@ enum TVTestMedia {
   }
 
   private static func fixtureOverrideOr(remote: String) -> URL {
-    if let override = LaunchArguments.fixtureURLValue {
-      return override
-    }
     guard let url = URL(string: remote) else {
       preconditionFailure("Invalid remote media URL: \(remote)")
     }
-    return url
+    return TestStreamURL.resolve(fallback: url)
   }
 
   private static func fixtureOverrideOr(bundled name: String, withExtension ext: String) -> URL {
-    if let override = LaunchArguments.fixtureURLValue {
-      return override
-    }
-    return bundled(name, withExtension: ext)
+    TestStreamURL.resolve(fallback: bundled(name, withExtension: ext))
   }
 
   private static func bundled(_ name: String, withExtension ext: String) -> URL {

--- a/Showcase/tvOS/ShowcaseApp.swift
+++ b/Showcase/tvOS/ShowcaseApp.swift
@@ -2,12 +2,16 @@ import SwiftUI
 
 @main
 struct TVOSShowcaseApp: App {
-  @AppStorage(TestStreamURL.defaultsKey) private var testStreamURL = ""
+  @AppStorage(TestStreamURL.revisionDefaultsKey) private var testStreamRevision = ""
+
+  init() {
+    TestStreamURL.startSession()
+  }
 
   var body: some Scene {
     WindowGroup {
       TVShowcaseRootView()
-        .id(testStreamURL)
+        .id(testStreamRevision)
     }
   }
 }

--- a/Showcase/tvOS/ShowcaseApp.swift
+++ b/Showcase/tvOS/ShowcaseApp.swift
@@ -2,9 +2,12 @@ import SwiftUI
 
 @main
 struct TVOSShowcaseApp: App {
+  @AppStorage(TestStreamURL.defaultsKey) private var testStreamURL = ""
+
   var body: some Scene {
     WindowGroup {
       TVShowcaseRootView()
+        .id(testStreamURL)
     }
   }
 }

--- a/Showcase/visionOS/Info.plist
+++ b/Showcase/visionOS/Info.plist
@@ -7,15 +7,7 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>audio</string>
-	</array>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>Connects to test streams and discovers media receivers on your local network.</string>
-	<key>NSBonjourServices</key>
-	<array>
-		<string>_googlecast._tcp</string>
-	</array>
+	<string>Connects to test streams and media servers on your local network.</string>
 </dict>
 </plist>

--- a/Showcase/visionOS/Info.plist
+++ b/Showcase/visionOS/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<!-- Required by this development showcase's arbitrary user-entered HTTP streams.
+	     NSAllowsArbitraryLoadsForMedia only applies to AVFoundation, not libVLC. -->
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/Showcase/visionOS/ShowcaseApp.swift
+++ b/Showcase/visionOS/ShowcaseApp.swift
@@ -2,12 +2,16 @@ import SwiftUI
 
 @main
 struct VisionShowcaseApp: App {
-  @AppStorage(TestStreamURL.defaultsKey) private var testStreamURL = ""
+  @AppStorage(TestStreamURL.revisionDefaultsKey) private var testStreamRevision = ""
+
+  init() {
+    TestStreamURL.startSession()
+  }
 
   var body: some Scene {
     WindowGroup {
       SimplePlaybackView()
-        .id(testStreamURL)
+        .id(testStreamRevision)
         .tint(.orange)
     }
     .defaultSize(width: 960, height: 640)

--- a/Showcase/visionOS/ShowcaseApp.swift
+++ b/Showcase/visionOS/ShowcaseApp.swift
@@ -2,9 +2,12 @@ import SwiftUI
 
 @main
 struct VisionShowcaseApp: App {
+  @AppStorage(TestStreamURL.defaultsKey) private var testStreamURL = ""
+
   var body: some Scene {
     WindowGroup {
       SimplePlaybackView()
+        .id(testStreamURL)
         .tint(.orange)
     }
     .defaultSize(width: 960, height: 640)

--- a/Showcase/visionOS/SimplePlaybackView.swift
+++ b/Showcase/visionOS/SimplePlaybackView.swift
@@ -5,6 +5,7 @@ import SwiftVLC
 struct SimplePlaybackView: View {
   @State private var player = Player()
   @State private var playbackError: String?
+  @State private var isShowingTestStreamSettings = false
 
   var body: some View {
     VStack(spacing: 18) {
@@ -35,6 +36,19 @@ struct SimplePlaybackView: View {
         .font(.subheadline.weight(.semibold))
         .foregroundStyle(.secondary)
         .labelStyle(.titleAndIcon)
+
+      Button {
+        isShowingTestStreamSettings = true
+      } label: {
+        Label("Test Stream", systemImage: "link")
+      }
+      .accessibilityIdentifier(AccessibilityID.TestStream.settingsLink)
+    }
+    .sheet(isPresented: $isShowingTestStreamSettings) {
+      NavigationStack {
+        TestStreamSettingsView()
+      }
+      .frame(minWidth: 620, minHeight: 420)
     }
   }
 
@@ -113,12 +127,9 @@ struct SimplePlaybackView: View {
 
 private enum VisionTestMedia {
   static var demo: URL {
-    if let override = LaunchArguments.fixtureURLValue {
-      return override
-    }
     guard let url = Bundle.main.url(forResource: "demo", withExtension: "mkv") else {
       preconditionFailure("Missing bundled media resource: demo.mkv")
     }
-    return url
+    return TestStreamURL.resolve(fallback: url)
   }
 }

--- a/Sources/SwiftVLC/Audio/Equalizer.swift
+++ b/Sources/SwiftVLC/Audio/Equalizer.swift
@@ -132,6 +132,8 @@ public final class Equalizer {
       throw .invalidInput("band must be in 0..<\(Self.bandCount)")
     }
     let band = try checkedUInt32(band, parameter: "band")
+    let current = libvlc_audio_equalizer_get_amp_at_index(pointer, band)
+    guard current != amp else { return }
     guard libvlc_audio_equalizer_set_amp_at_index(pointer, amp, band) == 0 else {
       throw .operationFailed("Set equalizer amplification for band \(band)")
     }

--- a/Sources/SwiftVLC/Core/Broadcaster.swift
+++ b/Sources/SwiftVLC/Core/Broadcaster.swift
@@ -79,8 +79,9 @@ final class Broadcaster<Element: Sendable>: Sendable {
     reconciliation = ReconciliationQueue()
   }
 
-  /// Returns an independent `AsyncStream` that yields every element
-  /// passed to ``broadcast(_:)`` while the stream is alive.
+  /// Returns an independent `AsyncStream` that is offered each element
+  /// passed to ``broadcast(_:)`` while the stream is alive. A bounded
+  /// policy can discard older buffered elements when its consumer lags.
   ///
   /// - Parameters:
   ///   - policy: Buffering behavior for this stream. `nil` uses the

--- a/Sources/SwiftVLC/Core/Logging.swift
+++ b/Sources/SwiftVLC/Core/Logging.swift
@@ -41,10 +41,12 @@ extension VLCInstance {
   /// Creates an `AsyncStream` of libVLC log messages.
   ///
   /// Multiple concurrent log streams per instance are supported. Each
-  /// active stream receives every log event that meets its own
-  /// `minimumLevel` filter. The underlying libVLC log callback is
-  /// installed on first subscription and removed when the last
-  /// consumer's stream terminates.
+  /// active stream is offered log events that meet its own `minimumLevel`
+  /// filter. Each subscription uses a bounded newest-wins buffer, so a
+  /// slow consumer can drop its own oldest entries without blocking
+  /// libVLC or other subscribers. The underlying libVLC log callback is
+  /// installed on first subscription and removed when the last consumer's
+  /// stream terminates.
   ///
   /// ```swift
   /// for await entry in VLCInstance.shared.logStream(minimumLevel: .warning) {

--- a/Sources/SwiftVLC/Core/VLCError.swift
+++ b/Sources/SwiftVLC/Core/VLCError.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-/// The single error type thrown by every throwing SwiftVLC API.
+/// The error type for failures originating in SwiftVLC operations.
 ///
-/// All throwing functions in SwiftVLC use Swift's typed throws form
-/// `throws(VLCError)`, so the cases below are exhaustive. A general
-/// `catch` is unnecessary when the compiler can statically see that
-/// this is the only possible error.
+/// Library operations that introduce failures use Swift's typed throws
+/// form `throws(VLCError)`, so the cases below are exhaustive for those
+/// calls. Scoped closure helpers use `rethrows` and can propagate the
+/// caller's own error type unchanged.
 ///
 /// Every case carries enough context (URL, operation name, reason string)
 /// to log meaningfully without consulting libVLC's own diagnostics.

--- a/Sources/SwiftVLC/Discovery/MediaDiscoverer.swift
+++ b/Sources/SwiftVLC/Discovery/MediaDiscoverer.swift
@@ -80,7 +80,10 @@ public final class MediaDiscoverer: Sendable {
   /// Discovered items are added/removed from this list dynamically.
   public var mediaList: MediaList? {
     guard let list = libvlc_media_discoverer_media_list(pointer) else { return nil }
-    return MediaList(retaining: list)
+    // libvlc_media_discoverer_media_list returns a caller-owned (+1)
+    // reference. Adopt it directly; retaining again leaks one list on
+    // every property access.
+    return MediaList(owning: list)
   }
 }
 

--- a/Sources/SwiftVLC/Discovery/MediaDiscoverer.swift
+++ b/Sources/SwiftVLC/Discovery/MediaDiscoverer.swift
@@ -84,9 +84,9 @@ public final class MediaDiscoverer: Sendable {
 
   static func adoptMediaList(_ pointer: OpaquePointer?) -> MediaList? {
     guard let pointer else { return nil }
-    // libvlc_media_discoverer_media_list returns a caller-owned (+1)
-    // reference. Adopt it directly; retaining again leaks one list on
-    // every property access.
+    // Pinned VLC c833c4be0 retains this list in lib/media_discoverer.c before
+    // returning it. Adopt that +1 reference; retaining again leaks one list
+    // on every property access. Recheck this contract when updating VLC.
     return MediaList(owning: pointer)
   }
 }

--- a/Sources/SwiftVLC/Discovery/MediaDiscoverer.swift
+++ b/Sources/SwiftVLC/Discovery/MediaDiscoverer.swift
@@ -79,11 +79,15 @@ public final class MediaDiscoverer: Sendable {
   ///
   /// Discovered items are added/removed from this list dynamically.
   public var mediaList: MediaList? {
-    guard let list = libvlc_media_discoverer_media_list(pointer) else { return nil }
+    Self.adoptMediaList(libvlc_media_discoverer_media_list(pointer))
+  }
+
+  static func adoptMediaList(_ pointer: OpaquePointer?) -> MediaList? {
+    guard let pointer else { return nil }
     // libvlc_media_discoverer_media_list returns a caller-owned (+1)
     // reference. Adopt it directly; retaining again leaks one list on
     // every property access.
-    return MediaList(owning: list)
+    return MediaList(owning: pointer)
   }
 }
 

--- a/Sources/SwiftVLC/Discovery/RendererDiscoverer.swift
+++ b/Sources/SwiftVLC/Discovery/RendererDiscoverer.swift
@@ -10,7 +10,8 @@ import Dispatch
 /// ```swift
 /// let services = RendererDiscoverer.availableServices()
 /// guard let service = services.first else { return }
-/// var player = Player()
+/// let player = Player()
+/// try player.play(url: mediaURL)
 ///
 /// let discoverer = try RendererDiscoverer(name: service.name)
 /// try discoverer.start()
@@ -18,12 +19,8 @@ import Dispatch
 /// for await event in discoverer.events {
 ///     switch event {
 ///     case let .itemAdded(renderer):
-///         let castPlayer = Player()
 ///         do {
-///             try castPlayer.setRenderer(renderer)
-///             try castPlayer.play(url: mediaURL)
-///             player.stop()
-///             player = castPlayer
+///             try await player.recast(to: renderer)
 ///         } catch {
 ///             print("Cast failed:", error)
 ///         }

--- a/Sources/SwiftVLC/Media/Media.swift
+++ b/Sources/SwiftVLC/Media/Media.swift
@@ -2,6 +2,42 @@ import CLibVLC
 import Foundation
 import Synchronization
 
+#if DEBUG
+/// Debug-only counters for proving that the retained callback boxes used by
+/// parse and thumbnail operations balance on every terminal path.
+///
+/// Weak `Media` probes cannot detect these leaks because each operation owns
+/// the native media pointer, not the Swift `Media` wrapper.
+enum MediaOperationLifetimeProbe {
+  private static let parseCount = Atomic<Int>(0)
+  private static let thumbnailCount = Atomic<Int>(0)
+
+  static var liveParseCount: Int {
+    parseCount.load(ordering: .relaxed)
+  }
+
+  static var liveThumbnailCount: Int {
+    thumbnailCount.load(ordering: .relaxed)
+  }
+
+  static func parseCreated() {
+    parseCount.add(1, ordering: .relaxed)
+  }
+
+  static func parseDestroyed() {
+    parseCount.subtract(1, ordering: .relaxed)
+  }
+
+  static func thumbnailCreated() {
+    thumbnailCount.add(1, ordering: .relaxed)
+  }
+
+  static func thumbnailDestroyed() {
+    thumbnailCount.subtract(1, ordering: .relaxed)
+  }
+}
+#endif
+
 /// The type of a media source as reported by libVLC.
 public enum MediaType: Sendable, Hashable, CustomStringConvertible {
   /// Media type could not be determined yet.
@@ -407,11 +443,17 @@ private final class ParseOperation: Sendable {
       instance: instance,
       continuation: continuation
     ))
+    #if DEBUG
+    MediaOperationLifetimeProbe.parseCreated()
+    #endif
   }
 
   deinit {
     let media = state.withLock { $0.media }
     libvlc_media_release(media)
+    #if DEBUG
+    MediaOperationLifetimeProbe.parseDestroyed()
+    #endif
   }
 
   func installCallbackBox(_ box: UnsafeMutableRawPointer) -> Bool {

--- a/Sources/SwiftVLC/Media/ThumbnailRequest.swift
+++ b/Sources/SwiftVLC/Media/ThumbnailRequest.swift
@@ -334,11 +334,17 @@ private final class ThumbnailOperation: Sendable {
       eventManager: eventManager,
       continuation: continuation
     ))
+    #if DEBUG
+    MediaOperationLifetimeProbe.thumbnailCreated()
+    #endif
   }
 
   deinit {
     let media = state.withLock { $0.media }
     libvlc_media_release(media)
+    #if DEBUG
+    MediaOperationLifetimeProbe.thumbnailDestroyed()
+    #endif
   }
 
   func installCallbackBox(_ box: UnsafeMutableRawPointer) -> Bool {

--- a/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
@@ -153,12 +153,14 @@ private final class MacPrivatePiPPresenter {
 
   private weak var hostView: MacNativePiPHostView?
   private weak var drawableView: MacNativePiPDrawableView?
+  private weak var player: Player?
   private var pictureInPictureViewController: NSViewController?
   private var contentViewController: NSViewController?
   private var delegate: MacPrivatePiPDelegate?
   private var onActiveChanged: (@MainActor @Sendable (Bool) -> Void)?
   private var dismissalCompletion: MacPrivatePiPDismissCompletion?
   private var isClosing = false
+  private var didPresentDrawable = false
 
   var isActive: Bool {
     pictureInPictureViewController != nil && !isClosing
@@ -205,12 +207,13 @@ private final class MacPrivatePiPPresenter {
 
     self.hostView = hostView
     self.drawableView = drawableView
+    self.player = player
     self.pictureInPictureViewController = pictureInPictureViewController
     self.onActiveChanged = onActiveChanged
 
     let delegate = MacPrivatePiPDelegate()
     delegate.shouldClose = { [weak self] in
-      self?.beginClose() ?? true
+      self?.prepareToClose() ?? true
     }
     delegate.willClose = { [weak self] in
       _ = self?.beginClose()
@@ -245,6 +248,7 @@ private final class MacPrivatePiPPresenter {
       MacPrivatePiPSelector.present,
       with: contentViewController
     )
+    didPresentDrawable = true
     onActiveChanged(true)
     return true
   }
@@ -282,6 +286,13 @@ private final class MacPrivatePiPPresenter {
 
   @discardableResult
   private func beginClose() -> Bool {
+    let canClose = prepareToClose()
+    restoreDrawableBeforeWindowTeardown()
+    return canClose
+  }
+
+  @discardableResult
+  private func prepareToClose() -> Bool {
     guard pictureInPictureViewController != nil else { return true }
     isClosing = true
     return prepareForClose()
@@ -327,24 +338,36 @@ private final class MacPrivatePiPPresenter {
   private func finish() {
     guard pictureInPictureViewController != nil || isClosing else { return }
 
-    let hostView = hostView
-    let drawableView = drawableView
+    let playerToRecover = didPresentDrawable ? player : nil
 
-    contentViewController?.view = NSView(frame: .zero)
-    if let hostView, let drawableView {
-      hostView.restoreDrawableView(drawableView)
-    }
+    // `pipWillClose:` normally restores the drawable while the floating
+    // window's graphics context is still alive. Keep this call as an
+    // idempotent fallback for failed presentation and runtimes that finish
+    // dismissal without sending the full delegate sequence.
+    restoreDrawableBeforeWindowTeardown()
 
     pictureInPictureViewController = nil
     contentViewController = nil
     delegate = nil
     dismissalCompletion = nil
     isClosing = false
-    self.hostView = nil
-    self.drawableView = nil
+    didPresentDrawable = false
+    hostView = nil
+    drawableView = nil
+    player = nil
 
     onActiveChanged?(false)
     onActiveChanged = nil
+    playerToRecover?.reopenVideoOutputAfterDrawableWindowMove()
+  }
+
+  private func restoreDrawableBeforeWindowTeardown() {
+    guard let hostView, let drawableView else { return }
+
+    if contentViewController?.view === drawableView {
+      contentViewController?.view = NSView(frame: .zero)
+    }
+    hostView.restoreDrawableView(drawableView)
   }
 
   private func configure(

--- a/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
@@ -146,11 +146,12 @@ final class MacNativePiPBackend: NSObject, @unchecked Sendable {
 }
 
 @MainActor
-private final class MacPrivatePiPPresenter {
+final class MacPrivatePiPPresenter {
   static var isRuntimeAvailable: Bool {
     makePictureInPictureViewController() != nil
   }
 
+  private let pictureInPictureViewControllerFactory: @MainActor () -> NSViewController?
   private weak var hostView: MacNativePiPHostView?
   private weak var drawableView: MacNativePiPDrawableView?
   private weak var player: Player?
@@ -161,6 +162,14 @@ private final class MacPrivatePiPPresenter {
   private var dismissalCompletion: MacPrivatePiPDismissCompletion?
   private var isClosing = false
   private var didPresentDrawable = false
+
+  init(
+    pictureInPictureViewControllerFactory: (@MainActor () -> NSViewController?)? = nil
+  ) {
+    self.pictureInPictureViewControllerFactory = pictureInPictureViewControllerFactory ?? {
+      Self.makePictureInPictureViewController()
+    }
+  }
 
   var isActive: Bool {
     pictureInPictureViewController != nil && !isClosing
@@ -203,7 +212,7 @@ private final class MacPrivatePiPPresenter {
       return true
     }
 
-    guard let pictureInPictureViewController = Self.makePictureInPictureViewController() else { return false }
+    guard let pictureInPictureViewController = pictureInPictureViewControllerFactory() else { return false }
 
     self.hostView = hostView
     self.drawableView = drawableView

--- a/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
@@ -484,7 +484,7 @@ private func setPrivateValue(
   return true
 }
 
-private final class MacPrivatePiPDelegate: NSObject, @unchecked Sendable {
+final class MacPrivatePiPDelegate: NSObject, @unchecked Sendable {
   var shouldClose: @MainActor @Sendable () -> Bool = { true }
   var willClose: @MainActor @Sendable () -> Void = {}
   var didClose: @MainActor @Sendable () -> Void = {}

--- a/Sources/SwiftVLC/Player/EventBridge.swift
+++ b/Sources/SwiftVLC/Player/EventBridge.swift
@@ -65,8 +65,8 @@ final class EventBridge: Sendable {
   }
 
   /// Creates a new independent `AsyncStream` for consuming player events.
-  /// Each stream receives all events broadcast after creation that pass
-  /// its filter, buffered per `policy`.
+  /// Each stream is offered events broadcast after creation that pass its
+  /// filter. Delivery under consumer lag follows `policy`.
   func makeStream(
     policy: EventBufferingPolicy?,
     filter: (@Sendable (PlayerEvent) -> Bool)?

--- a/Sources/SwiftVLC/Player/Player+Drawable.swift
+++ b/Sources/SwiftVLC/Player/Player+Drawable.swift
@@ -78,9 +78,11 @@ struct MacVideoOutputRecoveryNativeOperations {
 }
 
 private func selectedVideoTrackID(for player: OpaquePointer) -> String? {
-  guard let track = libvlc_media_player_get_selected_track(player, libvlc_track_video) else {
-    return nil
-  }
+  libvlc_media_player_get_selected_track(player, libvlc_track_video)
+    .flatMap(nativeTrackID(adopting:))
+}
+
+func nativeTrackID(adopting track: UnsafeMutablePointer<libvlc_media_track_t>) -> String? {
   defer { libvlc_media_track_release(track) }
   return track.pointee.psz_id.map(String.init(cString:))
 }

--- a/Sources/SwiftVLC/Player/Player+Drawable.swift
+++ b/Sources/SwiftVLC/Player/Player+Drawable.swift
@@ -1,5 +1,91 @@
 import CLibVLC
 
+#if os(macOS)
+@MainActor
+struct MacVideoOutputRecovery {
+  let expectedTrackID: String
+  let maximumDeselectionPolls: Int
+  let playbackIsCurrent: @MainActor () -> Bool
+  let playbackState: @MainActor () -> PlayerState
+  let selectedTrackID: @MainActor () -> String?
+  let waitForDeselection: @MainActor () async -> Void
+  let reselectTrack: @MainActor (String) -> Void
+
+  init(
+    expectedTrackID: String,
+    maximumDeselectionPolls: Int = 50,
+    playbackIsCurrent: @escaping @MainActor () -> Bool,
+    playbackState: @escaping @MainActor () -> PlayerState,
+    selectedTrackID: @escaping @MainActor () -> String?,
+    waitForDeselection: @escaping @MainActor () async -> Void,
+    reselectTrack: @escaping @MainActor (String) -> Void
+  ) {
+    self.expectedTrackID = expectedTrackID
+    self.maximumDeselectionPolls = maximumDeselectionPolls
+    self.playbackIsCurrent = playbackIsCurrent
+    self.playbackState = playbackState
+    self.selectedTrackID = selectedTrackID
+    self.waitForDeselection = waitForDeselection
+    self.reselectTrack = reselectTrack
+  }
+
+  func run() async {
+    for _ in 0..<maximumDeselectionPolls {
+      guard playbackIsCurrent() else { return }
+      guard let selectedTrackID = selectedTrackID() else { break }
+      guard selectedTrackID == expectedTrackID else { return }
+      await waitForDeselection()
+    }
+
+    guard playbackIsCurrent() else { return }
+    switch playbackState() {
+    case .idle, .stopped, .stopping, .error:
+      return
+    case .opening, .buffering, .playing, .paused:
+      break
+    }
+
+    if let selectedTrackID = selectedTrackID() {
+      guard selectedTrackID == expectedTrackID else { return }
+    }
+    reselectTrack(expectedTrackID)
+  }
+}
+
+@MainActor
+struct MacVideoOutputRecoveryNativeOperations {
+  let selectedTrackID: @MainActor (OpaquePointer) -> String?
+  let unselectVideoTrack: @MainActor (OpaquePointer) -> Void
+  let reselectVideoTrack: @MainActor (OpaquePointer, String) -> Void
+  let waitForDeselection: @MainActor () async -> Void
+
+  static var live: Self {
+    Self(
+      selectedTrackID: selectedVideoTrackID(for:),
+      unselectVideoTrack: {
+        libvlc_media_player_unselect_track_type($0, libvlc_track_video)
+      },
+      reselectVideoTrack: { player, trackID in
+        trackID.withCString { id in
+          libvlc_media_player_select_tracks_by_ids(player, libvlc_track_video, id)
+        }
+      },
+      waitForDeselection: {
+        try? await Task.sleep(for: .milliseconds(10))
+      }
+    )
+  }
+}
+
+private func selectedVideoTrackID(for player: OpaquePointer) -> String? {
+  guard let track = libvlc_media_player_get_selected_track(player, libvlc_track_video) else {
+    return nil
+  }
+  defer { libvlc_media_track_release(track) }
+  return track.pointee.psz_id.map(String.init(cString:))
+}
+#endif
+
 /// Platform-drawable attachment and the lazy native-handle replacement
 /// it requires after stopped drawable-hosted playback.
 extension Player {
@@ -98,19 +184,19 @@ extension Player {
   /// surface can become invalid when macOS destroys the old PiP window even
   /// though decoding and audio continue. Re-selecting the same video track
   /// rebuilds only that output against the drawable's new inline window.
-  func reopenVideoOutputAfterDrawableWindowMove() {
+  @discardableResult
+  func reopenVideoOutputAfterDrawableWindowMove(
+    using native: MacVideoOutputRecoveryNativeOperations = .live
+  ) -> Task<Void, Never>? {
     guard
       let media = currentMedia,
-      let selectedTrack = libvlc_media_player_get_selected_track(pointer, libvlc_track_video)
-    else { return }
-    defer { libvlc_media_track_release(selectedTrack) }
-    guard let trackIDPointer = selectedTrack.pointee.psz_id else { return }
+      let trackID = native.selectedTrackID(pointer)
+    else { return nil }
 
-    let trackID = String(cString: trackIDPointer)
     let nativePlayer = pointer
-    libvlc_media_player_unselect_track_type(nativePlayer, libvlc_track_video)
+    native.unselectVideoTrack(nativePlayer)
 
-    Task { @MainActor [weak self, weak media] in
+    return Task { @MainActor [weak self, weak media] in
       guard let self else { return }
 
       // Track selection is processed asynchronously by libVLC. Wait for the
@@ -118,40 +204,21 @@ extension Player {
       // into a no-op that leaves the invalid OpenGL surface alive. Some VLC
       // inputs keep their vout allocated while no video track is selected, so
       // the selected-track state is the reliable acknowledgement here.
-      for _ in 0..<50 {
-        guard pointer == nativePlayer, currentMedia === media else { return }
-        guard
-          let stillSelected = libvlc_media_player_get_selected_track(
-            nativePlayer,
-            libvlc_track_video
-          )
-        else {
-          break
+      await MacVideoOutputRecovery(
+        expectedTrackID: trackID,
+        playbackIsCurrent: { [weak self, weak media] in
+          guard let self, let media else { return false }
+          return pointer == nativePlayer && currentMedia === media
+        },
+        playbackState: { [weak self] in self?.state ?? .idle },
+        selectedTrackID: { native.selectedTrackID(nativePlayer) },
+        waitForDeselection: {
+          await native.waitForDeselection()
+        },
+        reselectTrack: { trackID in
+          native.reselectVideoTrack(nativePlayer, trackID)
         }
-        let stillSelectedID = stillSelected.pointee.psz_id.map(String.init(cString:))
-        libvlc_media_track_release(stillSelected)
-        guard stillSelectedID == trackID else { return }
-        try? await Task.sleep(for: .milliseconds(10))
-      }
-
-      guard
-        pointer == nativePlayer,
-        currentMedia === media,
-        state != .idle,
-        state != .stopped,
-        state != .stopping,
-        state != .error
-      else { return }
-
-      if let newlySelected = libvlc_media_player_get_selected_track(nativePlayer, libvlc_track_video) {
-        let newlySelectedID = newlySelected.pointee.psz_id.map(String.init(cString:))
-        libvlc_media_track_release(newlySelected)
-        guard newlySelectedID == trackID else { return }
-      }
-
-      trackID.withCString { id in
-        libvlc_media_player_select_tracks_by_ids(nativePlayer, libvlc_track_video, id)
-      }
+      ).run()
     }
   }
   #endif

--- a/Sources/SwiftVLC/Player/Player+Drawable.swift
+++ b/Sources/SwiftVLC/Player/Player+Drawable.swift
@@ -92,6 +92,70 @@ extension Player {
     needsDrawableRebindForPlayback = false
   }
 
+  #if os(macOS)
+  /// Reopens the active video output after its AppKit drawable moves between
+  /// windows. `VLCOpenGLVideoView` owns an `NSOpenGLContext` whose window
+  /// surface can become invalid when macOS destroys the old PiP window even
+  /// though decoding and audio continue. Re-selecting the same video track
+  /// rebuilds only that output against the drawable's new inline window.
+  func reopenVideoOutputAfterDrawableWindowMove() {
+    guard
+      let media = currentMedia,
+      let selectedTrack = libvlc_media_player_get_selected_track(pointer, libvlc_track_video)
+    else { return }
+    defer { libvlc_media_track_release(selectedTrack) }
+    guard let trackIDPointer = selectedTrack.pointee.psz_id else { return }
+
+    let trackID = String(cString: trackIDPointer)
+    let nativePlayer = pointer
+    libvlc_media_player_unselect_track_type(nativePlayer, libvlc_track_video)
+
+    Task { @MainActor [weak self, weak media] in
+      guard let self else { return }
+
+      // Track selection is processed asynchronously by libVLC. Wait for the
+      // deselection to settle so selecting the same ID cannot be coalesced
+      // into a no-op that leaves the invalid OpenGL surface alive. Some VLC
+      // inputs keep their vout allocated while no video track is selected, so
+      // the selected-track state is the reliable acknowledgement here.
+      for _ in 0..<50 {
+        guard pointer == nativePlayer, currentMedia === media else { return }
+        guard
+          let stillSelected = libvlc_media_player_get_selected_track(
+            nativePlayer,
+            libvlc_track_video
+          )
+        else {
+          break
+        }
+        let stillSelectedID = stillSelected.pointee.psz_id.map(String.init(cString:))
+        libvlc_media_track_release(stillSelected)
+        guard stillSelectedID == trackID else { return }
+        try? await Task.sleep(for: .milliseconds(10))
+      }
+
+      guard
+        pointer == nativePlayer,
+        currentMedia === media,
+        state != .idle,
+        state != .stopped,
+        state != .stopping,
+        state != .error
+      else { return }
+
+      if let newlySelected = libvlc_media_player_get_selected_track(nativePlayer, libvlc_track_video) {
+        let newlySelectedID = newlySelected.pointee.psz_id.map(String.init(cString:))
+        libvlc_media_track_release(newlySelected)
+        guard newlySelectedID == trackID else { return }
+      }
+
+      trackID.withCString { id in
+        libvlc_media_player_select_tracks_by_ids(nativePlayer, libvlc_track_video, id)
+      }
+    }
+  }
+  #endif
+
   func replaceNativePlayerForDrawablePlayback(
     target: AnyObject?,
     resumeBeforeRelease: Bool = false

--- a/Sources/SwiftVLC/Playlist/MediaList.swift
+++ b/Sources/SwiftVLC/Playlist/MediaList.swift
@@ -30,6 +30,15 @@ public final class MediaList: Sendable {
     pointer = ptr
   }
 
+  /// Adopts an already-retained `libvlc_media_list_t` pointer.
+  ///
+  /// Use this for libVLC APIs that return a caller-owned reference. The
+  /// reference is stored without an additional retain and released once
+  /// when this wrapper deinitializes.
+  init(owning ptr: OpaquePointer) {
+    pointer = ptr
+  }
+
   deinit {
     libvlc_media_list_release(pointer)
   }

--- a/Sources/SwiftVLC/SwiftVLC.docc/ComparisonWithVLCKit.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/ComparisonWithVLCKit.md
@@ -15,7 +15,7 @@ platforms, and its README documents CocoaPods (`VLCKit`,
 
 **SwiftVLC** is a Swift 6 binding to libVLC's C API, with no
 Objective-C layer in between. It targets modern Apple platforms (iOS
-18+, macOS 15+, tvOS 18+, visionOS 2+, macCatalyst 18+) and ships
+18+, macOS 15+, tvOS 18+, visionOS 2+, Mac Catalyst 18+) and ships
 through Swift Package Manager.
 
 ## libVLC generation
@@ -95,8 +95,12 @@ See <doc:ConcurrencyModel> for the full isolation map.
 | Logging | Delegate protocol | `AsyncStream<LogEntry>` with level filtering |
 | Dialog prompts | Delegate protocol | `AsyncStream<DialogEvent>` |
 
-Multiple consumers can subscribe to any SwiftVLC stream concurrently;
-each receives every event broadcast after creation.
+Multiple consumers can subscribe to SwiftVLC streams concurrently. Each
+subscription is independent and is offered events broadcast after its
+creation, subject to its own filter and buffering policy. Default bounded
+streams can drop their oldest events when a consumer falls behind; APIs
+such as ``Player/events(policy:filter:)`` expose an unbounded option when
+lossless delivery is required.
 
 ## SwiftUI
 

--- a/Sources/SwiftVLC/SwiftVLC.docc/ConcurrencyModel.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/ConcurrencyModel.md
@@ -44,20 +44,26 @@ Task.detached {
 
 Events, logs, dialogs, and discoverers all surface through
 `AsyncStream`. The streams are multiplexed: calling ``Player/events``
-twice returns two independent streams, both of which receive every
-event broadcast after their creation.
+twice returns two independent subscriptions. Each subscription is
+offered events broadcast after its creation, subject to its own filter
+and buffering policy.
 
 ```swift
 Task { for await e in player.events { handleA(e) } }
 Task { for await e in player.events { handleB(e) } }
 ```
 
-Backpressure is `bufferingNewest`; slow consumers drop oldest events
-rather than block the callback thread.
+``Player/events`` defaults to `.newest(64)`. Logs and discovery streams
+also use bounded newest-wins buffers. A slow consumer can therefore drop
+its own oldest buffered events rather than block the callback thread or
+other subscribers. Consumers that must not miss lifecycle transitions
+can use ``Player/stateTransitions`` or an explicitly filtered,
+`.unbounded` ``Player/events(policy:filter:)`` subscription.
 
-## Cancellation
+## Cancellation and stream termination
 
-Every async API that waits on libVLC honors task cancellation:
+Media parsing and thumbnail generation provide documented cooperative
+cancellation behavior:
 
 - ``Media/parse(timeout:instance:)``: canceling the enclosing task
   stops the parse.
@@ -65,6 +71,12 @@ Every async API that waits on libVLC honors task cancellation:
   canceling before libVLC accepts the request returns immediately. Once
   accepted, SwiftVLC waits for the terminal thumbnail event so callback
   and request teardown are complete before the task returns.
+
+Other asynchronous operations document their own completion contract.
+For example, ``Player/stopAndWait()`` and ``Player/shutdown()`` wait for
+native lifecycle teardown and do not advertise the parsing cancellation
+contract.
+
 - Streams finish when their owning type (`Player`, `VLCInstance`, or
   a discoverer) is released.
 

--- a/Sources/SwiftVLC/SwiftVLC.docc/DiscoveryAndCasting.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/DiscoveryAndCasting.md
@@ -42,7 +42,8 @@ apps can react as soon as a renderer appears or disappears:
 ```swift
 let services = RendererDiscoverer.availableServices()
 guard let service = services.first else { return }
-var player = Player()
+let player = Player()
+try player.play(url: mediaURL)
 
 let discoverer = try RendererDiscoverer(name: service.name)
 try discoverer.start()
@@ -51,12 +52,8 @@ for await event in discoverer.events {
     switch event {
     case .itemAdded(let renderer):
         print("Found", renderer.name, renderer.type)
-        let castPlayer = Player()
         do {
-            try castPlayer.setRenderer(renderer)
-            try castPlayer.play(url: mediaURL)
-            player.stop()
-            player = castPlayer
+            try await player.recast(to: renderer)
         } catch {
             print("Cast failed:", error)
         }
@@ -67,11 +64,12 @@ for await event in discoverer.events {
 ```
 
 libVLC applies renderer selection before a native media player's first
-play. SwiftVLC preserves that rule at the public API boundary: set the
-renderer before starting playback on a ``Player``. To retarget after
-local playback has already started, create a fresh ``Player`` as shown
-above. Pass `nil` to ``Player/setRenderer(_:)`` before playback starts
-to revert to local playback.
+play. SwiftVLC preserves that rule at the public API boundary: use
+``Player/setRenderer(_:)`` before starting playback on a ``Player``. To
+retarget after playback has started, await ``Player/recast(to:)``. It
+keeps the same ``Player`` while replacing the native handle and restarting
+the current media. Pass `nil` to `recast(to:)` to return active playback
+to local output, or to `setRenderer(_:)` before the first play.
 
 ## Inspecting a renderer
 
@@ -99,3 +97,4 @@ if renderer.canVideo && renderer.type == "chromecast" {
 
 ### Controlling output
 - ``Player/setRenderer(_:)``
+- ``Player/recast(to:)``

--- a/Sources/SwiftVLC/SwiftVLC.docc/GettingStarted.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/GettingStarted.md
@@ -19,15 +19,15 @@ The version string lives on the
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/harflabs/SwiftVLC.git", from: "x.y.z")
+    .package(url: "https://github.com/harflabs/SwiftVLC.git", from: "1.0.0")
 ],
 targets: [
     .target(name: "MyApp", dependencies: ["SwiftVLC"])
 ]
 ```
 
-SwiftVLC requires Swift 6.3 and supports iOS 18, macOS 15, tvOS 18,
-visionOS 2, and macCatalyst 18.
+SwiftVLC requires Swift 6.3 with Xcode 26.4 or later and supports iOS 18,
+macOS 15, tvOS 18, visionOS 2, and Mac Catalyst 18.
 
 ## Prepare libVLC at launch
 
@@ -100,8 +100,9 @@ Button(player.isPlaying ? "Pause" : "Play") {
 
 ## Handle errors as typed throws
 
-Every throwing API throws ``VLCError`` specifically, so `catch`
-clauses can match individual cases:
+Every failure introduced by SwiftVLC's typed throwing operations is a
+``VLCError``, so `catch` clauses for those calls can match individual
+cases:
 
 ```swift
 do {

--- a/Sources/SwiftVLC/SwiftVLC.docc/HandlingErrors.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/HandlingErrors.md
@@ -3,18 +3,18 @@
 How ``VLCError`` shapes the error surface, and how typed throws let
 you match on its cases exhaustively.
 
-## One error type for throwing APIs
+## One error type for library failures
 
-Every throwing SwiftVLC API uses Swift's typed throws form, with
-``VLCError`` as the only error it can produce:
+Every failure originating in SwiftVLC's own throwing operations is a
+``VLCError``. Those APIs use Swift's typed throws form:
 
 ```swift
 public func play(url: URL) throws(VLCError)
 ```
 
-The compiler therefore knows the complete set of cases a call site
-might see. Pattern matching can be exhaustive, with no residual
-`catch` branch needed:
+The compiler therefore knows the complete set of cases those calls might
+produce. Pattern matching can be exhaustive, with no residual `catch`
+branch needed:
 
 ```swift
 do {
@@ -43,6 +43,12 @@ do {
 APIs whose invalid case is naturally absence still use optionals, such
 as ``Equalizer/init(preset:)`` and lookup helpers that return `nil` for
 an unknown index.
+
+Scoped closure helpers such as `Player.withAdjustments(_:)`,
+`Player.withMarquee(_:)`, `Player.withLogo(_:)`, and
+`MediaList.withLocked(_:)` use `rethrows`. They do not introduce a new
+library failure, but they propagate any error thrown by the caller's
+closure, including application-defined error types.
 
 ## The cases at a glance
 

--- a/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
@@ -183,7 +183,8 @@ unavailable by default:
 
 Non-App-Store distributions that deliberately accept private framework
 risk may opt in through SwiftVLC's `PrivateMacOSPiP` SPI. That SPI is
-outside the stable public API contract and may change before `1.0`.
+outside the stable public API and semantic-versioning contract. It may
+change without a major-version release.
 
 ## Platform availability
 

--- a/Sources/SwiftVLC/SwiftVLC.docc/SwiftVLC.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/SwiftVLC.md
@@ -13,9 +13,10 @@ model does.
 - **Observable state.** ``Player`` is `@Observable` and `@MainActor`.
   SwiftUI views track `state`, `currentTime`, `duration`, and the
   track lists without manual bridging.
-- **Typed errors.** Every throwing API uses `throws(VLCError)`, so
-  the compiler sees the full error surface and a general `catch` is
-  not required for exhaustive handling.
+- **Typed errors.** Failures originating in SwiftVLC use
+  `throws(VLCError)`, so the compiler sees the full library error surface.
+  Scoped closure helpers use `rethrows` and propagate errors from the
+  caller's closure unchanged.
 - **Structured events.** Playback, discovery, logging, and dialog
   prompts all surface through `AsyncStream`. Multiple consumers can
   subscribe concurrently.

--- a/Tests/SwiftVLCTests/Audio/EqualizerBandsTests.swift
+++ b/Tests/SwiftVLCTests/Audio/EqualizerBandsTests.swift
@@ -107,6 +107,18 @@ extension Integration {
     }
 
     @Test
+    func `setAmplification skips re-apply when value is unchanged`() throws {
+      let eq = Equalizer()
+      var changeCount = 0
+      eq.onChange = { changeCount += 1 }
+      let current = try #require(eq.amplification(forBand: 0))
+
+      try eq.setAmplification(current, forBand: 0)
+
+      #expect(changeCount == 0, "Equal assignment should not trigger onChange")
+    }
+
+    @Test
     func `setAmplification rejects NaN values`() {
       let eq = Equalizer()
 

--- a/Tests/SwiftVLCTests/Discovery/MediaDiscovererTests.swift
+++ b/Tests/SwiftVLCTests/Discovery/MediaDiscovererTests.swift
@@ -142,6 +142,13 @@ extension Integration {
     }
 
     @Test
+    func `Bundled SAP discoverer exposes its media list`() throws {
+      let discoverer = try MediaDiscoverer(name: "sap", instance: TestInstance.shared)
+
+      #expect(discoverer.mediaList != nil)
+    }
+
+    @Test
     func `Deinit safety`() {
       let services = MediaDiscoverer.availableServices(category: .localDirectories)
       guard let service = services.first else { return }

--- a/Tests/SwiftVLCTests/Discovery/MediaDiscovererTests.swift
+++ b/Tests/SwiftVLCTests/Discovery/MediaDiscovererTests.swift
@@ -132,6 +132,16 @@ extension Integration {
     }
 
     @Test
+    func `Media list adapter adopts a caller-owned reference`() throws {
+      let pointer = try #require(libvlc_media_list_new())
+      let list = try #require(MediaDiscoverer.adoptMediaList(pointer))
+
+      #expect(list.pointer == pointer)
+      #expect(list.isEmpty)
+      #expect(MediaDiscoverer.adoptMediaList(nil) == nil)
+    }
+
+    @Test
     func `Deinit safety`() {
       let services = MediaDiscoverer.availableServices(category: .localDirectories)
       guard let service = services.first else { return }

--- a/Tests/SwiftVLCTests/Media/ThumbnailRequestTests.swift
+++ b/Tests/SwiftVLCTests/Media/ThumbnailRequestTests.swift
@@ -10,6 +10,9 @@ extension Integration {
       let media = try Media(url: TestMedia.testMP4URL)
       let data = try await media.thumbnail(at: .zero, width: 64, height: 0)
       #expect(!data.isEmpty)
+      #if DEBUG
+      #expect(MediaOperationLifetimeProbe.liveThumbnailCount == 0)
+      #endif
     }
 
     @Test

--- a/Tests/SwiftVLCTests/MemoryPressureTests.swift
+++ b/Tests/SwiftVLCTests/MemoryPressureTests.swift
@@ -306,6 +306,12 @@ extension Integration {
 
       let alive = probes.aliveCount()
       #expect(alive == 0, "\(alive) Media leaked after fire-and-forget parse")
+      #if DEBUG
+      #expect(
+        MediaOperationLifetimeProbe.liveParseCount == 0,
+        "Parse callback boxes remained retained after every operation completed"
+      )
+      #endif
     }
 
     // MARK: - Thumbnail cancellation chaos
@@ -347,6 +353,12 @@ extension Integration {
 
       let alive = probes.aliveCount()
       #expect(alive == 0, "\(alive) / \(iterations) Media leaked after thumbnail cancellation")
+      #if DEBUG
+      #expect(
+        MediaOperationLifetimeProbe.liveThumbnailCount == 0,
+        "Thumbnail callback boxes remained retained after cancellation cleanup"
+      )
+      #endif
     }
 
     // MARK: - Equalizer install/clear churn (deep)

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
@@ -596,6 +596,40 @@ extension Integration {
     }
 
     @Test
+    func `macOS private PiP delegate prepares the presenter for system close`() throws {
+      let player = Player(instance: TestInstance.shared)
+      let host = MacNativePiPHostView(frame: CGRect(x: 0, y: 0, width: 960, height: 540))
+      let drawable = host.drawableView
+      let controller = MacPrivatePiPViewControllerProbe()
+      let presenter = MacPrivatePiPPresenter(
+        pictureInPictureViewControllerFactory: { controller }
+      )
+      let mediaController = MacNativePiPMediaController()
+      mediaController.player = player
+      var activeStates: [Bool] = []
+
+      let didStart = presenter.start(
+        player: player,
+        hostView: host,
+        drawableView: drawable,
+        mediaController: mediaController,
+        onActiveChanged: { activeStates.append($0) },
+        onPlay: {},
+        onPause: {}
+      )
+      #expect(didStart)
+
+      let delegate = try #require(controller.delegate as? MacPrivatePiPDelegate)
+      #expect(delegate.shouldClose())
+      delegate.willClose()
+      delegate.didClose()
+
+      #expect(drawable.superview === host)
+      #expect(presenter.isActive == false)
+      expectNoDifference(activeStates, [true, false])
+    }
+
+    @Test
     func `macOS native PiP rejects instances without video output`() throws {
       let instance = try VLCInstance(arguments: ["--no-video-title-show", "--no-video", "--no-audio", "--quiet"])
       let player = Player(instance: instance)

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
@@ -2,6 +2,7 @@
 @_spi(PrivateMacOSPiP) @testable import SwiftVLC
 import AVFoundation
 import CLibVLC
+import CustomDump
 import SwiftUI
 import Testing
 
@@ -554,6 +555,47 @@ extension Integration {
     }
 
     @Test
+    func `macOS private PiP close restores the drawable before dismissal`() async {
+      let player = Player(instance: TestInstance.shared)
+      let host = MacNativePiPHostView(frame: CGRect(x: 0, y: 0, width: 960, height: 540))
+      let drawable = host.drawableView
+      let controller = MacPrivatePiPViewControllerProbe()
+      let presenter = MacPrivatePiPPresenter(
+        pictureInPictureViewControllerFactory: { controller }
+      )
+      let mediaController = MacNativePiPMediaController()
+      mediaController.player = player
+      var activeStates: [Bool] = []
+
+      let didStart = presenter.start(
+        player: player,
+        hostView: host,
+        drawableView: drawable,
+        mediaController: mediaController,
+        onActiveChanged: { activeStates.append($0) },
+        onPlay: {},
+        onPause: {}
+      )
+
+      #expect(didStart)
+      #expect(presenter.isActive)
+      #expect(controller.presentedViewController?.view === drawable)
+      #expect(drawable.superview == nil)
+
+      presenter.stop()
+
+      #expect(presenter.isActive == false)
+      #expect(drawable.superview === host)
+      #expect(drawable.frame == host.bounds)
+
+      await Task.yield()
+
+      #expect(drawable.superview === host)
+      #expect(controller.dismissCount == 1)
+      expectNoDifference(activeStates, [true, false])
+    }
+
+    @Test
     func `macOS native PiP rejects instances without video output`() throws {
       let instance = try VLCInstance(arguments: ["--no-video-title-show", "--no-video", "--no-audio", "--quiet"])
       let player = Player(instance: instance)
@@ -825,6 +867,31 @@ private final class MacWeakBox<T: AnyObject> {
 
   init(_ value: T?) {
     self.value = value
+  }
+}
+
+@MainActor
+private final class MacPrivatePiPViewControllerProbe: NSViewController {
+  @objc dynamic var delegate: NSObject?
+  @objc dynamic var replacementWindow: NSWindow?
+  @objc dynamic var replacementRect: NSValue?
+  @objc dynamic var playing = false
+  @objc dynamic var aspectRatio: NSValue?
+
+  private(set) var presentedViewController: NSViewController?
+  private(set) var dismissCount = 0
+
+  @objc(presentViewControllerAsPictureInPicture:)
+  func presentAsPictureInPicture(_ viewController: NSViewController) {
+    presentedViewController = viewController
+  }
+
+  @objc(dismissPictureInPictureWithCompletionHandler:)
+  func dismissPictureInPicture(
+    completion: @escaping @convention(block) () -> Void
+  ) {
+    dismissCount += 1
+    completion()
   }
 }
 

--- a/Tests/SwiftVLCTests/Player/MacVideoOutputRecoveryTests.swift
+++ b/Tests/SwiftVLCTests/Player/MacVideoOutputRecoveryTests.swift
@@ -1,5 +1,6 @@
 #if os(macOS)
 @testable import SwiftVLC
+import CLibVLC
 import CustomDump
 import Testing
 
@@ -211,6 +212,34 @@ extension Integration {
       if recovery != nil {
         Issue.record("Expected recovery not to start without an active video output")
       }
+    }
+
+    @Test
+    func `live native recovery operations are safe for an inactive player`() async {
+      let player = Player(instance: TestInstance.shared)
+      let native = MacVideoOutputRecoveryNativeOperations.live
+
+      #expect(native.selectedTrackID(player.pointer) == nil)
+      native.unselectVideoTrack(player.pointer)
+      native.reselectVideoTrack(player.pointer, "video")
+      await native.waitForDeselection()
+    }
+
+    @Test
+    func `native track adapter adopts and returns a parsed track identifier`() async throws {
+      let media = try Media(url: TestMedia.testMP4URL)
+      _ = try await media.parse()
+      let trackList = try #require(
+        libvlc_media_get_tracklist(media.pointer, libvlc_track_video)
+      )
+      defer { libvlc_media_tracklist_delete(trackList) }
+      try #require(libvlc_media_tracklist_count(trackList) > 0)
+      let track = try #require(libvlc_media_tracklist_at(trackList, 0))
+      let id = try #require(track.pointee.psz_id)
+      let expectedID = String(cString: id)
+      let ownedTrack = try #require(libvlc_media_track_hold(track))
+
+      #expect(nativeTrackID(adopting: ownedTrack) == expectedID)
     }
   }
 }

--- a/Tests/SwiftVLCTests/Player/MacVideoOutputRecoveryTests.swift
+++ b/Tests/SwiftVLCTests/Player/MacVideoOutputRecoveryTests.swift
@@ -1,0 +1,217 @@
+#if os(macOS)
+@testable import SwiftVLC
+import CustomDump
+import Testing
+
+extension Logic {
+  @Suite(.tags(.mainActor, .async))
+  @MainActor struct MacVideoOutputRecoveryTests {
+    @Test
+    func `waits for deselection before restoring the expected track`() async {
+      var selections: [String?] = ["video", nil, nil]
+      var events: [String] = []
+
+      await MacVideoOutputRecovery(
+        expectedTrackID: "video",
+        playbackIsCurrent: {
+          events.append("current")
+          return true
+        },
+        playbackState: {
+          events.append("playing")
+          return .playing
+        },
+        selectedTrackID: {
+          let selection = selections.removeFirst()
+          events.append("selected:\(selection ?? "none")")
+          return selection
+        },
+        waitForDeselection: {
+          events.append("wait")
+        },
+        reselectTrack: { trackID in
+          events.append("reselect:\(trackID)")
+        }
+      ).run()
+
+      expectNoDifference(
+        events,
+        [
+          "current",
+          "selected:video",
+          "wait",
+          "current",
+          "selected:none",
+          "current",
+          "playing",
+          "selected:none",
+          "reselect:video"
+        ]
+      )
+    }
+
+    @Test
+    func `aborts when the media or native player changes while waiting`() async {
+      var isCurrent = true
+      var selectedTrack: String? = "video"
+      var reselectedTracks: [String] = []
+
+      await MacVideoOutputRecovery(
+        expectedTrackID: "video",
+        playbackIsCurrent: { isCurrent },
+        playbackState: { .playing },
+        selectedTrackID: { selectedTrack },
+        waitForDeselection: {
+          selectedTrack = nil
+          isCurrent = false
+        },
+        reselectTrack: { reselectedTracks.append($0) }
+      ).run()
+
+      expectNoDifference(reselectedTracks, [])
+    }
+
+    @Test(
+      arguments: [
+        PlayerState.idle,
+        .stopped,
+        .stopping,
+        .error,
+      ]
+    )
+    func `does not restore video for terminal playback states`(state: PlayerState) async {
+      var reselectedTracks: [String] = []
+
+      await MacVideoOutputRecovery(
+        expectedTrackID: "video",
+        playbackIsCurrent: { true },
+        playbackState: { state },
+        selectedTrackID: { nil },
+        waitForDeselection: {},
+        reselectTrack: { reselectedTracks.append($0) }
+      ).run()
+
+      expectNoDifference(reselectedTracks, [])
+    }
+
+    @Test
+    func `does not overwrite a different track selected during recovery`() async {
+      var selections: [String?] = [nil, "replacement"]
+      var reselectedTracks: [String] = []
+
+      await MacVideoOutputRecovery(
+        expectedTrackID: "video",
+        playbackIsCurrent: { true },
+        playbackState: { .paused },
+        selectedTrackID: { selections.removeFirst() },
+        waitForDeselection: {},
+        reselectTrack: { reselectedTracks.append($0) }
+      ).run()
+
+      expectNoDifference(reselectedTracks, [])
+    }
+
+    @Test
+    func `bounded polling still makes a final restore attempt`() async {
+      var pollCount = 0
+      var reselectedTracks: [String] = []
+
+      await MacVideoOutputRecovery(
+        expectedTrackID: "video",
+        maximumDeselectionPolls: 2,
+        playbackIsCurrent: { true },
+        playbackState: { .buffering },
+        selectedTrackID: { "video" },
+        waitForDeselection: { pollCount += 1 },
+        reselectTrack: { reselectedTracks.append($0) }
+      ).run()
+
+      #expect(pollCount == 2)
+      expectNoDifference(reselectedTracks, ["video"])
+    }
+  }
+}
+
+extension Integration {
+  @Suite(.tags(.mainActor, .async))
+  @MainActor struct MacVideoOutputRecoveryIntegrationTests {
+    @Test
+    func `player wrapper performs recovery through controlled native operations`() async throws {
+      let player = Player(instance: TestInstance.shared)
+      try player.load(Media(url: TestMedia.twosecURL))
+      player._setStateForTesting(state: .playing)
+      var selections: [String?] = ["video", "video", nil, nil]
+      var events: [String] = []
+      let native = MacVideoOutputRecoveryNativeOperations(
+        selectedTrackID: { _ in
+          let selection = selections.removeFirst()
+          events.append("selected:\(selection ?? "none")")
+          return selection
+        },
+        unselectVideoTrack: { _ in
+          events.append("unselect")
+        },
+        reselectVideoTrack: { _, trackID in
+          events.append("reselect:\(trackID)")
+        },
+        waitForDeselection: {
+          events.append("wait")
+        }
+      )
+
+      let recovery = try #require(
+        player.reopenVideoOutputAfterDrawableWindowMove(using: native)
+      )
+      await recovery.value
+
+      expectNoDifference(
+        events,
+        [
+          "selected:video",
+          "unselect",
+          "selected:video",
+          "wait",
+          "selected:none",
+          "selected:none",
+          "reselect:video"
+        ]
+      )
+    }
+
+    @Test
+    func `player wrapper stops before unselecting when no video track is selected`() throws {
+      let player = Player(instance: TestInstance.shared)
+      try player.load(Media(url: TestMedia.twosecURL))
+      var events: [String] = []
+      let native = MacVideoOutputRecoveryNativeOperations(
+        selectedTrackID: { _ in
+          events.append("selected:none")
+          return nil
+        },
+        unselectVideoTrack: { _ in events.append("unselect") },
+        reselectVideoTrack: { _, _ in events.append("reselect") },
+        waitForDeselection: { events.append("wait") }
+      )
+
+      let recovery = player.reopenVideoOutputAfterDrawableWindowMove(using: native)
+
+      if recovery != nil {
+        Issue.record("Expected recovery not to start without a selected video track")
+      }
+      expectNoDifference(events, ["selected:none"])
+    }
+
+    @Test
+    func `live player wrapper exits safely without an active video output`() throws {
+      let player = Player(instance: TestInstance.shared)
+      try player.load(Media(url: TestMedia.twosecURL))
+
+      let recovery = player.reopenVideoOutputAfterDrawableWindowMove()
+
+      if recovery != nil {
+        Issue.record("Expected recovery not to start without an active video output")
+      }
+    }
+  }
+}
+#endif

--- a/Tests/SwiftVLCTests/Player/RemoteMP4SeekTests.swift
+++ b/Tests/SwiftVLCTests/Player/RemoteMP4SeekTests.swift
@@ -5,7 +5,11 @@ import Synchronization
 import Testing
 
 extension Integration {
-  @Suite(.tags(.mainActor, .async, .media), .serialized)
+  @Suite(
+    .tags(.mainActor, .async, .media),
+    .serialized,
+    .enabled(if: TestCondition.canPlayMedia, "Requires the rebuilt release XCFramework")
+  )
   @MainActor struct RemoteMP4SeekTests {
     @Test(.timeLimit(.minutes(1)))
     func `Remote MP4 seek requests the target range and resumes near the target`() async throws {

--- a/Tests/SwiftVLCTests/Player/RemoteMP4SeekTests.swift
+++ b/Tests/SwiftVLCTests/Player/RemoteMP4SeekTests.swift
@@ -1,0 +1,341 @@
+@testable import SwiftVLC
+import Darwin
+import Foundation
+import Synchronization
+import Testing
+
+extension Integration {
+  @Suite(.tags(.mainActor, .async, .media), .serialized)
+  @MainActor struct RemoteMP4SeekTests {
+    @Test(.timeLimit(.minutes(1)))
+    func `Remote MP4 seek requests the target range and resumes near the target`() async throws {
+      let fixtureURL = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("Showcase/UITests/iOS/Fixtures/test.mp4")
+      let fixture = try Data(contentsOf: fixtureURL)
+      let server = try MP4RangeProbeServer(data: fixture)
+      defer { server.stop() }
+
+      let instance = try VLCInstance(
+        arguments: VLCInstance.defaultArguments + [
+          "--vout=dummy",
+          "--aout=dummy",
+          "--no-hw-dec",
+          "--quiet"
+        ]
+      )
+      let player = Player(instance: instance)
+      defer { player.stop() }
+
+      try player.play(url: server.url)
+      try #require(
+        await poll(every: .milliseconds(50), timeout: .seconds(10)) {
+          player.state == .playing && player.isSeekable
+        },
+        "Waiting for remote MP4 playback to become seekable"
+      )
+
+      let nativeLanding = subscribeAndAwaitTime(atLeast: .seconds(34), on: player)
+      try player.seek(to: .seconds(36), fast: false)
+      let landedTime = try #require(
+        await nativeLanding.value,
+        "Waiting for a native time event near the 36 second seek target"
+      )
+
+      let targetRangeThreshold = fixture.count / 3
+      try #require(
+        await poll(every: .milliseconds(50), timeout: .seconds(5)) {
+          server.rangeStarts.contains { $0 > targetRangeThreshold }
+        },
+        "Expected a discontinuous HTTP range request after seeking, observed starts: \(server.rangeStarts)"
+      )
+      #expect(landedTime >= .seconds(34))
+    }
+
+    private func subscribeAndAwaitTime(
+      atLeast minimum: Duration,
+      on player: Player,
+      timeout: Duration = .seconds(8)
+    ) -> Task<Duration?, Never> {
+      let events = player.events
+      return Task.detached { @Sendable in
+        await withTaskGroup(of: Duration?.self) { group in
+          group.addTask {
+            for await event in events {
+              if case .timeChanged(let time) = event, time >= minimum {
+                return time
+              }
+            }
+            return nil
+          }
+          group.addTask {
+            try? await Task.sleep(for: timeout)
+            return nil
+          }
+          let first = await group.next() ?? nil
+          group.cancelAll()
+          return first
+        }
+      }
+    }
+  }
+}
+
+private final class MP4RangeProbeServer: Sendable {
+  private let socketFD: Int32
+  private let acceptQueue = DispatchQueue(label: "swiftvlc.mp4-range.accept")
+  private let clientQueue = DispatchQueue(
+    label: "swiftvlc.mp4-range.clients",
+    attributes: .concurrent
+  )
+  private let state = StateBox()
+  private let data: Data
+
+  let url: URL
+
+  var rangeStarts: [Int] {
+    state.mutex.withLock { $0.rangeStarts }
+  }
+
+  init(data: Data) throws {
+    self.data = data
+
+    let fd = socket(AF_INET, SOCK_STREAM, 0)
+    guard fd >= 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
+
+    var reuse: Int32 = 1
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size))
+
+    var address = sockaddr_in()
+    address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+    address.sin_family = sa_family_t(AF_INET)
+    address.sin_port = 0
+    address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+    let bindResult = withUnsafePointer(to: &address) { pointer in
+      pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+        Darwin.bind(fd, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_in>.size))
+      }
+    }
+    guard bindResult == 0 else {
+      let error = POSIXError(.init(rawValue: errno) ?? .EIO)
+      close(fd)
+      throw error
+    }
+
+    guard listen(fd, 8) == 0 else {
+      let error = POSIXError(.init(rawValue: errno) ?? .EIO)
+      close(fd)
+      throw error
+    }
+
+    var boundAddress = sockaddr_in()
+    var boundLength = socklen_t(MemoryLayout<sockaddr_in>.size)
+    let nameResult = withUnsafeMutablePointer(to: &boundAddress) { pointer in
+      pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+        getsockname(fd, sockaddrPointer, &boundLength)
+      }
+    }
+    guard nameResult == 0 else {
+      let error = POSIXError(.init(rawValue: errno) ?? .EIO)
+      close(fd)
+      throw error
+    }
+
+    let port = UInt16(bigEndian: boundAddress.sin_port)
+    socketFD = fd
+    url = URL(string: "http://127.0.0.1:\(port)/seek-fixture.mp4")!
+
+    acceptQueue.async { [fd, data, state, clientQueue] in
+      Self.acceptLoop(socketFD: fd, data: data, state: state, clientQueue: clientQueue)
+    }
+  }
+
+  deinit {
+    stop()
+  }
+
+  func stop() {
+    let clients = state.mutex.withLock { state -> [Int32]? in
+      guard !state.isStopped else { return nil }
+      state.isStopped = true
+      return Array(state.clients)
+    }
+    guard let clients else { return }
+    shutdown(socketFD, SHUT_RDWR)
+    close(socketFD)
+    for client in clients {
+      shutdown(client, SHUT_RDWR)
+    }
+  }
+
+  private static func acceptLoop(
+    socketFD: Int32,
+    data: Data,
+    state: StateBox,
+    clientQueue: DispatchQueue
+  ) {
+    while true {
+      let client = accept(socketFD, nil, nil)
+      if client < 0 {
+        return
+      }
+
+      var noSignal: Int32 = 1
+      setsockopt(
+        client,
+        SOL_SOCKET,
+        SO_NOSIGPIPE,
+        &noSignal,
+        socklen_t(MemoryLayout<Int32>.size)
+      )
+
+      let accepted = state.mutex.withLock { state -> Bool in
+        guard !state.isStopped else { return false }
+        state.clients.insert(client)
+        return true
+      }
+      guard accepted else {
+        close(client)
+        return
+      }
+
+      clientQueue.async {
+        handle(client: client, data: data, state: state)
+        _ = state.mutex.withLock { $0.clients.remove(client) }
+        shutdown(client, SHUT_RDWR)
+        close(client)
+      }
+    }
+  }
+
+  private static func handle(client: Int32, data: Data, state: StateBox) {
+    let request = readRequest(from: client)
+    let method = request.prefix { !$0.isWhitespace }
+    let requested = requestedRange(in: request, length: data.count)
+    let start = requested?.lowerBound ?? 0
+    let end = requested?.upperBound ?? (data.count - 1)
+    state.mutex.withLock { $0.rangeStarts.append(start) }
+
+    guard start >= 0, start < data.count, end >= start else {
+      _ = sendAll(Data("HTTP/1.1 416 Range Not Satisfiable\r\nConnection: close\r\n\r\n".utf8), to: client)
+      return
+    }
+
+    let responseLength = end - start + 1
+    var headers = [
+      requested == nil ? "HTTP/1.1 200 OK" : "HTTP/1.1 206 Partial Content",
+      "Accept-Ranges: bytes",
+      "Content-Type: video/mp4",
+      "Content-Length: \(responseLength)",
+      "Connection: close"
+    ]
+    if requested != nil {
+      headers.append("Content-Range: bytes \(start)-\(end)/\(data.count)")
+    }
+    let headerData = Data((headers.joined(separator: "\r\n") + "\r\n\r\n").utf8)
+    guard sendAll(headerData, to: client), method != "HEAD" else { return }
+
+    let chunkSize = 4 * 1024
+    var offset = start
+    while offset <= end {
+      if state.mutex.withLock({ $0.isStopped }) {
+        return
+      }
+      let chunkEnd = min(offset + chunkSize - 1, end)
+      guard sendRange(data, range: offset...chunkEnd, to: client) else { return }
+      offset = chunkEnd + 1
+      usleep(20000)
+    }
+  }
+
+  private static func requestedRange(in request: String, length: Int) -> ClosedRange<Int>? {
+    for line in request.components(separatedBy: "\r\n") {
+      guard line.lowercased().hasPrefix("range:") else { continue }
+      let value = line.dropFirst("range:".count).trimmingCharacters(in: .whitespaces)
+      guard value.lowercased().hasPrefix("bytes=") else { return nil }
+      let bounds = value.dropFirst("bytes=".count).split(separator: "-", maxSplits: 1, omittingEmptySubsequences: false)
+      guard let first = bounds.first, let start = Int(first), start < length else { return nil }
+      let requestedEnd = bounds.count == 2 ? Int(bounds[1]) : nil
+      return start...min(requestedEnd ?? (length - 1), length - 1)
+    }
+    return nil
+  }
+
+  private static func readRequest(from client: Int32) -> String {
+    var bytes: [UInt8] = []
+    var buffer = [UInt8](repeating: 0, count: 1024)
+    while bytes.count < 16 * 1024 {
+      let count = recv(client, &buffer, buffer.count, 0)
+      guard count > 0 else { break }
+      bytes.append(contentsOf: buffer.prefix(count))
+      if bytes.containsMP4ProbeHeaderTerminator {
+        break
+      }
+    }
+    return String(bytes: bytes, encoding: .utf8) ?? ""
+  }
+
+  private static func sendAll(_ data: Data, to client: Int32) -> Bool {
+    data.withUnsafeBytes { bytes in
+      guard let baseAddress = bytes.baseAddress else { return true }
+      var sent = 0
+      while sent < bytes.count {
+        let result = Darwin.send(client, baseAddress.advanced(by: sent), bytes.count - sent, 0)
+        if result < 0, errno == EINTR {
+          continue
+        }
+        guard result > 0 else { return false }
+        sent += result
+      }
+      return true
+    }
+  }
+
+  private static func sendRange(_ data: Data, range: ClosedRange<Int>, to client: Int32) -> Bool {
+    data.withUnsafeBytes { bytes in
+      guard let baseAddress = bytes.baseAddress else { return true }
+      var sent = 0
+      let count = range.count
+      while sent < count {
+        let result = Darwin.send(
+          client,
+          baseAddress.advanced(by: range.lowerBound + sent),
+          count - sent,
+          0
+        )
+        if result < 0, errno == EINTR {
+          continue
+        }
+        guard result > 0 else { return false }
+        sent += result
+      }
+      return true
+    }
+  }
+
+  private struct State: Sendable {
+    var isStopped = false
+    var clients: Set<Int32> = []
+    var rangeStarts: [Int] = []
+  }
+
+  private final class StateBox: Sendable {
+    let mutex = Mutex(State())
+  }
+}
+
+extension [UInt8] {
+  fileprivate var containsMP4ProbeHeaderTerminator: Bool {
+    guard count >= 4 else { return false }
+    return indices.dropFirst(3).contains { index in
+      self[index - 3] == 13
+        && self[index - 2] == 10
+        && self[index - 1] == 13
+        && self[index] == 10
+    }
+  }
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,14 +2,10 @@
 #
 # Coverage comes from a single `swift test --enable-code-coverage` run on a
 # headless macOS CI host (see .github/workflows/test.yml → the `test` job).
-# That environment cannot exercise a handful of on-device-only code paths —
-# most notably the native Picture-in-Picture teardown in Sources/SwiftVLC/PiP.
-# `PixelBufferRendererCallbackContext.releaseRetiredOpaqueRetainWhenPlayerIsQuiescent`
-# only takes its early-release branch once a real video output has torn down
-# (`libvlc_media_player_has_vout(player) == 0`); under the dummy/headless vout
-# used in CI that count never reaches 0, so the code always falls through to
-# its timed fallback and the quiescent branch is unreachable. Those lines are
-# real and exercised on device, so the per-PR patch gate must not fail on them.
+# That environment cannot execute every live C or system-framework boundary,
+# but the state machines around those boundaries are covered through controlled
+# dependencies. Patch coverage therefore remains enforceable without ignoring
+# production files.
 
 coverage:
   status:
@@ -22,16 +18,14 @@ coverage:
         # between runs; a real drop trips the check.
         threshold: 1%
 
-    # Patch (diff) coverage is advisory rather than blocking. New code should
-    # still be tested, and Codecov continues to post the patch number on every
-    # PR — but because diffs that touch the device-only PiP teardown paths
-    # cannot reach full coverage in headless CI, this annotates instead of
-    # failing the build. Codecov has no per-line ignore, so an advisory patch
-    # status is the least-blunt way to carve those lines out without hiding a
-    # whole heavily-tested file behind `ignore`.
+    # New executable lines must remain well tested. The small gap below 100%
+    # accommodates thin live C and system-framework calls that a headless test
+    # process cannot invoke safely; no production paths or files are ignored.
     patch:
       default:
-        informational: true
+        target: 85%
+        threshold: 0%
+        informational: false
 
 # Belt-and-suspenders: the LCOV export (scripts/export-lcov.sh) already strips
 # Tests/ and .build/, and the Showcase apps build from a separate Xcode project

--- a/scripts/fix-duplicate-symbols.sh
+++ b/scripts/fix-duplicate-symbols.sh
@@ -19,11 +19,18 @@
 # Usage:
 #   ./scripts/fix-duplicate-symbols.sh path/to/libvlc.xcframework
 #   ./scripts/fix-duplicate-symbols.sh path/to/libvlc.a
+#   ./scripts/fix-duplicate-symbols.sh --verify path/to/libvlc.xcframework
 #
 set -euo pipefail
 
-if [[ $# -lt 1 ]]; then
-  echo "Usage: $0 <xcframework-or-static-lib-path>"
+MODE="fix"
+if [[ "${1:-}" == "--verify" ]]; then
+  MODE="verify"
+  shift
+fi
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 [--verify] <xcframework-or-static-lib-path>"
   exit 1
 fi
 
@@ -90,41 +97,103 @@ if misaligned:
 PYEOF
 }
 
-fix_static_lib() {
+count_external_definitions() {
+  xcrun nm -g "$1" 2>/dev/null | awk -v symbol="$2" '
+    $NF == symbol && $(NF - 1) != "U" { count += 1 }
+    END { print count + 0 }
+  '
+}
+
+verify_thin_archive() {
+  local LIB_PATH="$1"
+  local ARCH="$2"
+  local SYMBOL
+  for SYMBOL in _json_parse_error _json_read; do
+    local COUNT
+    COUNT=$(count_external_definitions "$LIB_PATH" "$SYMBOL")
+    if [[ "$COUNT" -ne 1 ]]; then
+      echo "Error: $LIB_PATH ($ARCH) has $COUNT external definitions of $SYMBOL; expected 1" >&2
+      return 1
+    fi
+  done
+}
+
+verify_static_lib() (
+  set -euo pipefail
+  local LIB_PATH="$1"
+  local WORK_DIR
+  WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/swiftvlc-symbol-verify.XXXXXX")
+  trap 'rm -rf "$WORK_DIR"' EXIT
+
+  local ARCHS
+  read -r -a ARCHS <<< "$(xcrun lipo -archs "$LIB_PATH")"
+  if [[ ${#ARCHS[@]} -eq 0 ]]; then
+    echo "Error: no architectures found in $LIB_PATH" >&2
+    exit 1
+  fi
+
+  local ARCH
+  for ARCH in "${ARCHS[@]}"; do
+    local THIN="${WORK_DIR}/${ARCH}.a"
+    if [[ ${#ARCHS[@]} -gt 1 ]]; then
+      xcrun lipo -thin "$ARCH" "$LIB_PATH" -output "$THIN"
+    else
+      cp "$LIB_PATH" "$THIN"
+    fi
+    verify_thin_archive "$THIN" "$ARCH"
+  done
+)
+
+fix_static_lib() (
+  set -euo pipefail
   local LIB_PATH="$1"
   local WORK_DIR
   WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/swiftvlc-symbols.XXXXXX")
-  trap "rm -rf '$WORK_DIR'" RETURN
+  trap 'rm -rf "$WORK_DIR"' EXIT
 
   local SYMS_FILE="${WORK_DIR}/localize_syms.txt"
   printf "_json_parse_error\n_json_read\n" > "$SYMS_FILE"
 
-  local LIPO_INFO
-  LIPO_INFO=$(lipo -info "$LIB_PATH" 2>/dev/null)
   local ARCHS
-  ARCHS=$(echo "$LIPO_INFO" | sed 's/.*: //')
-  local IS_FAT=true
-  if echo "$LIPO_INFO" | grep -q "Non-fat"; then
-    IS_FAT=false
+  read -r -a ARCHS <<< "$(xcrun lipo -archs "$LIB_PATH")"
+  if [[ ${#ARCHS[@]} -eq 0 ]]; then
+    echo "Error: no architectures found in $LIB_PATH" >&2
+    exit 1
   fi
 
   local CHANGED=false
 
-  for ARCH in $ARCHS; do
+  local ARCH
+  for ARCH in "${ARCHS[@]}"; do
     local THIN="${WORK_DIR}/${ARCH}.a"
-    if $IS_FAT; then
-      lipo -thin "$ARCH" "$LIB_PATH" -output "$THIN"
+    if [[ ${#ARCHS[@]} -gt 1 ]]; then
+      xcrun lipo -thin "$ARCH" "$LIB_PATH" -output "$THIN"
     else
       cp "$LIB_PATH" "$THIN"
     fi
 
-    local COUNT
-    COUNT=$(nm "$THIN" 2>/dev/null | grep -c 'T _json_parse_error' || true)
-    if [[ "$COUNT" -gt 1 ]]; then
+    local PARSE_COUNT READ_COUNT
+    PARSE_COUNT=$(count_external_definitions "$THIN" _json_parse_error)
+    READ_COUNT=$(count_external_definitions "$THIN" _json_read)
+    if [[ "$PARSE_COUNT" -gt 1 || "$READ_COUNT" -gt 1 ]]; then
       local OBJ="libytdl_plugin_la-ytdl.o"
-      (cd "$WORK_DIR" && ar x "$THIN" "$OBJ" 2>/dev/null) || continue
-      nmedit -R "$SYMS_FILE" "${WORK_DIR}/${OBJ}" 2>/dev/null || continue
-      (cd "$WORK_DIR" && ar r "$THIN" "$OBJ" 2>/dev/null) || continue
+      rm -f "${WORK_DIR}/${OBJ}"
+      if ! (cd "$WORK_DIR" && xcrun ar x "$THIN" "$OBJ"); then
+        echo "Error: failed to extract $OBJ from $THIN" >&2
+        exit 1
+      fi
+      if [[ ! -f "${WORK_DIR}/${OBJ}" ]]; then
+        echo "Error: $OBJ was not found in $THIN" >&2
+        exit 1
+      fi
+      if ! xcrun nmedit -R "$SYMS_FILE" "${WORK_DIR}/${OBJ}"; then
+        echo "Error: failed to localize duplicate JSON symbols in $OBJ ($ARCH)" >&2
+        exit 1
+      fi
+      if ! (cd "$WORK_DIR" && xcrun ar r "$THIN" "$OBJ"); then
+        echo "Error: failed to replace $OBJ in $THIN" >&2
+        exit 1
+      fi
       rm -f "${WORK_DIR}/${OBJ}"
 
       # ar replaces long-name members without preserving the 8-byte object
@@ -132,34 +201,47 @@ fix_static_lib() {
       # static-library tool before lipo combines the architecture slices;
       # otherwise ld rejects the edited ytdl member on macOS.
       local REPACKED="${WORK_DIR}/${ARCH}-repacked.a"
-      libtool -static -a -D -no_warning_for_no_symbols \
+      xcrun libtool -static -a -D -no_warning_for_no_symbols \
         -o "$REPACKED" "$THIN"
       mv "$REPACKED" "$THIN"
       verify_macho_archive_alignment "$THIN"
       CHANGED=true
     fi
+
+    verify_thin_archive "$THIN" "$ARCH"
   done
 
   if $CHANGED; then
-    if $IS_FAT; then
+    if [[ ${#ARCHS[@]} -gt 1 ]]; then
       local THIN_FILES=()
-      for ARCH in $ARCHS; do
+      for ARCH in "${ARCHS[@]}"; do
         THIN_FILES+=("${WORK_DIR}/${ARCH}.a")
       done
-      lipo -create "${THIN_FILES[@]}" -output "$LIB_PATH"
+      xcrun lipo -create "${THIN_FILES[@]}" -output "$LIB_PATH"
     else
-      cp "${WORK_DIR}/${ARCHS}.a" "$LIB_PATH"
+      cp "${WORK_DIR}/${ARCHS[0]}.a" "$LIB_PATH"
     fi
     echo "  Fixed: $LIB_PATH"
+  fi
+
+  verify_static_lib "$LIB_PATH"
+)
+
+process_static_lib() {
+  if [[ "$MODE" == "verify" ]]; then
+    verify_static_lib "$1"
+    echo "  Verified: $1"
+  else
+    fix_static_lib "$1"
   fi
 }
 
 if [[ -d "$TARGET" ]] && [[ "$TARGET" == *.xcframework ]]; then
-  find "$TARGET" -name "libvlc.a" | while read -r lib; do
-    fix_static_lib "$lib"
+  find "$TARGET" -name "libvlc.a" -print0 | while IFS= read -r -d '' lib; do
+    process_static_lib "$lib"
   done
 elif [[ -f "$TARGET" ]] && [[ "$TARGET" == *.a ]]; then
-  fix_static_lib "$TARGET"
+  process_static_lib "$TARGET"
 else
   echo "Error: Expected an .xcframework directory or .a file"
   exit 1

--- a/scripts/fix-duplicate-symbols.sh
+++ b/scripts/fix-duplicate-symbols.sh
@@ -29,10 +29,71 @@ fi
 
 TARGET="$1"
 
+verify_macho_archive_alignment() {
+  python3 - "$1" <<'PYEOF'
+import os
+import sys
+
+path = sys.argv[1]
+archive_size = os.path.getsize(path)
+misaligned = []
+
+with open(path, "rb") as archive:
+    if archive.read(8) != b"!<arch>\n":
+        raise SystemExit(f"Error: {path} is not a thin archive")
+
+    header_offset = 8
+    while header_offset < archive_size:
+        archive.seek(header_offset)
+        header = archive.read(60)
+        if len(header) != 60 or header[58:60] != b"`\n":
+            raise SystemExit(
+                f"Error: malformed archive header at offset {header_offset} in {path}"
+            )
+
+        try:
+            member_size = int(header[48:58].decode("ascii").strip())
+        except ValueError as error:
+            raise SystemExit(
+                f"Error: invalid member size at offset {header_offset} in {path}"
+            ) from error
+
+        raw_name = header[:16].decode("ascii", errors="replace").strip()
+        data_offset = header_offset + 60
+        object_offset = data_offset
+        member_name = raw_name.rstrip("/")
+
+        if raw_name.startswith("#1/"):
+            try:
+                name_size = int(raw_name[3:])
+            except ValueError as error:
+                raise SystemExit(
+                    f"Error: invalid extended name at offset {header_offset} in {path}"
+                ) from error
+            archive.seek(data_offset)
+            member_name = archive.read(name_size).rstrip(b"\0").decode(
+                "utf-8", errors="replace"
+            )
+            object_offset += name_size
+
+        archive.seek(object_offset)
+        if archive.read(4) in (b"\xcf\xfa\xed\xfe", b"\xfe\xed\xfa\xcf"):
+            if object_offset % 8 != 0:
+                misaligned.append((member_name, object_offset))
+
+        next_header = data_offset + member_size
+        header_offset = next_header + (next_header % 2)
+
+if misaligned:
+    details = ", ".join(f"{name}@{offset}" for name, offset in misaligned[:8])
+    raise SystemExit(f"Error: misaligned 64-bit Mach-O archive members in {path}: {details}")
+PYEOF
+}
+
 fix_static_lib() {
   local LIB_PATH="$1"
   local WORK_DIR
-  WORK_DIR=$(mktemp -d)
+  WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/swiftvlc-symbols.XXXXXX")
   trap "rm -rf '$WORK_DIR'" RETURN
 
   local SYMS_FILE="${WORK_DIR}/localize_syms.txt"
@@ -65,6 +126,16 @@ fix_static_lib() {
       nmedit -R "$SYMS_FILE" "${WORK_DIR}/${OBJ}" 2>/dev/null || continue
       (cd "$WORK_DIR" && ar r "$THIN" "$OBJ" 2>/dev/null) || continue
       rm -f "${WORK_DIR}/${OBJ}"
+
+      # ar replaces long-name members without preserving the 8-byte object
+      # alignment required for 64-bit Mach-O archives. Repack with Apple's
+      # static-library tool before lipo combines the architecture slices;
+      # otherwise ld rejects the edited ytdl member on macOS.
+      local REPACKED="${WORK_DIR}/${ARCH}-repacked.a"
+      libtool -static -a -D -no_warning_for_no_symbols \
+        -o "$REPACKED" "$THIN"
+      mv "$REPACKED" "$THIN"
+      verify_macho_archive_alignment "$THIN"
       CHANGED=true
     fi
   done

--- a/scripts/patches/0005-upnp-init-failure-teardown.patch
+++ b/scripts/patches/0005-upnp-init-failure-teardown.patch
@@ -1,0 +1,50 @@
+# Prevent failed UPnP initialization from entering pupnp teardown.
+#
+# UpnpInstanceWrapper::get() deletes its provisional wrapper when UpnpInit2()
+# fails. The pinned VLC destructor unconditionally calls UpnpFinish(), even
+# though pupnp never initialized successfully. On affected Apple network
+# configurations that enters ThreadPoolShutdown() and can wait forever in
+# vlc_atomic_wait. Track initialization and registration independently so each
+# cleanup call only balances a lifecycle stage that completed.
+diff --git a/modules/services_discovery/upnp-wrapper.cpp b/modules/services_discovery/upnp-wrapper.cpp
+--- a/modules/services_discovery/upnp-wrapper.cpp
++++ b/modules/services_discovery/upnp-wrapper.cpp
+@@ -36,14 +36,17 @@ vlc::threads::mutex UpnpInstanceWrapper::s_lock;
+ 
+ UpnpInstanceWrapper::UpnpInstanceWrapper()
+     : m_handle( -1 )
++    , m_initialized( false )
+     , m_refcount( 0 )
+ {
+ }
+ 
+ UpnpInstanceWrapper::~UpnpInstanceWrapper()
+ {
+-    UpnpUnRegisterClient( m_handle );
+-    UpnpFinish();
++    if ( m_handle != -1 )
++        UpnpUnRegisterClient( m_handle );
++    if ( m_initialized )
++        UpnpFinish();
+ }
+ 
+ UpnpInstanceWrapper *UpnpInstanceWrapper::get(vlc_object_t *p_obj)
+@@ -73,6 +77,7 @@ UpnpInstanceWrapper *UpnpInstanceWrapper::get(vlc_object_t *p_obj)
+             delete instance;
+             return NULL;
+         }
++        instance->m_initialized = true;
+ 
+         ixmlRelaxParser( 1 );
+ 
+diff --git a/modules/services_discovery/upnp-wrapper.hpp b/modules/services_discovery/upnp-wrapper.hpp
+--- a/modules/services_discovery/upnp-wrapper.hpp
++++ b/modules/services_discovery/upnp-wrapper.hpp
+@@ -66,6 +66,7 @@ private:
+     static UpnpInstanceWrapper* s_instance;
+     static vlc::threads::mutex s_lock;
+     UpnpClient_Handle m_handle;
++    bool m_initialized;
+     int m_refcount;
+     typedef std::shared_ptr<Listener> ListenerPtr;
+     typedef std::vector<ListenerPtr> Listeners;

--- a/scripts/patches/0005-upnp-init-failure-teardown.patch
+++ b/scripts/patches/0005-upnp-init-failure-teardown.patch
@@ -9,16 +9,11 @@
 diff --git a/modules/services_discovery/upnp-wrapper.cpp b/modules/services_discovery/upnp-wrapper.cpp
 --- a/modules/services_discovery/upnp-wrapper.cpp
 +++ b/modules/services_discovery/upnp-wrapper.cpp
-@@ -36,14 +36,17 @@ vlc::threads::mutex UpnpInstanceWrapper::s_lock;
- 
- UpnpInstanceWrapper::UpnpInstanceWrapper()
+@@ -38,2 +38,3 @@ UpnpInstanceWrapper::UpnpInstanceWrapper()
      : m_handle( -1 )
 +    , m_initialized( false )
      , m_refcount( 0 )
- {
- }
- 
- UpnpInstanceWrapper::~UpnpInstanceWrapper()
+@@ -44,4 +45,6 @@ UpnpInstanceWrapper::~UpnpInstanceWrapper()
  {
 -    UpnpUnRegisterClient( m_handle );
 -    UpnpFinish();
@@ -27,24 +22,15 @@ diff --git a/modules/services_discovery/upnp-wrapper.cpp b/modules/services_disc
 +    if ( m_initialized )
 +        UpnpFinish();
  }
- 
- UpnpInstanceWrapper *UpnpInstanceWrapper::get(vlc_object_t *p_obj)
-@@ -73,6 +77,7 @@ UpnpInstanceWrapper *UpnpInstanceWrapper::get(vlc_object_t *p_obj)
-             delete instance;
-             return NULL;
-         }
-+        instance->m_initialized = true;
- 
-         ixmlRelaxParser( 1 );
- 
+@@ -68,2 +71,4 @@ UpnpInstanceWrapper *UpnpInstanceWrapper::get(vlc_object_t *p_obj)
+         int i_res = UpnpInit2( net_iface, 0 );
++        if( i_res == UPNP_E_SUCCESS )
++            instance->m_initialized = true;
+         free( net_iface );
 diff --git a/modules/services_discovery/upnp-wrapper.hpp b/modules/services_discovery/upnp-wrapper.hpp
 --- a/modules/services_discovery/upnp-wrapper.hpp
 +++ b/modules/services_discovery/upnp-wrapper.hpp
-@@ -66,6 +66,7 @@ private:
-     static UpnpInstanceWrapper* s_instance;
-     static vlc::threads::mutex s_lock;
+@@ -68,2 +68,3 @@ private:
      UpnpClient_Handle m_handle;
 +    bool m_initialized;
      int m_refcount;
-     typedef std::shared_ptr<Listener> ListenerPtr;
-     typedef std::vector<ListenerPtr> Listeners;

--- a/scripts/patches/0006-mp4-roll-seek-point.patch
+++ b/scripts/patches/0006-mp4-roll-seek-point.patch
@@ -1,0 +1,21 @@
+# Preserve the requested MP4 seek position when AAC roll metadata is present.
+#
+# AAC roll sample groups describe decoder preroll, not a track sync point. The
+# pinned VLC revision writes the group entry sample into i_sync_sample, which
+# can reset the audio track to sample zero. The demuxer then aligns every track
+# to that earlier point and remote playback reads from the beginning.
+#
+# Backport of VideoLAN commit ae06c7155afa34e82e5fb3eb6e24e99f0184b9d0.
+diff --git a/modules/demux/mp4/mp4.c b/modules/demux/mp4/mp4.c
+--- a/modules/demux/mp4/mp4.c
++++ b/modules/demux/mp4/mp4.c
+@@ -3577,7 +3577,8 @@ static int TrackTimeToSampleChunk( demux_t *p_demux, mp4_track_t *p_track,
+     }
+     else
+     {
++        uint32_t i_group_sample_entry;
+         const MP4_Box_data_sgpd_entry_t *p_entrydesc;
+         if( MP4_SampleToGroupInfo( p_track->p_stbl, i_sample,
+-                                  SAMPLEGROUP_roll, 0, &i_sync_sample,
++                                  SAMPLEGROUP_roll, 0, &i_group_sample_entry,
+                                   SAMPLE_GROUP_MATCH_EXACT, &p_entrydesc ) )

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -76,6 +76,12 @@ WORK_DIR=""
 RELEASE_RESTORE_DIR=""
 RELEASE_RESTORE_FILES=false
 
+make_temp_dir() {
+  local temp_root="${TMPDIR:-/tmp}"
+  mkdir -p "$temp_root"
+  mktemp -d "$temp_root/swiftvlc-release.XXXXXX"
+}
+
 cleanup() {
   local status=$?
 
@@ -102,7 +108,7 @@ cleanup() {
 trap cleanup EXIT
 
 begin_release_file_restore() {
-  RELEASE_RESTORE_DIR=$(mktemp -d)
+  RELEASE_RESTORE_DIR=$(make_temp_dir)
   cp Package.swift "$RELEASE_RESTORE_DIR/Package.swift"
   cp "$SHOWCASE_PROJECT" "$RELEASE_RESTORE_DIR/project.pbxproj"
   RELEASE_RESTORE_FILES=true
@@ -305,7 +311,7 @@ fi
 
 # ── Strip ─────────────────────────────────────────────────────────────────────
 
-WORK_DIR=$(mktemp -d)
+WORK_DIR=$(make_temp_dir)
 
 echo "Copying xcframework to temp dir..."
 cp -R "$XCFW_PATH" "$WORK_DIR/libvlc.xcframework"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -322,6 +322,9 @@ find "$WORK_DIR/libvlc.xcframework" -name '*.a' -exec strip -S {} \;
 AFTER_SIZE=$(du -sh "$WORK_DIR/libvlc.xcframework" | cut -f1)
 echo "  Before: $BEFORE_SIZE → After: $AFTER_SIZE"
 
+echo "Verifying duplicate symbols in stripped libraries..."
+"$SCRIPT_DIR/fix-duplicate-symbols.sh" --verify "$WORK_DIR/libvlc.xcframework"
+
 # ── Zip ───────────────────────────────────────────────────────────────────────
 
 echo "Creating zip..."

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -118,7 +118,16 @@ remote_pattern = re.compile(
     r'/\* End XCRemoteSwiftPackageReference section \*/'
 )
 
-if local_block in text:
+local_pattern = re.compile(
+    r'/\* Begin XCLocalSwiftPackageReference section \*/\n'
+    r'\t\tBA000001 /\* XCLocalSwiftPackageReference "\.\." \*/ = \{\n'
+    r'\t\t\tisa = XCLocalSwiftPackageReference;\n'
+    r'\t\t\trelativePath = "?\.\."?;\n'
+    r'\t\t\};\n'
+    r'/\* End XCLocalSwiftPackageReference section \*/'
+)
+
+if local_block in text or local_pattern.search(text):
     result = text
 else:
     result, n = remote_pattern.subn(local_block, text, count=1)


### PR DESCRIPTION
## Summary

- fix remote MP4 seeking, playback lifecycle, PiP, and other release blockers
- make custom showcase streams dynamic, session-only, redacted, and available across every app
- harden XCFramework builds, duplicate symbol repair, and release verification
- expand regression and showcase UI coverage

## Testing

- `./scripts/build-libvlc.sh --all`
- `swift test` with 1,602 tests passing
- `swift build -c release`
- iOS and macOS build-for-testing
- tvOS, visionOS, and Mac Catalyst builds
- iOS custom stream UI test
- duplicate symbol verification on all XCFramework slices

The macOS PiP UI test bundle builds successfully. The command-line UI launch did not materialize a test worker on this host.