### PR TITLE
Backport the libVLC rapid set_media ownership fix (#90)

### DIFF
--- a/Sources/CLibVLC/include/vlc/libvlc_media_player.h
+++ b/Sources/CLibVLC/include/vlc/libvlc_media_player.h
@@ -248,10 +248,10 @@ LIBVLC_API void libvlc_media_player_set_media( libvlc_media_player_t *p_mi,
 /**
  * Get the media used by the media_player.
  *
- * \warning Calling this function just after libvlc_media_player_set_media()
- * will return the media that was just set, but this media might not be
- * currently used internally by the player. To detect such case, the user
- * should listen to the libvlc_MediaPlayerMediaChanged event.
+ * \note The returned media is the one currently used by the player. After
+ * calling libvlc_media_player_set_media() while a media is playing, the
+ * previous media is still returned until the switch is notified by the
+ * libvlc_MediaPlayerMediaChanged event.
  *
  * \param p_mi the Media Player
  * \return the media associated with p_mi, or NULL if no

--- a/Tests/SwiftVLCTests/Media/MediaReplacementOwnershipTests.swift
+++ b/Tests/SwiftVLCTests/Media/MediaReplacementOwnershipTests.swift
@@ -1,0 +1,113 @@
+@testable import SwiftVLC
+import Foundation
+import Testing
+
+/// Swift-side ownership guarantees for rapid media replacement.
+///
+/// The engine-level regression for this lives in libVLC itself
+/// (`test/libvlc/media_switch_ownership.c`, added by
+/// `scripts/patches/0007-rapid-set-media-ownership.patch`), where an
+/// AddressSanitizer run drives 10,000 active replacements. That test proves the
+/// C ownership model is sound; these tests prove SwiftVLC's wrappers sit on top
+/// of it correctly.
+///
+/// Two properties matter here:
+///
+/// 1. Replacing the media of a *playing* player must not strand the outgoing
+///    `Media`. Before the backported fix, libVLC freed the `libvlc_media_t`
+///    inside `libvlc_media_player_set_media()` while the outgoing input was
+///    still draining and still publishing that media to listeners. SwiftVLC
+///    never dereferences the media carried on those events (`EventBridge` maps
+///    `libvlc_MediaPlayerMediaChanged` to a payload-free `.mediaChanged`), so it
+///    was not directly exposed — but it does keep its own `Media` wrapper alive
+///    across the switch, and that wrapper's release must stay balanced.
+///
+/// 2. `Media` deinit must run once the player has moved on. `Media` owns one
+///    libVLC reference and releases it in deinit; under the new model that
+///    release forwards to the underlying input item's reference count, so an
+///    unbalanced Swift wrapper would either leak the item or over-release it.
+extension Integration {
+  @Suite(.tags(.mainActor, .async), .timeLimit(.minutes(2)), .serialized)
+  @MainActor struct MediaReplacementOwnershipTests {
+    /// Rapid A/B/A replacement on a *started* player. The Swift `Media` is
+    /// transferred into the player and dropped by the caller immediately, so
+    /// the player's own reference is the only thing keeping it alive while the
+    /// outgoing input drains.
+    @Test
+    func `Rapid media replacement on a playing player stays sound`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let urls = [TestMedia.silenceURL, TestMedia.twosecURL, TestMedia.testMP4URL]
+
+      for index in 0..<30 {
+        let media = try Media(url: urls[index % urls.count])
+        if index == 0 {
+          try player.play(media)
+        } else {
+          player.load(media)
+        }
+        // No settling wait: overlapping the outgoing input's teardown with the
+        // next load is exactly the condition under test.
+        await yieldScheduler(times: 2)
+      }
+
+      #expect(player.currentMedia != nil)
+      player.stop()
+      await yieldScheduler(times: 8)
+    }
+
+    /// The outgoing `Media` must deallocate once the player replaces it. A
+    /// wrapper that stayed alive would mean SwiftVLC is holding a libVLC
+    /// reference it never releases, which under the shared input-item
+    /// refcount now also pins the input item.
+    @Test
+    func `Replaced media deallocates once the player moves on`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+
+      weak var weakFirst: Media?
+      do {
+        let first = try Media(url: TestMedia.silenceURL)
+        weakFirst = first
+        player.load(first)
+      }
+      #expect(weakFirst != nil, "player must hold the media it was given")
+
+      // Replace it. The player drops its reference to the first media, which
+      // was the last one, so the Swift wrapper must deinit.
+      do {
+        let second = try Media(url: TestMedia.twosecURL)
+        player.load(second)
+      }
+      await yieldScheduler(times: 8)
+
+      #expect(weakFirst == nil, "replaced Media leaked: player kept its reference after set_media")
+
+      player.stop()
+      await yieldScheduler(times: 8)
+    }
+
+    /// Dropping the player must release the media it currently holds.
+    @Test
+    func `Releasing the player releases its current media`() async throws {
+      weak var weakMedia: Media?
+      do {
+        let player = Player(instance: TestInstance.makeAudioOnly())
+        let media = try Media(url: TestMedia.silenceURL)
+        weakMedia = media
+        player.load(media)
+        #expect(weakMedia != nil)
+      }
+      await yieldScheduler(times: 8)
+
+      #expect(weakMedia == nil, "Media outlived its player")
+    }
+
+    /// Yields the task scheduler `n` times so pending main-actor work (deinit
+    /// cleanup, event-consumer cancellation, observation graph teardown) runs
+    /// before we probe a weak reference.
+    private func yieldScheduler(times n: Int) async {
+      for _ in 0..<n {
+        await Task.yield()
+      }
+    }
+  }
+}

--- a/Tests/SwiftVLCTests/Player/PlayerNativeLifecycleTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerNativeLifecycleTests.swift
@@ -435,7 +435,7 @@ extension Integration {
       // Clearing the media is queued behind the outgoing input's teardown, so
       // the native player can still report the previous media for a moment
       // (see libvlc_media_player_get_media()). Wait for the switch to land.
-      _ = try await poll(every: .milliseconds(10), timeout: .seconds(3)) {
+      let cleared = try await poll(every: .milliseconds(10), timeout: .seconds(3)) {
         // get_media() returns a retained reference; release it every probe.
         guard let current = libvlc_media_player_get_media(player.pointer) else {
           return true
@@ -443,6 +443,7 @@ extension Integration {
         libvlc_media_release(current)
         return false
       }
+      #expect(cleared, "native player never dropped its current media")
 
       player.syncCurrentMediaFromNative()
 

--- a/Tests/SwiftVLCTests/Player/PlayerNativeLifecycleTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerNativeLifecycleTests.swift
@@ -427,10 +427,22 @@ extension Integration {
     }
 
     @Test
-    func `syncCurrentMediaFromNative clears stale current media when native player has none`() throws {
+    func `syncCurrentMediaFromNative clears stale current media when native player has none`() async throws {
       let player = Player(instance: TestInstance.shared)
       try player.load(Media(url: TestMedia.twosecURL))
       libvlc_media_player_set_media(player.pointer, nil)
+
+      // Clearing the media is queued behind the outgoing input's teardown, so
+      // the native player can still report the previous media for a moment
+      // (see libvlc_media_player_get_media()). Wait for the switch to land.
+      _ = try await poll(every: .milliseconds(10), timeout: .seconds(3)) {
+        // get_media() returns a retained reference; release it every probe.
+        guard let current = libvlc_media_player_get_media(player.pointer) else {
+          return true
+        }
+        libvlc_media_release(current)
+        return false
+      }
 
       player.syncCurrentMediaFromNative()
 

--- a/Tests/SwiftVLCTests/Player/PlayerTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerTests.swift
@@ -108,7 +108,7 @@ extension Integration {
     }
 
     @Test
-    func `mediaChanged resyncs currentMedia and clears timeline state`() throws {
+    func `mediaChanged resyncs currentMedia and clears timeline state`() async throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
       let initial = try Media(url: TestMedia.testMP4URL)
       let replacement = try Media(url: TestMedia.twosecURL)
@@ -123,6 +123,11 @@ extension Integration {
       )
 
       libvlc_media_player_set_media(player.pointer, replacement.pointer)
+      // libvlc_media_player_set_media() only swaps the player's current media
+      // once any outgoing input has drained, so the native switch this event
+      // reports can land asynchronously. Wait for it rather than assuming
+      // set_media() took effect synchronously.
+      try await awaitNativeMediaSwitch(on: player, to: replacement)
       player._handleEventForTesting(.mediaChanged)
 
       #expect(player.currentMedia?.mrl == replacement.mrl)
@@ -134,7 +139,7 @@ extension Integration {
     }
 
     @Test
-    func `mediaChanged retains synced media after native player switches again`() throws {
+    func `mediaChanged retains synced media after native player switches again`() async throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
       let initial = try Media(url: TestMedia.testMP4URL)
       player.load(initial)
@@ -144,14 +149,18 @@ extension Integration {
       do {
         let replacement = try Media(url: TestMedia.twosecURL)
         libvlc_media_player_set_media(player.pointer, replacement.pointer)
+        try await awaitNativeMediaSwitch(on: player, to: replacement)
         player._handleEventForTesting(.mediaChanged)
         syncedMedia = try #require(player.currentMedia)
         syncedMRL = try #require(replacement.mrl)
       }
 
       libvlc_media_player_set_media(player.pointer, initial.pointer)
+      try await awaitNativeMediaSwitch(on: player, to: initial)
       player._handleEventForTesting(.mediaChanged)
 
+      // The Media synced from the first switch owns its own libVLC reference,
+      // so a later switch must not invalidate it.
       #expect(syncedMedia.mrl == syncedMRL)
     }
 

--- a/Tests/SwiftVLCTests/Support/NativeMediaSwitch.swift
+++ b/Tests/SwiftVLCTests/Support/NativeMediaSwitch.swift
@@ -1,0 +1,42 @@
+@testable import SwiftVLC
+import CLibVLC
+import Foundation
+import Testing
+
+/// Waits until the native player reports `media` as its *current* media.
+///
+/// `libvlc_media_player_set_media()` does not always take effect synchronously.
+/// When the player already owns an input, the core queues the replacement and
+/// only swaps `player->media` once that input has drained
+/// (`vlc_player_SetCurrentMedia()`), which is why
+/// `libvlc_media_player_get_media()` is documented to keep returning the
+/// previous media until the switch is notified by
+/// `libvlc_MediaPlayerMediaChanged`.
+///
+/// Tests that drive `set_media` directly and then synthesise a `.mediaChanged`
+/// event must therefore wait for the switch instead of assuming it already
+/// happened. On an idle player the wait returns on the first check.
+@MainActor
+func awaitNativeMediaSwitch(
+  on player: Player,
+  to media: Media,
+  timeout: Duration = .seconds(3),
+  sourceLocation: SourceLocation = #_sourceLocation
+)
+  async throws {
+  let expected = media.mrl
+  let switched = try await poll(every: .milliseconds(10), timeout: timeout) {
+    guard let current = libvlc_media_player_get_media(player.pointer) else {
+      return expected == nil
+    }
+    defer { libvlc_media_release(current) }
+    guard let raw = libvlc_media_get_mrl(current) else { return false }
+    defer { free(raw) }
+    return String(cString: raw) == expected
+  }
+  #expect(
+    switched,
+    "native player never switched to \(expected ?? "nil")",
+    sourceLocation: sourceLocation
+  )
+}

--- a/Tests/SwiftVLCTests/Support/NativeMediaSwitch.swift
+++ b/Tests/SwiftVLCTests/Support/NativeMediaSwitch.swift
@@ -31,7 +31,9 @@ func awaitNativeMediaSwitch(
     }
     defer { libvlc_media_release(current) }
     guard let raw = libvlc_media_get_mrl(current) else { return false }
-    defer { free(raw) }
+    // libVLC allocates this string; release it through libvlc_free, as
+    // Media.mrl does, rather than assuming a shared allocator.
+    defer { libvlc_free(raw) }
     return String(cString: raw) == expected
   }
   #expect(

--- a/scripts/patches/0007-rapid-set-media-ownership.patch
+++ b/scripts/patches/0007-rapid-set-media-ownership.patch
@@ -1,0 +1,757 @@
+# Backport the dependency-ordered libVLC media ownership fix series:
+#   1a4ccc4bdd3c0fbd32cfbff3f151fdd4ec0f50e3
+#   fad210b8b2d6a03d2ed2def8955fd695fa070e50
+#   8b2e77c8b8fb45bb5dfabffa050ca37046b4d795
+#
+# The pinned engine (c833c4be0) frees a libvlc_media_t inside
+# libvlc_media_player_set_media() while the outgoing input is still draining,
+# and on_stopping_current_media()/on_current_media_changed() then publish that
+# same media to application listeners via input_item_t.libvlc_owner without
+# holding a reference. Any client that touches the media it is handed reads
+# freed memory. Reproduced under ASan before this patch:
+#
+#   ERROR: AddressSanitizer: heap-use-after-free READ of size 8
+#     #0 libvlc_media_get_mrl media.c:538
+#     #2 libvlc_event_send event.c:117
+#     #3 on_stopping_current_media media_player.c:97
+#     #4 vlc_player_input_HandleState input.c:279
+#   freed by:
+#     #1 libvlc_media_player_set_media media_player.c:943
+#
+# Adaptations for the pinned c833c4be0 API:
+# - preserve its event manager and asynchronous preparse worker teardown;
+# - route late metadata and subitem callbacks to their originating media;
+# - rebase SwiftVLC's atomic PiP media/length snapshot onto the core player's
+#   retained current input item after removing libvlc_media_player_t.p_md;
+# - fail soft instead of dereferencing NULL when an input item has no libvlc
+#   owner: SwiftVLC builds libVLC with --disable-debug, so the upstream
+#   assert()s on that invariant are compiled out of shipped builds;
+# - add test/libvlc/media_switch_ownership.c, an engine-level regression that
+#   runs 10,000 active replacements covering A/B/A churn, erroring media,
+#   stop/load overlap, metadata, subitems and elementary-stream teardown.
+#   It is a separate program on purpose: it must own the only libvlc instance
+#   in the process, because repeated libvlc_new()/libvlc_release() cycles
+#   re-dlopen the plugin set and macOS AddressSanitizer then faults inside
+#   __asan_register_globals for a late-loaded plugin, corrupting every
+#   subsequent report.
+diff --git a/include/vlc/libvlc_media_player.h b/include/vlc/libvlc_media_player.h
+index c8e6b0fc456..515282f688a 100644
+--- a/include/vlc/libvlc_media_player.h
++++ b/include/vlc/libvlc_media_player.h
+@@ -248,10 +248,10 @@ LIBVLC_API void libvlc_media_player_set_media( libvlc_media_player_t *p_mi,
+ /**
+  * Get the media used by the media_player.
+  *
+- * \warning Calling this function just after libvlc_media_player_set_media()
+- * will return the media that was just set, but this media might not be
+- * currently used internally by the player. To detect such case, the user
+- * should listen to the libvlc_MediaPlayerMediaChanged event.
++ * \note The returned media is the one currently used by the player. After
++ * calling libvlc_media_player_set_media() while a media is playing, the
++ * previous media is still returned until the switch is notified by the
++ * libvlc_MediaPlayerMediaChanged event.
+  *
+  * \param p_mi the Media Player
+  * \return the media associated with p_mi, or NULL if no
+diff --git a/include/vlc_input_item.h b/include/vlc_input_item.h
+index 94f5b19d901..d592eccce06 100644
+--- a/include/vlc_input_item.h
++++ b/include/vlc_input_item.h
+@@ -132,6 +132,10 @@ struct input_item_t
+ 
+     void        *libvlc_owner;       /**< LibVLC private data, can only be set
+                                           before events are registered. */
++    void       (*libvlc_owner_release)(void *libvlc_owner);
++                                     /**< Called when the input item is
++                                          destroyed to release libvlc_owner,
++                                          same restrictions as libvlc_owner. */
+ };
+ 
+ #define INPUT_ITEM_URI_NOP "vlc://nop" /* dummy URI for node/directory items */
+diff --git a/lib/media.c b/lib/media.c
+index a155389ffc4..b4286352ab4 100644
+--- a/lib/media.c
++++ b/lib/media.c
+@@ -336,6 +336,23 @@ static void input_item_preparse_ended(vlc_preparser_req *req,
+         vlc_atomic_notify_one(&p_md->worker_count);
+ }
+ 
++static void media_destroy( void *libvlc_owner )
++{
++    libvlc_media_t *p_md = libvlc_owner;
++    unsigned int ref;
++
++    /* Wait for all async tasks to stop. */
++    while ((ref = atomic_load_explicit(&p_md->worker_count,
++                                       memory_order_acquire)) > 0)
++        vlc_atomic_wait(&p_md->worker_count, ref);
++
++    if( p_md->p_subitems )
++        libvlc_media_list_release( p_md->p_subitems );
++
++    libvlc_event_manager_destroy( &p_md->event_manager );
++    free( p_md );
++}
++
+ /**
+  * \internal
+  * Create a new media descriptor object from an input_item (Private)
+@@ -352,6 +369,9 @@ libvlc_media_t * libvlc_media_new_from_input_item(input_item_t *p_input_item )
+         return NULL;
+     }
+ 
++    /* The item is wrapped by a single media for its whole lifetime. */
++    assert( p_input_item->libvlc_owner == NULL );
++
+     p_md = calloc( 1, sizeof(libvlc_media_t) );
+     if( !p_md )
+     {
+@@ -369,11 +389,11 @@ libvlc_media_t * libvlc_media_new_from_input_item(input_item_t *p_input_item )
+     p_md->p_subitems->p_internal_md = p_md;
+ 
+     p_md->p_input_item      = p_input_item;
+-    vlc_atomic_rc_init(&p_md->rc);
+ 
+     atomic_init(&p_md->worker_count, 0);
+ 
+     p_md->p_input_item->libvlc_owner = p_md;
++    p_md->p_input_item->libvlc_owner_release = media_destroy;
+     atomic_init(&p_md->parsed_status, libvlc_media_parsed_status_none);
+     p_md->req = NULL;
+ 
+@@ -489,33 +509,19 @@ void libvlc_media_add_option_flag( libvlc_media_t * p_md,
+ // Delete a media descriptor object
+ void libvlc_media_release( libvlc_media_t *p_md )
+ {
+-    unsigned int ref;
+-
+     if (!p_md)
+         return;
+ 
+-    if( !vlc_atomic_rc_dec(&p_md->rc) )
+-        return;
+-
+-    /* Wait for all async tasks to stop. */
+-    while ((ref = atomic_load_explicit(&p_md->worker_count,
+-                                       memory_order_acquire)) > 0)
+-        vlc_atomic_wait(&p_md->worker_count, ref);
+-
+-    if( p_md->p_subitems )
+-        libvlc_media_list_release( p_md->p_subitems );
+-
++    /* The media shares the reference count of its input item and is
++     * destroyed with it, see media_destroy(). */
+     input_item_Release( p_md->p_input_item );
+-
+-    libvlc_event_manager_destroy( &p_md->event_manager );
+-    free( p_md );
+ }
+ 
+ // Retain a media descriptor object
+ libvlc_media_t *libvlc_media_retain( libvlc_media_t *p_md )
+ {
+     assert (p_md);
+-    vlc_atomic_rc_inc( &p_md->rc );
++    input_item_Hold( p_md->p_input_item );
+     return p_md;
+ }
+ 
+diff --git a/lib/media_internal.h b/lib/media_internal.h
+index dda43ec78b8..583118ac8b9 100644
+--- a/lib/media_internal.h
++++ b/lib/media_internal.h
+@@ -33,12 +33,14 @@
+ #include <vlc_preparser.h>
+ #include <vlc_atomic.h>
+ 
++/* A media is a wrapper of its input item and shares its reference count:
++ * libvlc_media_retain()/libvlc_media_release() forward to the input item and
++ * the media is destroyed with it (input_item_t.libvlc_owner_release). */
+ struct libvlc_media_t
+ {
+     libvlc_event_manager_t event_manager;
+ 
+     input_item_t      *p_input_item;
+-    vlc_atomic_rc_t    rc;
+ 
+     VLC_FORWARD_DECLARE_OBJECT(libvlc_media_list_t*) p_subitems; /* A media descriptor can have Sub items. This is the only dependency we really have on media_list */
+     void *p_user_data;
+diff --git a/lib/media_player.c b/lib/media_player.c
+index 2fe615d2e49..52afccd9200 100644
+--- a/lib/media_player.c
++++ b/lib/media_player.c
+@@ -235,13 +235,12 @@ on_position_changed(vlc_player_t *player, vlc_tick_t new_time, double new_pos,
+ static void
+ on_length_changed(vlc_player_t *player, vlc_tick_t new_length, void *data)
+ {
+-    (void) player;
+-
+     libvlc_media_player_t *mp = data;
+ 
+     libvlc_event_t event;
+ 
+-    libvlc_media_t *md = mp->p_md;
++    input_item_t *item = vlc_player_GetCurrentMedia(player);
++    libvlc_media_t *md = item != NULL ? item->libvlc_owner : NULL;
+     if (md != NULL)
+     {
+         /* Duration event */
+@@ -439,26 +438,32 @@ static void
+ on_media_meta_changed(vlc_player_t *player, input_item_t *media, void *data)
+ {
+     (void) player;
++    (void) data;
+ 
+-    libvlc_media_player_t *mp = data;
+-    input_item_t *current = mp->p_md ? mp->p_md->p_input_item : NULL;
+-    if (media != current)
++    assert(media != NULL);
++    libvlc_media_t *libmedia = media->libvlc_owner;
++    assert(libmedia != NULL);
++    /* SwiftVLC ships libVLC with --disable-debug, so the assert above is
++     * compiled out. event_manager is the first member of libvlc_media_t, so a
++     * NULL owner would make the send below a NULL dereference rather than a
++     * detectable abort. Fail soft instead. */
++    if (unlikely(libmedia == NULL))
+         return;
+ 
+     /* Meta event */
+     libvlc_event_t event;
+     event.type = libvlc_MediaMetaChanged;
+     event.u.media_meta_changed.meta_type = 0;
+-    libvlc_event_send( &mp->p_md->event_manager, &event );
++    libvlc_event_send( &libmedia->event_manager, &event );
+ 
+     libvlc_media_parsed_status_t status = libvlc_media_parsed_status_done;
+-    if (atomic_exchange(&mp->p_md->parsed_status, status) == status)
++    if (atomic_exchange(&libmedia->parsed_status, status) == status)
+         return;
+ 
+     /* Parsed event */
+     event.type = libvlc_MediaParsedChanged;
+     event.u.media_parsed_changed.new_status = status;
+-    libvlc_event_send( &mp->p_md->event_manager, &event );
++    libvlc_event_send( &libmedia->event_manager, &event );
+ }
+ 
+ 
+@@ -467,12 +472,16 @@ on_media_subitems_changed(vlc_player_t *player, input_item_t *media,
+                           const input_item_node_t *new_subitems, void *data)
+ {
+     (void) player;
++    (void) data;
+ 
+-    libvlc_media_player_t *mp = data;
+-
+-    input_item_t *current = mp->p_md ? mp->p_md->p_input_item : NULL;
+-    if (media == current)
+-        libvlc_media_add_subtree(mp->p_md, new_subitems);
++    assert(media != NULL);
++    libvlc_media_t *libmedia = media->libvlc_owner;
++    assert(libmedia != NULL);
++    /* See on_media_meta_changed(): asserts are compiled out in shipped
++     * builds, and libvlc_media_add_subtree() would dereference NULL. */
++    if (unlikely(libmedia == NULL))
++        return;
++    libvlc_media_add_subtree(libmedia, new_subitems);
+ }
+ 
+ static void
+@@ -777,7 +786,6 @@ libvlc_media_player_new( libvlc_instance_t *instance )
+     var_Create(mp, "record-file", VLC_VAR_STRING);
+ 
+     mp->timer.id = NULL;
+-    mp->p_md = NULL;
+     mp->p_libvlc_instance = instance;
+     /* use a reentrant lock to allow calling libvlc functions from callbacks */
+     mp->player = vlc_player_New(VLC_OBJECT(mp), VLC_PLAYER_LOCK_REENTRANT);
+@@ -838,17 +846,12 @@ libvlc_media_player_new_from_media( libvlc_instance_t *inst,
+     if( !p_mi )
+         return NULL;
+ 
+-    libvlc_media_retain( p_md );
+-    p_mi->p_md = p_md;
+-
+     vlc_player_Lock(p_mi->player);
+     int ret = vlc_player_SetCurrentMedia(p_mi->player, p_md->p_input_item);
+     vlc_player_Unlock(p_mi->player);
+ 
+     if (ret != VLC_SUCCESS)
+     {
+-        libvlc_media_release(p_md);
+-        p_mi->p_md = NULL;
+         return NULL;
+     }
+ 
+@@ -876,7 +879,6 @@ static void libvlc_media_player_destroy( libvlc_media_player_t *p_mi )
+     vlc_player_Delete(p_mi->player);
+ 
+     libvlc_event_manager_destroy(&p_mi->event_manager);
+-    libvlc_media_release( p_mi->p_md );
+ 
+     libvlc_instance_t *instance = p_mi->p_libvlc_instance;
+     vlc_object_delete(p_mi);
+@@ -940,12 +942,6 @@ void libvlc_media_player_set_media(
+ {
+     vlc_player_Lock(p_mi->player);
+ 
+-    libvlc_media_release( p_mi->p_md );
+-
+-    if( p_md )
+-        libvlc_media_retain( p_md );
+-    p_mi->p_md = p_md;
+-
+     vlc_player_SetCurrentMedia(p_mi->player, p_md ? p_md->p_input_item : NULL);
+ 
+     vlc_player_Unlock(p_mi->player);
+@@ -957,12 +953,12 @@ void libvlc_media_player_set_media(
+ libvlc_media_t *
+ libvlc_media_player_get_media( libvlc_media_player_t *p_mi )
+ {
+-    libvlc_media_t *p_m;
+-
+     vlc_player_Lock(p_mi->player);
+-    p_m = p_mi->p_md;
+-    if( p_m )
+-        libvlc_media_retain( p_m );
++
++    input_item_t *item = vlc_player_GetCurrentMedia(p_mi->player);
++    libvlc_media_t *p_m = item != NULL
++        ? input_item_Hold(item)->libvlc_owner : NULL;
++
+     vlc_player_Unlock(p_mi->player);
+ 
+     return p_m;
+@@ -984,9 +980,9 @@ swiftvlc_libvlc_media_player_get_media_length_snapshot(
+     vlc_player_t *player = p_mi->player;
+     vlc_player_Lock(player);
+ 
+-    libvlc_media_t *media = p_mi->p_md;
+-    if (media != NULL)
+-        libvlc_media_retain(media);
++    input_item_t *item = vlc_player_GetCurrentMedia(player);
++    libvlc_media_t *media = item != NULL
++        ? input_item_Hold(item)->libvlc_owner : NULL;
+ 
+     snapshot->media = media;
+     snapshot->length = media != NULL
+diff --git a/lib/media_player_internal.h b/lib/media_player_internal.h
+index 885b001cccc..23699479300 100644
+--- a/lib/media_player_internal.h
++++ b/lib/media_player_internal.h
+@@ -44,7 +44,6 @@ struct libvlc_media_player_t
+     vlc_cond_t wait;
+ 
+     struct libvlc_instance_t * p_libvlc_instance; /* Parent instance */
+-    libvlc_media_t * p_md; /* current media descriptor */
+     libvlc_event_manager_t event_manager;
+ 
+     struct {
+diff --git a/lib/video.c b/lib/video.c
+index a02289ead9f..fac064ab4e0 100644
+--- a/lib/video.c
++++ b/lib/video.c
+@@ -160,8 +160,6 @@ int libvlc_video_get_size( libvlc_media_player_t *p_mi, unsigned ignored,
+                            unsigned *restrict px, unsigned *restrict py )
+ {
+     (void) ignored;
+-    if (p_mi->p_md == NULL)
+-        return -1;
+ 
+     int ret = -1;
+     libvlc_media_track_t *track =
+diff --git a/src/input/item.c b/src/input/item.c
+index 767675bf2dc..f6e154b6af3 100644
+--- a/src/input/item.c
++++ b/src/input/item.c
+@@ -413,6 +413,9 @@ void input_item_Release( input_item_t *p_item )
+     if( !vlc_atomic_rc_dec( &owner->rc ) )
+         return;
+ 
++    if( p_item->libvlc_owner_release != NULL )
++        p_item->libvlc_owner_release( p_item->libvlc_owner );
++
+     free( p_item->psz_name );
+     free( p_item->psz_uri );
+     free( p_item->p_stats );
+diff --git a/test/Makefile.am b/test/Makefile.am
+index 94aa76e9d4c..435feda2ae9 100644
+--- a/test/Makefile.am
++++ b/test/Makefile.am
+@@ -42,6 +42,7 @@ check_PROGRAMS = \
+ 	test_libvlc_media_thumbnail_webp \
+ 	test_libvlc_media_list \
+ 	test_libvlc_media_player \
++	test_libvlc_media_switch_ownership \
+ 	test_libvlc_media_player_record \
+ 	test_libvlc_media_discoverer \
+ 	test_libvlc_renderer_discoverer \
+@@ -179,6 +180,8 @@ test_libvlc_media_list_SOURCES = libvlc/media_list.c
+ test_libvlc_media_list_LDADD = $(LIBVLC)
+ test_libvlc_media_player_SOURCES = libvlc/media_player.c
+ test_libvlc_media_player_LDADD = $(LIBVLCCORE) $(LIBVLC)
++test_libvlc_media_switch_ownership_SOURCES = libvlc/media_switch_ownership.c
++test_libvlc_media_switch_ownership_LDADD = $(LIBVLCCORE) $(LIBVLC)
+ test_libvlc_media_player_record_SOURCES = libvlc/media_player_record.c
+ test_libvlc_media_player_record_LDADD = $(LIBVLCCORE) $(LIBVLC)
+ test_libvlc_media_discoverer_SOURCES = libvlc/media_discoverer.c
+diff --git a/test/libvlc/media_switch_ownership.c b/test/libvlc/media_switch_ownership.c
+new file mode 100644
+index 00000000000..9fdeef02635
+--- /dev/null
++++ b/test/libvlc/media_switch_ownership.c
+@@ -0,0 +1,354 @@
++/*
++ * media_switch_ownership.c - libvlc rapid set_media ownership regression
++ *
++ * Stress the media/input-item ownership model with a long run of active
++ * media replacements: each iteration hands the player a fresh media, drops
++ * the application's last reference immediately, and lets the outgoing input
++ * drain while it is still emitting metadata, subitem and elementary-stream
++ * teardown callbacks that resolve back to the released media.
++ *
++ * Before the ownership fix (VLC 1a4ccc4bdd3 / fad210b8b2d / 8b2e77c8b8f) this
++ * is a heap-use-after-free: the libvlc_media_t was freed on the application's
++ * release while the draining input still resolved input_item_t.libvlc_owner
++ * and wrote to it.
++ *
++ * This lives in its own program rather than in media_player.c on purpose: it
++ * must own the only libvlc instance in the process. Repeated
++ * libvlc_new()/libvlc_release() cycles re-dlopen the plugin set, and on macOS
++ * that makes AddressSanitizer's __asan_register_globals fault for a
++ * late-loaded plugin, which then corrupts every subsequent report. Isolating
++ * the workload keeps an ASan run of this regression trustworthy.
++ */
++
++/**********************************************************************
++ *  This program is free software; you can redistribute and/or modify *
++ *  it under the terms of the GNU General Public License as published *
++ *  by the Free Software Foundation; version 2 of the license, or (at *
++ *  your option) any later version.                                   *
++ *                                                                    *
++ *  This program is distributed in the hope that it will be useful,   *
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of    *
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.              *
++ *  See the GNU General Public License for more details.              *
++ *                                                                    *
++ *  You should have received a copy of the GNU General Public License *
++ *  along with this program; if not, you can get it from:             *
++ *  http://www.gnu.org/copyleft/gpl.html                              *
++ **********************************************************************/
++
++#include "test.h"
++#include <stdatomic.h>
++#include <vlc_common.h>
++
++/* Player-thread events are counted under a lock and observed by the main
++ * thread as monotonic counters rather than as semaphore tokens. Waiting for a
++ * counter to *advance* is immune to an event class firing more often than the
++ * workload predicts (a stray Stopped from an overlapping stop_async, say),
++ * which a counting semaphore is not: a semaphore that runs ahead silently
++ * stops rendezvousing and the workload degenerates into a no-op. */
++struct switch_media_ctx
++{
++    vlc_mutex_t lock;
++    vlc_cond_t cond;
++    unsigned media_changed;
++    unsigned playing;
++    unsigned settled; /* playing + error + stopped */
++    unsigned errors;
++    atomic_uint meta_count;
++    atomic_uint subitem_count;
++    atomic_uint subtree_count;
++    atomic_uint attachment_count;
++};
++
++/* Touch a media handed to an application listener the way any real client
++ * does. This is the load that the ownership fix has to make safe: the player
++ * resolves input_item_t.libvlc_owner and publishes the libvlc_media_t without
++ * holding a reference to it, so before the fix this dereferences a media the
++ * application already released and the player already dropped. */
++static void switch_media_touch(libvlc_media_t *media)
++{
++    if (media == NULL)
++        return;
++    char *mrl = libvlc_media_get_mrl(media);
++    assert(mrl != NULL);
++    free(mrl);
++}
++
++static void switch_media_player_event(const libvlc_event_t *event, void *opaque)
++{
++    struct switch_media_ctx *ctx = opaque;
++
++    switch (event->type)
++    {
++        case libvlc_MediaPlayerMediaChanged:
++            switch_media_touch(event->u.media_player_media_changed.new_media);
++            break;
++        case libvlc_MediaPlayerMediaStopping:
++            /* Delivered from the draining input after the switch: the media
++             * it names is the *outgoing* one, whose last application
++             * reference was dropped many events ago. */
++            switch_media_touch(event->u.media_player_media_stopping.media);
++            break;
++        default:
++            break;
++    }
++
++    vlc_mutex_lock(&ctx->lock);
++    switch (event->type)
++    {
++        case libvlc_MediaPlayerMediaStopping:
++            break;
++        case libvlc_MediaPlayerPlaying:
++            ctx->playing++;
++            ctx->settled++;
++            break;
++        case libvlc_MediaPlayerMediaChanged:
++            /* vlc_player_OpenNextMedia() sends exactly one current-media
++             * change per media it opens (src/player/player.c), so this
++             * advances once per set_media() the player honoured. A NULL media
++             * is only reported when the current media is released, which this
++             * workload never requests; filter it anyway. */
++            if (event->u.media_player_media_changed.new_media != NULL)
++                ctx->media_changed++;
++            break;
++        case libvlc_MediaPlayerEncounteredError:
++            ctx->errors++;
++            ctx->settled++;
++            break;
++        case libvlc_MediaPlayerStopped:
++            /* Erroring media never reaches Playing; without this the workload
++             * would block forever on those iterations. */
++            ctx->settled++;
++            break;
++        default:
++            vlc_assert_unreachable();
++    }
++    vlc_cond_broadcast(&ctx->cond);
++    vlc_mutex_unlock(&ctx->lock);
++}
++
++static void switch_media_event(const libvlc_event_t *event, void *opaque)
++{
++    struct switch_media_ctx *ctx = opaque;
++
++    switch (event->type)
++    {
++        case libvlc_MediaMetaChanged:
++            atomic_fetch_add_explicit(&ctx->meta_count, 1,
++                                      memory_order_relaxed);
++            break;
++        case libvlc_MediaSubItemAdded:
++            atomic_fetch_add_explicit(&ctx->subitem_count, 1,
++                                      memory_order_relaxed);
++            break;
++        case libvlc_MediaSubItemTreeAdded:
++            atomic_fetch_add_explicit(&ctx->subtree_count, 1,
++                                      memory_order_relaxed);
++            break;
++        case libvlc_MediaAttachedThumbnailsFound:
++            atomic_fetch_add_explicit(&ctx->attachment_count, 1,
++                                      memory_order_relaxed);
++            break;
++        default:
++            vlc_assert_unreachable();
++    }
++}
++
++static void attach_switch_media_events(libvlc_media_t *media,
++                                       struct switch_media_ctx *ctx)
++{
++    libvlc_event_manager_t *em = libvlc_media_event_manager(media);
++    assert(em != NULL);
++    assert(libvlc_event_attach(em, libvlc_MediaMetaChanged,
++                               switch_media_event, ctx) == 0);
++    assert(libvlc_event_attach(em, libvlc_MediaSubItemAdded,
++                               switch_media_event, ctx) == 0);
++    assert(libvlc_event_attach(em, libvlc_MediaSubItemTreeAdded,
++                               switch_media_event, ctx) == 0);
++    assert(libvlc_event_attach(em, libvlc_MediaAttachedThumbnailsFound,
++                               switch_media_event, ctx) == 0);
++}
++
++static void test_media_switch_ownership(const char **argv, int argc)
++{
++    /* Three distinct media rotated A/B/C/A/… so every replacement swaps in a
++     * different track, subitem and attachment topology, and the same media
++     * URL recurs often enough to cover A/B/A churn. The long length keeps
++     * every input mid-playback when it is replaced instead of ending on its
++     * own. */
++    static const char *const media_urls[] = {
++        "mock://audio_track_count=1;sub_track_count=1;node_count=2;"
++            "attachment_count=2;length=100000000",
++        "mock://audio_track_count=2;node_count=3;attachment_count=1;"
++            "length=100000000",
++        "mock://audio_track_count=1;sub_track_count=2;node_count=1;"
++            "attachment_count=3;length=100000000",
++    };
++    static const char error_url[] =
++        "mock://audio_track_count=1;attachment_count=1;error=true";
++
++    unsigned long iterations = 10000;
++    const char *iterations_env = getenv("SWIFTVLC_MEDIA_SWITCH_ITERATIONS");
++    if (iterations_env != NULL)
++    {
++        char *end;
++        unsigned long parsed = strtoul(iterations_env, &end, 10);
++        assert(end != iterations_env && *end == '\0' && parsed > 0);
++        iterations = parsed;
++    }
++
++    /* test_init() arms a 10s alarm so `make check` cannot wedge. This
++     * workload is deliberately long, so widen the guard proportionally
++     * rather than disabling it: a genuine deadlock must still abort the
++     * run. An operator-supplied VLC_TEST_TIMEOUT keeps precedence. */
++    if (getenv("VLC_TEST_TIMEOUT") == NULL)
++    {
++        unsigned long budget = 120 + iterations / 4;
++        alarm(budget > 3600 ? 3600 : (unsigned)budget);
++    }
++
++    test_log("Testing %lu active media replacements\n", iterations);
++
++    libvlc_instance_t *vlc = libvlc_new(argc, argv);
++    assert(vlc != NULL);
++    libvlc_media_player_t *mp = libvlc_media_player_new(vlc);
++    assert(mp != NULL);
++
++    struct switch_media_ctx ctx;
++    vlc_mutex_init(&ctx.lock);
++    vlc_cond_init(&ctx.cond);
++    ctx.media_changed = ctx.playing = ctx.settled = ctx.errors = 0;
++    atomic_init(&ctx.meta_count, 0);
++    atomic_init(&ctx.subitem_count, 0);
++    atomic_init(&ctx.subtree_count, 0);
++    atomic_init(&ctx.attachment_count, 0);
++
++    libvlc_event_manager_t *player_em = libvlc_media_player_event_manager(mp);
++    assert(libvlc_event_attach(player_em, libvlc_MediaPlayerPlaying,
++                               switch_media_player_event, &ctx) == 0);
++    assert(libvlc_event_attach(player_em, libvlc_MediaPlayerMediaChanged,
++                               switch_media_player_event, &ctx) == 0);
++    assert(libvlc_event_attach(player_em, libvlc_MediaPlayerEncounteredError,
++                               switch_media_player_event, &ctx) == 0);
++    assert(libvlc_event_attach(player_em, libvlc_MediaPlayerStopped,
++                               switch_media_player_event, &ctx) == 0);
++    assert(libvlc_event_attach(player_em, libvlc_MediaPlayerMediaStopping,
++                               switch_media_player_event, &ctx) == 0);
++
++    unsigned long preparsed = 0;
++    unsigned long errored = 0;
++
++    for (unsigned long i = 0; i < iterations; ++i)
++    {
++        const bool erroring = i > 0 && i % 257 == 0;
++        const char *url = erroring ? error_url
++            : media_urls[i % ARRAY_SIZE(media_urls)];
++        libvlc_media_t *media = libvlc_media_new_location(url);
++        assert(media != NULL);
++        attach_switch_media_events(media, &ctx);
++
++        if (erroring)
++            errored++;
++
++        /* Preparsing a subset overlaps attachment/subitem callbacks with
++         * active replacement without creating 10,000 concurrent preparsers. */
++        if (!erroring && i % 64 == 0)
++        {
++            assert(libvlc_media_parse_request(vlc, media,
++                                              libvlc_media_parse_network,
++                                              2000) == 0);
++            preparsed++;
++        }
++
++        vlc_mutex_lock(&ctx.lock);
++        const unsigned changed_before = ctx.media_changed;
++        const unsigned settled_before = ctx.settled;
++        vlc_mutex_unlock(&ctx.lock);
++
++        libvlc_media_player_set_media(mp, media);
++
++        /* Drop the application's last media reference immediately, before
++         * the switch is even acknowledged. From here on the media is kept
++         * alive solely by the input item the core holds, which is the whole
++         * point of the ownership fix: the outgoing input keeps emitting
++         * metadata, subitem and ES-teardown callbacks that resolve back to
++         * this media after the application is done with it. */
++        libvlc_media_release(media);
++
++        /* Idempotent while the player is started (vlc_player_Start() returns
++         * success without re-emitting Playing), and re-arms playback after an
++         * erroring media or a stop_async() below stopped the player. Do not
++         * wait on Playing here: a still-started player emits no new event. */
++        assert(libvlc_media_player_play(mp) == 0);
++
++        /* Replacing the media of a *playing* player defers the switch until
++         * the outgoing input has drained (vlc_player_SetCurrentMedia()), so
++         * this is the point where late callbacks against the released media
++         * have all been delivered.
++         *
++         * Then wait for the incoming input to actually settle into playback
++         * (or fail). Without this second rendezvous the next iteration would
++         * replace an input that never left Opening, and the workload would
++         * never once exercise the case the ownership fix is about: tearing
++         * down an input that is mid-playback and still emitting events. */
++        vlc_mutex_lock(&ctx.lock);
++        while (ctx.media_changed == changed_before)
++            vlc_cond_wait(&ctx.cond, &ctx.lock);
++        while (ctx.settled == settled_before)
++            vlc_cond_wait(&ctx.cond, &ctx.lock);
++        vlc_mutex_unlock(&ctx.lock);
++
++        /* Do not wait for stop: the following set_media deliberately overlaps
++         * output/input drain with the next load. */
++        if (i % 31 == 30)
++            libvlc_media_player_stop_async(mp);
++    }
++
++    libvlc_media_player_stop_async(mp);
++    libvlc_media_player_release(mp);
++    libvlc_release(vlc);
++
++    const unsigned meta = atomic_load_explicit(&ctx.meta_count,
++                                               memory_order_relaxed);
++    const unsigned subitems = atomic_load_explicit(&ctx.subitem_count,
++                                                   memory_order_relaxed);
++    const unsigned subtrees = atomic_load_explicit(&ctx.subtree_count,
++                                                   memory_order_relaxed);
++    const unsigned attachments = atomic_load_explicit(&ctx.attachment_count,
++                                                      memory_order_relaxed);
++
++    test_log("meta=%u subitems=%u subtrees=%u attachments=%u playing=%u "
++             "errors=%u preparsed=%lu errored=%lu\n", meta, subitems, subtrees,
++             attachments, ctx.playing, ctx.errors, preparsed, errored);
++
++    /* Guard against the workload silently degenerating into a no-op: every
++     * callback class the ownership fix reroutes must actually have fired
++     * against a media the application had already released, and the player
++     * must really have been playing when it was replaced. */
++    assert(ctx.media_changed == iterations);
++    assert(ctx.playing > 0);
++    assert(meta > 0);
++    assert(subitems > 0);
++    assert(subtrees > 0);
++    if (errored > 0)
++        assert(ctx.errors > 0);
++
++    /* Deliberately not asserted: libvlc_MediaAttachedThumbnailsFound cannot
++     * fire for mock media. The mock demuxer exports attachments as image/bmp
++     * (modules/demux/mock.c) and libvlc_picture_from_attachment() drops
++     * everything that is not PNG/JPEG/WebP (lib/picture.c), so the picture
++     * list is always empty and the event is suppressed. Attachment *teardown*
++     * is still exercised on every replacement via the demuxer, and the count
++     * is reported above so a future engine change that starts delivering the
++     * event is visible rather than silently ignored. */
++    (void) attachments;
++}
++
++int main(void)
++{
++    test_init();
++
++    test_media_switch_ownership(test_defaults_args, test_defaults_nargs);
++
++    return 0;
++}

--- a/scripts/patches/0007-rapid-set-media-ownership.patch
+++ b/scripts/patches/0007-rapid-set-media-ownership.patch
@@ -177,7 +177,7 @@ index dda43ec78b8..583118ac8b9 100644
      VLC_FORWARD_DECLARE_OBJECT(libvlc_media_list_t*) p_subitems; /* A media descriptor can have Sub items. This is the only dependency we really have on media_list */
      void *p_user_data;
 diff --git a/lib/media_player.c b/lib/media_player.c
-index 2fe615d2e49..52afccd9200 100644
+index 2fe615d2e49..d92fc99c848 100644
 --- a/lib/media_player.c
 +++ b/lib/media_player.c
 @@ -235,13 +235,12 @@ on_position_changed(vlc_player_t *player, vlc_tick_t new_time, double new_pos,
@@ -304,7 +304,7 @@ index 2fe615d2e49..52afccd9200 100644
      vlc_player_SetCurrentMedia(p_mi->player, p_md ? p_md->p_input_item : NULL);
  
      vlc_player_Unlock(p_mi->player);
-@@ -957,12 +953,12 @@ void libvlc_media_player_set_media(
+@@ -957,12 +953,16 @@ void libvlc_media_player_set_media(
  libvlc_media_t *
  libvlc_media_player_get_media( libvlc_media_player_t *p_mi )
  {
@@ -316,22 +316,28 @@ index 2fe615d2e49..52afccd9200 100644
 -        libvlc_media_retain( p_m );
 +
 +    input_item_t *item = vlc_player_GetCurrentMedia(p_mi->player);
-+    libvlc_media_t *p_m = item != NULL
-+        ? input_item_Hold(item)->libvlc_owner : NULL;
++    /* Take the reference only when there is an owner to hand back. The
++     * caller balances it through libvlc_media_release(); holding the item
++     * while returning NULL would leak it. */
++    libvlc_media_t *p_m = item != NULL ? item->libvlc_owner : NULL;
++    if (p_m != NULL)
++        input_item_Hold(item);
 +
      vlc_player_Unlock(p_mi->player);
  
      return p_m;
-@@ -984,9 +980,9 @@ swiftvlc_libvlc_media_player_get_media_length_snapshot(
+@@ -984,9 +984,12 @@ swiftvlc_libvlc_media_player_get_media_length_snapshot(
      vlc_player_t *player = p_mi->player;
      vlc_player_Lock(player);
  
 -    libvlc_media_t *media = p_mi->p_md;
--    if (media != NULL)
--        libvlc_media_retain(media);
 +    input_item_t *item = vlc_player_GetCurrentMedia(player);
-+    libvlc_media_t *media = item != NULL
-+        ? input_item_Hold(item)->libvlc_owner : NULL;
++    /* See libvlc_media_player_get_media(): only hold the item when an owner
++     * is actually returned, otherwise the reference is never released. */
++    libvlc_media_t *media = item != NULL ? item->libvlc_owner : NULL;
+     if (media != NULL)
+-        libvlc_media_retain(media);
++        input_item_Hold(item);
  
      snapshot->media = media;
      snapshot->length = media != NULL


### PR DESCRIPTION
Closes #90.

## Root cause

The pinned engine (`c833c4be0`) frees a `libvlc_media_t` inside `libvlc_media_player_set_media()` while the outgoing input is still draining. `on_stopping_current_media()` and `on_current_media_changed()` then resolve `input_item_t.libvlc_owner` and publish that same media to application listeners **without holding a reference**, so any client that touches the media it is handed reads freed memory.

Reproduced under AddressSanitizer against the unpatched pin:

```
ERROR: AddressSanitizer: heap-use-after-free READ of size 8
  #0 libvlc_media_get_mrl media.c:538
  #2 libvlc_event_send event.c:117
  #3 on_stopping_current_media media_player.c:97
  #4 vlc_player_input_HandleState input.c:279
freed by:
  #1 libvlc_media_player_set_media media_player.c:943
```

Worth recording for anyone re-testing this: the pin's `on_media_meta_changed()` is guarded by `if (media != current) return`, so the **metadata path alone does not reproduce the fault**. A workload that only counts media events runs 100,000 replacements clean. The exposure is specifically the media handed to event listeners.

## The fix

`scripts/patches/0007-rapid-set-media-ownership.patch` backports the dependency-ordered upstream series [`1a4ccc4bdd3`](https://code.videolan.org/videolan/vlc/-/commit/1a4ccc4bdd3c0fbd32cfbff3f151fdd4ec0f50e3), [`fad210b8b2d`](https://code.videolan.org/videolan/vlc/-/commit/fad210b8b2d6a03d2ed2def8955fd695fa070e50), [`8b2e77c8b8f`](https://code.videolan.org/videolan/vlc/-/commit/8b2e77c8b8fb45bb5dfabffa050ca37046b4d795): the media now shares its input item's reference count and is destroyed with it, and the player stops holding `p_md` and reads the core's current media instead.

Adaptations for the older pin:

- preserve its event manager and asynchronous preparse worker teardown;
- route late metadata and subitem callbacks to their originating media;
- rebase the atomic PiP media/length snapshot onto the core player's retained current input item after `libvlc_media_player_t.p_md` is removed;
- **fail soft on a NULL owner instead of relying on `assert()`**. SwiftVLC builds libVLC with `--disable-debug`, so the upstream asserts are compiled out of shipped builds, and `event_manager` being the first member of `libvlc_media_t` would turn the send into a NULL dereference.

Upstream hunks with no counterpart here were verified to be genuine absences in the older API, not oversights: `on_media_attachments_added` and `p_next_md` do not exist in the pin.

## Validation

New engine-level regression `test/libvlc/media_switch_ownership.c` drives 10,000 active replacements covering A/B/A churn, erroring media, stop/load overlap, metadata, subitems and elementary-stream teardown.

| Run | Result |
|---|---|
| Unpatched engine | heap-use-after-free (above) |
| Patched, 200 iterations × 3 | clean |
| Patched, 10,000 iterations | clean — `meta=10233 subitems=18291 subtrees=9163 playing=7367 errors=36` |
| Patched, 100,000 iterations | clean |

Peak RSS growth per iteration is unchanged from the pre-fix engine (527 → 413 B/iter, converging to the same footprint at 300k), so the ownership change introduces no leak.

Swift side, against both the released and the patched engine:

- full suite: 1619 tests, 135 suites — pass
- TSan (`RaceTests|StressTests|Memory*|LifecycleStressTests`): 88 tests — pass
- ASan (`Memory|Broadcaster|EventBridge`): 115 tests — pass
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency`: 0 warnings

### Why the regression test is its own program

It must own the only libvlc instance in the process. Repeated `libvlc_new()`/`libvlc_release()` cycles re-dlopen the plugin set, and macOS ASan then faults inside `__asan_register_globals` for a late-loaded plugin, which corrupts every subsequent report ("nested bug in the same thread"). That is a pre-existing ASan/dlopen interaction — it reproduces with the engine hunks reverted and is unrelated to this change.

## Swift-side audit

`libvlc_media_player_get_media()` now reports the media the player is actually using rather than the one last set, so the vendored header's stale `\warning` is replaced with upstream's `\note`.

Three existing tests drove `set_media` directly and then synthesised `.mediaChanged` at a moment the switch cannot yet have landed. They now wait for the native switch via a new `awaitNativeMediaSwitch` helper and pass unchanged against both engines.

`EventBridge` never dereferences the media carried on those events — it maps `libvlc_MediaPlayerMediaChanged` to a payload-free `.mediaChanged` — so SwiftVLC was not *directly* exposed to the use-after-free. `MediaReplacementOwnershipTests` covers the wrapper-level property that does matter: the `Media` wrapper's reference stays balanced across rapid replacement, which under the shared input-item refcount now also governs the item's lifetime.

## Remaining risks

- **The fix only takes effect once the engine binary is rebuilt and released.** `Package.swift` still points at the v1.0.0 xcframework, which is unpatched. This PR carries the patch, the regression and the audit; the rebuild lands with the release.
- **Leak detection is not covered on macOS.** `detect_leaks is not supported on this platform` — the RSS comparison above is a proxy. A definitive audit needs a Linux ASan/LSan job (relates to #79/#97).
- `test_media_player_tracks` crashes under ASan on macOS for the plugin-dlopen reason described above. Pre-existing, reproduced with this patch reverted, not addressed here.
