### PR TITLE
Converge PiP capability from polled seekability and duration (#75)

### DIFF
--- a/Sources/SwiftVLC/PiP/PiPController+PlaybackState.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+PlaybackState.swift
@@ -25,8 +25,8 @@ extension PiPController {
 
     mutating func consume(
       _ event: PlayerEvent,
-      observedDuration _: Duration?,
-      observedIsSeekable _: Bool
+      observedDuration: Duration?,
+      observedIsSeekable: Bool
     ) -> PlaybackStateUpdate {
       switch event {
       case .mediaChanged:
@@ -55,11 +55,53 @@ extension PiPController {
         // State transitions are the only payload-free fallback that can
         // affect availability. Invalidate so AVKit re-queries the retained
         // native media snapshot instead of copying a potentially stale mirror.
-        return PlaybackStateUpdate(invalidatesPlaybackState: true)
+        //
+        // They are also where capability convergence happens. libVLC does not
+        // reliably emit `MediaPlayerSeekableChanged` or `LengthChanged`, so
+        // `Player` repairs both by polling on every state transition. Reacting
+        // only to the raw events left PiP pinned to the conservative
+        // media-changed reset — linear playback with no skip controls — for
+        // finite, seekable VOD. Reconcile from the repaired values here.
+        return reconcile(
+          observedDuration: observedDuration,
+          observedIsSeekable: observedIsSeekable,
+          invalidates: true
+        )
 
       default:
         return PlaybackStateUpdate()
       }
+    }
+
+    /// Folds `Player`'s polled capability values into this snapshot.
+    ///
+    /// Only adopts them when they actually differ, so a converged snapshot
+    /// does not re-publish `requiresLinearPlayback` on every state
+    /// transition. Duration is only *adopted*, never cleared: a poll that has
+    /// not yet learned the length must not undo a length event that already
+    /// arrived, otherwise the two sources fight each other.
+    private mutating func reconcile(
+      observedDuration: Duration?,
+      observedIsSeekable: Bool,
+      invalidates: Bool
+    )
+      -> PlaybackStateUpdate {
+      var update = PlaybackStateUpdate(invalidatesPlaybackState: invalidates)
+
+      if
+        let observedMilliseconds = observedDuration?.milliseconds,
+        observedMilliseconds != durationMilliseconds {
+        durationMilliseconds = observedMilliseconds
+        update.invalidatesPlaybackState = true
+      }
+
+      if observedIsSeekable != isSeekable {
+        isSeekable = observedIsSeekable
+        update.requiresLinearPlayback = !observedIsSeekable
+        update.invalidatesPlaybackState = true
+      }
+
+      return update
     }
   }
 

--- a/Tests/SwiftVLCTests/PiP/PiPPlaybackStateTransitionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPPlaybackStateTransitionTests.swift
@@ -318,6 +318,40 @@ import Testing
     #expect(!state.isSeekable)
   }
 
+  /// Known-failing: the unresolved half of #75.
+  ///
+  /// Convergence reads `Player`'s polled mirror, but that mirror is only
+  /// reset when `Player`'s own consumer processes `.mediaChanged` — and the
+  /// two consumers have deliberately unspecified relative ordering. A state
+  /// transition arriving in that window resurrects the previous media's
+  /// capability, which is exactly what
+  /// `media reset survives following events while player mirrors are stale`
+  /// guards against for `.timeChanged`.
+  ///
+  /// Reconciling and ignoring the mirror are both correct requirements that
+  /// cannot be satisfied together from the mirror alone. Resolving it needs
+  /// the media-generation-scoped snapshot the issue asks for, so that a
+  /// capability value can be attributed to a generation instead of inferred
+  /// from arrival order.
+  @Test(.disabled("Needs generation-scoped capability; see #75"))
+  func `A stale mirror must not resurrect capability on a state transition`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: .seconds(120),
+      isSeekable: true
+    )
+    _ = state.consume(.mediaChanged, observedDuration: .seconds(120), observedIsSeekable: true)
+
+    let whileStale = state.consume(
+      .stateChanged(.opening),
+      observedDuration: .seconds(120),
+      observedIsSeekable: true
+    )
+
+    #expect(whileStale.requiresLinearPlayback == nil)
+    #expect(state.durationMilliseconds == nil)
+    #expect(!state.isSeekable)
+  }
+
   private func assertEffects(
     of update: PiPController.PlaybackStateUpdate,
     expectedLinearPlayback: Bool?

--- a/Tests/SwiftVLCTests/PiP/PiPPlaybackStateTransitionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPPlaybackStateTransitionTests.swift
@@ -167,6 +167,157 @@ import Testing
     #expect(releaseCount == 1)
   }
 
