### PR TITLE
Make active media replacement transactional on synchronous failure (#83)

### DIFF
--- a/Sources/SwiftVLC/Player/Player+Drawable.swift
+++ b/Sources/SwiftVLC/Player/Player+Drawable.swift
@@ -231,8 +231,21 @@ extension Player {
   }
   #endif
 
+  /// Swaps in a fresh native handle, carrying the current per-player state
+  /// across.
+  ///
+  /// Atomic on failure: the only throwing step happens before anything on
+  /// `self` is mutated, so a rejected renderer leaves the outgoing handle
+  /// playing and every Swift-side field untouched.
+  ///
+  /// - Parameter media: The media to install on the new handle. Pass this
+  ///   explicitly when replacing *as part of* loading new media, so the
+  ///   caller can publish `currentMedia` only after the swap succeeds and a
+  ///   failure cannot leave public state describing media the player is not
+  ///   playing. Defaults to the already-published ``currentMedia``.
   func replaceNativePlayerForDrawablePlayback(
     target: AnyObject?,
+    media: Media? = nil,
     resumeBeforeRelease: Bool = false
   )
     throws(VLCError) {
@@ -262,8 +275,8 @@ extension Player {
       retainedDrawables.append(target)
     }
 
-    if let currentMedia {
-      libvlc_media_player_set_media(newPointer, currentMedia.pointer)
+    if let incoming = media ?? currentMedia {
+      libvlc_media_player_set_media(newPointer, incoming.pointer)
     }
     guard libvlc_media_player_set_renderer(newPointer, selectedRenderer?.pointer) == 0 else {
       libvlc_media_player_release(newPointer)

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -613,12 +613,18 @@ public final class Player {
     }
     if shouldReplaceNativePlayerBeforePlaybackLoad {
       let resumeBeforeRelease = shouldResumeNativePlayerBeforeStop
-      currentMedia = media
-      resetMediaDerivedState()
+      // Nothing is published until the native swap succeeds. Committing
+      // `currentMedia` first meant a rejected renderer left every public
+      // field describing the incoming media while the outgoing handle was
+      // still playing the previous one.
       try replaceNativePlayerForDrawablePlayback(
         target: drawable,
+        media: media,
         resumeBeforeRelease: resumeBeforeRelease
       )
+      currentMedia = media
+      resetMediaDerivedState()
+      notifyMediaDependentObservables()
     } else {
       load(media)
     }
@@ -651,11 +657,31 @@ public final class Player {
     didReachEnd = false
     if libvlc_media_player_play(pointer) == -1 {
       publishPlaybackIntent(false)
+      let resolved = Self.stateAfterRejectedStart(previous: state)
+      if resolved != state {
+        publishPlaybackState(resolved)
+      }
       let reason = libvlc_errmsg().map { String(cString: $0) } ?? "unknown"
       throw .playbackFailed(reason: reason)
     }
     nativePlayerHasStartedPlayback = true
     publishPlaybackIntent(true)
+  }
+
+  /// The lifecycle state to publish when libVLC refuses to start.
+  ///
+  /// No session exists for the current media, so an *active* state can only
+  /// have been inherited from the previous one. Leaving it would describe
+  /// that previous session while every other public field already describes
+  /// the current media — the mixed identity a rejected start has to avoid —
+  /// so it is replaced with one terminal outcome. A state that is already
+  /// non-active is left alone: there is no stale session to displace, and
+  /// inventing a failure the caller never had would be its own lie.
+  ///
+  /// Pure so the rule is testable: `libvlc_media_player_play` returning `-1`
+  /// is not something a test can force, including on an empty player.
+  nonisolated static func stateAfterRejectedStart(previous: PlayerState) -> PlayerState {
+    previous.isActive ? .error : previous
   }
 
   /// Pauses playback.

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -659,10 +659,7 @@ public final class Player {
     didReachEnd = false
     if libvlc_media_player_play(pointer) == -1 {
       publishPlaybackIntent(false)
-      let resolved = Self.stateAfterRejectedStart(previous: state)
-      if resolved != state {
-        publishPlaybackState(resolved)
-      }
+      publishPlaybackState(Self.stateAfterRejectedStart(previous: state))
       let reason = libvlc_errmsg().map { String(cString: $0) } ?? "unknown"
       throw .playbackFailed(reason: reason)
     }

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -623,8 +623,10 @@ public final class Player {
         resumeBeforeRelease: resumeBeforeRelease
       )
       currentMedia = media
+      // No `notifyMediaDependentObservables()` here: the swap already issued
+      // it, and the keypaths it refreshes read from the native handle rather
+      // than from `currentMedia`, so a second pass is pure churn.
       resetMediaDerivedState()
-      notifyMediaDependentObservables()
     } else {
       load(media)
     }

--- a/Tests/SwiftVLCTests/Player/PlayerReplacementTransactionTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerReplacementTransactionTests.swift
@@ -1,0 +1,123 @@
+@testable import SwiftVLC
+import Foundation
+import Testing
+
+/// Active media replacement must be a transaction.
+///
+/// `play(_:)` on a player that is already playing swaps in a fresh native
+/// handle. That swap can fail synchronously — a selected renderer may be
+/// rejected — and libVLC can also refuse the subsequent start. Publishing the
+/// incoming media before either of those succeeded left the observable
+/// surface describing media B while the outgoing handle was still playing A:
+/// `currentMedia`, `duration`, `position` and the rest all belonged to
+/// different generations at once.
+///
+/// The rule these tests pin: every public field belongs entirely to the
+/// restored previous media or to a terminal outcome for the new one. There is
+/// no in-between.
+extension Integration {
+  @Suite(.tags(.mainActor, .async), .timeLimit(.minutes(1)))
+  @MainActor struct PlayerReplacementTransactionTests {
+    /// The native swap must not publish the incoming media itself — that is
+    /// the caller's job, and only after the swap has succeeded. If this
+    /// function published, a later failure could not be unwound.
+    @Test
+    func `Native replacement does not publish the incoming media`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let first = try Media(url: TestMedia.silenceURL)
+      player.load(first)
+      let firstMRL = player.currentMedia?.mrl
+
+      let incoming = try Media(url: TestMedia.twosecURL)
+      try player.replaceNativePlayerForDrawablePlayback(
+        target: nil,
+        media: incoming
+      )
+
+      #expect(
+        player.currentMedia?.mrl == firstMRL,
+        "the native swap published currentMedia; the caller can no longer make the commit transactional"
+      )
+    }
+
+    /// The success path still commits, so the reordering did not turn a
+    /// working replacement into a no-op.
+    @Test
+    func `A successful active replacement publishes the new media`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.silenceURL))
+      // Drives `shouldReplaceNativePlayerBeforePlaybackLoad` true so
+      // `play(_:)` takes the handle-replacement branch rather than `load`.
+      player._setStateForTesting(state: .playing)
+
+      let replacement = try Media(url: TestMedia.twosecURL)
+      let replacementMRL = replacement.mrl
+      try? player.play(replacement)
+
+      #expect(player.currentMedia?.mrl == replacementMRL)
+      #expect(player.duration == nil, "media-derived state was not reset for the new generation")
+      #expect(player.position == 0)
+      #expect(player.currentTime == .zero)
+    }
+
+    /// A rejected start leaves no session for the current media, so an active
+    /// state can only have been inherited from the previous one and must not
+    /// survive — that is exactly the mixed identity this issue is about.
+    ///
+    /// Driven through the pure rule rather than a real rejection:
+    /// `libvlc_media_player_play` returning `-1` is not forceable from a
+    /// test, and notably does *not* happen on a player with no media.
+    @Test
+    func `A rejected start replaces an inherited active state`() {
+      for active in [PlayerState.playing, .opening, .buffering] {
+        #expect(
+          Player.stateAfterRejectedStart(previous: active) == .error,
+          "a start rejection kept the previous session's \(active) state"
+        )
+      }
+    }
+
+    /// A rejected start from a non-active state must not invent a failure the
+    /// caller never had. Only an inherited *active* state is the problem.
+    @Test
+    func `A rejected start from a settled player does not fabricate a session`() {
+      for settled in [PlayerState.idle, .stopped, .paused, .stopping, .error] {
+        #expect(
+          Player.stateAfterRejectedStart(previous: settled) == settled,
+          "a start rejection rewrote the settled \(settled) state"
+        )
+      }
+    }
+
+    /// Whatever the outcome, the media identity and the timeline fields must
+    /// agree with each other — never one from each generation.
+    @Test
+    func `Public fields never mix generations across a replacement`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let first = try Media(url: TestMedia.silenceURL)
+      player.load(first)
+      player._setStateForTesting(
+        state: .playing,
+        currentTime: .seconds(5),
+        duration: .seconds(30),
+        position: 0.5
+      )
+      let firstMRL = player.currentMedia?.mrl
+
+      let replacement = try Media(url: TestMedia.twosecURL)
+      let replacementMRL = replacement.mrl
+      try? player.play(replacement)
+
+      if player.currentMedia?.mrl == replacementMRL {
+        // Committed to the new generation: the old timeline must be gone.
+        #expect(player.duration == nil)
+        #expect(player.currentTime == .zero)
+        #expect(player.position == 0)
+      } else {
+        // Restored: the previous media and its timeline stay intact together.
+        #expect(player.currentMedia?.mrl == firstMRL)
+        #expect(player.duration == .seconds(30))
+      }
+    }
+  }
+}

