### PR TITLE
Bound deferred PiP pause retries and reconcile playback intent (#103)

### DIFF
--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -211,7 +211,6 @@ public final class PiPController: NSObject {
   @ObservationIgnored
   private var deferredPause: DeferredPauseState = .idle
 
-  /// State of PiP's pause-debouncing state machine. See ``deferredPause``.
   /// How a deferred PiP pause finished.
   ///
   /// Not surfaced on ``PiPEvent`` because that is a public non-frozen enum and
@@ -230,8 +229,9 @@ public final class PiPController: NSObject {
     case rejected
   }
 
-  /// The outcome of the most recent deferred pause. Internal rather than
-  /// public: it exists so the bound and the reconciliation are assertable.
+  /// The outcome of the most recent deferred pause, or `nil` while one is in
+  /// flight. Internal rather than public: it exists so the bound and the
+  /// reconciliation are assertable.
   @ObservationIgnored
   private(set) var deferredPauseOutcome: DeferredPauseOutcome?
 
@@ -677,6 +677,11 @@ public final class PiPController: NSObject {
     if case .scheduled(let task, _) = deferredPause {
       task.cancel()
       deferredPause = .idle
+      // A pause that is cancelled before it can be issued is a cancellation,
+      // whichever caller cancelled it. `scheduleDeferredPause` clears this
+      // again straight afterwards, so a supersede reads as "in flight"
+      // rather than as the superseded attempt's outcome.
+      deferredPauseOutcome = .cancelled
     }
   }
 
@@ -686,6 +691,10 @@ public final class PiPController: NSObject {
   /// `.issued`) or exits cleanly (transitioning back to `.idle`).
   private func scheduleDeferredPause() {
     cancelDeferredPause()
+    // A new attempt is in flight and has not finished yet. Without this the
+    // previous attempt's outcome would stay readable for the whole debounce,
+    // so a reader could not tell a settled result from a stale one.
+    deferredPauseOutcome = nil
 
     let generation = DeferredPauseState.nextGeneration(after: deferredPause)
     let debounce = pauseDebounce

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -212,6 +212,29 @@ public final class PiPController: NSObject {
   private var deferredPause: DeferredPauseState = .idle
 
   /// State of PiP's pause-debouncing state machine. See ``deferredPause``.
+  /// How a deferred PiP pause finished.
+  ///
+  /// Not surfaced on ``PiPEvent`` because that is a public non-frozen enum and
+  /// adding a case would be source-breaking for exhaustive switches. The
+  /// user-visible half of the outcome is reconciled onto
+  /// ``Player/isPlaybackRequestedActive`` instead, which is already
+  /// observable.
+  enum DeferredPauseOutcome: Equatable {
+    /// libVLC accepted the pause.
+    case issued
+    /// Superseded, or the session left a pausable state before it could be
+    /// issued.
+    case cancelled
+    /// The input never became pausable within the retry bound. Playback keeps
+    /// running and the published intent is reconciled back to active.
+    case rejected
+  }
+
+  /// The outcome of the most recent deferred pause. Internal rather than
+  /// public: it exists so the bound and the reconciliation are assertable.
+  @ObservationIgnored
+  private(set) var deferredPauseOutcome: DeferredPauseOutcome?
+
   fileprivate enum DeferredPauseState {
     /// No deferred pause in flight; libVLC matches PiP intent.
     case idle
@@ -667,6 +690,7 @@ public final class PiPController: NSObject {
     let generation = DeferredPauseState.nextGeneration(after: deferredPause)
     let debounce = pauseDebounce
     let task = Task { @MainActor [weak self] in
+      var attemptsRemaining = Self.maxDeferredPauseAttempts
       while !Task.isCancelled {
         do {
           try await Task.sleep(for: debounce)
@@ -683,20 +707,53 @@ public final class PiPController: NSObject {
         case .playing:
           if playbackDriver.pause() {
             deferredPause = .issued
+            deferredPauseOutcome = .issued
             return
           }
-          continue
+          // libVLC refused. Retry, but not forever.
+          attemptsRemaining -= 1
         case .opening, .buffering:
           // Avoid pausing libVLC while it is still stabilizing input state.
-          // Keep waiting unless AVKit changes its mind first.
-          continue
+          // Keep waiting unless AVKit changes its mind first — bounded, so an
+          // input that never stabilizes cannot retry indefinitely.
+          attemptsRemaining -= 1
         default:
           deferredPause = .idle
+          deferredPauseOutcome = .cancelled
+          return
+        }
+
+        if attemptsRemaining <= 0 {
+          deferredPause = .idle
+          settleUnpausableInput()
           return
         }
       }
     }
     deferredPause = .scheduled(task: task, generation: generation)
+  }
+
+  /// How many debounce intervals a deferred pause may retry before the input
+  /// is treated as unpausable.
+  ///
+  /// At the default 250 ms debounce this is ten seconds — long enough for a
+  /// slow network open to stabilize, short enough that a permanently
+  /// unpausable input does not leave a paused UI over continuing playback
+  /// indefinitely.
+  static let maxDeferredPauseAttempts = 40
+
+  /// Reconciles after a deferred pause has been abandoned.
+  ///
+  /// The input never became pausable, so playback is still running. The
+  /// public intent was already published as inactive when PiP asked to pause;
+  /// leaving it there would show paused controls over playing media — the
+  /// visible half of this bug. Republish the truth on both surfaces.
+  private func settleUnpausableInput() {
+    deferredPauseOutcome = .rejected
+    guard player.state.isActive else { return }
+    player.setPlaybackIntentFromExternalControl(true)
+    pipPlaybackActive = true
+    invalidatePictureInPicturePlaybackState()
   }
 
   /// The generation id of an in-flight scheduled pause, or 0 if no

--- a/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
@@ -106,6 +106,40 @@ extension Integration {
       #expect(!player.isPlaybackRequestedActive, "a successful pause must leave intent inactive")
     }
 
+    /// The outcome describes the *current* attempt. Leaving a settled value
+    /// visible while a new pause is in flight would let a reader — a test, or
+    /// a future diagnostic — mistake the previous attempt's result for this
+    /// one's, which is exactly the confusion the typed outcome exists to
+    /// remove.
+    @Test
+    func `A newly scheduled pause clears the previous outcome`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = PlaybackRecorder()
+      recorder.pauseSucceeds = true
+      player._setStateForTesting(state: .playing)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(20)
+      )
+
+      // Settle a first pause so there is an outcome to go stale.
+      controller._setPlayingForTesting(false)
+      let settled = await awaitDeferredPauseOutcome(controller)
+      #expect(settled)
+      #expect(controller.deferredPauseOutcome == .issued)
+
+      // Resume, then request another pause. The second attempt is still
+      // debouncing, so no outcome describes it yet.
+      controller._setPlayingForTesting(true)
+      controller._setPlayingForTesting(false)
+
+      #expect(
+        controller.deferredPauseOutcome == nil,
+        "a pause in flight reported the previous attempt's outcome"
+      )
+    }
+
     /// Leaving a pausable state cancels the retry rather than exhausting it.
     @Test
     func `Leaving a playing state cancels the deferred pause`() async {

--- a/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
@@ -17,12 +17,15 @@ extension Integration {
       var cancelPendingPauseCount = 0
       var shouldResume = false
       var seekTargets: [Int64] = []
+      /// Models an input libVLC refuses to pause, so the deferred-pause retry
+      /// bound can be exercised.
+      var pauseSucceeds = true
 
       var driver: PiPController.PlaybackDriver {
         .init(
           pause: {
             self.pauseCount += 1
-            return true
+            return self.pauseSucceeds
           },
           resume: {
             self.resumeCount += 1
@@ -35,6 +38,107 @@ extension Integration {
           seek: { self.seekTargets.append($0.milliseconds) }
         )
       }
+    }
+
+    // MARK: - Deferred pause bounding
+
+    /// A permanently unpausable input used to retry every debounce interval
+    /// forever while the published intent already said inactive — paused
+    /// controls over continuing playback. It must settle to a typed rejection
+    /// within a fixed bound and reconcile the intent back to playing.
+    @Test
+    func `A permanently unpausable input settles to a rejection and stays playing`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = PlaybackRecorder()
+      recorder.pauseSucceeds = false
+      // State first: the controller's observers latch the initial values at
+      // init, so a transition afterwards broadcasts an active intent that
+      // cancels the very pause under test.
+      player._setStateForTesting(state: .playing)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(1)
+      )
+
+      controller._setPlayingForTesting(false)
+      #expect(!player.isPlaybackRequestedActive, "PiP should publish inactive intent immediately")
+
+      let settled = await awaitDeferredPauseOutcome(controller)
+      #expect(settled, "the deferred pause never stopped retrying")
+
+      #expect(controller.deferredPauseOutcome == .rejected)
+      #expect(
+        recorder.pauseCount <= PiPController.maxDeferredPauseAttempts,
+        "retried past the bound: \(recorder.pauseCount)"
+      )
+      #expect(
+        player.isPlaybackRequestedActive,
+        "intent stayed inactive while playback continued — paused UI over playing media"
+      )
+      #expect(controller._pipPlaybackActiveForTesting())
+    }
+
+    /// A rejection that clears must still pause: the bound exists to stop
+    /// runaway retries, not to give up on a slow input.
+    @Test
+    func `A transient rejection still pauses once the input becomes pausable`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = PlaybackRecorder()
+      recorder.pauseSucceeds = false
+      // State first: the controller's observers latch the initial values at
+      // init, so a transition afterwards broadcasts an active intent that
+      // cancels the very pause under test.
+      player._setStateForTesting(state: .playing)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(1)
+      )
+
+      controller._setPlayingForTesting(false)
+      try? await Task.sleep(for: .milliseconds(5))
+      recorder.pauseSucceeds = true
+
+      let settled = await awaitDeferredPauseOutcome(controller)
+      #expect(settled)
+      #expect(controller.deferredPauseOutcome == .issued)
+      #expect(!player.isPlaybackRequestedActive, "a successful pause must leave intent inactive")
+    }
+
+    /// Leaving a pausable state cancels the retry rather than exhausting it.
+    @Test
+    func `Leaving a playing state cancels the deferred pause`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = PlaybackRecorder()
+      recorder.pauseSucceeds = false
+      // State first: the controller's observers latch the initial values at
+      // init, so a transition afterwards broadcasts an active intent that
+      // cancels the very pause under test.
+      player._setStateForTesting(state: .playing)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(1)
+      )
+
+      controller._setPlayingForTesting(false)
+      player._setStateForTesting(state: .stopped)
+
+      let settled = await awaitDeferredPauseOutcome(controller)
+      #expect(settled)
+      #expect(controller.deferredPauseOutcome == .cancelled)
+    }
+
+    private func awaitDeferredPauseOutcome(_ controller: PiPController) async -> Bool {
+      let deadline = ContinuousClock.now + .seconds(5)
+      while controller.deferredPauseOutcome == nil {
+        if ContinuousClock.now >= deadline {
+          return false
+        }
+        try? await Task.sleep(for: .milliseconds(5))
+      }
+      return true
     }
 
     @Test


