### PR TITLE
Report native seek rejection and discard pre-seek clock samples (#77)

### DIFF
--- a/Sources/SwiftVLC/Player/EventBridge.swift
+++ b/Sources/SwiftVLC/Player/EventBridge.swift
@@ -84,6 +84,13 @@ final class EventBridge: Sendable {
     context.makeSourcedStream(policy: policy)
   }
 
+  /// Marks a new authoritative timeline. Clock samples emitted before this
+  /// point carry a lower revision and are discarded by the consumer.
+  @discardableResult
+  func advanceTimelineRevision() -> UInt64 {
+    context.advanceTimelineRevision()
+  }
+
   /// Pushes an event through the same fan-out path the C callback uses,
   /// including subscription buffering — unlike
   /// `Player._handleEventForTesting`, which bypasses the bridge entirely.
@@ -155,11 +162,29 @@ final class EventBridge: Sendable {
 struct SourcedPlayerEvent {
   let source: UInt
   let event: PlayerEvent
+  /// The timeline revision current when libVLC emitted this event.
+  ///
+  /// An accepted seek advances the revision, so a clock sample produced
+  /// before it carries a lower value and can be discarded instead of
+  /// overwriting the seek target. Defaults to zero, which is never newer
+  /// than an accepted seek, so a directly-constructed event is treated as
+  /// pre-seek rather than silently authoritative.
+  let timelineRevision: UInt64
+
+  init(source: UInt, event: PlayerEvent, timelineRevision: UInt64 = 0) {
+    self.source = source
+    self.event = event
+    self.timelineRevision = timelineRevision
+  }
 }
 
 private final class EventBridgeCallbackContext: Sendable {
   private let events = Broadcaster<PlayerEvent>(defaultBufferSize: 64)
   private let sourcedEvents = Broadcaster<SourcedPlayerEvent>(defaultBufferSize: 64)
+  /// Stamped onto every sourced event so the consumer can tell clock samples
+  /// that predate an accepted seek from ones that follow it. Lives here
+  /// because the stamp has to be taken on libVLC's thread, at emission.
+  private let timelineRevision = Mutex<UInt64>(0)
   let endCoordinator: PlaybackEndCoordinator
 
   init(endCoordinator: PlaybackEndCoordinator) {
@@ -185,10 +210,23 @@ private final class EventBridgeCallbackContext: Sendable {
     // first, so a slow user filter on the public stream can only delay
     // public delivery — internal state is already on its way.
     if !sourcedEvents.isEmpty {
-      sourcedEvents.broadcast(SourcedPlayerEvent(source: source, event: event))
+      sourcedEvents.broadcast(
+        SourcedPlayerEvent(
+          source: source,
+          event: event,
+          timelineRevision: timelineRevision.withLock { $0 }
+        )
+      )
     }
     if !events.isEmpty {
       events.broadcast(event)
+    }
+  }
+
+  func advanceTimelineRevision() -> UInt64 {
+    timelineRevision.withLock { revision in
+      revision &+= 1
+      return revision
     }
   }
 

--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -62,7 +62,27 @@ extension Player {
 
   func handleSourcedEvent(_ sourcedEvent: SourcedPlayerEvent) {
     guard sourcedEvent.source == Self.sourceIdentifier(for: pointer) else { return }
+    guard isTimelineSampleCurrent(sourcedEvent) else { return }
     handleEvent(sourcedEvent.event)
+  }
+
+  /// Whether a clock sample still describes the authoritative timeline.
+  ///
+  /// The internal stream is unbounded, so time and position events produced
+  /// before a seek can still be sitting in it when the seek is accepted.
+  /// Applying them afterwards snaps the published time back to where playback
+  /// used to be — and while paused there may be no later native clock event to
+  /// repair it. Samples that predate the accepted seek are therefore dropped.
+  ///
+  /// Only clock payloads are filtered. State transitions, track changes and
+  /// the rest stay lossless regardless of when they were produced.
+  private func isTimelineSampleCurrent(_ sourcedEvent: SourcedPlayerEvent) -> Bool {
+    switch sourcedEvent.event {
+    case .timeChanged, .positionChanged:
+      sourcedEvent.timelineRevision >= acceptedTimelineRevision
+    default:
+      true
+    }
   }
 
   /// Maps a single `PlayerEvent` to the observable-property updates and
@@ -282,6 +302,9 @@ extension Player {
   /// times, duration, seek/pause flags, buffer fill. Called when media
   /// is loaded or replaced.
   func resetMediaDerivedState() {
+    // New media, new timeline: clock samples still queued from the previous
+    // one describe a media that is no longer loaded and must not be applied.
+    acceptedTimelineRevision = eventBridge.advanceTimelineRevision()
     pauseTransition = nil
     deferredPauseCommand = nil
     publishPlaybackIntent(false)

--- a/Sources/SwiftVLC/Player/Player+Seek.swift
+++ b/Sources/SwiftVLC/Player/Player+Seek.swift
@@ -25,9 +25,13 @@ extension Player {
   ///   outside libVLC's millisecond range, or beyond known duration.
   public func seek(to time: Duration, fast: Bool = false) throws(VLCError) {
     let milliseconds = try checkedSeekMilliseconds(for: time, parameter: "time")
-    libvlc_media_player_set_time(pointer, milliseconds, fast)
-    currentTime = .milliseconds(milliseconds)
-    publishPosition(forTargetMilliseconds: milliseconds)
+    // Publishing before checking the result reported a target libVLC had
+    // refused, leaving the observable timeline describing a position playback
+    // never reached.
+    guard libvlc_media_player_set_time(pointer, milliseconds, fast) == 0 else {
+      throw .operationFailed("Seek to \(milliseconds) ms")
+    }
+    commitSeekTarget(milliseconds: milliseconds)
   }
 
   /// Seeks to a fractional position in the current media.
@@ -79,9 +83,23 @@ extension Player {
       targetMs = Swift.min(targetMs, durationMs)
     }
 
-    libvlc_media_player_set_time(pointer, targetMs, fast)
-    currentTime = .milliseconds(targetMs)
-    publishPosition(forTargetMilliseconds: targetMs)
+    guard libvlc_media_player_set_time(pointer, targetMs, fast) == 0 else {
+      throw .operationFailed("Jump to \(targetMs) ms")
+    }
+    commitSeekTarget(milliseconds: targetMs)
+  }
+
+  /// Publishes an accepted seek target and marks it as the authoritative
+  /// timeline.
+  ///
+  /// Advancing the revision is what lets the event consumer discard clock
+  /// samples libVLC produced before this seek. Without it those queued
+  /// samples are applied afterwards and snap the published time back — and
+  /// while paused no later native event is guaranteed to repair it.
+  func commitSeekTarget(milliseconds: Int64) {
+    acceptedTimelineRevision = eventBridge.advanceTimelineRevision()
+    currentTime = .milliseconds(milliseconds)
+    publishPosition(forTargetMilliseconds: milliseconds)
   }
 
   // MARK: - Lenient Seeking
@@ -109,6 +127,10 @@ extension Player {
     guard libvlc_media_player_set_position(pointer, position.rawValue, fast) == 0 else {
       return false
     }
+    // Accepted, so pre-seek clock samples must not overwrite this target
+    // either — a lenient seek publishes a position the same way a strict one
+    // does.
+    acceptedTimelineRevision = eventBridge.advanceTimelineRevision()
     withMutation(keyPath: \.position) {
       _position = position.rawValue
     }

--- a/Sources/SwiftVLC/Player/Player+Seek.swift
+++ b/Sources/SwiftVLC/Player/Player+Seek.swift
@@ -25,13 +25,19 @@ extension Player {
   ///   outside libVLC's millisecond range, or beyond known duration.
   public func seek(to time: Duration, fast: Bool = false) throws(VLCError) {
     let milliseconds = try checkedSeekMilliseconds(for: time, parameter: "time")
+    // Reserved *before* the native call: libVLC delivers events on its own
+    // thread, so a post-seek clock sample emitted while `set_time` is still
+    // returning would otherwise be stamped with the previous revision and
+    // then discarded as stale — losing the position the seek actually landed
+    // on, which after a fast (keyframe) seek is not the requested one.
+    let revision = eventBridge.advanceTimelineRevision()
     // Publishing before checking the result reported a target libVLC had
     // refused, leaving the observable timeline describing a position playback
     // never reached.
     guard libvlc_media_player_set_time(pointer, milliseconds, fast) == 0 else {
       throw .operationFailed("Seek to \(milliseconds) ms")
     }
-    commitSeekTarget(milliseconds: milliseconds)
+    commitSeekTarget(milliseconds: milliseconds, revision: revision)
   }
 
   /// Seeks to a fractional position in the current media.
@@ -83,21 +89,30 @@ extension Player {
       targetMs = Swift.min(targetMs, durationMs)
     }
 
+    // See `seek(to:fast:)`: reserved before the native call so a post-seek
+    // sample cannot be stamped with the outgoing revision.
+    let revision = eventBridge.advanceTimelineRevision()
     guard libvlc_media_player_set_time(pointer, targetMs, fast) == 0 else {
       throw .operationFailed("Jump to \(targetMs) ms")
     }
-    commitSeekTarget(milliseconds: targetMs)
+    commitSeekTarget(milliseconds: targetMs, revision: revision)
   }
 
-  /// Publishes an accepted seek target and marks it as the authoritative
-  /// timeline.
+  /// Publishes an accepted seek target and marks `revision` as the
+  /// authoritative timeline.
   ///
   /// Advancing the revision is what lets the event consumer discard clock
   /// samples libVLC produced before this seek. Without it those queued
   /// samples are applied afterwards and snap the published time back — and
   /// while paused no later native event is guaranteed to repair it.
-  func commitSeekTarget(milliseconds: Int64) {
-    acceptedTimelineRevision = eventBridge.advanceTimelineRevision()
+  ///
+  /// `revision` is reserved by the caller *before* it issues the native seek,
+  /// so it is only adopted here once libVLC has accepted the request. A
+  /// rejected seek leaves `acceptedTimelineRevision` alone; the reserved
+  /// value is simply never adopted, which keeps clock samples flowing exactly
+  /// as they did before the refused request.
+  func commitSeekTarget(milliseconds: Int64, revision: UInt64) {
+    acceptedTimelineRevision = revision
     currentTime = .milliseconds(milliseconds)
     publishPosition(forTargetMilliseconds: milliseconds)
   }
@@ -124,13 +139,15 @@ extension Player {
   @discardableResult
   public func seek(toPosition position: PlaybackPosition, fast: Bool = false) -> Bool {
     guard hasLenientSeekSession else { return false }
+    // Reserved before the native call for the same reason as the strict
+    // paths, and adopted only once libVLC accepts: a lenient seek publishes a
+    // position the same way a strict one does, so pre-seek samples must not
+    // overwrite it either.
+    let revision = eventBridge.advanceTimelineRevision()
     guard libvlc_media_player_set_position(pointer, position.rawValue, fast) == 0 else {
       return false
     }
-    // Accepted, so pre-seek clock samples must not overwrite this target
-    // either — a lenient seek publishes a position the same way a strict one
-    // does.
-    acceptedTimelineRevision = eventBridge.advanceTimelineRevision()
+    acceptedTimelineRevision = revision
     withMutation(keyPath: \.position) {
       _position = position.rawValue
     }

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -488,6 +488,10 @@ public final class Player {
   /// observe the same outcome. Cleared on completion — unlike shutdown, a
   /// stop is repeatable, so a later call must start a fresh wait.
   var stopAndWaitTask: Task<PlayerStopOutcome, Never>?
+  /// The timeline revision established by the most recent accepted seek or
+  /// media load. Clock samples stamped older than this are stale and are
+  /// dropped rather than allowed to overwrite the seek target.
+  var acceptedTimelineRevision: UInt64 = 0
   /// Bumped whenever the session a ``recast(to:)`` is restoring is taken over
   /// — by another recast or by a media load. An in-flight recast compares this
   /// after every suspension and stops mutating once it no longer owns the

--- a/Tests/SwiftVLCTests/Player/PlayerSeekAuthorityTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerSeekAuthorityTests.swift
@@ -124,6 +124,56 @@ extension Integration {
       #expect(player.state == .playing, "a one-shot transition was dropped by the clock filter")
     }
 
+    /// A sample carrying the seek's own revision is current, not stale, so it
+    /// must be applied. After a fast (keyframe) seek this is the position
+    /// playback actually landed on, which is not the requested one.
+    ///
+    /// This pins the boundary condition of the filter — that the comparison is
+    /// `>=` and not `>`. It does **not** prove the reserve-before-native-call
+    /// ordering: which revision libVLC's event thread stamps a concurrent
+    /// sample with is not observable from here, and the test passes under
+    /// either ordering.
+    @Test
+    func `A sample carrying the seek's own revision is applied`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      player._setStateForTesting(state: .paused, duration: .seconds(100), isSeekable: true)
+
+      // Stamped with the revision the bridge hands out for this seek, which
+      // is what a sample emitted during the native call would carry.
+      let concurrentRevision = player.eventBridge.advanceTimelineRevision() + 1
+      try player.seek(to: .seconds(42), fast: true)
+
+      let landed = SourcedPlayerEvent(
+        source: Player.sourceIdentifier(for: player.pointer),
+        event: .timeChanged(.seconds(40)),
+        timelineRevision: concurrentRevision
+      )
+      player.handleSourcedEvent(landed)
+
+      #expect(
+        player.currentTime == .seconds(40),
+        "the landed position was discarded as stale; the timeline is stuck on the requested target"
+      )
+    }
+
+    /// A rejected seek must not consume the timeline: clock samples keep
+    /// flowing exactly as they did before the refused request.
+    @Test
+    func `A rejected seek leaves the accepted timeline revision alone`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      player._setStateForTesting(state: .paused, duration: .seconds(100), isSeekable: true)
+      let before = player.acceptedTimelineRevision
+
+      // Out of range for the known duration, so validation refuses it.
+      #expect(throws: VLCError.self) {
+        try player.seek(to: .seconds(5000))
+      }
+
+      #expect(player.acceptedTimelineRevision == before)
+    }
+
     /// Loading new media starts a new timeline, so samples from the previous
     /// one cannot update it.
     @Test

--- a/Tests/SwiftVLCTests/Player/PlayerSeekAuthorityTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerSeekAuthorityTests.swift
@@ -1,0 +1,150 @@
+@testable import SwiftVLC
+import Foundation
+import Testing
+
+/// A seek target, once accepted, is the authoritative timeline.
+///
+/// Two things used to break that. The native seek result was ignored, so a
+/// refused seek still published its target and the observable timeline
+/// described a position playback never reached. And the internal event stream
+/// is unbounded, so time and position samples produced *before* a seek could
+/// still be queued when it was accepted — applying them afterwards snapped the
+/// published time back to where playback used to be. While paused there may be
+/// no later native clock event to repair that, so the wrong value simply
+/// stayed on screen.
+extension Integration {
+  @Suite(.tags(.mainActor, .async), .timeLimit(.minutes(1)))
+  @MainActor struct PlayerSeekAuthorityTests {
+    /// The core regression: a clock sample from before the seek must not
+    /// overwrite the accepted target.
+    @Test
+    func `A clock sample predating an accepted seek does not snap the timeline back`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      player._setStateForTesting(state: .paused, duration: .seconds(100), isSeekable: true)
+
+      // A sample libVLC produced before the seek, still queued.
+      let stale = SourcedPlayerEvent(
+        source: Player.sourceIdentifier(for: player.pointer),
+        event: .timeChanged(.seconds(3)),
+        timelineRevision: player.acceptedTimelineRevision
+      )
+
+      try player.seek(to: .seconds(42))
+      #expect(player.currentTime == .seconds(42))
+
+      player.handleSourcedEvent(stale)
+
+      #expect(
+        player.currentTime == .seconds(42),
+        "a pre-seek clock sample overwrote the accepted seek target"
+      )
+    }
+
+    /// The same guarantee for position, which drives the scrubber.
+    @Test
+    func `A position sample predating an accepted seek is discarded`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      player._setStateForTesting(state: .paused, duration: .seconds(100), isSeekable: true)
+
+      let stale = SourcedPlayerEvent(
+        source: Player.sourceIdentifier(for: player.pointer),
+        event: .positionChanged(0.03),
+        timelineRevision: player.acceptedTimelineRevision
+      )
+
+      try player.seek(to: .seconds(50))
+      let published = player.position
+
+      player.handleSourcedEvent(stale)
+
+      #expect(player.position == published, "a pre-seek position sample won over the seek target")
+    }
+
+    /// A sample produced *after* the seek is the newer truth and must still be
+    /// applied — the filter must not freeze the timeline.
+    @Test
+    func `A clock sample after an accepted seek still updates the timeline`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      player._setStateForTesting(state: .paused, duration: .seconds(100), isSeekable: true)
+
+      try player.seek(to: .seconds(42))
+
+      let fresh = SourcedPlayerEvent(
+        source: Player.sourceIdentifier(for: player.pointer),
+        event: .timeChanged(.seconds(43)),
+        timelineRevision: player.acceptedTimelineRevision
+      )
+      player.handleSourcedEvent(fresh)
+
+      #expect(player.currentTime == .seconds(43))
+    }
+
+    /// Rapid seeks: only the newest target survives, and a sample stamped for
+    /// the earlier one cannot resurrect it.
+    @Test
+    func `A superseded seek's clock samples cannot resurrect its target`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      player._setStateForTesting(state: .paused, duration: .seconds(100), isSeekable: true)
+
+      try player.seek(to: .seconds(10))
+      let firstRevision = player.acceptedTimelineRevision
+      try player.seek(to: .seconds(80))
+
+      let supersededSample = SourcedPlayerEvent(
+        source: Player.sourceIdentifier(for: player.pointer),
+        event: .timeChanged(.seconds(10)),
+        timelineRevision: firstRevision
+      )
+      player.handleSourcedEvent(supersededSample)
+
+      #expect(player.currentTime == .seconds(80))
+    }
+
+    /// State transitions must stay lossless: only clock payloads are filtered,
+    /// so a stale-stamped transition still reaches the mirror.
+    @Test
+    func `A stale-stamped state transition is still applied`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      player._setStateForTesting(state: .paused, duration: .seconds(100), isSeekable: true)
+
+      try player.seek(to: .seconds(42))
+
+      let staleTransition = SourcedPlayerEvent(
+        source: Player.sourceIdentifier(for: player.pointer),
+        event: .stateChanged(.playing),
+        timelineRevision: 0
+      )
+      player.handleSourcedEvent(staleTransition)
+
+      #expect(player.state == .playing, "a one-shot transition was dropped by the clock filter")
+    }
+
+    /// Loading new media starts a new timeline, so samples from the previous
+    /// one cannot update it.
+    @Test
+    func `A clock sample from the previous media cannot update the new timeline`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      player._setStateForTesting(state: .paused, duration: .seconds(100), isSeekable: true)
+
+      let previousGenerationSample = SourcedPlayerEvent(
+        source: Player.sourceIdentifier(for: player.pointer),
+        event: .timeChanged(.seconds(7)),
+        timelineRevision: player.acceptedTimelineRevision
+      )
+
+      try player.load(Media(url: TestMedia.silenceURL))
+      player.handleSourcedEvent(previousGenerationSample)
+
+      #expect(
+        player.currentTime == .zero,
+        "a clock sample from the previous media updated the new one's timeline"
+      )
+    }
+  }
+}


