### PR TITLE
Make stopAndWait report output-safe completion truthfully (#92)

### DIFF
--- a/Sources/SwiftVLC/Player/Player+Teardown.swift
+++ b/Sources/SwiftVLC/Player/Player+Teardown.swift
@@ -91,14 +91,26 @@ extension Player {
     if terminal == .stopped || terminal == .error, state != terminal {
       handleEvent(.stateChanged(terminal))
     }
-    // The wait ended without a stopped state. If the native player is sitting
-    // in `.error`, that — not a bare timeout — is what the caller needs to
-    // know: the error arrived but the stop that releases the outputs never
-    // followed.
-    if outcome == .timedOut, terminal == .error {
+    return Self.resolveStopOutcome(waitOutcome: outcome, nativeState: terminal)
+  }
+
+  /// Folds the native handle's resting state into the wait's verdict.
+  ///
+  /// A wait that ended without a stop means one of two different things, and
+  /// the caller needs them distinguished: the pipeline is merely slow, or the
+  /// session errored and the stop that releases the outputs never followed.
+  ///
+  /// Pure so the rule is testable without live playback, which CI cannot
+  /// drive (see `TestCondition.canPlayMedia`).
+  nonisolated static func resolveStopOutcome(
+    waitOutcome: PlayerStopOutcome,
+    nativeState: PlayerState
+  )
+    -> PlayerStopOutcome {
+    if waitOutcome == .timedOut, nativeState == .error {
       return .failedButStillDraining
     }
-    return outcome
+    return waitOutcome
   }
 
   /// Waits for the *output-safe* terminal state and reports why the wait
@@ -108,9 +120,14 @@ extension Player {
   /// but does not end the wait, because libVLC emits the error before the
   /// stopped state that performs the release; if no stopped state follows
   /// within the ceiling, the error is what the caller needs to hear about.
-  private nonisolated static func awaitOutputSafeStop(
+  /// - Parameter timeout: The defensive ceiling. Injectable so the decision
+  ///   logic can be exercised against a synthetic event stream, without
+  ///   needing live playback — CI cannot drive libVLC to `.playing`
+  ///   (see `TestCondition.canPlayMedia`).
+  nonisolated static func awaitOutputSafeStop(
     on stream: AsyncStream<SourcedPlayerEvent>,
-    source: UInt
+    source: UInt,
+    timeout: Duration = .seconds(10)
   )
     async -> PlayerStopOutcome {
     await withTaskGroup(of: PlayerStopOutcome?.self) { group in
@@ -136,7 +153,7 @@ extension Player {
         // verdict was already taken, so either way "no stop observed" is the
         // honest report. The stop task itself is unstructured and is never
         // cancelled by a caller, which is what keeps the drain protected.
-        try? await Task.sleep(for: .seconds(10))
+        try? await Task.sleep(for: timeout)
         return .timedOut
       }
       let outcome: PlayerStopOutcome = switch await group.next() {

--- a/Sources/SwiftVLC/Player/Player+Teardown.swift
+++ b/Sources/SwiftVLC/Player/Player+Teardown.swift
@@ -33,7 +33,10 @@ extension Player {
   /// to completion so no caller is ever told the outputs are free while
   /// they are still live.
   ///
-  /// - Returns: Whether the native outputs are known to have been released.
+  /// - Returns: Why the wait ended. Only ``PlayerStopOutcome/stopped``
+  ///   establishes that the outputs were released; test it directly or
+  ///   through ``PlayerStopOutcome/isOutputSafe`` rather than treating a
+  ///   returned value as a success flag.
   @discardableResult
   public func stopAndWait() async -> PlayerStopOutcome {
     // Concurrent callers join one in-flight stop and all observe the same

--- a/Sources/SwiftVLC/Player/Player+Teardown.swift
+++ b/Sources/SwiftVLC/Player/Player+Teardown.swift
@@ -17,14 +17,49 @@ extension Player {
   /// Awaits the **explicit-stop** path only: on the media-replacement
   /// path the outgoing handle's `Stopped` is unobservable (see
   /// ``events(policy:filter:)``), and ``recast(to:)`` awaits
-  /// new-session readiness instead. Returns immediately when the player
-  /// is already terminal. A defensive 10-second ceiling keeps a wedged
-  /// pipeline from hanging the caller.
-  public func stopAndWait() async {
+  /// new-session readiness instead. A defensive 10-second ceiling keeps a
+  /// wedged pipeline from hanging the caller.
+  ///
+  /// Only ``PlayerStopOutcome/stopped`` means the outputs were released.
+  /// A native error is **not** treated as completion: libVLC reports the
+  /// error first and the stopped state that performs the release arrives
+  /// afterwards, so this keeps waiting and reports
+  /// ``PlayerStopOutcome/failedButStillDraining`` if that follow-up never
+  /// comes. Check the result — or ``PlayerStopOutcome/isOutputSafe`` —
+  /// before deactivating an audio session or detaching a drawable.
+  ///
+  /// Concurrent callers join one in-flight stop and all receive the same
+  /// outcome. Cancelling a caller does not abandon the drain; the stop runs
+  /// to completion so no caller is ever told the outputs are free while
+  /// they are still live.
+  ///
+  /// - Returns: Whether the native outputs are known to have been released.
+  @discardableResult
+  public func stopAndWait() async -> PlayerStopOutcome {
+    // Concurrent callers join one in-flight stop and all observe the same
+    // outcome; a second caller must not be told the outputs are released
+    // just because someone else asked first.
+    if let inFlight = stopAndWaitTask {
+      return await inFlight.value
+    }
+    let task = Task { @MainActor [self] in
+      let outcome = await performStopAndWait()
+      stopAndWaitTask = nil
+      return outcome
+    }
+    stopAndWaitTask = task
+    return await task.value
+  }
+
+  private func performStopAndWait() async -> PlayerStopOutcome {
+    // `.error` is deliberately absent here. libVLC reports the error first
+    // and the stopped state that actually releases the outputs afterwards
+    // (see `PlayerEndReachedTests`), so returning on `.error` would promise
+    // output safety while the outputs are still draining.
     switch nativePlaybackState {
-    case .idle, .stopped, .error:
+    case .idle, .stopped:
       stop()
-      return
+      return .stopped
     default:
       break
     }
@@ -35,14 +70,14 @@ extension Player {
     // so an in-flight stop completing right here costs nothing instead
     // of the full defensive timeout.
     switch nativePlaybackState {
-    case .idle, .stopped, .error:
+    case .idle, .stopped:
       stop()
-      return
+      return .stopped
     default:
       break
     }
     stop()
-    await Self.awaitTerminalStop(on: stream, source: source)
+    let outcome = await Self.awaitOutputSafeStop(on: stream, source: source)
     // The internal consumer mirrors the same terminal event onto
     // `state` on its own main-actor schedule and may still be draining
     // its backlog when the dedicated wait resumes. Reconcile here so
@@ -53,35 +88,68 @@ extension Player {
     if terminal == .stopped || terminal == .error, state != terminal {
       handleEvent(.stateChanged(terminal))
     }
+    // The wait ended without a stopped state. If the native player is sitting
+    // in `.error`, that — not a bare timeout — is what the caller needs to
+    // know: the error arrived but the stop that releases the outputs never
+    // followed.
+    if outcome == .timedOut, terminal == .error {
+      return .failedButStillDraining
+    }
+    return outcome
   }
 
-  private static func awaitTerminalStop(
+  /// Waits for the *output-safe* terminal state and reports why the wait
+  /// ended.
+  ///
+  /// Only `.stopped` releases the outputs. An observed `.error` is recorded
+  /// but does not end the wait, because libVLC emits the error before the
+  /// stopped state that performs the release; if no stopped state follows
+  /// within the ceiling, the error is what the caller needs to hear about.
+  private nonisolated static func awaitOutputSafeStop(
     on stream: AsyncStream<SourcedPlayerEvent>,
     source: UInt
   )
-    async {
-    await withTaskGroup(of: Bool.self) { group in
+    async -> PlayerStopOutcome {
+    await withTaskGroup(of: PlayerStopOutcome?.self) { group in
       group.addTask {
         for await sourced in stream {
-          if
+          guard
             sourced.source == source,
-            case .stateChanged(let state) = sourced.event,
-            state == .stopped || state == .error {
-            return true
+            case .stateChanged(let state) = sourced.event
+          else { continue }
+          // Only `.stopped` ends the wait. An `.error` is ignored here: the
+          // release happens on the stopped state that follows it, and the
+          // caller learns about a stuck error from the native state read
+          // back in `performStopAndWait()`.
+          if state == .stopped {
+            return .stopped
           }
         }
-        return false
+        // The stream finished without a stopped state.
+        return nil
       }
       group.addTask {
+        // This child only ends early when the group is cancelled after a
+        // verdict was already taken, so either way "no stop observed" is the
+        // honest report. The stop task itself is unstructured and is never
+        // cancelled by a caller, which is what keeps the drain protected.
         try? await Task.sleep(for: .seconds(10))
-        return false
+        return .timedOut
       }
-      if let first = await group.next(), !first {
+      let outcome: PlayerStopOutcome = switch await group.next() {
+      case .some(.some(let first)):
+        first
+      default:
+        // The observer's stream finished without ever reporting a stop.
+        .timedOut
+      }
+      if outcome == .timedOut {
         #if DEBUG
         Signposts.signposter.emitEvent("Player.stopAndWait.timeout")
         #endif
       }
       group.cancelAll()
+      return outcome
     }
   }
 

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -484,6 +484,10 @@ public final class Player {
   /// completion so late callers still await a finished task rather than
   /// returning while an earlier teardown is mid-flight.
   var shutdownTask: Task<Void, Never>?
+  /// The in-flight ``stopAndWait()``, so concurrent callers join one stop and
+  /// observe the same outcome. Cleared on completion — unlike shutdown, a
+  /// stop is repeatable, so a later call must start a fresh wait.
+  var stopAndWaitTask: Task<PlayerStopOutcome, Never>?
   let instance: VLCInstance
 
   // MARK: - Lifecycle

--- a/Sources/SwiftVLC/Player/PlayerStopOutcome.swift
+++ b/Sources/SwiftVLC/Player/PlayerStopOutcome.swift
@@ -1,0 +1,44 @@
+/// The result of ``Player/stopAndWait()``, describing whether the native
+/// audio and video outputs are known to have been released.
+///
+/// ``Player/stopAndWait()`` exists so callers have a point in time after
+/// which nothing is still draining — most commonly before
+/// `AVAudioSession.setActive(false, options: .notifyOthersOnDeactivation)`,
+/// which fails session-busy while an audio output is alive, or before
+/// detaching a drawable. Only ``stopped`` establishes that. The remaining
+/// cases all mean *outputs may still be draining*, and are distinguished so a
+/// caller can retry, back off, or surface the condition instead of proceeding
+/// on a promise that was not kept.
+///
+/// There is deliberately no `cancelled` case. Cancelling a caller does not
+/// abandon the drain: the stop runs to completion and every caller is told
+/// the real output state. Returning early on cancellation would hand back a
+/// result indistinguishable from success while an audio output was still
+/// alive, which is the failure this type exists to prevent.
+public enum PlayerStopOutcome: Sendable, Equatable {
+  /// The native player reached its stopped state and released its outputs.
+  /// This is the only outcome that makes immediate teardown safe.
+  case stopped
+
+  /// The defensive ceiling elapsed before the native player reported
+  /// stopped. Outputs may still be draining.
+  case timedOut
+
+  /// The session ended in a native error and no stopped state followed
+  /// within the defensive ceiling.
+  ///
+  /// A libVLC error is *not* by itself an output-safe condition: an error
+  /// is reported first and the stopped state that actually releases the
+  /// outputs arrives afterwards. This outcome means that follow-up never
+  /// came, so outputs may still be draining.
+  case failedButStillDraining
+
+  /// Whether the native outputs are known to have been released.
+  ///
+  /// `true` only for ``stopped``. Use this rather than testing for
+  /// individual failure cases, so a future outcome cannot silently read as
+  /// success.
+  public var isOutputSafe: Bool {
+    self == .stopped
+  }
+}

--- a/Tests/SwiftVLCTests/Player/PlayerStopOutcomeTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerStopOutcomeTests.swift
@@ -132,6 +132,168 @@ extension Integration {
       )
     }
 
+    // MARK: - Wait logic, driven without live playback
+
+    //
+    // CI cannot reach `.playing` (`TestCondition.canPlayMedia`), so the
+    // decision logic is exercised directly against a synthetic event stream.
+    // These cover the branches the playback tests can only reach on a
+    // developer machine.
+
+    /// A stop for the awaited handle ends the wait as output-safe.
+    @Test
+    func `A stopped event for the awaited source reports stopped`() async {
+      let stream = Self.eventStream([
+        SourcedPlayerEvent(source: 7, event: .stateChanged(.stopped))
+      ])
+
+      let outcome = await Player.awaitOutputSafeStop(
+        on: stream,
+        source: 7,
+        timeout: .seconds(5)
+      )
+
+      #expect(outcome == .stopped)
+    }
+
+    /// The core of the fix: an error is not a stop. It must not end the wait,
+    /// so a stream carrying only an error times out rather than reporting the
+    /// outputs released.
+    @Test
+    func `An error event alone never reports output-safe`() async {
+      let stream = Self.eventStream([
+        SourcedPlayerEvent(source: 7, event: .stateChanged(.error))
+      ])
+
+      let outcome = await Player.awaitOutputSafeStop(
+        on: stream,
+        source: 7,
+        timeout: .milliseconds(50)
+      )
+
+      #expect(outcome == .timedOut)
+      #expect(!outcome.isOutputSafe)
+    }
+
+    /// An error followed by the stop that actually releases the outputs is
+    /// the real libVLC ordering, and must resolve as output-safe.
+    @Test
+    func `An error followed by a stop reports stopped`() async {
+      let stream = Self.eventStream([
+        SourcedPlayerEvent(source: 7, event: .stateChanged(.error)),
+        SourcedPlayerEvent(source: 7, event: .stateChanged(.stopped))
+      ])
+
+      let outcome = await Player.awaitOutputSafeStop(
+        on: stream,
+        source: 7,
+        timeout: .seconds(5)
+      )
+
+      #expect(outcome == .stopped)
+    }
+
+    /// A stop belonging to a different native handle must be ignored: it says
+    /// nothing about the handle this caller is waiting on.
+    @Test
+    func `A stop from another source is ignored`() async {
+      let stream = Self.eventStream([
+        SourcedPlayerEvent(source: 99, event: .stateChanged(.stopped))
+      ])
+
+      let outcome = await Player.awaitOutputSafeStop(
+        on: stream,
+        source: 7,
+        timeout: .milliseconds(50)
+      )
+
+      #expect(outcome == .timedOut)
+    }
+
+    /// Non-state events must not be mistaken for a terminal transition.
+    @Test
+    func `Unrelated events do not end the wait`() async {
+      let stream = Self.eventStream([
+        SourcedPlayerEvent(source: 7, event: .timeChanged(.seconds(1))),
+        SourcedPlayerEvent(source: 7, event: .stateChanged(.playing))
+      ])
+
+      let outcome = await Player.awaitOutputSafeStop(
+        on: stream,
+        source: 7,
+        timeout: .milliseconds(50)
+      )
+
+      #expect(outcome == .timedOut)
+    }
+
+    /// Nothing arriving at all resolves as a timeout rather than hanging.
+    @Test
+    func `An empty stream times out`() async {
+      let stream = Self.eventStream([])
+
+      let outcome = await Player.awaitOutputSafeStop(
+        on: stream,
+        source: 7,
+        timeout: .milliseconds(50)
+      )
+
+      #expect(outcome == .timedOut)
+    }
+
+    /// A ceiling reached while the handle sits in error is reported as the
+    /// error it is, not as a bare timeout — the two mean different things to
+    /// a caller deciding whether to retry or surface a failure.
+    @Test
+    func `A timeout with the handle in error reports failedButStillDraining`() {
+      #expect(
+        Player.resolveStopOutcome(waitOutcome: .timedOut, nativeState: .error)
+          == .failedButStillDraining
+      )
+    }
+
+    /// A timeout with no error stays a timeout.
+    @Test
+    func `A timeout without an error stays a timeout`() {
+      #expect(
+        Player.resolveStopOutcome(waitOutcome: .timedOut, nativeState: .stopped)
+          == .timedOut
+      )
+      #expect(
+        Player.resolveStopOutcome(waitOutcome: .timedOut, nativeState: .playing)
+          == .timedOut
+      )
+    }
+
+    /// An observed stop is output-safe regardless of what the handle reports
+    /// afterwards — the release already happened.
+    @Test
+    func `An observed stop is never downgraded`() {
+      #expect(
+        Player.resolveStopOutcome(waitOutcome: .stopped, nativeState: .error)
+          == .stopped
+      )
+      #expect(
+        Player.resolveStopOutcome(waitOutcome: .stopped, nativeState: .stopped)
+          == .stopped
+      )
+    }
+
+    /// Builds a finite stream of the given events. The stream finishes after
+    /// the last one, which also exercises the "source ended without a stop"
+    /// path.
+    private static func eventStream(
+      _ events: [SourcedPlayerEvent]
+    )
+      -> AsyncStream<SourcedPlayerEvent> {
+      AsyncStream { continuation in
+        for event in events {
+          continuation.yield(event)
+        }
+        continuation.finish()
+      }
+    }
+
     /// The result has to stay trustworthy across repeated cycles, since that
     /// is how it is used in practice: stop, tear down outputs, play again.
     @Test(.enabled(if: TestCondition.canPlayMedia))

--- a/Tests/SwiftVLCTests/Player/PlayerStopOutcomeTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerStopOutcomeTests.swift
@@ -58,7 +58,12 @@ extension Integration {
         }
         return false
       }
-      _ = await sawError.value
+      // Asserted, not discarded: if the error is never observed the player
+      // took some other path and the invariant below would pass vacuously.
+      try #require(
+        await sawError.value,
+        "the unopenable media never reported an error, so the post-error path was not exercised"
+      )
 
       let outcome = await player.stopAndWait()
 

--- a/Tests/SwiftVLCTests/Player/PlayerStopOutcomeTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerStopOutcomeTests.swift
@@ -1,0 +1,150 @@
+@testable import SwiftVLC
+import Foundation
+import Testing
+
+/// `stopAndWait()` must report output safety truthfully.
+///
+/// The whole point of the API is to give callers a moment after which nothing
+/// is still draining — it is what you call before
+/// `AVAudioSession.setActive(false, …)` or before detaching a drawable. A
+/// result that reads as success while an audio output is alive is worse than
+/// no result at all, so these tests pin the cases where that could happen:
+///
+/// - A native error is **not** completion. libVLC emits the error first and
+///   the stopped state that actually releases the outputs afterwards, so
+///   returning on `.error` would promise safety mid-drain.
+/// - Concurrent callers must join one stop and all see the same answer.
+/// - Repeated play/stop/detach cycles must stay safe.
+extension Integration {
+  @Suite(.tags(.mainActor, .async), .timeLimit(.minutes(2)))
+  @MainActor struct PlayerStopOutcomeTests {
+    /// An idle player has nothing draining, so the result is immediately
+    /// output-safe.
+    @Test
+    func `Idle player reports an output-safe stop`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+
+      let outcome = await player.stopAndWait()
+
+      #expect(outcome == .stopped)
+      #expect(outcome.isOutputSafe)
+    }
+
+    /// An unopenable media drives libVLC to `.error`, and the `.stopped` that
+    /// actually releases the outputs only arrives afterwards. This pins the
+    /// invariant that falls out of no longer treating `.error` as terminal:
+    /// an output-safe answer is never returned while the native handle is
+    /// still sitting in error.
+    ///
+    /// The error is awaited as an *event* rather than polled as a resting
+    /// state — libVLC moves through error to stopped faster than any poll
+    /// interval reliably catches.
+    @Test(.enabled(if: TestCondition.canPlayMedia))
+    func `Native error does not report output-safe completion early`() async throws {
+      let missingPath = "/nonexistent/swiftvlc-\(UUID().uuidString).mp4"
+      let player = Player(instance: TestInstance.makePlayback())
+      let events = player.events(policy: .unbounded, filter: nil)
+
+      try player.play(Media(path: missingPath))
+
+      let sawError = Task.detached { @Sendable in
+        for await event in events {
+          if case .encounteredError = event {
+            return true
+          }
+          if case .stateChanged(.stopped) = event {
+            return false
+          }
+        }
+        return false
+      }
+      _ = await sawError.value
+
+      let outcome = await player.stopAndWait()
+
+      // Either the stop landed (the normal case, since `.stopped` follows the
+      // error) or we are explicitly told the drain never finished. What must
+      // never happen is an output-safe answer while the handle sits in error.
+      if outcome.isOutputSafe {
+        #expect(
+          player.nativePlaybackState != .error,
+          "reported output-safe while the native handle was still in error"
+        )
+      } else {
+        #expect(outcome == .failedButStillDraining || outcome == .timedOut)
+      }
+    }
+
+    /// Concurrent callers join one in-flight stop, so none of them can be
+    /// told the outputs are free on the strength of someone else's request.
+    @Test(.enabled(if: TestCondition.canPlayMedia))
+    func `Concurrent callers receive the same terminal result`() async throws {
+      let player = Player(instance: TestInstance.makePlayback())
+      try player.play(url: TestMedia.twosecURL)
+      try #require(
+        await poll(until: { player.state == .playing }),
+        "Waiting for: player.state == .playing"
+      )
+
+      var callers: [Task<PlayerStopOutcome, Never>] = []
+      for _ in 0..<6 {
+        callers.append(Task { @MainActor in await player.stopAndWait() })
+      }
+
+      var outcomes: [PlayerStopOutcome] = []
+      for caller in callers {
+        await outcomes.append(caller.value)
+      }
+
+      #expect(outcomes.count == 6)
+      #expect(
+        Set(outcomes).count == 1,
+        "concurrent callers disagreed about output safety: \(outcomes)"
+      )
+      #expect(outcomes.first == .stopped)
+    }
+
+    /// A caller whose task is cancelled must still be told the truth. The
+    /// drain is deliberately not abandoned, so the reported state stays
+    /// accurate rather than becoming indistinguishable from success.
+    @Test(.enabled(if: TestCondition.canPlayMedia))
+    func `Cancelled caller still receives an accurate result`() async throws {
+      let player = Player(instance: TestInstance.makePlayback())
+      try player.play(url: TestMedia.twosecURL)
+      try #require(
+        await poll(until: { player.state == .playing }),
+        "Waiting for: player.state == .playing"
+      )
+
+      let caller = Task { @MainActor in await player.stopAndWait() }
+      caller.cancel()
+      let outcome = await caller.value
+
+      #expect(outcome == .stopped)
+      #expect(
+        player.nativePlaybackState == .stopped,
+        "drain was abandoned on cancellation: \(player.nativePlaybackState)"
+      )
+    }
+
+    /// The result has to stay trustworthy across repeated cycles, since that
+    /// is how it is used in practice: stop, tear down outputs, play again.
+    @Test(.enabled(if: TestCondition.canPlayMedia))
+    func `Repeated play and stop cycles stay output-safe`() async throws {
+      let player = Player(instance: TestInstance.makePlayback())
+
+      for cycle in 0..<3 {
+        try player.play(url: TestMedia.twosecURL)
+        try #require(
+          await poll(until: { player.state == .playing }),
+          "Waiting for: player.state == .playing (cycle \(cycle))"
+        )
+
+        let outcome = await player.stopAndWait()
+
+        #expect(outcome == .stopped, "cycle \(cycle) was not output-safe")
+        #expect(player.nativePlaybackState == .stopped, "cycle \(cycle)")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #92.

## Root cause

`stopAndWait()` documents that the audio and video outputs are released when it returns — it is what you call before `AVAudioSession.setActive(false, options: .notifyOthersOnDeactivation)` or before detaching a drawable. Two things broke that promise.

**1. A native error was treated as completion.** `.error` appeared in both early-return switches and in the wait predicate. But libVLC reports the error *first* and the stopped state that actually performs the release *afterwards* — the repo's own `PlayerEndReachedTests` documents exactly that ordering, and the issue cites it. So returning on `.error` handed the caller an "outputs are free" answer mid-drain.

**2. The result was `Void`.** Timeout, cancellation, and success were indistinguishable. The timeout child used `try? await Task.sleep(…)`, which swallows the cancellation error and returns the same thing as a full ten-second wait.

## The fix

`stopAndWait()` now returns `PlayerStopOutcome` — `stopped`, `timedOut`, or `failedButStillDraining` — with `isOutputSafe` true only for `stopped`. It is `@discardableResult`, so the existing call sites (including the three Showcase apps) are unaffected and this is not a source-breaking change.

- Only a real stop ends the wait. If the native handle is still in `.error` when the ceiling elapses, that is reported as `failedButStillDraining` rather than a bare timeout.
- Concurrent callers join one in-flight stop through a shared task and all observe the same outcome, mirroring the `shutdown()` joining added in #100.

### Why there is no `cancelled` case

The issue offers a choice: *"either protect output draining from cancellation or report that it remains incomplete."* This takes the first, stronger option. The stop runs in an unstructured task, so cancelling a caller cannot abandon the drain — it completes and every caller is told the real output state.

That makes a `cancelled` case unreachable, and shipping an unreachable public enum case is worse than not having one. Returning early on cancellation would also reintroduce precisely the failure this change exists to remove: a result indistinguishable from success while an audio output is still alive. The behaviour is documented on both `stopAndWait()` and `PlayerStopOutcome`.

## Validation

New `PlayerStopOutcomeTests`: idle fast path, the post-error invariant, concurrent callers agreeing, a cancelled caller still receiving an accurate result, and repeated play/stop cycles.

| | Result |
|---|---|
| Full suite | 1632 tests, 137 suites — pass |
| TSan (race/stress/memory + stop suites) | 99 tests — pass |
| ASan (`Memory\|Broadcaster\|EventBridge` + stop suites) | 126 tests — pass |
| `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` | 0 warnings |
| swiftformat / swiftlint | clean |

**Honest note on what the error test proves.** I tried to build a test that fails against the pre-fix `.error`-as-terminal behaviour and could not make one reliable: with the unopenable-file fixture libVLC moves through error to stopped faster than any poll interval catches, so the native handle never rests in `.error` at the decision point and both versions return the same thing. I verified this by temporarily restoring the old `.error` handling — the test still passed. It is therefore an *invariant guard* (an output-safe answer is never returned while the handle sits in error), not a reproduction. The `.error` correction itself rests on the ordering evidence in `PlayerEndReachedTests`, which is the issue's own cited evidence. The concurrency and cancellation tests do pin genuinely new behaviour.

## Remaining risks

- The four playback-driven tests self-skip under `CI=true` (`TestCondition.canPlayMedia`), so CI exercises only the idle fast path. They run locally and were verified there. This is the pre-existing CI blind spot the repo already tracks, not something new to this change.
- `failedButStillDraining` is reached only when the ten-second ceiling elapses with the handle in `.error`; that path is not covered by an automated test because it needs a wedged pipeline to reproduce.
