### PR TITLE
Remove synchronous main-queue hops from PiP callback paths (#86)

### DIFF
--- a/Sources/SwiftVLC/PiP/PiPCallbackSnapshot.swift
+++ b/Sources/SwiftVLC/PiP/PiPCallbackSnapshot.swift
@@ -1,0 +1,78 @@
+#if os(iOS) || os(macOS)
+
+import CoreMedia
+import Synchronization
+
+/// The state AVKit's synchronous queries need, readable from any thread.
+///
+/// AVKit asks for a playback range and a paused flag from arbitrary threads
+/// and expects an answer immediately. Answering by blocking on the main actor
+/// closes a deadlock cycle — the main thread is frequently waiting on libVLC
+/// or video-output teardown, which can in turn be gated behind the callback
+/// thread. Publishing the few values those queries need into a lock the main
+/// actor updates lets the callback thread answer without ever waiting on
+/// main.
+///
+/// The lock is only ever held across plain field reads and writes. It never
+/// calls libVLC, never touches the main actor, and never runs caller-supplied
+/// code, so it cannot participate in a lock-ordering cycle of its own.
+struct PiPCallbackSnapshot: @unchecked Sendable {
+  /// The native handle the queries should interrogate, or `nil` while no
+  /// player is attached. Carried here rather than read through the owner so
+  /// the callback thread never touches main-actor state.
+  var playerPointer: OpaquePointer?
+  /// PiP's control timebase, used to place the current time inside the
+  /// reported range.
+  var controlTimebase: CMTimebase?
+  /// Whether PiP should render as playing. Mirrors
+  /// ``PiPController/pipPlaybackActive``.
+  var isPlaybackActive = false
+  /// Bumped whenever the attached player handle changes.
+  ///
+  /// A query reads the whole snapshot under one lock acquisition, so the
+  /// pointer and timebase it works with always belong to the same generation.
+  /// The generation is what makes that guarantee checkable rather than
+  /// incidental.
+  var generation: UInt64 = 0
+
+  /// `true` once a handle has been published, so a query can distinguish
+  /// "not attached yet" from "attached to a player that reports nothing".
+  var isAttached: Bool {
+    playerPointer != nil
+  }
+}
+
+extension PiPController {
+  /// Republishes everything the callback threads read.
+  ///
+  /// Called from the main actor whenever the attached handle, the timebase or
+  /// the playback flag changes. Cheap enough to call unconditionally: it is a
+  /// handful of field writes under an uncontended lock.
+  func refreshCallbackSnapshot() {
+    let pointer: OpaquePointer? = player.pointer
+    let timebase = controlTimebase
+    let active = pipPlaybackActive
+
+    callbackSnapshot.withLock { snapshot in
+      if snapshot.playerPointer != pointer {
+        snapshot.generation &+= 1
+      }
+      snapshot.playerPointer = pointer
+      snapshot.controlTimebase = timebase
+      snapshot.isPlaybackActive = active
+    }
+  }
+
+  /// Clears the snapshot so in-flight callbacks stop interrogating a handle
+  /// that is being torn down.
+  func invalidateCallbackSnapshot() {
+    callbackSnapshot.withLock { snapshot in
+      snapshot.playerPointer = nil
+      snapshot.controlTimebase = nil
+      snapshot.isPlaybackActive = false
+      snapshot.generation &+= 1
+    }
+  }
+}
+
+#endif

--- a/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
@@ -374,17 +374,35 @@ func pipMainActorSyncBounded<T: Sendable>(
     return MainActor.assumeIsolated(body)
   }
 
-  let box = Mutex<T?>(nil)
+  let state = Mutex(BoundedHopState<T>())
   let done = DispatchSemaphore(value: 0)
   DispatchQueue.main.async {
+    // The caller may already have given up. Running `body` then would perform
+    // side effects for a result nobody will see — for the close veto that
+    // means reparenting the replacement window *after* telling AppKit the
+    // close was allowed. When the main actor is genuinely wedged, which is
+    // the case this exists for, the closure has not started yet and this
+    // check is what stops it.
+    guard !state.withLock({ $0.abandoned }) else { return }
     let value = MainActor.assumeIsolated(body)
-    box.withLock { $0 = value }
+    state.withLock { $0.value = value }
     done.signal()
   }
+
   guard done.wait(timeout: .now() + timeout) == .success else {
+    state.withLock { $0.abandoned = true }
     return fallback
   }
-  return box.withLock { $0 } ?? fallback
+  // Unwraps exactly one level, so a `T` that is itself optional round-trips a
+  // genuine `nil` instead of collapsing into `fallback`.
+  guard let value = state.withLock({ $0.value }) else { return fallback }
+  return value
+}
+
+/// Result slot for ``pipMainActorSyncBounded(timeout:fallback:_:)``.
+private struct BoundedHopState<Value> {
+  var value: Value?
+  var abandoned = false
 }
 
 func pipMainActorAsync(_ body: @escaping @MainActor @Sendable () -> Void) {

--- a/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
@@ -4,6 +4,7 @@ import AVKit
 import CLibVLC
 import Dispatch
 import Foundation
+import Synchronization
 
 // MARK: - AVPictureInPictureControllerDelegate
 
@@ -14,7 +15,8 @@ extension PiPController: AVPictureInPictureControllerDelegate {
   public nonisolated func pictureInPictureControllerWillStartPictureInPicture(
     _: AVPictureInPictureController
   ) {
-    pipMainActorSync {
+    pipMainActorAsync { [weak self] in
+      guard let self else { return }
       pendingStopReason = nil
       // Auto-PiP starts arrive from AVKit without start() or an intent
       // transition — last chance to issue the deferred session
@@ -32,7 +34,8 @@ extension PiPController: AVPictureInPictureControllerDelegate {
   public nonisolated func pictureInPictureControllerDidStartPictureInPicture(
     _: AVPictureInPictureController
   ) {
-    pipMainActorSync {
+    pipMainActorAsync { [weak self] in
+      guard let self else { return }
       pendingStopReason = nil
       syncPlaybackStateForPictureInPicture()
       invalidatePictureInPicturePlaybackState()
@@ -49,7 +52,8 @@ extension PiPController: AVPictureInPictureControllerDelegate {
   public nonisolated func pictureInPictureControllerWillStopPictureInPicture(
     _: AVPictureInPictureController
   ) {
-    pipMainActorSync {
+    pipMainActorAsync { [weak self] in
+      guard let self else { return }
       pipEventBroadcaster.broadcast(.willStop(reason: resolveStopReason()))
     }
   }
@@ -61,7 +65,8 @@ extension PiPController: AVPictureInPictureControllerDelegate {
   public nonisolated func pictureInPictureControllerDidStopPictureInPicture(
     _: AVPictureInPictureController
   ) {
-    pipMainActorSync {
+    pipMainActorAsync { [weak self] in
+      guard let self else { return }
       let reason = resolveStopReason()
       pendingStopReason = nil
       updatePiPActive(false)
@@ -82,7 +87,8 @@ extension PiPController: AVPictureInPictureControllerDelegate {
     _: AVPictureInPictureController,
     restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler: @escaping @Sendable (Bool) -> Void
   ) {
-    pipMainActorSync {
+    pipMainActorAsync { [weak self] in
+      guard let self else { return }
       // Record the reason before the host app's restore hook runs, so
       // the stop delegate callbacks see it no matter how AVKit orders
       // them relative to the hook's completion.
@@ -106,7 +112,8 @@ extension PiPController: AVPictureInPictureControllerDelegate {
     _: AVPictureInPictureController,
     failedToStartPictureInPictureWithError error: Error
   ) {
-    pipMainActorSync {
+    pipMainActorAsync { [weak self] in
+      guard let self else { return }
       notePendingStopReason(.failure)
       updatePiPActive(false)
       pipEventBroadcaster.broadcast(.failedToStart(error))
@@ -134,17 +141,17 @@ final class PiPPlaybackDelegateProxy: NSObject, AVPictureInPictureSampleBufferPl
   /// `@unchecked Sendable` is the narrow concession that lets AVKit
   /// hand the proxy between threads. The owner field is the only state,
   /// it's `weak` (ARC-atomic in Swift), and every read happens inside
-  /// a `pipMainActorSync` hop to the main actor. Concurrent AVKit
-  /// callbacks funnel through that bounce, so owner access is
-  /// effectively serialized on the main actor even though the proxy
-  /// itself is nominally nonisolated.
+  /// a `pipMainActorAsync` enqueue onto the main actor, or through the
+  /// lock-protected `PiPCallbackSnapshot` for the two queries AVKit needs
+  /// answered synchronously. Neither path blocks the callback thread on
+  /// main, so owner access is serialized without a deadlock edge.
   weak var owner: PiPController?
 
   func pictureInPictureController(
     _: AVPictureInPictureController,
     setPlaying playing: Bool
   ) {
-    pipMainActorSync { [weak self] in
+    pipMainActorAsync { [weak self] in
       self?.owner?.handleSetPlaying(playing)
     }
   }
@@ -152,14 +159,40 @@ final class PiPPlaybackDelegateProxy: NSObject, AVPictureInPictureSampleBufferPl
   func pictureInPictureControllerTimeRangeForPlayback(
     _: AVPictureInPictureController
   ) -> CMTimeRange {
-    pipMainActorSync { [weak self] in
-      guard let owner = self?.owner else { return .invalid }
-      let currentTime = owner.controlTimebase.map(CMTimebaseGetTime) ?? .zero
-      return Self.nativePlaybackTimeRange(
-        playerPointer: owner.player.pointer,
-        currentTime: currentTime
-      )
-    }
+    resolveTimeRangeForPlayback()
+  }
+
+  /// The body of the time-range query, separated from AVKit's entry point so
+  /// forward-progress tests can drive it without constructing an
+  /// `AVPictureInPictureController` (which AVKit refuses to let tests make).
+  ///
+  /// Answered without hopping to the main actor: AVKit calls this from
+  /// arbitrary threads, and blocking one of them on main is what lets a
+  /// teardown already waiting on that thread deadlock.
+  func resolveTimeRangeForPlayback() -> CMTimeRange {
+    guard let snapshot = currentCallbackSnapshot() else { return .invalid }
+    return Self.timeRange(for: snapshot)
+  }
+
+  /// Reads the whole snapshot under a single lock acquisition, so the pointer
+  /// and timebase a query works with always belong to the same generation.
+  private func currentCallbackSnapshot() -> PiPCallbackSnapshot? {
+    // `Mutex` is non-copyable, so the lock is used in place rather than bound.
+    guard let snapshot = owner?.callbackSnapshot.withLock({ $0 }) else { return nil }
+    return snapshot.isAttached ? snapshot : nil
+  }
+
+  /// Assembles the reported range from one generation's handle and timebase.
+  ///
+  /// libVLC is queried *after* the lock is released — the snapshot lock must
+  /// never be held across a call that could itself block.
+  static func timeRange(for snapshot: PiPCallbackSnapshot) -> CMTimeRange {
+    guard let playerPointer = snapshot.playerPointer else { return .invalid }
+    let currentTime = snapshot.controlTimebase.map(CMTimebaseGetTime) ?? .zero
+    return nativePlaybackTimeRange(
+      playerPointer: playerPointer,
+      currentTime: currentTime
+    )
   }
 
   /// Queries the native player without consulting Swift-side media mirrors.
@@ -273,11 +306,17 @@ final class PiPPlaybackDelegateProxy: NSObject, AVPictureInPictureSampleBufferPl
   func pictureInPictureControllerIsPlaybackPaused(
     _: AVPictureInPictureController
   ) -> Bool {
-    pipMainActorSync { [weak self] in
-      // Default to paused when the owner is gone so AVKit renders a
-      // stable UI while teardown drains.
-      !(self?.owner?.pipPlaybackActive ?? false)
-    }
+    resolveIsPlaybackPaused()
+  }
+
+  /// The body of the paused query. See ``resolveTimeRangeForPlayback()`` for
+  /// why it is split out.
+  ///
+  /// Snapshot read, no main-actor hop. Defaults to paused when nothing is
+  /// attached so AVKit renders a stable UI while teardown drains.
+  func resolveIsPlaybackPaused() -> Bool {
+    guard let snapshot = currentCallbackSnapshot() else { return true }
+    return !snapshot.isPlaybackActive
   }
 
   func pictureInPictureController(
@@ -285,7 +324,7 @@ final class PiPPlaybackDelegateProxy: NSObject, AVPictureInPictureSampleBufferPl
     skipByInterval skipInterval: CMTime,
     completion completionHandler: @escaping @Sendable () -> Void
   ) {
-    pipMainActorSync { [weak self] in
+    pipMainActorAsync { [weak self] in
       guard let owner = self?.owner else {
         completionHandler()
         return
@@ -298,22 +337,62 @@ final class PiPPlaybackDelegateProxy: NSObject, AVPictureInPictureSampleBufferPl
     _: AVPictureInPictureController,
     didTransitionToRenderSize size: CMVideoDimensions
   ) {
-    pipMainActorSync { [weak self] in
+    pipMainActorAsync { [weak self] in
       self?.owner?.handleRenderSizeTransition(size)
     }
   }
 }
 
-/// AVKit may invoke the proxy's callbacks from non-main threads but
-/// expects synchronous answers. Bounce onto the main actor without
-/// routing through an async task so the answer is immediate.
-func pipMainActorSync<T: Sendable>(
-  _ body: @MainActor @Sendable () -> T
+/// Runs `body` on the main actor without blocking the calling thread.
+///
+/// AVKit invokes most of its callbacks from non-main threads and does not
+/// need a return value from them. Blocking those threads on the main actor
+/// closes a deadlock cycle: the main thread routinely waits on libVLC or
+/// video-output teardown, and that teardown can be gated behind the very
+/// callback thread that is now parked waiting for main. Enqueueing instead
+/// removes the callback-waits-for-main edge, so no cycle can form.
+///
+/// Already on the main thread, `body` still runs synchronously — reordering
+/// a callback relative to work the caller has already done would change
+/// observable behaviour for no benefit.
+/// Runs `body` on the main actor and waits, but only for `timeout`.
+///
+/// The escape hatch for the one callback that genuinely cannot be answered
+/// from a snapshot: AppKit's close veto has to run main-actor UI work
+/// (reparenting the replacement window) *before* it returns. Blocking is
+/// unavoidable there, so the wait is bounded instead — if the main actor is
+/// wedged behind teardown, the caller degrades to `fallback` rather than
+/// joining the deadlock.
+///
+/// Everything else should use ``pipMainActorAsync`` or read a snapshot.
+func pipMainActorSyncBounded<T: Sendable>(
+  timeout: DispatchTimeInterval = .milliseconds(250),
+  fallback: T,
+  _ body: @escaping @MainActor @Sendable () -> T
 ) -> T {
   if Thread.isMainThread {
     return MainActor.assumeIsolated(body)
   }
-  return DispatchQueue.main.sync {
+
+  let box = Mutex<T?>(nil)
+  let done = DispatchSemaphore(value: 0)
+  DispatchQueue.main.async {
+    let value = MainActor.assumeIsolated(body)
+    box.withLock { $0 = value }
+    done.signal()
+  }
+  guard done.wait(timeout: .now() + timeout) == .success else {
+    return fallback
+  }
+  return box.withLock { $0 } ?? fallback
+}
+
+func pipMainActorAsync(_ body: @escaping @MainActor @Sendable () -> Void) {
+  if Thread.isMainThread {
+    MainActor.assumeIsolated(body)
+    return
+  }
+  DispatchQueue.main.async {
     MainActor.assumeIsolated(body)
   }
 }

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -105,7 +105,14 @@ public final class PiPController: NSObject {
   @ObservationIgnored
   private var callbackRegistration: DirectPiPVideoCallbackRegistration?
   @ObservationIgnored
-  var controlTimebase: CMTimebase?
+  var controlTimebase: CMTimebase? {
+    didSet { refreshCallbackSnapshot() }
+  }
+
+  /// What AVKit's synchronous callbacks read instead of blocking on the main
+  /// actor. See ``PiPCallbackSnapshot``.
+  @ObservationIgnored
+  nonisolated let callbackSnapshot = Mutex(PiPCallbackSnapshot())
   @ObservationIgnored
   private var stateObserverTask: Task<Void, Never>?
   @ObservationIgnored
@@ -180,7 +187,10 @@ public final class PiPController: NSObject {
   /// transitions. PiP queries state immediately after calling
   /// `setPlaying` and would otherwise see stale values.
   @ObservationIgnored
-  var pipPlaybackActive: Bool = false
+  var pipPlaybackActive: Bool = false {
+    didSet { refreshCallbackSnapshot() }
+  }
+
   /// Desired playback state from the PiP controls while libVLC is still
   /// catching up. During this window player events can still report the
   /// previous state, so the event observer must not overwrite
@@ -428,6 +438,10 @@ public final class PiPController: NSObject {
     // successor's claim is preserved without us touching it here.
     pipController?.delegate = nil
     playbackDelegateProxy.owner = nil
+    // Stop any in-flight AVKit query from interrogating a handle that is
+    // about to be released. Cleared before the relinquish below, so the
+    // window where a callback could see a dead pointer never opens.
+    invalidateCallbackSnapshot()
     renderer.setDisplayLayer(nil)
     renderer.setTimebase(nil)
     if let callbackRegistration {
@@ -526,6 +540,10 @@ public final class PiPController: NSObject {
     let registration = DirectPiPVideoCallbackRegistration(renderer: renderer)
     callbackRegistration = registration
     player.claimDirectPiPVideoCallbacks(registration)
+    // Publish the handle the AVKit callback threads will interrogate. Until
+    // this runs the snapshot reports "not attached" and the synchronous
+    // queries answer with their stable defaults.
+    refreshCallbackSnapshot()
   }
 
   private func setupPiPController() {

--- a/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
@@ -8,6 +8,7 @@
 import AppKit
 import CLibVLC
 import Foundation
+import Synchronization
 
 @MainActor
 final class MacNativePiPBackend: NSObject, @unchecked Sendable {
@@ -494,7 +495,11 @@ final class MacPrivatePiPDelegate: NSObject, @unchecked Sendable {
 
   @objc(pipShouldClose:)
   func pipShouldClose(_: NSObject) -> Bool {
-    pipMainActorSync { [weak self] in
+    // The one place a blocking hop survives: the veto has to reparent the
+    // replacement window on the main actor before AppKit continues, so it
+    // cannot be served from a snapshot. Bounded, so a main actor wedged
+    // behind teardown degrades to allowing the close instead of deadlocking.
+    pipMainActorSyncBounded(fallback: true) { [weak self] in
       self?.shouldClose() ?? true
     }
   }
@@ -536,7 +541,13 @@ final class MacPrivatePiPDelegate: NSObject, @unchecked Sendable {
 }
 
 final class MacNativePiPMediaController: NSObject, @unchecked Sendable {
-  weak var player: Player?
+  weak var player: Player? {
+    didSet { MainActor.assumeIsolated { refreshCallbackSnapshot() } }
+  }
+
+  /// What AppKit's synchronous queries read instead of blocking on the main
+  /// actor. See ``PiPCallbackSnapshot``.
+  let callbackSnapshot = Mutex(PiPCallbackSnapshot())
 
   @objc func play() {
     Task { @MainActor [weak self] in
@@ -574,32 +585,49 @@ final class MacNativePiPMediaController: NSObject, @unchecked Sendable {
     }
   }
 
+  // These four are queries AppKit expects answered synchronously from its own
+  // threads. They read the snapshot rather than the main-actor `player`, then
+  // call libVLC *after* releasing the lock — libVLC's own locking is
+  // independent of the main actor, so no cycle can form.
+
   @objc func mediaLength() -> Int64 {
-    pipMainActorSync { [weak self] in
-      guard let player = self?.player else { return -1 }
-      let length = libvlc_media_player_get_length(player.pointer)
-      return length > 0 ? length : -1
-    }
+    guard let pointer = callbackSnapshot.withLock({ $0.playerPointer }) else { return -1 }
+    let length = libvlc_media_player_get_length(pointer)
+    return length > 0 ? length : -1
   }
 
   @objc func mediaTime() -> Int64 {
-    pipMainActorSync { [weak self] in
-      guard let player = self?.player else { return 0 }
-      return max(libvlc_media_player_get_time(player.pointer), 0)
-    }
+    guard let pointer = callbackSnapshot.withLock({ $0.playerPointer }) else { return 0 }
+    return max(libvlc_media_player_get_time(pointer), 0)
   }
 
   @objc func isMediaSeekable() -> Bool {
-    pipMainActorSync { [weak self] in
-      guard let player = self?.player else { return false }
-      return libvlc_media_player_is_seekable(player.pointer)
-    }
+    guard let pointer = callbackSnapshot.withLock({ $0.playerPointer }) else { return false }
+    return libvlc_media_player_is_seekable(pointer)
   }
 
   @objc func isMediaPlaying() -> Bool {
-    pipMainActorSync { [weak self] in
-      guard let player = self?.player else { return false }
-      return player.isPlaybackRequestedActive
+    // Read straight from the player's nonisolated mirror rather than the
+    // snapshot: intent can change on the main actor an instant before AppKit
+    // asks, and a snapshot republished afterwards would answer with the
+    // previous value.
+    player?.nonisolatedPlaybackIntent.load(ordering: .acquiring) ?? false
+  }
+
+  /// Republished whenever the attached player or its playback intent changes.
+  ///
+  /// Reads main-actor state, so it is main-actor isolated; the query side only
+  /// ever reads the published result under the lock.
+  @MainActor
+  func refreshCallbackSnapshot() {
+    let pointer = player?.pointer
+    let active = player?.isPlaybackRequestedActive ?? false
+    callbackSnapshot.withLock { snapshot in
+      if snapshot.playerPointer != pointer {
+        snapshot.generation &+= 1
+      }
+      snapshot.playerPointer = pointer
+      snapshot.isPlaybackActive = active
     }
   }
 }

--- a/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
@@ -542,7 +542,7 @@ final class MacPrivatePiPDelegate: NSObject, @unchecked Sendable {
 
 final class MacNativePiPMediaController: NSObject, @unchecked Sendable {
   weak var player: Player? {
-    didSet { MainActor.assumeIsolated { refreshCallbackSnapshot() } }
+    didSet { publishCallbackSnapshot() }
   }
 
   /// What AppKit's synchronous queries read instead of blocking on the main
@@ -612,6 +612,17 @@ final class MacNativePiPMediaController: NSObject, @unchecked Sendable {
     // asks, and a snapshot republished afterwards would answer with the
     // previous value.
     player?.nonisolatedPlaybackIntent.load(ordering: .acquiring) ?? false
+  }
+
+  /// Publishes the snapshot without assuming the caller is already on the main
+  /// actor. `assumeIsolated` would trap if this class is ever mutated from a
+  /// background thread, and it is nominally nonisolated.
+  private func publishCallbackSnapshot() {
+    if Thread.isMainThread {
+      MainActor.assumeIsolated { refreshCallbackSnapshot() }
+    } else {
+      Task { @MainActor [weak self] in self?.refreshCallbackSnapshot() }
+    }
   }
 
   /// Republished whenever the attached player or its playback intent changes.

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 #if os(iOS)
 import AVFoundation
 import AVKit
@@ -867,12 +868,23 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
 
 final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling, @unchecked Sendable {
   weak var player: Player? {
-    didSet { MainActor.assumeIsolated { refreshCallbackSnapshot() } }
+    didSet { publishCallbackSnapshot() }
   }
 
   /// What VLC's native PiP module reads instead of blocking on the main
   /// actor. See ``PiPCallbackSnapshot``.
   let callbackSnapshot = Mutex(PiPCallbackSnapshot())
+
+  /// Publishes without assuming the caller is already on the main actor.
+  /// `assumeIsolated` would trap if this nominally nonisolated class is ever
+  /// mutated from a background thread.
+  private func publishCallbackSnapshot() {
+    if Thread.isMainThread {
+      MainActor.assumeIsolated { refreshCallbackSnapshot() }
+    } else {
+      Task { @MainActor [weak self] in self?.refreshCallbackSnapshot() }
+    }
+  }
 
   /// Republished whenever the attached player changes.
   @MainActor

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -866,7 +866,26 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
 }
 
 final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling, @unchecked Sendable {
-  weak var player: Player?
+  weak var player: Player? {
+    didSet { MainActor.assumeIsolated { refreshCallbackSnapshot() } }
+  }
+
+  /// What VLC's native PiP module reads instead of blocking on the main
+  /// actor. See ``PiPCallbackSnapshot``.
+  let callbackSnapshot = Mutex(PiPCallbackSnapshot())
+
+  /// Republished whenever the attached player changes.
+  @MainActor
+  func refreshCallbackSnapshot() {
+    let pointer = player?.pointer
+    callbackSnapshot.withLock { snapshot in
+      if snapshot.playerPointer != pointer {
+        snapshot.generation &+= 1
+      }
+      snapshot.playerPointer = pointer
+    }
+  }
+
   weak var owner: PiPController?
 
   @objc func play() {
@@ -919,35 +938,32 @@ final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling,
     }
   }
 
+  // Synchronous queries VLC's native PiP module makes from its own threads.
+  // They read the snapshot and then call libVLC after releasing the lock,
+  // never blocking on the main actor.
+
   @objc func mediaLength() -> Int64 {
-    pipMainActorAsync { [weak self] in
-      guard let player = self?.player else { return 0 }
-      let length = libvlc_media_player_get_length(player.pointer)
-      // VLC's native PiP module checks for VLC_TICK_INVALID (0), not
-      // libvlc's public unknown-length sentinel (-1).
-      return length > 0 ? length : 0
-    }
+    guard let pointer = callbackSnapshot.withLock({ $0.playerPointer }) else { return 0 }
+    let length = libvlc_media_player_get_length(pointer)
+    // VLC's native PiP module checks for VLC_TICK_INVALID (0), not
+    // libvlc's public unknown-length sentinel (-1).
+    return length > 0 ? length : 0
   }
 
   @objc func mediaTime() -> Int64 {
-    pipMainActorAsync { [weak self] in
-      guard let player = self?.player else { return 0 }
-      return max(libvlc_media_player_get_time(player.pointer), 0)
-    }
+    guard let pointer = callbackSnapshot.withLock({ $0.playerPointer }) else { return 0 }
+    return max(libvlc_media_player_get_time(pointer), 0)
   }
 
   @objc func isMediaSeekable() -> Bool {
-    pipMainActorAsync { [weak self] in
-      guard let player = self?.player else { return false }
-      return libvlc_media_player_is_seekable(player.pointer)
-    }
+    guard let pointer = callbackSnapshot.withLock({ $0.playerPointer }) else { return false }
+    return libvlc_media_player_is_seekable(pointer)
   }
 
   @objc func isMediaPlaying() -> Bool {
-    pipMainActorAsync { [weak self] in
-      guard let player = self?.player else { return false }
-      return player.isPlaybackRequestedActive
-    }
+    // Straight from the player's nonisolated mirror: intent can change on the
+    // main actor an instant before the query arrives.
+    player?.nonisolatedPlaybackIntent.load(ordering: .acquiring) ?? false
   }
 }
 

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -920,7 +920,7 @@ final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling,
   }
 
   @objc func mediaLength() -> Int64 {
-    pipMainActorSync { [weak self] in
+    pipMainActorAsync { [weak self] in
       guard let player = self?.player else { return 0 }
       let length = libvlc_media_player_get_length(player.pointer)
       // VLC's native PiP module checks for VLC_TICK_INVALID (0), not
@@ -930,21 +930,21 @@ final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling,
   }
 
   @objc func mediaTime() -> Int64 {
-    pipMainActorSync { [weak self] in
+    pipMainActorAsync { [weak self] in
       guard let player = self?.player else { return 0 }
       return max(libvlc_media_player_get_time(player.pointer), 0)
     }
   }
 
   @objc func isMediaSeekable() -> Bool {
-    pipMainActorSync { [weak self] in
+    pipMainActorAsync { [weak self] in
       guard let player = self?.player else { return false }
       return libvlc_media_player_is_seekable(player.pointer)
     }
   }
 
   @objc func isMediaPlaying() -> Bool {
-    pipMainActorSync { [weak self] in
+    pipMainActorAsync { [weak self] in
       guard let player = self?.player else { return false }
       return player.isPlaybackRequestedActive
     }

--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -1,5 +1,6 @@
 import CLibVLC
 import os
+import Synchronization
 
 /// Event consumer that mirrors `PlayerEvent`s onto `Player`'s
 /// `@Observable` properties, plus the deferred-pause / playback-intent
@@ -237,6 +238,10 @@ extension Player {
   func publishPlaybackIntent(_ active: Bool) {
     guard isPlaybackRequestedActive != active else { return }
     isPlaybackRequestedActive = active
+    // Mirrored synchronously so off-main callers — AVKit and AppKit PiP
+    // callbacks, which must answer immediately — can read the current intent
+    // without hopping to the main actor.
+    nonisolatedPlaybackIntent.store(active, ordering: .releasing)
     withMutation(keyPath: \.isPlaying) {}
     playbackIntentBridge.broadcast(active)
   }

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -1,6 +1,7 @@
 import CLibVLC
 import Foundation
 import Observation
+import Synchronization
 
 /// An observable media player.
 ///
@@ -412,6 +413,14 @@ public final class Player {
   let eventBridge: EventBridge
   nonisolated let endCoordinator = PlaybackEndCoordinator()
   nonisolated let playbackIntentBridge: Broadcaster<Bool>
+  /// ``isPlaybackRequestedActive`` mirrored for readers that cannot touch the
+  /// main actor.
+  ///
+  /// AVKit and AppKit ask PiP whether playback is paused from their own
+  /// threads and expect an answer immediately. Blocking those threads on the
+  /// main actor is what lets a teardown already waiting on them deadlock, so
+  /// the value they need is published here and read atomically instead.
+  nonisolated let nonisolatedPlaybackIntent = Atomic<Bool>(false)
   var eventTask: Task<Void, Never>?
   var _position: Double = 0
   var _equalizer: Equalizer?

--- a/Tests/SwiftVLCTests/PiP/PiPCallbackForwardProgressTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPCallbackForwardProgressTests.swift
@@ -1,0 +1,151 @@
+#if os(iOS) || os(macOS)
+@testable import SwiftVLC
+import CoreMedia
+import Dispatch
+import Foundation
+import Synchronization
+import Testing
+
+/// AVKit's synchronous PiP callbacks must answer while the main actor is busy.
+///
+/// The deadlock this guards against is a cycle: the main thread waits on
+/// libVLC or video-output teardown, that teardown is gated behind an AVKit
+/// callback thread, and the callback thread is parked in
+/// `DispatchQueue.main.sync`. Removing the last edge — callbacks never wait on
+/// main — is what makes the cycle impossible, so these tests pin that the
+/// synchronous queries return *without* the main actor being available.
+@Suite(.tags(.logic), .timeLimit(.minutes(1)))
+struct PiPCallbackForwardProgressTests {
+  /// The paused query has to answer from a background thread while the main
+  /// thread is blocked. Before the fix this call would sit in
+  /// `DispatchQueue.main.sync` until the stall ended.
+  @Test
+  func `The paused query answers while the main thread is blocked`() {
+    let proxy = PiPPlaybackDelegateProxy()
+    let released = DispatchSemaphore(value: 0)
+    let stalled = DispatchSemaphore(value: 0)
+
+    // Occupy the main thread for the duration of the query.
+    DispatchQueue.main.async {
+      stalled.signal()
+      released.wait()
+    }
+    #expect(stalled.wait(timeout: .now() + 5) == .success)
+
+    let answered = DispatchSemaphore(value: 0)
+    let result = Mutex<Bool?>(nil)
+    DispatchQueue.global().async {
+      result.withLock { $0 = proxy.resolveIsPlaybackPaused() }
+      answered.signal()
+    }
+
+    let progressed = answered.wait(timeout: .now() + 3) == .success
+    released.signal()
+
+    #expect(progressed, "the paused query blocked on a stalled main actor")
+    // No owner attached, so it reports the stable default rather than
+    // inventing playback.
+    #expect(result.withLock { $0 } == true)
+  }
+
+  /// Same guarantee for the time-range query, which additionally has to reach
+  /// libVLC — that call happens after the snapshot lock is released.
+  @Test
+  func `The time-range query answers while the main thread is blocked`() {
+    let proxy = PiPPlaybackDelegateProxy()
+    let released = DispatchSemaphore(value: 0)
+    let stalled = DispatchSemaphore(value: 0)
+
+    DispatchQueue.main.async {
+      stalled.signal()
+      released.wait()
+    }
+    #expect(stalled.wait(timeout: .now() + 5) == .success)
+
+    let answered = DispatchSemaphore(value: 0)
+    DispatchQueue.global().async {
+      _ = proxy.resolveTimeRangeForPlayback()
+      answered.signal()
+    }
+
+    let progressed = answered.wait(timeout: .now() + 3) == .success
+    released.signal()
+
+    #expect(progressed, "the time-range query blocked on a stalled main actor")
+  }
+
+  /// A query reads the pointer and timebase in one lock acquisition, so it can
+  /// never assemble a range from two different generations.
+  @Test
+  func `A query never mixes generations`() throws {
+    let snapshot = Mutex(PiPCallbackSnapshot())
+    let first = try #require(OpaquePointer(bitPattern: 0x1))
+    let second = try #require(OpaquePointer(bitPattern: 0x2))
+
+    snapshot.withLock {
+      $0.playerPointer = first
+      $0.generation = 7
+    }
+
+    let observed = snapshot.withLock { $0 }
+
+    // A concurrent republication cannot retroactively change what the reader
+    // already took.
+    snapshot.withLock {
+      $0.playerPointer = second
+      $0.generation = 8
+    }
+
+    #expect(observed.playerPointer == first)
+    #expect(observed.generation == 7)
+    #expect(snapshot.withLock { $0.generation } == 8)
+  }
+
+  /// An unattached snapshot reports "not attached" so queries fall back to
+  /// stable defaults instead of dereferencing a released handle.
+  @Test
+  func `An invalidated snapshot reports as unattached`() {
+    let snapshot = Mutex(PiPCallbackSnapshot())
+    snapshot.withLock { $0.playerPointer = try? #require(OpaquePointer(bitPattern: 0x1)) }
+    #expect(snapshot.withLock { $0.isAttached })
+
+    snapshot.withLock {
+      $0.playerPointer = nil
+      $0.generation &+= 1
+    }
+
+    #expect(!snapshot.withLock { $0.isAttached })
+  }
+
+  /// The bounded hop is the one remaining blocking call. It must give up and
+  /// return the fallback rather than joining a wedged main actor.
+  @Test
+  func `The bounded main-actor hop degrades instead of deadlocking`() {
+    let released = DispatchSemaphore(value: 0)
+    let stalled = DispatchSemaphore(value: 0)
+
+    DispatchQueue.main.async {
+      stalled.signal()
+      released.wait()
+    }
+    #expect(stalled.wait(timeout: .now() + 5) == .success)
+
+    let answered = DispatchSemaphore(value: 0)
+    let result = Mutex<Bool?>(nil)
+    DispatchQueue.global().async {
+      let value = pipMainActorSyncBounded(timeout: .milliseconds(50), fallback: true) {
+        false
+      }
+      result.withLock { $0 = value }
+      answered.signal()
+    }
+
+    let progressed = answered.wait(timeout: .now() + 3) == .success
+    released.signal()
+
+    #expect(progressed, "the bounded hop never returned")
+    #expect(result.withLock { $0 } == true, "it returned the main-actor value, not the fallback")
+  }
+}
+
+#endif

--- a/Tests/SwiftVLCTests/PiP/PiPCallbackForwardProgressTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPCallbackForwardProgressTests.swift
@@ -146,6 +146,58 @@ struct PiPCallbackForwardProgressTests {
     #expect(progressed, "the bounded hop never returned")
     #expect(result.withLock { $0 } == true, "it returned the main-actor value, not the fallback")
   }
+
+  /// After the bounded hop gives up, the queued body must not run.
+  ///
+  /// For the close veto that body reparents the replacement window — running
+  /// it once the caller has already told AppKit the close was allowed would
+  /// apply UI side effects for a decision that was never delivered.
+  @Test
+  func `A timed-out bounded hop does not run its body afterwards`() {
+    let released = DispatchSemaphore(value: 0)
+    let stalled = DispatchSemaphore(value: 0)
+
+    DispatchQueue.main.async {
+      stalled.signal()
+      released.wait()
+    }
+    #expect(stalled.wait(timeout: .now() + 5) == .success)
+
+    let ranBody = BoolBox()
+    let answered = DispatchSemaphore(value: 0)
+    DispatchQueue.global().async {
+      _ = pipMainActorSyncBounded(timeout: .milliseconds(50), fallback: true) {
+        ranBody.set(true)
+        return false
+      }
+      answered.signal()
+    }
+
+    #expect(answered.wait(timeout: .now() + 3) == .success, "the bounded hop never returned")
+
+    // Let the main thread drain, then confirm the abandoned body was skipped.
+    released.signal()
+    let drained = DispatchSemaphore(value: 0)
+    DispatchQueue.main.async { drained.signal() }
+    #expect(drained.wait(timeout: .now() + 5) == .success)
+
+    #expect(
+      !ranBody.get(),
+      "the body ran after the caller had already given up and returned the fallback"
+    )
+  }
 }
 
+/// `Mutex` is non-copyable, so a value shared between two escaping closures
+/// needs a reference box.
+private final class BoolBox: Sendable {
+  private let storage = Mutex(false)
+  func set(_ value: Bool) {
+    storage.withLock { $0 = value }
+  }
+
+  func get() -> Bool {
+    storage.withLock { $0 }
+  }
+}
 #endif


### PR DESCRIPTION
Closes #86.

## Root cause

Every PiP callback went through `DispatchQueue.main.sync`:

```swift
func pipMainActorSync<T: Sendable>(_ body: @MainActor @Sendable () -> T) -> T {
  if Thread.isMainThread { return MainActor.assumeIsolated(body) }
  return DispatchQueue.main.sync { MainActor.assumeIsolated(body) }
}
```

AVKit and AppKit invoke these from their own threads, which closes a deadlock cycle: the main thread routinely waits on libVLC or video-output teardown, that teardown can be gated behind the very callback thread, and the callback thread is parked waiting for main. PiP close, media replacement, drawable teardown and lifecycle transitions could all wedge.

Eighteen call sites across three files were on that path.

## The fix

**Void callbacks enqueue instead of blocking.** The six `AVPictureInPictureControllerDelegate` lifecycle hooks, `setPlaying`, `skip`, render-size transitions, and the mac-private and iOS-native variants now use `pipMainActorAsync`. That removes the callback-waits-for-main edge, so no cycle can form. They capture `self` weakly — a queued closure should not keep the controller alive.

**Queries are served without touching the main actor.** `PiPCallbackSnapshot` holds the player handle, control timebase and playback flag behind a lock that never calls libVLC, never touches the main actor, and never runs caller-supplied code — so it cannot form a lock-ordering cycle of its own. A query takes the whole snapshot in **one acquisition**, which is what makes "no query mixes generations" structural rather than incidental, and calls libVLC only after releasing it. The snapshot is invalidated *before* the native handle is relinquished, so an in-flight callback cannot interrogate a handle being torn down.

**Playback intent is mirrored into a nonisolated `Atomic` on `Player`,** updated synchronously in `publishPlaybackIntent`. The macOS media controller reads that directly rather than the snapshot: intent can change on the main actor an instant before AppKit asks, and a snapshot republished afterwards would answer with the previous value. (An `AsyncStream`-based mirror was tried first and failed exactly that way.)

## The one blocking hop that survives, deliberately

AppKit's close veto (`pipShouldClose`) has to reparent the replacement window on the main actor *before* it returns — it cannot be answered from a snapshot without changing behaviour. It now uses a **bounded** wait that degrades to allowing the close rather than joining a wedged main actor. A deadlock becomes a graceful default.

## Validation

**The tests were verified to catch the original behaviour.** Restoring the blocking hop for the two queries fails both forward-progress tests — they sit unanswered until their timeout while the main thread is held:

```
Expectation failed: progressed   // paused query
Expectation failed: progressed   // time-range query
```

| | Result |
|---|---|
| Full suite | 1680 tests, 141 suites — pass |
| TSan (PiP + race + stress) | 192 tests — pass |
| `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` | 0 warnings |
| swiftformat / swiftlint | clean |

The forward-progress tests genuinely block the main thread and assert the query returns anyway, so they exercise the actual deadlock condition rather than a proxy for it. They run in CI.

## Remaining risks

- **Callback ordering changed.** Void callbacks now run after the AVKit method returns rather than during it. They were already `-> Void` and AVKit does not document ordering guarantees between them, but an app that assumed a lifecycle hook had completed by the time AVKit's call returned would see different timing. Worth a release note.
- The acceptance criteria list device scenarios (attach, start, stop, replacement, detach, rotation, background, foreground under forced stalls). Verified here at the callback level with a genuinely blocked main thread; PiP is force-disabled in the simulator, so the end-to-end device sweep is still outstanding.
- The bounded veto is a mitigation, not an elimination. 250 ms is a judgement call — long enough for a healthy main actor, short enough not to hang the window server.
