### PR TITLE
Fix the adaptive segment source double-recycle (#91)

### DIFF
--- a/scripts/patches/0008-adaptive-segment-double-recycle.patch
+++ b/scripts/patches/0008-adaptive-segment-double-recycle.patch
@@ -1,53 +1,52 @@
-Fix a use-after-free when an encrypted segment's chunk cannot be prepared.
-
-ISegment::toChunk() releases the chunk source twice on the prepareChunk()
-failure path: once explicitly through recycleSource(), and again when it
-deletes the chunk, because ~AbstractChunk() releases the source the chunk
-owns. For ChunkType::Segment, HTTPConnectionManager::recycleSource() is not
-cacheable and falls through to deleteSource() -> delete, so the source is
-already freed by the time ~AbstractChunk() dispatches source->recycle()
-through its vtable.
-
-Reproduced under AddressSanitizer with the accompanying test:
-
-  ERROR: AddressSanitizer: heap-use-after-free
-  READ of size 8
-      #0 adaptive::http::AbstractChunk::~AbstractChunk()   Chunk.cpp:91
-      #1 adaptive::playlist::SegmentChunk::~SegmentChunk() SegmentChunk.cpp:47
-      #2 adaptive::playlist::ISegment::toChunk(...)        Segment.cpp:115
-  freed by thread T0 here:
-      #1 adaptive::playlist::ISegment::toChunk(...)        Segment.cpp:107
-
-That crash site matches the report in VLC #29845 (intermittent EXC_BAD_ACCESS
-in adaptive::http::AbstractChunk::~AbstractChunk on iOS arm64 after roughly
-ten minutes of HLS playback, on the PlaylistManager thread by way of
-SegmentTracker and AbstractStream).
-
-prepareChunk() only does work for encrypted segments and only fails when
-CommonEncryptionSession::start() fails, which for AES-128 HLS means the key
-could not be resolved: the #EXT-X-KEY URI failed to fetch, returned something
-other than 16 bytes, or carried no IV. Keys are cached, so this bites at key
-rotation or after cache eviction rather than at startup -- which matches the
-"fine for ten minutes, then crash" profile of the report. Builds without
-gcrypt are unaffected, since start() then always succeeds.
-
-For Init and Index chunk types the source is cacheable, so the second release
-pushes the same pointer into HTTPConnectionManager::cache twice and inflates
-cache_total, which later double-frees on purge and trips the
-assert(cache_total >= purged->contentLength).
-
-Introduced by ff7e38fe13353889c0f603f883134e75885b20f6 ("adaptive: recycle the
-chunk source when prepareChunk fails"), which modelled this on the
-createChunk() failure branch below it. That branch is correct precisely
-because no chunk was constructed there to own the source.
-
-Still present in VLC master as of 59361740a96.
-
-The test overrides prepareChunk() rather than driving real encryption, so it
-runs regardless of whether the build has gcrypt, and counts releases instead
-of freeing so the double release is a deterministic assertion rather than
-undefined behaviour in non-sanitizer builds.
-
+# Fix a use-after-free when an encrypted segment's chunk cannot be prepared.
+#
+# ISegment::toChunk() releases the chunk source twice on the prepareChunk()
+# failure path: once explicitly through recycleSource(), and again when it
+# deletes the chunk, because ~AbstractChunk() releases the source the chunk
+# owns. For ChunkType::Segment, HTTPConnectionManager::recycleSource() is not
+# cacheable and falls through to deleteSource() -> delete, so the source is
+# already freed by the time ~AbstractChunk() dispatches source->recycle()
+# through its vtable.
+#
+# Reproduced under AddressSanitizer with the accompanying test:
+#
+#   ERROR: AddressSanitizer: heap-use-after-free
+#   READ of size 8
+#       #0 adaptive::http::AbstractChunk::~AbstractChunk()   Chunk.cpp:91
+#       #1 adaptive::playlist::SegmentChunk::~SegmentChunk() SegmentChunk.cpp:47
+#       #2 adaptive::playlist::ISegment::toChunk(...)        Segment.cpp:115
+#   freed by thread T0 here:
+#       #1 adaptive::playlist::ISegment::toChunk(...)        Segment.cpp:107
+#
+# That crash site matches the report in VLC #29845 (intermittent EXC_BAD_ACCESS
+# in adaptive::http::AbstractChunk::~AbstractChunk on iOS arm64 after roughly
+# ten minutes of HLS playback, on the PlaylistManager thread by way of
+# SegmentTracker and AbstractStream).
+#
+# prepareChunk() only does work for encrypted segments and only fails when
+# CommonEncryptionSession::start() fails, which for AES-128 HLS means the key
+# could not be resolved: the #EXT-X-KEY URI failed to fetch, returned something
+# other than 16 bytes, or carried no IV. Keys are cached, so this bites at key
+# rotation or after cache eviction rather than at startup -- which matches the
+# "fine for ten minutes, then crash" profile of the report. Builds without
+# gcrypt are unaffected, since start() then always succeeds.
+#
+# For Init and Index chunk types the source is cacheable, so the second release
+# pushes the same pointer into HTTPConnectionManager::cache twice and inflates
+# cache_total, which later double-frees on purge and trips the
+# assert(cache_total >= purged->contentLength).
+#
+# Introduced by ff7e38fe13353889c0f603f883134e75885b20f6 ("adaptive: recycle the
+# chunk source when prepareChunk fails"), which modelled this on the
+# createChunk() failure branch below it. That branch is correct precisely
+# because no chunk exists there to own the source.
+#
+# Still present in VLC master as of 59361740a96.
+#
+# The test overrides prepareChunk() rather than driving real encryption, so it
+# runs regardless of whether the build has gcrypt, and counts releases instead
+# of freeing so the double release is a deterministic assertion rather than
+# undefined behaviour in non-sanitizer builds.
 diff --git a/modules/demux/Makefile.am b/modules/demux/Makefile.am
 index bf78b53ad99..1a733fc327a 100644
 --- a/modules/demux/Makefile.am
@@ -81,10 +80,10 @@ index 681fb8e575f..2eb0bdeff0b 100644
              }
 diff --git a/modules/demux/adaptive/test/playlist/SegmentChunk.cpp b/modules/demux/adaptive/test/playlist/SegmentChunk.cpp
 new file mode 100644