--- a/Tests/SwiftVLCTests/Player/PlayerReplacementTransactionTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerReplacementTransactionTests.swift
@@ -25,8 +25,10 @@ extension Integration {
     func `Native replacement does not publish the incoming media`() throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
       let first = try Media(url: TestMedia.silenceURL)
+      // Reference identity, captured before the `sending` transfer. Comparing
+      // MRLs would pass vacuously if both happened to be nil.
+      let firstIdentity = ObjectIdentifier(first)
       player.load(first)
-      let firstMRL = player.currentMedia?.mrl
 
       let incoming = try Media(url: TestMedia.twosecURL)
       try player.replaceNativePlayerForDrawablePlayback(
@@ -35,7 +37,7 @@ extension Integration {
       )
 
       #expect(
-        player.currentMedia?.mrl == firstMRL,
+        player.currentMedia.map(ObjectIdentifier.init) == firstIdentity,
         "the native swap published currentMedia; the caller can no longer make the commit transactional"
       )
     }
@@ -51,10 +53,10 @@ extension Integration {
       player._setStateForTesting(state: .playing)
 
       let replacement = try Media(url: TestMedia.twosecURL)
-      let replacementMRL = replacement.mrl
+      let replacementIdentity = ObjectIdentifier(replacement)
       try? player.play(replacement)
 
-      #expect(player.currentMedia?.mrl == replacementMRL)
+      #expect(player.currentMedia.map(ObjectIdentifier.init) == replacementIdentity)
       #expect(player.duration == nil, "media-derived state was not reset for the new generation")
       #expect(player.position == 0)
       #expect(player.currentTime == .zero)
@@ -95,6 +97,7 @@ extension Integration {
     func `Public fields never mix generations across a replacement`() throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
       let first = try Media(url: TestMedia.silenceURL)
+      let firstIdentity = ObjectIdentifier(first)
       player.load(first)
       player._setStateForTesting(
         state: .playing,
@@ -102,20 +105,19 @@ extension Integration {
         duration: .seconds(30),
         position: 0.5
       )
-      let firstMRL = player.currentMedia?.mrl
 
       let replacement = try Media(url: TestMedia.twosecURL)
-      let replacementMRL = replacement.mrl
+      let replacementIdentity = ObjectIdentifier(replacement)
       try? player.play(replacement)
 
-      if player.currentMedia?.mrl == replacementMRL {
+      if player.currentMedia.map(ObjectIdentifier.init) == replacementIdentity {
         // Committed to the new generation: the old timeline must be gone.
         #expect(player.duration == nil)
         #expect(player.currentTime == .zero)
         #expect(player.position == 0)
       } else {
         // Restored: the previous media and its timeline stay intact together.
-        #expect(player.currentMedia?.mrl == firstMRL)
+        #expect(player.currentMedia.map(ObjectIdentifier.init) == firstIdentity)
         #expect(player.duration == .seconds(30))
       }
     }


### PR DESCRIPTION
Closes #83.

## Root cause

`play(_:)` on an already-playing player takes the handle-replacement branch, and it published the incoming media *before* the swap that can reject it:

```swift
currentMedia = media
resetMediaDerivedState()
try replaceNativePlayerForDrawablePlayback(target: drawable, …)  // can throw
```

A renderer that fails to apply therefore left `currentMedia`, `duration`, `position`, `currentTime` and the rest describing media B while the outgoing native handle was still playing A — public state split across two generations at once.

Worth recording, because it narrows the fix: **the swap itself was already atomic.** Its only throwing step is the `set_renderer` guard, which releases the candidate handle and returns before anything on `self` is mutated — `pointer`, `nativeHandleLifetime` and the event bridge are all still the outgoing ones. Nothing needed unwinding. The defect was entirely the caller committing first.

A rejected start had the mirrored problem. `resetMediaDerivedState()` does not touch `state`, so when libVLC refuses to start, an active `state` inherited from the previous session survives while every other field already describes the new media.

## The fix

- `replaceNativePlayerForDrawablePlayback` takes the incoming media as a parameter instead of reading the published `currentMedia`. `play(_:)` installs it on the new handle and publishes `currentMedia` + resets derived state only after the swap succeeds. On failure nothing was published, and the previous media keeps its complete state.
- A rejected start replaces an inherited *active* state with one terminal outcome. A state that is already settled is left alone — inventing a failure the caller never had would be its own lie.

## Validation

New `PlayerReplacementTransactionTests`: the swap does not publish, the success path still commits and resets (so the reorder did not turn a working replacement into a no-op), both branches of the rejected-start rule, and a generation-consistency check asserting the media identity and timeline fields always agree.

| | Result |
|---|---|
| Full suite | 1646 tests, 138 suites — pass |
| `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` | 0 warnings |
| swiftformat / swiftlint | clean |

**What these tests do and do not prove.** I could not force either synchronous failure from a test: applying a renderer requires a real renderer item, and `libvlc_media_player_play` returning `-1` is not reachable on demand — notably it does *not* fail on a player with no media, which an earlier draft of these tests wrongly assumed and which is why that draft failed. So the failure paths are covered by pinning the contracts that make them safe (the swap does not publish; the rejected-start rule is a pure function tested over every state) rather than by reproducing a rejection. The reorder's correctness rests on the swap's existing atomicity, which is visible in the code and stated above.

## Remaining risks

- The "no callback from a discarded candidate handle mutates either result" criterion holds structurally — the candidate handle is released before the throw and its event manager is never attached to the bridge — but is not separately asserted, for the same reason: the failure cannot be triggered.
- Authoritative native transport state remains #70's scope; this change only stops the *observable* fields from mixing generations, it does not make `state` authoritative.
