### PR TITLE
Converge PiP capability from generation-scoped polled values (#75)

### DIFF
--- a/Sources/SwiftVLC/PiP/PiPController+PlaybackState.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+PlaybackState.swift
@@ -17,6 +17,17 @@ extension PiPController {
   struct PlaybackStateObservationState {
     private(set) var durationMilliseconds: Int64?
     private(set) var isSeekable: Bool
+    /// The capability generation current when this media was adopted.
+    private var generationAtReset: UInt64?
+    /// Whether `Player`'s capability values are known to describe *this*
+    /// media. False between seeing a media change and seeing evidence that
+    /// `Player` has processed the same change.
+    private var trustsPolledCapability = true
+    /// Set once a payload has reported the value for this media. A payload is
+    /// authoritative for its generation; the polled mirror may only fill in
+    /// what no payload has covered, never contradict one.
+    private var hasDurationPayload = false
+    private var hasSeekablePayload = false
 
     init(duration: Duration?, isSeekable: Bool) {
       durationMilliseconds = duration?.milliseconds
@@ -25,8 +36,7 @@ extension PiPController {
 
     mutating func consume(
       _ event: PlayerEvent,
-      observedDuration _: Duration?,
-      observedIsSeekable _: Bool
+      capability: PlayerCapabilitySnapshot
     ) -> PlaybackStateUpdate {
       switch event {
       case .mediaChanged:
@@ -35,16 +45,27 @@ extension PiPController {
         // the previous media's values.
         durationMilliseconds = nil
         isSeekable = false
+        hasDurationPayload = false
+        hasSeekablePayload = false
+        generationAtReset = capability.generation
+        // If the snapshot already holds the reset values, `Player` has
+        // processed this same media change and its capability can be trusted
+        // straight away — the common case, since `load(_:)` resets
+        // synchronously. Otherwise the snapshot still describes the outgoing
+        // media and must be ignored until the generation moves on.
+        trustsPolledCapability = capability.isReset
         return PlaybackStateUpdate(
           invalidatesPlaybackState: true,
           requiresLinearPlayback: true
         )
 
       case .lengthChanged(let duration):
+        hasDurationPayload = true
         durationMilliseconds = duration.milliseconds
         return PlaybackStateUpdate(invalidatesPlaybackState: true)
 
       case .seekableChanged(let seekable):
+        hasSeekablePayload = true
         isSeekable = seekable
         return PlaybackStateUpdate(
           invalidatesPlaybackState: true,
@@ -55,11 +76,61 @@ extension PiPController {
         // State transitions are the only payload-free fallback that can
         // affect availability. Invalidate so AVKit re-queries the retained
         // native media snapshot instead of copying a potentially stale mirror.
-        return PlaybackStateUpdate(invalidatesPlaybackState: true)
+        //
+        // They are also where convergence happens: `Player` polls duration and
+        // seekability on every transition precisely because libVLC does not
+        // reliably emit the change events. Reacting only to those events left
+        // finite seekable VOD pinned to the conservative media-changed reset —
+        // linear playback with no skip controls.
+        return reconcile(with: capability, invalidates: true)
+
+      case .timeChanged:
+        // `Player` polls from its own `.timeChanged` handler too, and does so
+        // exactly while duration or seekability are still unknown. Steady
+        // playback can run without another state transition, so convergence
+        // has to be reachable from a clock tick as well.
+        //
+        // `invalidates: false` because this fires at the clock rate: it must
+        // publish only when a value genuinely changed.
+        return reconcile(with: capability, invalidates: false)
 
       default:
         return PlaybackStateUpdate()
       }
+    }
+
+    /// Folds `Player`'s polled capability into this snapshot, when it can be
+    /// shown to describe the same media.
+    private mutating func reconcile(
+      with capability: PlayerCapabilitySnapshot,
+      invalidates: Bool
+    )
+      -> PlaybackStateUpdate {
+      var update = PlaybackStateUpdate(invalidatesPlaybackState: invalidates)
+
+      if !trustsPolledCapability {
+        // The generation moving past the one seen at the reset is the proof
+        // that `Player` has processed the media change; its capability now
+        // describes this media rather than the outgoing one.
+        guard capability.generation != generationAtReset else { return update }
+        trustsPolledCapability = true
+      }
+
+      if
+        !hasDurationPayload,
+        let milliseconds = capability.durationMilliseconds,
+        milliseconds != durationMilliseconds {
+        durationMilliseconds = milliseconds
+        update.invalidatesPlaybackState = true
+      }
+
+      if !hasSeekablePayload, capability.isSeekable != isSeekable {
+        isSeekable = capability.isSeekable
+        update.requiresLinearPlayback = !capability.isSeekable
+        update.invalidatesPlaybackState = true
+      }
+
+      return update
     }
   }
 

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -772,8 +772,7 @@ public final class PiPController: NSObject {
         let rate = player.rate
         let playbackStateUpdate = playbackStateObservation.consume(
           event,
-          observedDuration: player.duration,
-          observedIsSeekable: player.isSeekable
+          capability: player.capabilitySnapshot.withLock { $0 }
         )
         applyObservedPlaybackStateUpdate(playbackStateUpdate)
 

--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -310,9 +310,11 @@ extension Player {
     // New media, new timeline: clock samples still queued from the previous
     // one describe a media that is no longer loaded and must not be applied.
     acceptedTimelineRevision = eventBridge.advanceTimelineRevision()
-    // New media, new capability generation. Bumped together with the reset so
-    // a reader never sees the new generation alongside the old values.
-    advanceCapabilityGeneration()
+    // `duration` and `isSeekable` publish the capability snapshot from their
+    // own `didSet`, so clearing them one at a time would briefly expose
+    // "duration cleared, seekability still the previous media's". Suppress
+    // those partial publishes and emit one atomic snapshot below.
+    isSuppressingCapabilityPublish = true
     pauseTransition = nil
     deferredPauseCommand = nil
     publishPlaybackIntent(false)
@@ -326,6 +328,12 @@ extension Player {
     withMutation(keyPath: \.position) {
       _position = 0
     }
+    isSuppressingCapabilityPublish = false
+    // New media, new capability generation. The bump and the reset values are
+    // written under one lock acquisition, so a reader can never see the new
+    // generation carrying the outgoing media's capability — which would make
+    // it distrust the poll for the rest of that media's lifetime.
+    advanceCapabilityGeneration()
   }
 
   /// Signals every observable whose value is read live from libVLC and

--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -310,6 +310,9 @@ extension Player {
     // New media, new timeline: clock samples still queued from the previous
     // one describe a media that is no longer loaded and must not be applied.
     acceptedTimelineRevision = eventBridge.advanceTimelineRevision()
+    // New media, new capability generation. Bumped together with the reset so
+    // a reader never sees the new generation alongside the old values.
+    advanceCapabilityGeneration()
     pauseTransition = nil
     deferredPauseCommand = nil
     publishPlaybackIntent(false)

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -429,6 +429,10 @@ public final class Player {
   /// for consumers that must not mistake the previous media's capability for
   /// the current one. See ``PlayerCapabilitySnapshot``.
   nonisolated let capabilitySnapshot = Mutex(PlayerCapabilitySnapshot())
+  /// Set while a multi-property capability change is in progress, so the
+  /// per-property `didSet` publishes do not expose an intermediate mix of the
+  /// outgoing and incoming media. See ``resetMediaDerivedState()``.
+  @ObservationIgnored var isSuppressingCapabilityPublish = false
   var eventTask: Task<Void, Never>?
   var _position: Double = 0
   var _equalizer: Equalizer?

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -36,10 +36,14 @@ public final class Player {
   public internal(set) var currentTime: Duration = .zero
 
   /// Total media duration (nil until known).
-  public internal(set) var duration: Duration?
+  public internal(set) var duration: Duration? {
+    didSet { publishCapabilitySnapshot() }
+  }
 
   /// Whether the current media is seekable.
-  public internal(set) var isSeekable: Bool = false
+  public internal(set) var isSeekable: Bool = false {
+    didSet { publishCapabilitySnapshot() }
+  }
 
   /// Whether the current media can be paused.
   public internal(set) var isPausable: Bool = false
@@ -421,6 +425,10 @@ public final class Player {
   /// main actor is what lets a teardown already waiting on them deadlock, so
   /// the value they need is published here and read atomically instead.
   nonisolated let nonisolatedPlaybackIntent = Atomic<Bool>(false)
+  /// Duration and seekability tagged with the media generation they describe,
+  /// for consumers that must not mistake the previous media's capability for
+  /// the current one. See ``PlayerCapabilitySnapshot``.
+  nonisolated let capabilitySnapshot = Mutex(PlayerCapabilitySnapshot())
   var eventTask: Task<Void, Never>?
   var _position: Double = 0
   var _equalizer: Equalizer?

--- a/Sources/SwiftVLC/Player/PlayerCapabilitySnapshot.swift
+++ b/Sources/SwiftVLC/Player/PlayerCapabilitySnapshot.swift
@@ -1,0 +1,55 @@
+import Synchronization
+
+/// Duration and seekability tagged with the media generation they describe.
+///
+/// ``Player`` repairs both by polling, because libVLC does not reliably emit
+/// `MediaPlayerSeekableChanged` or `MediaPlayerLengthChanged`. Consumers that
+/// react only to those raw events therefore miss capability the poll
+/// discovered — but they cannot simply read `Player`'s observable mirror
+/// either, because `Player` and its consumers process the same native event on
+/// independent schedules, so the mirror can still describe the *previous*
+/// media.
+///
+/// The generation resolves that: a reader can tell whether the values in front
+/// of it belong to the media it currently believes is loaded, instead of
+/// guessing from arrival order.
+struct PlayerCapabilitySnapshot: Sendable, Equatable {
+  /// Bumped whenever the loaded media changes.
+  var generation: UInt64 = 0
+  var durationMilliseconds: Int64?
+  var isSeekable = false
+
+  /// Whether these are the conservative values a media starts at.
+  ///
+  /// Seeing this immediately after a media change is how a reader knows
+  /// `Player` has already processed that change, rather than still holding the
+  /// outgoing media's capability.
+  var isReset: Bool {
+    durationMilliseconds == nil && !isSeekable
+  }
+}
+
+extension Player {
+  /// Republishes ``duration`` and ``isSeekable`` under the current generation.
+  func publishCapabilitySnapshot() {
+    let milliseconds = duration?.milliseconds
+    let seekable = isSeekable
+    capabilitySnapshot.withLock { snapshot in
+      snapshot.durationMilliseconds = milliseconds
+      snapshot.isSeekable = seekable
+    }
+  }
+
+  /// Starts a new capability generation with the conservative values.
+  ///
+  /// Called from ``resetMediaDerivedState()``, so the bump and the reset are
+  /// atomic from a reader's point of view: there is no window in which the new
+  /// generation is visible alongside the previous media's values.
+  func advanceCapabilityGeneration() {
+    capabilitySnapshot.withLock { snapshot in
+      snapshot.generation &+= 1
+      snapshot.durationMilliseconds = nil
+      snapshot.isSeekable = false
+    }
+  }
+}

--- a/Sources/SwiftVLC/Player/PlayerCapabilitySnapshot.swift
+++ b/Sources/SwiftVLC/Player/PlayerCapabilitySnapshot.swift
@@ -31,7 +31,12 @@ struct PlayerCapabilitySnapshot: Sendable, Equatable {
 
 extension Player {
   /// Republishes ``duration`` and ``isSeekable`` under the current generation.
+  ///
+  /// A no-op while a multi-property change is in flight: publishing after each
+  /// individual assignment would let a reader observe one media's duration
+  /// beside another's seekability.
   func publishCapabilitySnapshot() {
+    guard !isSuppressingCapabilityPublish else { return }
     let milliseconds = duration?.milliseconds
     let seekable = isSeekable
     capabilitySnapshot.withLock { snapshot in

--- a/Tests/SwiftVLCTests/PiP/PiPPlaybackStateTransitionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPPlaybackStateTransitionTests.swift
@@ -14,8 +14,11 @@ import Testing
 
     let update = state.consume(
       .mediaChanged,
-      observedDuration: nil,
-      observedIsSeekable: false
+      capability: PlayerCapabilitySnapshot(
+        generation: 1,
+        durationMilliseconds: nil,
+        isSeekable: false
+      )
     )
 
     #expect(update.invalidatesPlaybackState)
@@ -32,8 +35,11 @@ import Testing
 
     let update = state.consume(
       .mediaChanged,
-      observedDuration: .seconds(120),
-      observedIsSeekable: true
+      capability: PlayerCapabilitySnapshot(
+        generation: 1,
+        durationMilliseconds: Duration.seconds(120).milliseconds,
+        isSeekable: true
+      )
     )
 
     #expect(update.invalidatesPlaybackState)
@@ -51,8 +57,11 @@ import Testing
 
     let becameSeekable = state.consume(
       .seekableChanged(true),
-      observedDuration: nil,
-      observedIsSeekable: false
+      capability: PlayerCapabilitySnapshot(
+        generation: 1,
+        durationMilliseconds: nil,
+        isSeekable: false
+      )
     )
     #expect(becameSeekable.invalidatesPlaybackState)
     #expect(becameSeekable.requiresLinearPlayback == false)
@@ -61,8 +70,11 @@ import Testing
 
     let becameLinear = state.consume(
       .seekableChanged(false),
-      observedDuration: nil,
-      observedIsSeekable: true
+      capability: PlayerCapabilitySnapshot(
+        generation: 1,
+        durationMilliseconds: nil,
+        isSeekable: true
+      )
     )
     #expect(becameLinear.invalidatesPlaybackState)
     #expect(becameLinear.requiresLinearPlayback == true)
@@ -79,24 +91,33 @@ import Testing
 
     let payloadUpdate = state.consume(
       .seekableChanged(true),
-      observedDuration: nil,
-      observedIsSeekable: false
+      capability: PlayerCapabilitySnapshot(
+        generation: 1,
+        durationMilliseconds: nil,
+        isSeekable: false
+      )
     )
     #expect(payloadUpdate.invalidatesPlaybackState)
     #expect(payloadUpdate.requiresLinearPlayback == false)
 
     let whileStale = state.consume(
       .timeChanged(.seconds(1)),
-      observedDuration: nil,
-      observedIsSeekable: false
+      capability: PlayerCapabilitySnapshot(
+        generation: 1,
+        durationMilliseconds: nil,
+        isSeekable: false
+      )
     )
     #expect(whileStale == PiPController.PlaybackStateUpdate())
     #expect(state.isSeekable)
 
     let mirrorCaughtUp = state.consume(
       .timeChanged(.seconds(2)),
-      observedDuration: nil,
-      observedIsSeekable: true
+      capability: PlayerCapabilitySnapshot(
+        generation: 1,
+        durationMilliseconds: nil,
+        isSeekable: true
+      )
     )
     #expect(mirrorCaughtUp == PiPController.PlaybackStateUpdate())
     #expect(state.isSeekable)
@@ -111,13 +132,19 @@ import Testing
 
     _ = state.consume(
       .mediaChanged,
-      observedDuration: .seconds(120),
-      observedIsSeekable: true
+      capability: PlayerCapabilitySnapshot(
+        generation: 1,
+        durationMilliseconds: Duration.seconds(120).milliseconds,
+        isSeekable: true
+      )
     )
     let whileStale = state.consume(
       .timeChanged(.zero),
-      observedDuration: .seconds(120),
-      observedIsSeekable: true
+      capability: PlayerCapabilitySnapshot(
+        generation: 1,
+        durationMilliseconds: Duration.seconds(120).milliseconds,
+        isSeekable: true
+      )
     )
 
     #expect(whileStale == PiPController.PlaybackStateUpdate())
@@ -134,8 +161,11 @@ import Testing
 
     let update = state.consume(
       .lengthChanged(.seconds(90)),
-      observedDuration: nil,
-      observedIsSeekable: false
+      capability: PlayerCapabilitySnapshot(
+        generation: 1,
+        durationMilliseconds: nil,
+        isSeekable: false
+      )
     )
 
     #expect(update.invalidatesPlaybackState)
@@ -165,6 +195,185 @@ import Testing
     #expect(nativeRange.isValid)
     #expect(nativeRange.duration.isPositiveInfinity)
     #expect(releaseCount == 1)
+  }
+
+  // MARK: - Capability convergence
+
+  /// The regression this issue is about. libVLC does not reliably emit
+  /// `MediaPlayerSeekableChanged`, so `Player` repairs seekability by polling.
+  /// Reacting only to the raw event left finite seekable VOD pinned to the
+  /// conservative media-changed reset: linear playback, no skip controls.
+  @Test
+  func `Finite seekable VOD converges without a seekable event`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: nil,
+      isSeekable: false
+    )
+    // `Player` has already processed the media change, so the snapshot holds
+    // the reset values under the new generation.
+    _ = state.consume(
+      .mediaChanged,
+      capability: PlayerCapabilitySnapshot(generation: 2)
+    )
+
+    let update = state.consume(
+      .stateChanged(.playing),
+      capability: PlayerCapabilitySnapshot(
+        generation: 2,
+        durationMilliseconds: 600_000,
+        isSeekable: true
+      )
+    )
+
+    #expect(update.requiresLinearPlayback == false, "PiP stayed linear for seekable VOD")
+    assertEffects(of: update, expectedLinearPlayback: false)
+  }
+
+  /// Steady playback can run without another state transition, so convergence
+  /// has to be reachable from a clock tick too.
+  @Test
+  func `Capability converges on a clock tick`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: nil,
+      isSeekable: false
+    )
+    _ = state.consume(
+      .mediaChanged,
+      capability: PlayerCapabilitySnapshot(generation: 2)
+    )
+
+    let update = state.consume(
+      .timeChanged(.seconds(5)),
+      capability: PlayerCapabilitySnapshot(
+        generation: 2,
+        durationMilliseconds: 600_000,
+        isSeekable: true
+      )
+    )
+
+    #expect(update.requiresLinearPlayback == false)
+    assertEffects(of: update, expectedLinearPlayback: false)
+  }
+
+  /// **The case that broke my first attempt.** A state transition arriving
+  /// before `Player` has processed the media change must not resurrect the
+  /// previous media's capability — the generation is what proves the snapshot
+  /// is still describing the outgoing media.
+  @Test
+  func `A stale mirror does not resurrect capability on a state transition`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: .seconds(120),
+      isSeekable: true
+    )
+    let stale = PlayerCapabilitySnapshot(
+      generation: 1,
+      durationMilliseconds: 120_000,
+      isSeekable: true
+    )
+    _ = state.consume(.mediaChanged, capability: stale)
+
+    let update = state.consume(.stateChanged(.opening), capability: stale)
+
+    #expect(update.requiresLinearPlayback == nil, "stale capability was adopted")
+    #expect(state.durationMilliseconds == nil)
+    #expect(!state.isSeekable)
+  }
+
+  /// Once the generation moves past the reset, the same values are the *new*
+  /// media's and must be adopted.
+  @Test
+  func `Capability is adopted once the generation moves on`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: .seconds(120),
+      isSeekable: true
+    )
+    _ = state.consume(
+      .mediaChanged,
+      capability: PlayerCapabilitySnapshot(
+        generation: 1,
+        durationMilliseconds: 120_000,
+        isSeekable: true
+      )
+    )
+
+    let update = state.consume(
+      .stateChanged(.playing),
+      capability: PlayerCapabilitySnapshot(
+        generation: 2,
+        durationMilliseconds: 300_000,
+        isSeekable: true
+      )
+    )
+
+    #expect(update.requiresLinearPlayback == false)
+    #expect(state.durationMilliseconds == 300_000)
+  }
+
+  /// Unseekable live media must stay linear: convergence must not invent
+  /// capability the media does not have.
+  @Test
+  func `Unseekable live media stays linear`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: nil,
+      isSeekable: false
+    )
+    _ = state.consume(
+      .mediaChanged,
+      capability: PlayerCapabilitySnapshot(generation: 2)
+    )
+
+    let update = state.consume(
+      .stateChanged(.playing),
+      capability: PlayerCapabilitySnapshot(generation: 2)
+    )
+
+    #expect(update.requiresLinearPlayback == nil, "linear playback was republished")
+    assertEffects(of: update, expectedLinearPlayback: nil)
+  }
+
+  /// A clock tick on a converged snapshot must produce nothing — invalidating
+  /// AVKit at the clock rate would be worse than the bug being fixed.
+  @Test
+  func `A clock tick on a converged snapshot produces no update`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: .seconds(600),
+      isSeekable: true
+    )
+
+    let update = state.consume(
+      .timeChanged(.seconds(5)),
+      capability: PlayerCapabilitySnapshot(
+        generation: 1,
+        durationMilliseconds: 600_000,
+        isSeekable: true
+      )
+    )
+
+    #expect(update == PiPController.PlaybackStateUpdate())
+  }
+
+  /// A poll that has not learned the length must not undo a length event that
+  /// already arrived, or the two sources fight each other.
+  @Test
+  func `A polled nil duration does not clear a length payload`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: nil,
+      isSeekable: true
+    )
+    _ = state.consume(
+      .lengthChanged(.seconds(420)),
+      capability: PlayerCapabilitySnapshot(generation: 1, isSeekable: true)
+    )
+
+    _ = state.consume(
+      .stateChanged(.playing),
+      capability: PlayerCapabilitySnapshot(generation: 1, isSeekable: true)
+    )
+
+    #expect(
+      state.durationMilliseconds == 420_000,
+      "a polled nil duration erased a length the media had already reported"
+    )
   }
 
   private func assertEffects(

--- a/Tests/SwiftVLCTests/Player/PlayerCapabilitySnapshotTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerCapabilitySnapshotTests.swift
@@ -1,0 +1,84 @@
+@testable import SwiftVLC
+import Synchronization
+import Testing
+
+/// The snapshot is a `nonisolated` `Mutex` so consumers that cannot hop to the
+/// main actor — AVKit's synchronous PiP queries, most of all — can read it.
+/// That makes the atomicity of each publish a real contract rather than an
+/// incidental property of the current call sites.
+@Suite(.tags(.logic, .mainActor))
+@MainActor struct PlayerCapabilitySnapshotTests {
+  @Test
+  func `Publishing mirrors duration and seekability`() {
+    let player = Player(instance: TestInstance.shared)
+
+    player._setStateForTesting(duration: .seconds(120), isSeekable: true)
+
+    let snapshot = player.capabilitySnapshot.withLock { $0 }
+    #expect(snapshot.durationMilliseconds == 120_000)
+    #expect(snapshot.isSeekable)
+    #expect(!snapshot.isReset)
+  }
+
+  /// The invariant ``PlayerCapabilitySnapshot/isReset`` exists to prove: a
+  /// reader seeing the new generation must see the conservative values with it.
+  @Test
+  func `A media reset publishes the new generation with reset values`() {
+    let player = Player(instance: TestInstance.shared)
+
+    player._setStateForTesting(duration: .seconds(120), isSeekable: true)
+    let before = player.capabilitySnapshot.withLock { $0 }
+
+    player.resetMediaDerivedState()
+
+    let after = player.capabilitySnapshot.withLock { $0 }
+    #expect(after.generation == before.generation &+ 1)
+    #expect(after.durationMilliseconds == nil)
+    #expect(after.isSeekable == false)
+    #expect(after.isReset)
+  }
+
+  /// `duration` and `isSeekable` publish from their own `didSet`, so clearing
+  /// them one at a time would otherwise expose "this media's duration beside
+  /// the previous one's seekability". A PiP observer that sampled such a
+  /// snapshot right after a media change would find `isReset` false, conclude
+  /// `Player` had not yet processed the change, and distrust the polled
+  /// capability for the rest of that media — leaving finite seekable VOD
+  /// pinned to linear playback with no skip controls, which is the very
+  /// regression this snapshot was introduced to fix.
+  @Test
+  func `A partial capability change does not reach readers`() {
+    let player = Player(instance: TestInstance.shared)
+
+    player._setStateForTesting(duration: .seconds(120), isSeekable: true)
+
+    player.isSuppressingCapabilityPublish = true
+    player.duration = nil
+    defer { player.isSuppressingCapabilityPublish = false }
+
+    let midChange = player.capabilitySnapshot.withLock { $0 }
+    #expect(
+      midChange.durationMilliseconds == 120_000,
+      "a half-applied capability change was published"
+    )
+    #expect(midChange.isSeekable)
+  }
+
+  /// Suppression must not swallow the change permanently: the reset publishes
+  /// the whole new state in one lock acquisition once the flag clears.
+  @Test
+  func `Publishing resumes once suppression clears`() {
+    let player = Player(instance: TestInstance.shared)
+
+    player.isSuppressingCapabilityPublish = true
+    player._setStateForTesting(duration: .seconds(90), isSeekable: true)
+    #expect(player.capabilitySnapshot.withLock { $0 }.isReset)
+
+    player.isSuppressingCapabilityPublish = false
+    player.publishCapabilitySnapshot()
+
+    let snapshot = player.capabilitySnapshot.withLock { $0 }
+    #expect(snapshot.durationMilliseconds == 90000)
+    #expect(snapshot.isSeekable)
+  }
+}


### PR DESCRIPTION
Closes #75. Supersedes #112, which I marked draft after finding it introduced a regression.

## Root cause

libVLC does not reliably emit `MediaPlayerSeekableChanged` or `LengthChanged`, so `Player` repairs both by *polling* on every state transition. The PiP observer updated its capability snapshot only from the raw change events, so when the seekable event never arrived, finite seekable VOD stayed pinned to the conservative `.mediaChanged` reset — linear playback, no skip controls, indefinitely.

## Why the obvious fix is wrong

My first attempt (#112) simply read `Player`'s observable mirror. That is unsound: `Player` and the PiP observer consume the same native event on independent schedules, so a transition arriving *before* `Player` has processed the media change resurrects the previous media's capability.

Two existing tests already guarded exactly that for `.timeChanged`. The same hazard applied to `.stateChanged`, where nothing covered it — which is how it slipped through:

```
consume(.mediaChanged,            observed: 120s, seekable: true)
consume(.stateChanged(.opening),  observed: 120s, seekable: true)
→ requiresLinearPlayback == false   (expected nil)
→ durationMilliseconds  == 120000   (expected nil)
```

Reconciling from the mirror and ignoring the mirror are both correct requirements, and **they cannot both be satisfied from the mirror alone** — arrival order cannot distinguish "polling repaired this media" from "the mirror still describes the previous one".

## The fix

`Player` publishes duration and seekability tagged with a **media generation**, bumped atomically with the reset inside `resetMediaDerivedState()`, so a reader never sees a new generation beside the outgoing media's values.

The observer adopts polled capability only once it can *show* the values describe the current media:

- the snapshot already held the reset values when the media change arrived — meaning `Player` had processed the same change, which is the common `load(_:)` path, since that resets synchronously; **or**
- the generation has moved past the one seen at the reset.

**Within a generation, payloads stay authoritative.** A `.seekableChanged` or `.lengthChanged` payload marks its value covered, and the poll may only fill in what no payload reported, never contradict one. That is what keeps both pre-existing staleness guarantees intact rather than trading one bug for another.

Convergence also runs on `.timeChanged`, where `Player` polls precisely while duration or seekability are unknown, with `invalidates: false` so a converged snapshot does not invalidate AVKit at the clock rate.

Both PiP backends pick this up for free: `PiPController` is the single `consume` call site and routes the result through `applyPlaybackStateUpdate`, whose `setRequiresLinearPlayback` closure reaches the iOS native controller.

## Validation

**Removing convergence fails three tests**, including finite seekable VOD publishing no `requiresLinearPlayback` value at all:

```
Expectation failed: (update.requiresLinearPlayback → nil) == false
Expectation failed: (linearPlaybackValues → []) == [false]
```

**The stale-mirror test passes in both states — that is the point.** It exists to guard the regression the first attempt introduced, not to prove the convergence.

| | Result |
|---|---|
| Full suite | 1688 tests, 141 suites — pass |
| PiP state transitions | 14 tests — pass (all 7 pre-existing, unmodified in intent) |
| iOS Simulator build (`xcodebuild`) | clean |
| `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` | 0 warnings |
| swiftformat / swiftlint | clean |

## Remaining risks

- **Needs device verification.** The acceptance criteria describe device outcomes (working skip controls; VOD → live → VOD on both backends). This is verified at the state-machine level both backends consume; PiP is force-disabled in the simulator, so I cannot confirm end to end.
- There remains a brief window on the engine-initiated media-change path where PiP holds the conservative reset until the generation advances. That is deliberate: showing linear playback for a moment is the safe failure, and it self-corrects on the next event.