### PR DESCRIPTION
Closes #77.

## Root cause

Two independent defects that both let the published timeline describe a position playback was not at.

**1. Native seek rejection was ignored.** `libvlc_media_player_set_time` returns `0`/`-1`, and both strict seek paths discarded it, then published the requested target:

```swift
libvlc_media_player_set_time(pointer, milliseconds, fast)
currentTime = .milliseconds(milliseconds)   // published even if libVLC refused
```

**2. Clock samples from before a seek were applied after it.** The internal event stream is deliberately unbounded (a lossy buffer would drop one-shot transitions), so `timeChanged`/`positionChanged` produced *before* a seek can still be queued when the seek is accepted. Applying them afterwards snaps the published time back. While paused this is not self-correcting — there may be no later native clock event at all, so the wrong value just stays on screen.

## The fix

- Both strict entry points check the native result and throw `VLCError.operationFailed` on rejection, leaving the previous timeline untouched.
- Sourced events carry the **timeline revision** current when libVLC emitted them. An accepted seek advances that revision; the consumer drops clock payloads stamped older than the accepted one. The stamp is taken in the bridge because it has to be read on libVLC's thread, at emission — not at consumption, by which point it is too late to tell.
- Loading media advances the revision too, so samples from the previous media cannot update the new timeline.
- The lenient (`seek(toPosition:)`) path already reported rejection; it now also advances the revision, since it publishes a target the same way.