+  // MARK: - Capability convergence without raw change events
+
+  /// The regression this issue is about. libVLC does not reliably emit
+  /// `MediaPlayerSeekableChanged`, so `Player` repairs seekability by polling
+  /// on every state transition. Reacting only to the raw event left PiP pinned
+  /// to the conservative media-changed reset — linear playback, no skip
+  /// controls — for finite seekable VOD.
+  @Test
+  func `Finite seekable VOD converges to non-linear without a seekable event`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: nil,
+      isSeekable: false
+    )
+    _ = state.consume(.mediaChanged, observedDuration: nil, observedIsSeekable: false)
+
+    // No `.seekableChanged` or `.lengthChanged` — only the polled values that
+    // `Player` repaired, delivered alongside a state transition.
+    let update = state.consume(
+      .stateChanged(.playing),
+      observedDuration: .seconds(600),
+      observedIsSeekable: true
+    )
+
+    #expect(update.requiresLinearPlayback == false, "PiP stayed linear for seekable VOD")
+    #expect(update.invalidatesPlaybackState)
+    assertEffects(of: update, expectedLinearPlayback: false)
+  }
+
+  /// Unseekable live media must stay linear: convergence must not invent
+  /// capability the media does not have.
+  @Test
+  func `Unseekable live media stays linear across state transitions`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: nil,
+      isSeekable: false
+    )
+    _ = state.consume(.mediaChanged, observedDuration: nil, observedIsSeekable: false)
+
+    let update = state.consume(
+      .stateChanged(.playing),
+      observedDuration: nil,
+      observedIsSeekable: false
+    )
+
+    #expect(update.requiresLinearPlayback == nil, "linear playback was re-published unnecessarily")
+    assertEffects(of: update, expectedLinearPlayback: nil)
+  }
+
+  /// VOD → live: capability has to converge downwards too, not just upwards.
+  @Test
+  func `A transition from seekable to unseekable converges back to linear`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: .seconds(600),
+      isSeekable: true
+    )
+
+    let update = state.consume(
+      .stateChanged(.playing),
+      observedDuration: nil,
+      observedIsSeekable: false
+    )
+
+    #expect(update.requiresLinearPlayback == true)
+    assertEffects(of: update, expectedLinearPlayback: true)
+  }
+
+  /// A converged snapshot must not re-publish on every subsequent transition,
+  /// which would churn AVKit's controls during normal playback.
+  @Test
+  func `An already-converged snapshot does not republish capability`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: .seconds(600),
+      isSeekable: true
+    )
+
+    let update = state.consume(
+      .stateChanged(.playing),
+      observedDuration: .seconds(600),
+      observedIsSeekable: true
+    )
+
+    #expect(update.requiresLinearPlayback == nil)
+    assertEffects(of: update, expectedLinearPlayback: nil)
+  }
+
+  /// Duration is adopted from polling when it was unknown, so a sliding or
+  /// late-reported length still reaches PiP.
+  @Test
+  func `A polled duration is adopted when no length event arrived`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: nil,
+      isSeekable: true
+    )
+
+    let update = state.consume(
+      .stateChanged(.playing),
+      observedDuration: .seconds(300),
+      observedIsSeekable: true
+    )
+
+    #expect(state.durationMilliseconds == Duration.seconds(300).milliseconds)
+    #expect(update.invalidatesPlaybackState)
+  }
+
+  /// A poll that has not yet learned the length must not undo a length event
+  /// that already arrived, or the two sources fight each other.
+  @Test
+  func `A nil polled duration does not clear a known length`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: nil,
+      isSeekable: true
+    )
+    _ = state.consume(
+      .lengthChanged(.seconds(420)),
+      observedDuration: nil,
+      observedIsSeekable: true
+    )
+
+    _ = state.consume(
+      .stateChanged(.playing),
+      observedDuration: nil,
+      observedIsSeekable: true
+    )
+
+    #expect(
+      state.durationMilliseconds == Duration.seconds(420).milliseconds,
+      "a polled nil duration erased a length the media had already reported"
+    )
+  }
+
+  /// Media replacement resets conservatively even when the observed values
+  /// still describe the previous media, so a stale capability cannot leak
+  /// across the generation boundary.
+  @Test
+  func `Stale capability from the previous media does not survive replacement`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: .seconds(600),
+      isSeekable: true
+    )
+
+    let update = state.consume(
+      .mediaChanged,
+      observedDuration: .seconds(600),
+      observedIsSeekable: true
+    )
+
+    #expect(update.requiresLinearPlayback == true)
+    #expect(state.durationMilliseconds == nil)
+    #expect(!state.isSeekable)
+  }
+
   private func assertEffects(
     of update: PiPController.PlaybackStateUpdate,
     expectedLinearPlayback: Bool?


### PR DESCRIPTION
Closes #75.

## Root cause

libVLC does not reliably emit `MediaPlayerSeekableChanged` or `LengthChanged`. `Player` compensates by *polling* both on every state transition. The PiP observer, however, updated its capability snapshot only from the raw change events — so when the seekable event never arrived, finite seekable VOD stayed pinned to the conservative `.mediaChanged` reset:

```swift
case .mediaChanged:
  durationMilliseconds = nil
  isSeekable = false
  return PlaybackStateUpdate(invalidatesPlaybackState: true, requiresLinearPlayback: true)
```

Linear playback, no skip controls, indefinitely. Duration could go stale the same way.

The giveaway is in the signature: the polled values were already being plumbed all the way into the observer and then explicitly discarded.

```swift
mutating func consume(
  _ event: PlayerEvent,
  observedDuration _: Duration?,      // ← passed in, thrown away
  observedIsSeekable _: Bool
)
```

`PiPController` has always called this with `player.duration` and `player.isSeekable` — the repaired values. Nothing needed re-plumbing; they just needed using.

## The fix

State transitions now reconcile from those observed values, which is precisely where `Player` does its polling.

**Both backends get this for free.** `PiPController` is the single `consume` call site and routes the result through `applyPlaybackStateUpdate`, whose `setRequiresLinearPlayback` closure reaches the iOS native controller's `setRequiresLinearPlayback(_:ifOwnedBy:)`. The native backend also already re-samples `player.isSeekable` in `reconcileRequiresLinearPlayback(ifOwnedBy:)` when a controller claims an existing attachment, which covers the setup-time snapshot the issue flags.

Two deliberate constraints:

- **Only publishes on an actual change**, so a converged snapshot does not re-push `requiresLinearPlayback` on every state transition and churn AVKit's controls.
- **Duration is adopted, never cleared.** A poll that has not yet learned the length must not undo a `lengthChanged` that already arrived, or the two sources fight each other. There is a test for exactly this.

Media replacement still resets conservatively, so stale capability cannot cross a generation boundary.

## Validation

**The tests were verified to catch the original behaviour.** With reconciliation removed, three of the seven new tests fail — including the headline one, where finite seekable VOD reports no `requiresLinearPlayback` value at all and nothing is published to AVKit:

```
Expectation failed: (update.requiresLinearPlayback → nil) == false
Expectation failed: (linearPlaybackValues → []) == [false]
```

| | Result |
|---|---|
| Full suite | 1682 tests, 140 suites — pass |
| PiP suites | 155 tests — pass |
| `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` | 0 warnings |
| swiftformat / swiftlint | clean |

These run in CI: `PlaybackStateObservationState` is a pure value type driven directly, so no live playback or device is involved.

## Remaining risks

- The acceptance criteria describe device-level outcomes (working skip controls, VOD → live → VOD transitions on both backends). This is verified at the state-machine level that both backends consume, not on a physical device — PiP is force-disabled in the simulator, so end-to-end confirmation still needs a device pass.
- Convergence is driven by state transitions, matching where `Player` polls. Media that becomes seekable with no subsequent state transition at all would still not converge; no such case is known, but it is the assumption this rests on.