-index 00000000000..cdbb27ac284
+index 00000000000..ed94001308f
 --- /dev/null
 +++ b/modules/demux/adaptive/test/playlist/SegmentChunk.cpp
-@@ -0,0 +1,143 @@
+@@ -0,0 +1,142 @@
 +/*****************************************************************************
 + * SegmentChunk.cpp: ISegment::toChunk source ownership
 + *****************************************************************************
@@ -123,7 +122,6 @@ index 00000000000..cdbb27ac284
 +#include <vlc_block.h>
 +
 +#include <string>
-+#include <vector>
 +
 +using namespace adaptive;
 +using namespace adaptive::http;

--- a/scripts/patches/0008-adaptive-segment-double-recycle.patch
+++ b/scripts/patches/0008-adaptive-segment-double-recycle.patch
@@ -1,0 +1,253 @@
+Fix a use-after-free when an encrypted segment's chunk cannot be prepared.
+
+ISegment::toChunk() releases the chunk source twice on the prepareChunk()
+failure path: once explicitly through recycleSource(), and again when it
+deletes the chunk, because ~AbstractChunk() releases the source the chunk
+owns. For ChunkType::Segment, HTTPConnectionManager::recycleSource() is not
+cacheable and falls through to deleteSource() -> delete, so the source is
+already freed by the time ~AbstractChunk() dispatches source->recycle()
+through its vtable.
+
+Reproduced under AddressSanitizer with the accompanying test:
+
+  ERROR: AddressSanitizer: heap-use-after-free
+  READ of size 8
+      #0 adaptive::http::AbstractChunk::~AbstractChunk()   Chunk.cpp:91
+      #1 adaptive::playlist::SegmentChunk::~SegmentChunk() SegmentChunk.cpp:47
+      #2 adaptive::playlist::ISegment::toChunk(...)        Segment.cpp:115
+  freed by thread T0 here:
+      #1 adaptive::playlist::ISegment::toChunk(...)        Segment.cpp:107
+
+That crash site matches the report in VLC #29845 (intermittent EXC_BAD_ACCESS
+in adaptive::http::AbstractChunk::~AbstractChunk on iOS arm64 after roughly
+ten minutes of HLS playback, on the PlaylistManager thread by way of
+SegmentTracker and AbstractStream).
+
+prepareChunk() only does work for encrypted segments and only fails when
+CommonEncryptionSession::start() fails, which for AES-128 HLS means the key
+could not be resolved: the #EXT-X-KEY URI failed to fetch, returned something
+other than 16 bytes, or carried no IV. Keys are cached, so this bites at key
+rotation or after cache eviction rather than at startup -- which matches the
+"fine for ten minutes, then crash" profile of the report. Builds without
+gcrypt are unaffected, since start() then always succeeds.
+
+For Init and Index chunk types the source is cacheable, so the second release
+pushes the same pointer into HTTPConnectionManager::cache twice and inflates
+cache_total, which later double-frees on purge and trips the
+assert(cache_total >= purged->contentLength).
+
+Introduced by ff7e38fe13353889c0f603f883134e75885b20f6 ("adaptive: recycle the
+chunk source when prepareChunk fails"), which modelled this on the
+createChunk() failure branch below it. That branch is correct precisely
+because no chunk was constructed there to own the source.
+
+Still present in VLC master as of 59361740a96.
+
+The test overrides prepareChunk() rather than driving real encryption, so it
+runs regardless of whether the build has gcrypt, and counts releases instead
+of freeing so the double release is a deterministic assertion rather than
+undefined behaviour in non-sanitizer builds.
+
+diff --git a/modules/demux/Makefile.am b/modules/demux/Makefile.am
+index bf78b53ad99..1a733fc327a 100644
+--- a/modules/demux/Makefile.am
++++ b/modules/demux/Makefile.am
+@@ -523,6 +523,7 @@ adaptive_test_SOURCES = \
+     demux/adaptive/test/tools/Conversions.cpp \
+     demux/adaptive/test/playlist/Inheritables.cpp \
+     demux/adaptive/test/playlist/M3U8.cpp \
++    demux/adaptive/test/playlist/SegmentChunk.cpp \
+     demux/adaptive/test/playlist/SegmentBase.cpp \
+     demux/adaptive/test/playlist/SegmentList.cpp \
+     demux/adaptive/test/playlist/SegmentTemplate.cpp \
+diff --git a/modules/demux/adaptive/playlist/Segment.cpp b/modules/demux/adaptive/playlist/Segment.cpp
+index 681fb8e575f..2eb0bdeff0b 100644
+--- a/modules/demux/adaptive/playlist/Segment.cpp
++++ b/modules/demux/adaptive/playlist/Segment.cpp
+@@ -104,7 +104,13 @@ SegmentChunk* ISegment::toChunk(SharedResources *res, size_t index, BaseRepresen
+             chunk->discontinuitySequenceNumber = getDiscontinuitySequenceNumber();
+             if(!prepareChunk(res, chunk, rep))
+             {
+-                res->getConnManager()->recycleSource(source);
++                /* Do not recycle the source here: the chunk owns it, and
++                   ~AbstractChunk() releases it. Recycling it as well released
++                   it twice -- for ChunkType::Segment recycleSource() frees it
++                   outright, so the chunk destructor's source->recycle() then
++                   dispatched through freed memory. This differs from the
++                   createChunk() failure path below, where recycling is correct
++                   precisely because no chunk was constructed to own it. */
+                 delete chunk;
+                 return nullptr;
+             }
+diff --git a/modules/demux/adaptive/test/playlist/SegmentChunk.cpp b/modules/demux/adaptive/test/playlist/SegmentChunk.cpp
+new file mode 100644
+index 00000000000..cdbb27ac284
+--- /dev/null
++++ b/modules/demux/adaptive/test/playlist/SegmentChunk.cpp
+@@ -0,0 +1,143 @@
++/*****************************************************************************
++ * SegmentChunk.cpp: ISegment::toChunk source ownership
++ *****************************************************************************
++ * Copyright (C) 2026 VideoLabs, VideoLAN and VLC Authors
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published
++ * by the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++#ifdef HAVE_CONFIG_H
++# include "config.h"
++#endif
++
++#include "../../playlist/Segment.h"
++#include "../../playlist/SegmentChunk.hpp"
++#include "../../playlist/BasePlaylist.hpp"
++#include "../../playlist/BasePeriod.h"
++#include "../../playlist/BaseAdaptationSet.h"
++#include "../../playlist/BaseRepresentation.h"
++#include "../../http/HTTPConnectionManager.h"
++#include "../../http/Chunk.h"
++#include "../../SharedResources.hpp"
++
++#include "../test.hpp"
++
++#include <vlc_block.h>
++
++#include <string>
++#include <vector>
++
++using namespace adaptive;
++using namespace adaptive::http;
++using namespace adaptive::playlist;
++
++namespace
++{
++    /* Counts releases instead of freeing, so that a double release is
++       observable as a count rather than as undefined behaviour. In the real
++       engine both release paths free the source: for ChunkType::Segment,
++       HTTPConnectionManager::recycleSource() falls through to deleteSource()
++       -> delete, and HTTPChunkSource::recycle() is delete this. A second
++       release there is a use-after-free through the source vtable, inside
++       AbstractChunk::~AbstractChunk(). */
++    unsigned releaseCount = 0;
++
++    class CountingChunkSource : public AbstractChunkSource
++    {
++        public:
++            CountingChunkSource(ChunkType t, const BytesRange &range)
++                : AbstractChunkSource(t, range) {}
++            virtual ~CountingChunkSource() = default;
++            void recycle() override { releaseCount++; }
++            const std::string & getContentType() const override { return contentType; }
++            RequestStatus getRequestStatus() const override { return RequestStatus::Success; }
++            block_t * readBlock() override { return nullptr; }
++            block_t * read(size_t) override { return nullptr; }
++            bool hasMoreData() const override { return false; }
++            size_t getBytesRead() const override { return 0; }
++
++        private:
++            std::string contentType;
++    };
++
++    class CountingConnectionManager : public AbstractConnectionManager
++    {
++        public:
++            CountingConnectionManager() : AbstractConnectionManager(nullptr) {}
++            virtual ~CountingConnectionManager() = default;
++            void closeAllConnections() override {}
++            AbstractConnection * getConnection(ConnectionParams &) override { return nullptr; }
++            AbstractChunkSource *makeSource(const std::string &,
++                                            const ID &, ChunkType t,
++                                            const BytesRange &br) override
++            {
++                return new CountingChunkSource(t, br);
++            }
++            void recycleSource(AbstractChunkSource *) override { releaseCount++; }
++            void start(AbstractChunkSource *) override {}
++            void cancel(AbstractChunkSource *) override {}
++    };
++
++    /* prepareChunk() is only reached, and only fails, for encrypted segments
++       whose key cannot be resolved -- an AES-128 HLS key URI that 404s, that
++       returns something other than 16 bytes, or an #EXT-X-KEY carrying no IV.
++       Overriding it keeps this test independent of whether the build has
++       gcrypt, while exercising the same branch of toChunk(). */
++    class UnpreparableSegment : public Segment
++    {
++        public:
++            explicit UnpreparableSegment(ICanonicalUrl *parent) : Segment(parent) {}
++            virtual ~UnpreparableSegment() = default;
++
++        protected:
++            bool prepareChunk(SharedResources *, SegmentChunk *,
++                              BaseRepresentation *) override
++            {
++                return false;
++            }
++    };
++}
++
++int SegmentChunkOwnership_test()
++{
++    BasePlaylist playlist(nullptr);
++    BasePeriod *period = new BasePeriod(&playlist);
++    playlist.addPeriod(period);
++    BaseAdaptationSet *set = new BaseAdaptationSet(period);
++    period->addAdaptationSet(set);
++    BaseRepresentation *rep = new BaseRepresentation(set);
++    set->addRepresentation(rep);
++
++    /* SharedResources takes ownership: ~SharedResources() deletes it. */
++    SharedResources resources(nullptr, nullptr, new CountingConnectionManager());
++
++    UnpreparableSegment segment(rep);
++    segment.setSourceUrl("http://example.com/segment.ts");
++
++    releaseCount = 0;
++    SegmentChunk *chunk = segment.toChunk(&resources, 0, rep);
++
++    /* The failure is reported by returning nullptr. */
++    Expect(chunk == nullptr);
++
++    /* The source must be released exactly once. toChunk() used to recycle it
++       explicitly *and* delete the chunk, whose ~AbstractChunk() releases the
++       source it owns -- so the source was released twice. With a real
++       HTTPChunkSource the first release frees it and the second is a virtual
++       call through freed memory, faulting inside AbstractChunk::~AbstractChunk
++       on the PlaylistManager thread. */
++    Expect(releaseCount == 1);
++
++    return 0;
++}
+diff --git a/modules/demux/adaptive/test/test.cpp b/modules/demux/adaptive/test/test.cpp
+index 747eb0db703..84aa631b74f 100644
+--- a/modules/demux/adaptive/test/test.cpp
++++ b/modules/demux/adaptive/test/test.cpp
+@@ -50,5 +50,7 @@ int main()
+     TEST(M3U8MasterPlaylist) ||
+     TEST(M3U8Playlist) ||
+     TEST(SegmentTracker)
++    ||
++    TEST(SegmentChunkOwnership)
+     ;
+ }
+diff --git a/modules/demux/adaptive/test/test.hpp b/modules/demux/adaptive/test/test.hpp
+index 2814704fede..8bc057ade7c 100644
+--- a/modules/demux/adaptive/test/test.hpp
++++ b/modules/demux/adaptive/test/test.hpp
+@@ -49,5 +49,6 @@ int CommandsQueue_test();
+ int BufferingLogic_test();
+ int FakeEsOut_test();
+ int SegmentTracker_test();
++int SegmentChunkOwnership_test();
+ 
+ #endif


