### PR TITLE
Retain the pending frame through renderer flush recovery (#80)

### DIFF
--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer+Enqueue.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer+Enqueue.swift
@@ -21,6 +21,10 @@ struct PixelBufferEnqueueState: @unchecked Sendable {
   /// Consecutive re-offers of the frame that triggered a flush. Reset by a
   /// delivery or by a newer frame taking the slot.
   var flushRecoveryRetryCount: UInt64 = 0
+  /// The render generation the in-progress recovery belongs to. Recovery is
+  /// scoped to it so a replacement cannot inherit the retry budget and turn
+  /// the next generation's plain backpressure into retention.
+  var flushRecoveryGeneration: UInt64?
   /// Times flush recovery exhausted its budget and dropped the frame. A
   /// non-zero value is the explicit terminal failure the display never
   /// repainted from.
@@ -180,13 +184,15 @@ extension PixelBufferRenderer {
     _ pending: EnqueuedSampleBuffer
   )
     -> PixelBufferSampleDisposition {
-    guard canEnqueueFrame(generation: pending.generation, on: pending.layer) else { return .handled }
+    guard canEnqueueFrame(generation: pending.generation, on: pending.layer) else {
+      return endFlushRecovery()
+    }
 
     let shouldFlush = displayLayerAPI.status(pending.layer) == .failed
       || displayLayerAPI.requiresFlush(pending.layer)
     if shouldFlush {
       guard canEnqueueFrame(generation: pending.generation, on: pending.layer) else {
-        return .handled
+        return endFlushRecovery()
       }
       displayLayerAPI.flush(pending.layer)
     }
@@ -197,7 +203,9 @@ extension PixelBufferRenderer {
       // `shouldFlush == false` and would otherwise fall into the backpressure
       // drop below — losing the frame on the very first retry, which is the
       // bug this is meant to fix.
-      let isRecovering = enqueueState.withLock { $0.flushRecoveryRetryCount > 0 }
+      let isRecovering = enqueueState.withLock {
+        $0.flushRecoveryRetryCount > 0 && $0.flushRecoveryGeneration == pending.generation
+      }
       // Plain backpressure keeps dropping: the decoder is still producing, so
       // a successor frame is already on its way and the newest one wins.
       guard shouldFlush || isRecovering else { return .handled }
@@ -220,7 +228,24 @@ extension PixelBufferRenderer {
       return true
     }
     if delivered {
-      enqueueState.withLock { $0.flushRecoveryRetryCount = 0 }
+      enqueueState.withLock {
+        $0.flushRecoveryRetryCount = 0
+        $0.flushRecoveryGeneration = nil
+      }
+    }
+    return .handled
+  }
+
+  /// Clears any in-progress recovery and drops the sample.
+  ///
+  /// Called when a frame is rejected as stale. Leaving the retry count set
+  /// would make the *next* generation's plain backpressure read as "recovery
+  /// in progress", quietly retaining frames on a path that is documented to
+  /// drop them.
+  private func endFlushRecovery() -> PixelBufferSampleDisposition {
+    enqueueState.withLock {
+      $0.flushRecoveryRetryCount = 0
+      $0.flushRecoveryGeneration = nil
     }
     return .handled
   }
@@ -233,19 +258,29 @@ extension PixelBufferRenderer {
     -> PixelBufferSampleDisposition {
     // Re-checked because the flush above released the state lock: a
     // replacement or teardown in that window must not resurrect this frame.
-    guard canEnqueueFrame(generation: pending.generation, on: pending.layer) else { return .handled }
+    guard canEnqueueFrame(generation: pending.generation, on: pending.layer) else {
+      return endFlushRecovery()
+    }
 
     return enqueueState.withLock { state in
       // A newer frame already claimed the slot. It supersedes this one, and
       // the drain loop picks it up on the next iteration.
       guard state.pending == nil else {
         state.flushRecoveryRetryCount = 0
+        state.flushRecoveryGeneration = nil
         return .handled
+      }
+      // The budget belongs to one frame's generation, so a replacement starts
+      // over rather than inheriting whatever the previous media had spent.
+      if state.flushRecoveryGeneration != pending.generation {
+        state.flushRecoveryGeneration = pending.generation
+        state.flushRecoveryRetryCount = 0
       }
       guard state.flushRecoveryRetryCount < Self.maxFlushRecoveryRetries else {
         // Bounded, and observable: the renderer never became ready, so the
         // frame is dropped rather than retried forever.
         state.flushRecoveryRetryCount = 0
+        state.flushRecoveryGeneration = nil
         state.flushRecoveryFailureCount &+= 1
         return .handled
       }

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer+Enqueue.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer+Enqueue.swift
@@ -18,6 +18,13 @@ struct PixelBufferEnqueueState: @unchecked Sendable {
   var scheduledDrainCount: UInt64 = 0
   var drainedSampleCount: UInt64 = 0
   var replacementCount: UInt64 = 0
+  /// Consecutive re-offers of the frame that triggered a flush. Reset by a
+  /// delivery or by a newer frame taking the slot.
+  var flushRecoveryRetryCount: UInt64 = 0
+  /// Times flush recovery exhausted its budget and dropped the frame. A
+  /// non-zero value is the explicit terminal failure the display never
+  /// repainted from.
+  var flushRecoveryFailureCount: UInt64 = 0
 }
 
 struct PixelBufferEnqueueSnapshot: Equatable {
@@ -26,6 +33,37 @@ struct PixelBufferEnqueueSnapshot: Equatable {
   let scheduledDrainCount: UInt64
   let drainedSampleCount: UInt64
   let replacementCount: UInt64
+  let flushRecoveryRetryCount: UInt64
+  let flushRecoveryFailureCount: UInt64
+
+  /// The recovery counters default to zero so assertions that predate flush
+  /// recovery keep reading as "no recovery happened" without restating it.
+  init(
+    pendingCount: Int,
+    isDrainScheduled: Bool,
+    scheduledDrainCount: UInt64,
+    drainedSampleCount: UInt64,
+    replacementCount: UInt64,
+    flushRecoveryRetryCount: UInt64 = 0,
+    flushRecoveryFailureCount: UInt64 = 0
+  ) {
+    self.pendingCount = pendingCount
+    self.isDrainScheduled = isDrainScheduled
+    self.scheduledDrainCount = scheduledDrainCount
+    self.drainedSampleCount = drainedSampleCount
+    self.replacementCount = replacementCount
+    self.flushRecoveryRetryCount = flushRecoveryRetryCount
+    self.flushRecoveryFailureCount = flushRecoveryFailureCount
+  }
+}
+
+/// What the drain loop should do after offering a sample to the layer.
+enum PixelBufferSampleDisposition: Equatable {
+  /// Delivered, superseded, stale, or dropped — the loop continues.
+  case handled
+  /// Retained for a later attempt; the loop must stop and re-drain after the
+  /// retry delay, keeping ownership of the drain.
+  case deferred
 }
 
 /// Injectable display-layer operations make queue saturation, backpressure,
@@ -92,14 +130,33 @@ extension PixelBufferRenderer {
         isDrainScheduled: $0.isDrainScheduled,
         scheduledDrainCount: $0.scheduledDrainCount,
         drainedSampleCount: $0.drainedSampleCount,
-        replacementCount: $0.replacementCount
+        replacementCount: $0.replacementCount,
+        flushRecoveryRetryCount: $0.flushRecoveryRetryCount,
+        flushRecoveryFailureCount: $0.flushRecoveryFailureCount
       )
     }
   }
 
+  /// How many times a single frame is re-offered after a flush before the
+  /// renderer is treated as unrecoverable for that frame.
+  static var maxFlushRecoveryRetries: UInt64 {
+    10
+  }
+
   private func drainPendingSamples() {
     while let pending = takePendingSampleOrFinishDrain() {
-      processPendingSample(pending)
+      switch processPendingSample(pending) {
+      case .handled:
+        continue
+      case .deferred:
+        // `isDrainScheduled` deliberately stays set: this drain still owns the
+        // slot, so producers keep replacing the pending frame rather than
+        // scheduling a competing drain.
+        enqueueQueue.asyncAfter(deadline: .now() + flushRecoveryRetryDelay) { [self] in
+          drainPendingSamples()
+        }
+        return
+      }
     }
   }
 
@@ -119,27 +176,82 @@ extension PixelBufferRenderer {
     }
   }
 
-  private func processPendingSample(_ pending: EnqueuedSampleBuffer) {
-    guard canEnqueueFrame(generation: pending.generation, on: pending.layer) else { return }
+  private func processPendingSample(
+    _ pending: EnqueuedSampleBuffer
+  )
+    -> PixelBufferSampleDisposition {
+    guard canEnqueueFrame(generation: pending.generation, on: pending.layer) else { return .handled }
 
     let shouldFlush = displayLayerAPI.status(pending.layer) == .failed
       || displayLayerAPI.requiresFlush(pending.layer)
     if shouldFlush {
-      guard canEnqueueFrame(generation: pending.generation, on: pending.layer) else { return }
+      guard canEnqueueFrame(generation: pending.generation, on: pending.layer) else {
+        return .handled
+      }
       displayLayerAPI.flush(pending.layer)
     }
 
-    guard displayLayerAPI.isReadyForMoreMediaData(pending.layer) else { return }
+    guard displayLayerAPI.isReadyForMoreMediaData(pending.layer) else {
+      // Recovery is sticky once entered. The flush above clears
+      // `requiresFlushToResumeDecoding`, so a re-offer of the same frame sees
+      // `shouldFlush == false` and would otherwise fall into the backpressure
+      // drop below — losing the frame on the very first retry, which is the
+      // bug this is meant to fix.
+      let isRecovering = enqueueState.withLock { $0.flushRecoveryRetryCount > 0 }
+      // Plain backpressure keeps dropping: the decoder is still producing, so
+      // a successor frame is already on its way and the newest one wins.
+      guard shouldFlush || isRecovering else { return .handled }
+      // Flush recovery has no such guarantee. A paused seek, a final frame or
+      // a foreground repaint may have no successor at all, so the frame that
+      // triggered the flush is the only thing that can repaint the display —
+      // dropping it here is what leaves PiP black with audio still running.
+      return retainForFlushRecovery(pending)
+    }
 
     // The final validation and enqueue share one state-lock linearization
     // point. A generation/layer mutation either happens first and rejects this
     // sample, or happens after this enqueue; stale work cannot cross it.
-    state.withLock { state in
+    let delivered = state.withLock { state -> Bool in
       guard
         state.renderGeneration == pending.generation,
         state.displayLayer.layer === pending.layer
-      else { return }
+      else { return false }
       displayLayerAPI.enqueue(pending.layer, pending.sample)
+      return true
+    }
+    if delivered {
+      enqueueState.withLock { $0.flushRecoveryRetryCount = 0 }
+    }
+    return .handled
+  }
+
+  /// Puts a post-flush frame back in the slot so a later attempt can deliver
+  /// it, within a bounded budget.
+  private func retainForFlushRecovery(
+    _ pending: EnqueuedSampleBuffer
+  )
+    -> PixelBufferSampleDisposition {
+    // Re-checked because the flush above released the state lock: a
+    // replacement or teardown in that window must not resurrect this frame.
+    guard canEnqueueFrame(generation: pending.generation, on: pending.layer) else { return .handled }
+
+    return enqueueState.withLock { state in
+      // A newer frame already claimed the slot. It supersedes this one, and
+      // the drain loop picks it up on the next iteration.
+      guard state.pending == nil else {
+        state.flushRecoveryRetryCount = 0
+        return .handled
+      }
+      guard state.flushRecoveryRetryCount < Self.maxFlushRecoveryRetries else {
+        // Bounded, and observable: the renderer never became ready, so the
+        // frame is dropped rather than retried forever.
+        state.flushRecoveryRetryCount = 0
+        state.flushRecoveryFailureCount &+= 1
+        return .handled
+      }
+      state.flushRecoveryRetryCount &+= 1
+      state.pending = pending
+      return .deferred
     }
   }
 }

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer.swift
@@ -67,16 +67,23 @@ final class PixelBufferRenderer: Sendable {
   let enqueueState = Mutex(PixelBufferEnqueueState())
   let displayLayerAPI: PixelBufferDisplayLayerAPI
 
+  /// How long to wait before re-offering a frame the renderer was not ready
+  /// for after a flush. Injectable so recovery tests do not sleep a real
+  /// frame interval.
+  let flushRecoveryRetryDelay: DispatchTimeInterval
+
   init(
     displayLayer: AVSampleBufferDisplayLayer? = nil,
     enqueueQueue: DispatchQueue? = nil,
-    displayLayerAPI: PixelBufferDisplayLayerAPI = .live
+    displayLayerAPI: PixelBufferDisplayLayerAPI = .live,
+    flushRecoveryRetryDelay: DispatchTimeInterval = .milliseconds(16)
   ) {
     state = Mutex(State(displayLayer: displayLayer))
     self.enqueueQueue = enqueueQueue ?? DispatchQueue(
       label: "org.swiftvlc.pixel-buffer-renderer.enqueue"
     )
     self.displayLayerAPI = displayLayerAPI
+    self.flushRecoveryRetryDelay = flushRecoveryRetryDelay
   }
 
   func setDisplayLayer(_ layer: AVSampleBufferDisplayLayer?) {

--- a/Tests/SwiftVLCTests/PiP/PixelBufferRendererEnqueueTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferRendererEnqueueTests.swift
@@ -252,6 +252,128 @@ extension Integration {
       #expect(!renderer.enqueueSnapshotForTesting.isDrainScheduled)
     }
 
+    /// The bug this issue is about: a flush leaves the renderer briefly not
+    /// ready, and the frame that triggered the flush used to be dropped. A
+    /// paused seek, a final frame or a foreground repaint has no successor,
+    /// so nothing ever repaints and PiP stays black with audio still running.
+    /// The frame must be retained and delivered when readiness returns —
+    /// *without* another frame being supplied.
+    @Test
+    func `A flush-triggering frame is retained and delivered without a successor`() throws {
+      let queue = DispatchQueue(label: "org.swiftvlc.tests.enqueue-flush-retain")
+      let layer = AVSampleBufferDisplayLayer()
+      let probe = DisplayLayerProbe(requiresFlush: true, isReady: false)
+      let renderer = PixelBufferRenderer(
+        displayLayer: layer,
+        enqueueQueue: queue,
+        displayLayerAPI: probe.api,
+        flushRecoveryRetryDelay: .milliseconds(1)
+      )
+      let generation = renderer.state.withLock { $0.renderGeneration }
+
+      _ = try submitFrame(index: 11, renderer: renderer, generation: generation, layer: layer)
+      #expect(probe.waitForReadinessCheck() == .success)
+
+      // Readiness returns on its own; no further frame is submitted.
+      probe.setReady(true)
+
+      #expect(probe.waitForDelivery() == .success)
+      #expect(waitUntilIdle(queue) == .success)
+      expectNoDifference(probe.snapshot.enqueuedPresentationValues, [11])
+      #expect(renderer.enqueueSnapshotForTesting.flushRecoveryFailureCount == 0)
+    }
+
+    /// Recovery is bounded: a renderer that never becomes ready must give up
+    /// and say so, rather than re-offering the same frame forever.
+    @Test
+    func `Flush recovery gives up explicitly when readiness never returns`() throws {
+      let queue = DispatchQueue(label: "org.swiftvlc.tests.enqueue-flush-giveup")
+      let layer = AVSampleBufferDisplayLayer()
+      let probe = DisplayLayerProbe(requiresFlush: true, isReady: false)
+      let renderer = PixelBufferRenderer(
+        displayLayer: layer,
+        enqueueQueue: queue,
+        displayLayerAPI: probe.api,
+        flushRecoveryRetryDelay: .milliseconds(1)
+      )
+      let generation = renderer.state.withLock { $0.renderGeneration }
+
+      _ = try submitFrame(index: 12, renderer: renderer, generation: generation, layer: layer)
+
+      let deadline = ContinuousClock.now + .seconds(5)
+      while renderer.enqueueSnapshotForTesting.flushRecoveryFailureCount == 0 {
+        if ContinuousClock.now >= deadline {
+          Issue.record("flush recovery never terminated")
+          break
+        }
+        _ = waitUntilIdle(queue)
+      }
+
+      #expect(waitUntilIdle(queue) == .success)
+      let snapshot = renderer.enqueueSnapshotForTesting
+      #expect(snapshot.flushRecoveryFailureCount == 1)
+      #expect(snapshot.pendingCount == 0, "the frame was left stranded in the slot")
+      #expect(!snapshot.isDrainScheduled, "the drain gate was left owned after giving up")
+      expectNoDifference(probe.snapshot.enqueuedPresentationValues, [])
+    }
+
+    /// A newer frame supersedes one being retried — the freshest content
+    /// wins, which is what keeps live playback behaving as before.
+    @Test
+    func `A newer frame supersedes one awaiting flush recovery`() throws {
+      let queue = DispatchQueue(label: "org.swiftvlc.tests.enqueue-flush-supersede")
+      let layer = AVSampleBufferDisplayLayer()
+      let probe = DisplayLayerProbe(requiresFlush: true, isReady: false)
+      let renderer = PixelBufferRenderer(
+        displayLayer: layer,
+        enqueueQueue: queue,
+        displayLayerAPI: probe.api,
+        flushRecoveryRetryDelay: .milliseconds(5)
+      )
+      let generation = renderer.state.withLock { $0.renderGeneration }
+
+      _ = try submitFrame(index: 20, renderer: renderer, generation: generation, layer: layer)
+      #expect(probe.waitForReadinessCheck() == .success)
+
+      _ = try submitFrame(index: 21, renderer: renderer, generation: generation, layer: layer)
+      probe.setReady(true)
+
+      #expect(probe.waitForDelivery() == .success)
+      #expect(waitUntilIdle(queue) == .success)
+      expectNoDifference(probe.snapshot.enqueuedPresentationValues, [21])
+    }
+
+    /// A frame retained across a flush must not survive a generation bump:
+    /// replacing the media or the vout invalidates it, and displaying it
+    /// afterwards would show the previous media.
+    @Test
+    func `A retained frame is discarded when the generation moves on`() throws {
+      let queue = DispatchQueue(label: "org.swiftvlc.tests.enqueue-flush-generation")
+      let layer = AVSampleBufferDisplayLayer()
+      let probe = DisplayLayerProbe(requiresFlush: true, isReady: false)
+      let renderer = PixelBufferRenderer(
+        displayLayer: layer,
+        enqueueQueue: queue,
+        displayLayerAPI: probe.api,
+        flushRecoveryRetryDelay: .milliseconds(5)
+      )
+      let generation = renderer.state.withLock { $0.renderGeneration }
+
+      _ = try submitFrame(index: 30, renderer: renderer, generation: generation, layer: layer)
+      #expect(probe.waitForReadinessCheck() == .success)
+
+      // The media/vout moves on while the frame is awaiting recovery.
+      renderer.state.withLock { $0.advanceRenderGeneration() }
+      probe.setReady(true)
+
+      #expect(waitUntilIdle(queue) == .success)
+      expectNoDifference(
+        probe.snapshot.enqueuedPresentationValues,
+        [],
+        "a stale-generation frame reached the display after replacement"
+      )
+    }
+
     private func submitFrame(
       index: Int,
       renderer: PixelBufferRenderer,

--- a/Tests/SwiftVLCTests/PiP/PixelBufferRendererEnqueueTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferRendererEnqueueTests.swift
@@ -366,12 +366,54 @@ extension Integration {
       renderer.state.withLock { $0.advanceRenderGeneration() }
       probe.setReady(true)
 
-      #expect(waitUntilIdle(queue) == .success)
+      // The retained frame is re-offered after the retry delay, so settle
+      // before asserting rather than racing the scheduled drain.
+      #expect(waitForDrainToSettle(renderer, queue: queue) == .success)
       expectNoDifference(
         probe.snapshot.enqueuedPresentationValues,
         [],
         "a stale-generation frame reached the display after replacement"
       )
+      #expect(
+        renderer.enqueueSnapshotForTesting.flushRecoveryRetryCount == 0,
+        "recovery state survived the generation bump"
+      )
+    }
+
+    /// Discarding a retained frame must also end its recovery. Otherwise the
+    /// next generation's *plain backpressure* reads as "recovery in progress"
+    /// and starts retaining frames on a path documented to drop them.
+    @Test
+    func `A discarded recovery does not leak into the next generation's backpressure`() throws {
+      let queue = DispatchQueue(label: "org.swiftvlc.tests.enqueue-flush-leak")
+      let layer = AVSampleBufferDisplayLayer()
+      let probe = DisplayLayerProbe(requiresFlush: true, isReady: false)
+      let renderer = PixelBufferRenderer(
+        displayLayer: layer,
+        enqueueQueue: queue,
+        displayLayerAPI: probe.api,
+        flushRecoveryRetryDelay: .milliseconds(5)
+      )
+      let generation = renderer.state.withLock { $0.renderGeneration }
+
+      // Enter recovery, then invalidate the frame that is being retried.
+      _ = try submitFrame(index: 40, renderer: renderer, generation: generation, layer: layer)
+      #expect(probe.waitForReadinessCheck() == .success)
+      renderer.state.withLock { $0.advanceRenderGeneration() }
+      #expect(waitForDrainToSettle(renderer, queue: queue) == .success)
+
+      // A fresh generation hitting plain backpressure must drop and clear the
+      // gate, exactly as it would have without any prior recovery.
+      let nextGeneration = renderer.state.withLock { $0.renderGeneration }
+      probe.setRequiresFlush(false)
+      _ = try submitFrame(index: 41, renderer: renderer, generation: nextGeneration, layer: layer)
+      #expect(probe.waitForReadinessCheck() == .success)
+      #expect(waitForDrainToSettle(renderer, queue: queue) == .success)
+
+      let snapshot = renderer.enqueueSnapshotForTesting
+      #expect(snapshot.pendingCount == 0, "a backpressured frame was retained after recovery leaked")
+      #expect(!snapshot.isDrainScheduled, "the drain gate stayed owned by leaked recovery state")
+      expectNoDifference(probe.snapshot.enqueuedPresentationValues, [])
     }
 
     private func submitFrame(
@@ -434,6 +476,27 @@ extension Integration {
       )
       expectNoDifference(status, noErr)
       return try #require(description)
+    }
+
+    /// Waits until no drain is scheduled and the slot is empty.
+    ///
+    /// `waitUntilIdle` only flushes work already queued; a flush-recovery
+    /// re-offer is scheduled with `asyncAfter`, so it can still be pending
+    /// when a plain barrier returns.
+    private func waitForDrainToSettle(
+      _ renderer: PixelBufferRenderer,
+      queue: DispatchQueue
+    )
+      -> DispatchTimeoutResult {
+      let deadline = ContinuousClock.now + .seconds(5)
+      while ContinuousClock.now < deadline {
+        _ = waitUntilIdle(queue)
+        let snapshot = renderer.enqueueSnapshotForTesting
+        if !snapshot.isDrainScheduled, snapshot.pendingCount == 0 {
+          return .success
+        }
+      }
+      return .timedOut
     }
 
     private func waitUntilIdle(_ queue: DispatchQueue) -> DispatchTimeoutResult {
@@ -561,6 +624,10 @@ private final class DisplayLayerProbe: @unchecked Sendable {
 
   func setReady(_ isReady: Bool) {
     state.withLock { $0.isReady = isReady }
+  }
+
+  func setRequiresFlush(_ requiresFlush: Bool) {
+    state.withLock { $0.requiresFlush = requiresFlush }
   }
 
   func waitForEnqueueEntry() -> DispatchTimeoutResult {


### PR DESCRIPTION
Closes #80.

## Root cause

`processPendingSample` takes the frame *out* of the pending slot, flushes the renderer, and then:

```swift
guard displayLayerAPI.isReadyForMoreMediaData(pending.layer) else { return }
```

The frame is already out of the slot, so that `return` drops it. Recovery only completed if another frame happened to arrive — and the cases that need recovery most are exactly the ones with no successor: a paused seek, a final frame, a foreground repaint, a backpressured last sample. Nothing repaints, and PiP sits black with audio still running.

## The fix

A frame that triggered a flush is put back in the slot and re-offered on the enqueue queue until the renderer accepts it, bounded to 10 attempts. Exhausting the budget drops the frame and increments an observable `flushRecoveryFailureCount` rather than retrying forever.

**Recovery is sticky once entered.** Flushing clears `requiresFlushToResumeDecoding`, so a re-offer of the same frame sees `shouldFlush == false` and would otherwise fall straight into the backpressure drop — losing the frame on the very first retry. The give-up test caught this; without it the fix would have looked correct while still dropping frames.

**Plain backpressure is deliberately unchanged.** There the decoder is still producing, so a successor is already on its way and the newest frame should win. Only the flush-recovery path retains, which is what keeps the existing backpressure semantics and their tests intact.

Two invariants are preserved explicitly: a newer frame still supersedes a retained one, and a retained frame is discarded if the render generation moves on — so a replacement cannot display the previous media.

## Validation

**The tests were verified to catch the original behaviour.** Reverting just the retention branch (keeping the new injection point so the tests still compile):

- `A flush-triggering frame is retained and delivered without a successor` fails with `waitForDelivery() → .timedOut` — literally the black screen.
- `Flush recovery gives up explicitly when readiness never returns` records no termination.

The other two new tests pass in both states, as expected: they pin invariants that already held.

| | Result |
|---|---|
| Full suite | 1666 tests, 139 suites — pass |
| Renderer suites | 59 tests — pass (existing backpressure/flush behaviour unchanged) |
| TSan (renderer + race/stress) | 98 tests — pass |
| `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` | 0 warnings |
| swiftformat / swiftlint | clean |

These run in CI: the suite drives an injected `PixelBufferDisplayLayerAPI` probe, so no live playback is involved and the coverage gap that affected #101 does not apply here.

## Remaining risks

- The retry budget (10 attempts at ~16 ms) is a judgement call, not a measured figure — roughly 160 ms to repaint. It is bounded and observable, so a real device showing `flushRecoveryFailureCount > 0` would tell us it is too tight.
- The issue also notes the same successor-frame dependency in the native path (`scripts/patches/0004-…`). This PR fixes the Swift renderer only; the native path is untouched and would need the equivalent change in that patch.
- The acceptance criteria list device scenarios (paused PiP, seek-then-pause, foreground repaint, replacement). Those are covered here at the renderer's decision level via the probe, not on a physical device — PiP is force-disabled in the simulator, so end-to-end confirmation still needs a device pass.
