### PR TITLE
Remove RTSP support claims from docs and Showcase (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,9 @@ The `Showcase/` directory contains separate folders, targets, and schemes for ea
 Every showcase target accepts an app-wide test stream URL. The override is
 kept in memory for the current app session, redacted to its scheme, host, and a
 hidden path in the UI, and used by showcases that otherwise load bundled or
-public sample media. HTTP, HTTPS, HLS, UDP, and other URL schemes
-supported by the bundled libVLC are accepted.
+public sample media. HTTP, HTTPS, UDP, and other URL schemes supported by
+the bundled libVLC are accepted, including HLS through its `.m3u8` HTTP(S)
+URL.
 
 - **iOS and Mac Catalyst:** open **Set App-Wide Stream URL** in the **Test Stream** section on the first screen.
 - **macOS:** use **Test Stream** in the toolbar or **Test Stream URL** in the sidebar's **Configuration** section.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Swift wrapper around [libVLC](https://www.videolan.org/vlc/libvlc.html) for iO
 
 AVFoundation is excellent for Apple's native media stack, but its
 container, codec, subtitle, and network-protocol support is limited to
-what Apple ships. Apps that need MKV, SSA/ASS subtitles, RTSP, SMB,
+what Apple ships. Apps that need MKV, SSA/ASS subtitles, SMB,
 UPnP, or other VLC-backed formats and protocols need a broader engine.
 
 [VLC](https://www.videolan.org/)'s engine, **libVLC**, supports a broad set of codecs, containers, subtitles, and network protocols through embeddable C APIs.
@@ -152,8 +152,8 @@ The `Showcase/` directory contains separate folders, targets, and schemes for ea
 Every showcase target accepts an app-wide test stream URL. The override is
 kept in memory for the current app session, redacted to its scheme, host, and a
 hidden path in the UI, and used by showcases that otherwise load bundled or
-public sample media. HTTP, HTTPS, HLS, RTSP, UDP, and other URL schemes
-supported by VLC are accepted.
+public sample media. HTTP, HTTPS, HLS, UDP, and other URL schemes
+supported by the bundled libVLC are accepted.
 
 - **iOS and Mac Catalyst:** open **Set App-Wide Stream URL** in the **Test Stream** section on the first screen.
 - **macOS:** use **Test Stream** in the toolbar or **Test Stream URL** in the sidebar's **Configuration** section.

--- a/Showcase/Shared/TestStreamURL.swift
+++ b/Showcase/Shared/TestStreamURL.swift
@@ -108,7 +108,7 @@ struct TestStreamSettingsView: View {
       } header: {
         Text("Stream URL")
       } footer: {
-        Text("The override is used throughout this Showcase and kept only until the app closes. HTTP, HLS, UDP, and other URL schemes supported by the bundled libVLC are accepted.")
+        Text("The override is used throughout this Showcase and kept only until the app closes. HTTP, HTTPS, UDP, and other URL schemes supported by the bundled libVLC are accepted. HLS works through its .m3u8 URL.")
       }
 
       Section("Current Source") {

--- a/Showcase/Shared/TestStreamURL.swift
+++ b/Showcase/Shared/TestStreamURL.swift
@@ -108,7 +108,7 @@ struct TestStreamSettingsView: View {
       } header: {
         Text("Stream URL")
       } footer: {
-        Text("The override is used throughout this Showcase and kept only until the app closes. HTTP, HLS, RTSP, UDP, and other VLC-supported URL schemes are accepted.")
+        Text("The override is used throughout this Showcase and kept only until the app closes. HTTP, HLS, UDP, and other URL schemes supported by the bundled libVLC are accepted.")
       }
 
       Section("Current Source") {

--- a/Sources/SwiftVLC/Media/Media.swift
+++ b/Sources/SwiftVLC/Media/Media.swift
@@ -48,7 +48,7 @@ public enum MediaType: Sendable, Hashable, CustomStringConvertible {
   case directory
   /// An optical disc (DVD, Blu-ray, Audio CD).
   case disc
-  /// A network stream (HTTP, RTSP, etc.).
+  /// A network stream (HTTP, HLS, etc.).
   case stream
   /// A playlist (M3U, PLS, XSPF, etc.).
   case playlist
@@ -103,7 +103,7 @@ public final class Media: Sendable {
 
   /// Creates media from a URL.
   ///
-  /// Works for both local `file://` URLs and remote `http://`/`rtsp://` streams.
+  /// Works for both local `file://` URLs and remote `http://`/`https://` streams.
   /// - Parameter url: The media source URL.
   /// - Throws: `VLCError.mediaCreationFailed` if the URL is invalid.
   public init(url: URL) throws(VLCError) {

--- a/Sources/SwiftVLC/Media/Media.swift
+++ b/Sources/SwiftVLC/Media/Media.swift
@@ -103,7 +103,9 @@ public final class Media: Sendable {
 
   /// Creates media from a URL.
   ///
-  /// Works for both local `file://` URLs and remote `http://`/`https://` streams.
+  /// Accepts any URL. Local `file://` paths and remote `http://`/`https://`
+  /// streams are the common cases; whether another scheme opens depends on the
+  /// access modules present in the bundled libVLC.
   /// - Parameter url: The media source URL.
   /// - Throws: `VLCError.mediaCreationFailed` if the URL is invalid.
   public init(url: URL) throws(VLCError) {

--- a/Sources/SwiftVLC/Player/PlaybackValues.swift
+++ b/Sources/SwiftVLC/Player/PlaybackValues.swift
@@ -95,7 +95,7 @@ public struct Volume: Sendable, Hashable, Comparable, ExpressibleByFloatLiteral 
 /// for some media but audio/video sync degrades; SwiftVLC clamps to
 /// keep observable behavior predictable.
 ///
-/// Live streams (HLS, RTSP) often reject any rate other than `1.0`.
+/// Live streams (HLS, UDP) often reject any rate other than `1.0`.
 /// Use `Player.setPlaybackRate(_:)` so the UI can react to rejection.
 ///
 /// ```swift

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -160,7 +160,7 @@ public final class Player {
   /// Sets the playback rate, throwing if libVLC rejects the value.
   ///
   /// Typical rejections:
-  /// - Live streams (HLS, RTSP) that only support `1.0` playback.
+  /// - Live streams (HLS, UDP) that only support `1.0` playback.
   /// - No media loaded yet. libVLC ignores the call until playback
   ///   starts.
   /// - Format-specific decoder limitations.

--- a/Sources/SwiftVLC/SwiftVLC.docc/Logging.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/Logging.md
@@ -17,7 +17,7 @@ Task {
 ```
 
 Each ``LogEntry`` carries a severity ``LogLevel``, the message text,
-and the libVLC module name (e.g. `avcodec`, `http`, `rtsp`) when the
+and the libVLC module name (e.g. `avcodec`, `http`, `mp4`) when the
 emitter provided one.
 
 ## Multiple consumers


### PR DESCRIPTION
Closes part of #67.

## Problem

We advertise RTSP support in several places, and it does not work on any platform we ship.

The bundled libVLC has no RTSP client. VLC's `extras/package/apple/build.conf` passes `--disable-gpl --disable-gnuv3` to the contrib bootstrap, and `contrib/src/live555/rules.mak` gates the package behind `GNUV3`:

```make
ifdef BUILD_NETWORK
ifdef GNUV3
PKGS += live555
endif
endif
```

So live555 is never built. Confirmed against the shipped binary: `Vendor/libvlc.xcframework/ios-arm64/libvlc.a` registers 289 modules, none of them live555.

That leaves satip as the only module claiming the `rtsp` shortcut, since `modules/access/satip.c` declares `add_shortcut("rtsp", "satip")` at `set_capability("access", 201)`. SAT>IP is a DVB tuner protocol that uses RTSP for signaling, so it connects and then fails on PLAY against a normal camera, which matches the `Failed to play RTSP session` reported in #67.

There is no workaround on the current binary. avio only claims the rtmp shortcuts, and its `avio://` form goes through `avio_open2`, which resolves protocols rather than demuxers, so it cannot reach FFmpeg's RTSP demuxer. avformat is registered as a `demux` rather than an `access_demux`, so it needs a byte stream that `rtsp://` never produces.

## Change

Docs only, no behavior change. Removes RTSP from:

- `README.md` motivation list and Showcase stream URL section
- `Showcase/Shared/TestStreamURL.swift` stream URL footer
- `Media.swift` `init(url:)` doc comment, which claimed `rtsp://` streams work
- `Media.swift` `MediaType.stream`, `Player.swift`, and `PlaybackValues.swift` doc comments that used RTSP as an example
- `SwiftVLC.docc/Logging.md`, which listed `rtsp` as an example libVLC module name when no such module exists in our build

## Follow-up

Actually shipping RTSP means rebuilding libVLC with live555, which carries a licensing decision. live555 relicensed to LGPLv3 in late 2016, which is why the Apple build excludes it, and LGPLv3 static linking is a problem for App Store apps. VLCKit pins live555 to 2016.10.21, the last LGPLv2.1 release, and drops the GNUV3 gate. Whether a 2016 live555 still compiles against VLC 4 is untested, since VLCKit is on VLC 3. Tracking in #67.

## Verification

`swift build` clean.