### PR DESCRIPTION
Toward #91.

## Summary

VLC [#29845](https://code.videolan.org/videolan/vlc/-/work_items/29845) reports an intermittent `EXC_BAD_ACCESS` in `adaptive::http::AbstractChunk::~AbstractChunk` on iOS arm64 after roughly ten minutes of HLS playback, on the PlaylistManager thread via `SegmentTracker` and `AbstractStream`. The report uses the engine commit we pin.

I found the defect by reading the ownership graph rather than by soaking, and reproduced it deterministically. **The crash frame in the ASan report is the frame in the upstream report.**

## No upstream fix exists

Of the **2776** commits between `c833c4be0` and `origin/master` (`59361740a96`), exactly **5** touch `modules/demux/adaptive/`. Their cumulative diff is **6 files, +8/−7 lines**: a `block_SkipBytes` readability change, a missing-include build fix, an ID3-sniffing bounds change, a debug-logging arg, and a test fix. None touches chunk, tracker, or stream lifetime.

`Chunk.cpp`, `Chunk.h`, `Downloader.cpp`, `SegmentTracker.cpp`, `Streams.cpp`, `PlaylistManager.cpp` and `HTTPConnectionManager.cpp` are **byte-identical between our pin and current master**. `git log --all --grep=29845` returns nothing.

So this is a live upstream bug, not pin staleness.

## Root cause

`ISegment::toChunk()` releases the chunk source **twice** on the `prepareChunk()` failure path:

```cpp
if(!prepareChunk(res, chunk, rep))
{
    res->getConnManager()->recycleSource(source);   // release #1
    delete chunk;                                   // ~AbstractChunk -> source->recycle()  release #2
    return nullptr;
}
```

`AbstractChunk::~AbstractChunk()` is `{ source->recycle(); }` — unconditional, never null-checked, never nulled (`Chunk.cpp:89-92`). The chunk owns the source.

For `ChunkType::Segment` — the HLS media-segment case — `recycleSource()` computes `b_cacheable = false` and falls through to `deleteSource()` → `delete` (`HTTPConnectionManager.cpp:210-238`). The source is freed. `delete chunk` then dispatches `source->recycle()` **through the freed object's vtable**.

For `Init`/`Index` the source *is* cacheable, so the same double release instead pushes one pointer into `HTTPConnectionManager::cache` twice and inflates `cache_total` — a later double-free on purge, and the `assert(cache_total >= purged->contentLength)` in debug builds.

### Why "ten minutes, then crash"

`prepareChunk()` only does work for encrypted segments, and only fails when `CommonEncryptionSession::start()` fails. For AES-128 HLS that means the key could not be resolved: an `#EXT-X-KEY` URI that failed to fetch, returned other than 16 bytes, or carried no IV. **Keys are cached**, so this bites at key rotation or after cache eviction — not at startup. That is exactly the reported profile of healthy playback followed by a crash.

`HAVE_GCRYPT` is defined in every shipped platform config (iOS device, iOS simulator, tvOS, visionOS, Catalyst, macOS), so the path is live in what we ship. Builds without gcrypt are unaffected, since `start()` then always returns true.

### Provenance

Introduced by upstream [`ff7e38fe1335`](https://code.videolan.org/videolan/vlc/-/commit/ff7e38fe13353889c0f603f883134e75885b20f6) ("adaptive: recycle the chunk source when prepareChunk fails", 2022-05-17), modelled on the `createChunk()` failure branch immediately below it. That branch is correct precisely *because* no chunk was constructed there to own the source. Present in VLC 4.0 master since May 2022.

## Validation

New engine test `modules/demux/adaptive/test/playlist/SegmentChunk.cpp`, wired into `adaptive_test`.

**With the bug restored**, the test fails on the release count. **Under ASan with real frees**, it reproduces the upstream crash exactly:

```
ERROR: AddressSanitizer: heap-use-after-free
READ of size 8
    #0 adaptive::http::AbstractChunk::~AbstractChunk()   Chunk.cpp:91
    #1 adaptive::playlist::SegmentChunk::~SegmentChunk() SegmentChunk.cpp:47
    #2 adaptive::playlist::ISegment::toChunk(...)        Segment.cpp:115
freed by thread T0 here:
    #1 adaptive::playlist::ISegment::toChunk(...)        Segment.cpp:107
SUMMARY: AddressSanitizer: heap-use-after-free Chunk.cpp:91 in adaptive::http::AbstractChunk::~AbstractChunk()
```

With the fix applied the whole `adaptive_test` suite passes (exit 0).

The committed test overrides `prepareChunk()` rather than driving real encryption, so it runs whether or not the build has gcrypt, and **counts** releases rather than freeing — so the double release is a deterministic assertion in every build rather than undefined behaviour that may or may not trap.

Patch applies cleanly to a pristine `c833c4be0` and in sequence after `0001`–`0007`.

## Remaining risk — this does not close #91 on its own

- **Inert until the engine is rebuilt and released.** `Package.swift` still points at the unpatched v1.0.0 xcframework. Same standing caveat as #90.
- **The acceptance criteria are not met by this PR.** #91 requires multi-hour physical-device HLS soaks across live/VOD/event, TS/fMP4, ABR changes, discontinuities, expired windows, retries and cancellation, with allocation provenance captured. This PR fixes one proven defect on that path; it does not prove the path is clean. The soak still needs to run on hardware.
- **Two further defects found in the same audit, not fixed here** because they are out of this PR's scope and neither matches the reported stack. They want their own issues — say the word and I'll file them:
  - `HTTPChunkBufferedSource::recycle()` mutates `p_read`/`consumed`/`contentLength` with no lock while the downloader thread may be writing the same fields under one (`Chunk.cpp:470-477`).
  - `recycleSource()` has no `isDone()` guard, unlike `start()`, so an Init/Index source destroyed mid-download can be cached while still queued and `held` in the downloader — and `held` is a `bool`, not a counter.
- **Not upstreamed yet.** Worth sending to VideoLAN with the reproduction attached, since it affects every VLC 4.0 consumer playing encrypted HLS.