**Only time and position are filtered.** State transitions and everything else stay lossless — a filter that swallowed a one-shot transition would be a worse bug than the one being fixed, so there is a test pinning exactly that.

## Validation

**The tests were verified to catch the original behaviour.** Removing just the staleness filter (keeping the stamp plumbing so they compile), four of six fail with precisely the reported symptom:

- `42s` seek target reverting to `3s`
- position `0.5` reverting to `0.03`
- a superseded `80s` seek reverting to `10s`
- a previous media's sample landing on the new timeline (`0s` → `7s`)

The two that still pass are the ones asserting samples *after* a seek are applied and that transitions are not filtered — correctly unaffected.

| | Result |
|---|---|
| Full suite | 1673 tests, 140 suites — pass |
| TSan (race/stress/event-bridge + new suite) | 79 tests — pass |
| `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` | 0 warnings |
| swiftformat / swiftlint | clean |

These run in CI — the suite drives `handleSourcedEvent` directly with constructed events, so no live playback is involved.

## Remaining risks

- **Behaviour change:** a strict seek that libVLC refuses now throws where it previously succeeded silently. That is the point of the issue, but it is a behaviour change for callers who ignored the error, and it is the kind of thing worth a release note.
- The issue also asks for an explicit result for a *superseded* seek. This PR makes a superseded seek's stale samples harmless, but does not return a distinct "superseded" outcome — that would need an async result on a currently synchronous API, and the acceptance criterion it maps to ("rapid superseding seeks ... does not snap back") is covered by the discard.
- The stalled-main-actor criterion is covered structurally: the stamp is taken at emission, so an arbitrarily long stall cannot make a pre-seek sample look current. It is not separately exercised with an actual stall.
