### PR TITLE
Make shutdown concurrent-call safe and permanently inert (#100)

### DIFF
--- a/Sources/SwiftVLC/Player/EventBridge.swift
+++ b/Sources/SwiftVLC/Player/EventBridge.swift
@@ -45,7 +45,13 @@ final class EventBridge: Sendable {
 
     Self.detachEvents(attachedEventTypes, from: eventManager, opaque: contextOpaque)
     attachedEventTypes = []
-    context.finishAll()
+    // `terminate()`, not `finishAll()`: invalidation is permanent. The
+    // mid-life native handle swap goes through `reattach(to:)` and never
+    // lands here, so the only callers are shutdown and deinit — after which
+    // the event source is gone for good. `Player.events` is a computed
+    // property that subscribes per access, so `finishAll()` would hand a
+    // post-shutdown caller a live stream that never finishes.
+    context.terminate()
   }
 
   /// Moves the existing streams to a replacement native media player.
@@ -189,6 +195,14 @@ private final class EventBridgeCallbackContext: Sendable {
   func finishAll() {
     events.finishAll()
     sourcedEvents.finishAll()
+  }
+
+  /// Permanently closes both broadcasters, so streams handed out after this
+  /// point are already finished rather than waiting on a source that will
+  /// never emit again.
+  func terminate() {
+    events.terminate()
+    sourcedEvents.terminate()
   }
 }
 

--- a/Sources/SwiftVLC/Player/Player+Drawable.swift
+++ b/Sources/SwiftVLC/Player/Player+Drawable.swift
@@ -139,6 +139,12 @@ extension Player {
   }
 
   func applyDrawable(_ newDrawable: AnyObject?) {
+    // A shut-down player must not bind a new video output. Detaching stays
+    // allowed so a view tearing down after shutdown still clears cleanly, and
+    // so shutdown's own `drawable = nil` path is unaffected.
+    if isShutdown, newDrawable != nil {
+      return
+    }
     // libVLC stores `drawable-nsobject` as a raw pointer. Once this exact
     // handle has started, replacing the variable cannot revoke a pointer an
     // opening or draining vout already copied. Retain every outgoing drawable

--- a/Sources/SwiftVLC/Player/Player+Teardown.swift
+++ b/Sources/SwiftVLC/Player/Player+Teardown.swift
@@ -94,9 +94,28 @@ extension Player {
   /// draining. The player is **unusable afterwards**: its event streams
   /// are finished and its native handle is replaced by an inert one so
   /// stray calls are harmless no-ops. Idempotent.
+  /// Concurrent callers all join the *same* teardown: the first caller
+  /// installs the task, every other caller awaits it, and none of them
+  /// returns before the native handle has actually been released. Returning
+  /// early on the flag alone would let a second caller observe a player that
+  /// still has a draining libVLC thread, which is precisely what this
+  /// method's contract promises is impossible.
   public func shutdown() async {
-    guard !isShutdown else { return }
+    if let inFlight = shutdownTask {
+      await inFlight.value
+      return
+    }
+    // Set before the task is created — and therefore before any suspension —
+    // so commands issued from now on already see a retiring player.
     isShutdown = true
+    let task = Task { @MainActor [self] in
+      await performShutdown()
+    }
+    shutdownTask = task
+    await task.value
+  }
+
+  private func performShutdown() async {
     // A still-attached list player would keep driving the handle being
     // torn down (its native binding retains it past the release) —
     // detach through the public setter so suppression and the native
@@ -114,7 +133,9 @@ extension Player {
     eventTask?.cancel()
     eventTask = nil
     _marqueeRestoreTask?.cancel()
-    playbackIntentBridge.finishAll()
+    // Permanent: `playbackIntentEvents` also subscribes per access, so a
+    // post-shutdown subscriber must get an already-finished stream.
+    playbackIntentBridge.terminate()
     libvlc_media_player_set_nsobject(pointer, nil)
 
     let bridge = eventBridge

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -476,7 +476,14 @@ public final class Player {
   var retainedDrawablesUntilNativePlayerRelease: [AnyObject] = []
   var selectedRenderer: RendererItem?
   var nativePlayerHasStartedPlayback = false
+  /// Set synchronously by the first ``shutdown()`` caller, before it
+  /// suspends, so every command issued from that point on sees a player that
+  /// is already retiring.
   var isShutdown = false
+  /// The single teardown every ``shutdown()`` caller joins. Retained after
+  /// completion so late callers still await a finished task rather than
+  /// returning while an earlier teardown is mid-flight.
+  var shutdownTask: Task<Void, Never>?
   let instance: VLCInstance
 
   // MARK: - Lifecycle
@@ -506,7 +513,9 @@ public final class Player {
   isolated deinit {
     eventTask?.cancel()
     _marqueeRestoreTask?.cancel()
-    playbackIntentBridge.finishAll()
+    // The player is going away for good, so future subscribers must receive
+    // an already-finished stream rather than one that can never emit.
+    playbackIntentBridge.terminate()
     #if os(iOS) || os(macOS)
     retireDirectPiPVideoCallbacksForHandleEnd()
     #endif
@@ -563,6 +572,10 @@ public final class Player {
   /// without a copy. The compiler enforces the transfer: the caller
   /// cannot keep using the transferred reference after the call.
   public func load(_ media: sending Media) {
+    // A shut-down player is inert: adopting media here would attach it to the
+    // retiring handle's inert replacement and publish a `currentMedia` the
+    // player can never play.
+    guard !isShutdown else { return }
     currentMedia = media
     resetMediaDerivedState()
     // No `markLibraryStop()` here: setting media on a *started* handle
@@ -588,6 +601,12 @@ public final class Player {
   ///   start, or ``VLCError/operationFailed(_:)`` if a selected renderer
   ///   cannot be applied to a replacement native player.
   public func play(_ media: sending Media) throws(VLCError) {
+    // Guarded here as well as in `play()`: the replacement branch below
+    // creates a fresh native handle and video output before `play()` is ever
+    // reached, which a shut-down player must never do.
+    guard !isShutdown else {
+      throw .invalidState("play(_:) called on a player that has been shut down")
+    }
     if shouldReplaceNativePlayerBeforePlaybackLoad {
       let resumeBeforeRelease = shouldResumeNativePlayerBeforeStop
       currentMedia = media
@@ -621,6 +640,9 @@ public final class Player {
   ///   start, or ``VLCError/operationFailed(_:)`` if a selected renderer
   ///   cannot be applied to a replacement native player.
   public func play() throws(VLCError) {
+    guard !isShutdown else {
+      throw .invalidState("play() called on a player that has been shut down")
+    }
     try prepareDrawableForPlayback()
     didReachEnd = false
     if libvlc_media_player_play(pointer) == -1 {

--- a/Tests/SwiftVLCTests/Player/PlayerShutdownInertnessTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerShutdownInertnessTests.swift
@@ -1,0 +1,162 @@
+@testable import SwiftVLC
+import Foundation
+import Testing
+
+/// Post-`shutdown()` guarantees: one shared teardown, permanent inertness,
+/// and immediately-finished streams.
+///
+/// `shutdown()` promises that on return no libVLC thread owned by the player
+/// is still draining and the player is unusable afterwards. Three things have
+/// to hold for that to be true for *every* caller rather than just the first:
+///
+/// 1. Concurrent callers must join the same teardown. Returning early on a
+///    flag that the first caller set before suspending hands the second
+///    caller a player whose native handle is still being released.
+/// 2. Commands issued after shutdown — including from tasks that were
+///    already suspended when it began — must not create media or outputs.
+/// 3. `events` and `playbackIntentEvents` are computed properties that
+///    subscribe per access, so a stream requested after shutdown must arrive
+///    already finished rather than waiting forever on a dead source.
+extension Integration {
+  @Suite(.tags(.mainActor, .async), .timeLimit(.minutes(1)))
+  @MainActor struct PlayerShutdownInertnessTests {
+    /// Every concurrent caller must observe the fully torn-down player, not
+    /// an intermediate state. The first caller suspends across the offloaded
+    /// native teardown, so a caller that returned on the flag alone would run
+    /// during that window and see pre-teardown state.
+    @Test
+    func `Concurrent shutdown callers all join the same teardown`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.silenceURL))
+
+      var callers: [Task<Bool, Never>] = []
+      for _ in 0..<8 {
+        callers.append(Task { @MainActor in
+          await player.shutdown()
+          // Both are only published at the very end of the teardown.
+          return player.currentMedia == nil && player.state == .idle
+        })
+      }
+
+      var observed: [Bool] = []
+      for caller in callers {
+        await observed.append(caller.value)
+      }
+
+      #expect(observed.count == 8)
+      #expect(
+        !observed.contains(false),
+        "a concurrent shutdown() caller returned before teardown completed"
+      )
+    }
+
+    /// Sequential callers must stay idempotent and still join.
+    @Test
+    func `Repeated shutdown calls remain idempotent`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      await player.shutdown()
+      await player.shutdown()
+      await player.shutdown()
+
+      #expect(player.currentMedia == nil)
+      #expect(player.state == .idle)
+    }
+
+    /// A shut-down player must not adopt media: the handle it would attach to
+    /// is the inert replacement.
+    @Test
+    func `load after shutdown does not create media`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      await player.shutdown()
+
+      try player.load(Media(url: TestMedia.silenceURL))
+
+      #expect(player.currentMedia == nil, "shut-down player adopted media")
+    }
+
+    /// Both playback entry points must reject explicitly rather than
+    /// silently driving the inert replacement handle.
+    @Test
+    func `play after shutdown rejects with an explicit error`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      await player.shutdown()
+
+      #expect(throws: VLCError.self) {
+        try player.play()
+      }
+      #expect(throws: VLCError.self) {
+        try player.play(Media(url: TestMedia.silenceURL))
+      }
+      #expect(player.currentMedia == nil)
+      #expect(!player.isPlaying)
+    }
+
+    /// A command racing shutdown from an already-suspended task must not
+    /// resurrect the player. The command runs after shutdown returns, which
+    /// is the suspension point the issue calls out.
+    @Test
+    func `command resumed after shutdown cannot create media`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+
+      async let teardown: Void = player.shutdown()
+      await teardown
+
+      // Simulates a task that was suspended across the shutdown and only now
+      // gets to issue its command.
+      await Task.yield()
+      try player.load(Media(url: TestMedia.silenceURL))
+      #expect(throws: VLCError.self) {
+        try player.play()
+      }
+
+      #expect(player.currentMedia == nil)
+    }
+
+    /// `events` subscribes per access, so a post-shutdown subscriber must get
+    /// an already-finished stream. Before terminating the broadcaster this
+    /// stream stayed open forever and the iteration below would hang.
+    @Test
+    func `Event stream requested after shutdown finishes immediately`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      await player.shutdown()
+
+      var received = 0
+      for await _ in player.events {
+        received += 1
+      }
+      #expect(received == 0)
+    }
+
+    /// Same guarantee for the playback-intent stream.
+    @Test
+    func `Playback intent stream requested after shutdown finishes immediately`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      await player.shutdown()
+
+      var received = 0
+      for await _ in player.playbackIntentEvents {
+        received += 1
+      }
+      #expect(received == 0)
+    }
+
+    /// A stream opened *before* shutdown must also finish, so consumers
+    /// awaiting it are released rather than stranded.
+    @Test
+    func `Event stream opened before shutdown finishes on shutdown`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let stream = player.events
+
+      let drained = Task {
+        var count = 0
+        for await _ in stream {
+          count += 1
+        }
+        return count
+      }
+
+      await player.shutdown()
+      _ = await drained.value
+    }
+  }
+}


### PR DESCRIPTION
Closes #100.

## Root cause

Three independent gaps, all reachable from a normal `shutdown()`.

**1. Concurrent callers did not join the teardown.** `shutdown()` set `isShutdown` before its first suspension and returned early for everyone else:

```swift
guard !isShutdown else { return }
isShutdown = true
```

The first caller then suspends across the offloaded native teardown. Any concurrent caller runs during that window, hits the guard, and returns — handed a player whose native handle is still being released. That is precisely the guarantee `shutdown()` exists to provide.

**2. Nothing consulted `isShutdown` afterwards.** It was written in exactly one place and read nowhere else, so a retired player still accepted commands that create media and outputs.

**3. Streams used `finishAll()`, which is the non-permanent variant.** `Broadcaster` documents `finishAll()` as allowing new subscribers to re-attach and `terminate()` as the permanent form. Both `Player.events` and `playbackIntentEvents` are *computed properties* that subscribe per access, so a stream requested after shutdown was live, never finished, and its consumer hung forever.

## The fix

- **One shared teardown.** A `shutdownTask` is installed by the first caller and awaited by the rest; it is retained after completion so late callers still await a finished task. `isShutdown` is still set synchronously, before the task is created, so commands issued from that instant already see a retiring player.
- **Inertness at the state-creating entry points.** `load(_:)` no-ops, `play()` and `play(_:)` reject with `VLCError.invalidState`, and `applyDrawable` ignores a new drawable. `play(_:)` is guarded separately from `play()` because its replacement branch builds a fresh native handle and video output *before* `play()` is reached. Detaching a drawable stays allowed so a view tearing down after shutdown still clears cleanly, and so shutdown's own `drawable = nil` path is unaffected.
- **Permanent termination.** `EventBridge.invalidate()` and the playback-intent bridge now `terminate()`. This is safe for `invalidate()` because the mid-life native handle swap goes through `reattach(to:)` and never reaches it — its only callers are shutdown and `deinit`, after which the source is gone for good. No existing `VLCError` case was added, so this is not a source-breaking change.

## Validation

New `PlayerShutdownInertnessTests` (8 tests) covers each acceptance criterion: concurrent callers all observing the fully torn-down player, sequential idempotency, `load`/`play` inertness, a command resumed after shutdown, and streams requested both after and before shutdown.

**The tests were verified to fail without the fix.** Stashing only `Sources/` and re-running: 6 of 8 fail, and the two stream tests do not merely fail — they hang until the suite time limit (128s for the run), which is exactly the pre-fix "stream never finishes" behaviour they exist to catch.

| | Result |
|---|---|
| Full suite | 1627 tests, 136 suites — pass |
| TSan (race/stress/memory + new suite) | 96 tests — pass |
| ASan (`Memory\|Broadcaster\|EventBridge` + new suite) | 123 tests — pass |
| `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` | 0 warnings |
| swiftformat / swiftlint | clean |

## Remaining risks

- Inertness is enforced at the media- and output-creating entry points rather than across the whole public surface. Property reads and transport commands like `pause()`/`stop()` on the inert replacement handle stay harmless no-ops, which matches the method's documented "stray calls are harmless no-ops" contract; a blanket guard on every accessor would be a much larger and more invasive change than this issue calls for.
- The replacement handle is still a real (media-less, output-less) libVLC player rather than a structurally unusable one, since `pointer` is non-optional throughout `Player`. Behaviourally it is now unreachable for anything that could create media or outputs.