### PR DESCRIPTION
Closes #103.

## Root cause

`PiPController`'s deferred-pause loop had two `continue` paths with no attempt bound:

- libVLC refused the pause (input still reports `.playing` after the request), and
- the input was still `.opening` or `.buffering`.

Both re-armed the debounce timer unconditionally, so an input that never becomes pausable retried forever. Measured on the original code: **2500 pause attempts in five seconds**.

The second-order problem is worse than the spin. `handleSetPlaying(false)` had already published inactive playback intent before the loop started, so `Player.isPlaybackRequestedActive` read `false` while the media kept playing. PiP showed a paused control set over audible, advancing playback, with nothing to reconcile the two.

## Implementation

Retries are bounded at `maxDeferredPauseAttempts = 40` debounce intervals — ten seconds at the default 250 ms. Long enough to cover a slow network open, short enough that a paused UI cannot sit over playing media indefinitely.

The loop now records a typed `DeferredPauseOutcome`:

- `.issued` — the pause landed (including after a transient rejection).
- `.cancelled` — the session left a playable state, or a new intent superseded it.
- `.rejected` — the bound was exhausted.

On `.rejected` the controller **reconciles rather than just giving up**: if the player is still active it republishes active intent and restores its own `pipPlaybackActive` mirror, then invalidates the PiP playback state. The controls end up telling the truth — playback is running — instead of showing a pause that never happened.

### Why not a new `PiPEvent` case

`PiPEvent` is a public non-frozen enum; adding a case is source-breaking for downstream exhaustive switches, which isn't something to do silently in a minor release. The outcome is internal, and the user-visible half of it surfaces on `Player.isPlaybackRequestedActive`, which is already observable.

## Validation

Three tests, all runnable in CI — the loop reads `Player`'s observable state, so `_setStateForTesting` drives it without live playback:

1. a permanently unpausable input stops at the bound and records `.rejected`, with intent reconciled back to active;
2. a rejection that clears before the bound still pauses normally;
3. leaving a playing state mid-wait records `.cancelled`.

**Discrimination proven** by removing the bound and re-running test 1:

```
Expectation failed: (recorder.pauseCount → 2500) <= (PiPController.maxDeferredPauseAttempts → 40)
```

2500 retries against a bound of 40, and no outcome ever recorded.

Full suite: 1684 tests pass. iOS Simulator build clean. `-strict-concurrency=complete` and SwiftLint clean.

## Remaining risk

The bound is a wall-clock heuristic. An input that legitimately takes more than ten seconds to become pausable would be reported as `.rejected` and left playing — which is still the honest outcome, and strictly better than the previous silent spin, but it is a threshold rather than a proof.

Not device-verified. The reconciliation path (`.rejected` → controls return to playing) is worth a look on hardware with a live stream that refuses to pause.
