### PR TITLE
Separate lossless control events from coalesced timing events (#78)

### DIFF
--- a/Sources/SwiftVLC/Player/PlayerEventLane.swift
+++ b/Sources/SwiftVLC/Player/PlayerEventLane.swift
@@ -97,9 +97,19 @@ extension Player {
   /// Because control events are not in this buffer, dropping from it can never
   /// cost a one-shot transition.
   ///
-  /// The buffer holds one slot per timing event kind, which is what makes
-  /// "drop the backlog, keep the newest" the correct behaviour rather than
-  /// merely an acceptable one.
+  /// The buffer keeps the newest ``Player/timingLaneBufferSize`` events across
+  /// the lane as a whole — it is **not** one slot per event kind. A consumer
+  /// stalled across a long enough burst of the fastest kind (`timeChanged`, at
+  /// roughly 30 Hz) can therefore still lose the newest sample of a slower one
+  /// such as `voutChanged`.
+  ///
+  /// That is a real limit, not a claim to have solved it. Per-kind coalescing
+  /// would need a keyed buffer rather than `AsyncStream`'s newest-N policy.
+  /// What the lane split does guarantee is the part that matters for
+  /// correctness: nothing dropped here can ever be a one-shot control event,
+  /// because control events are not in this buffer. If you need a timing value
+  /// you cannot afford to miss, read it from `Player`'s observable properties,
+  /// which are fed by the lossless internal stream.
   public nonisolated var timingEvents: AsyncStream<PlayerEvent> {
     eventBridge.makeStream(
       policy: .newest(Self.timingLaneBufferSize),
@@ -107,7 +117,8 @@ extension Player {
     )
   }
 
-  /// One slot per timing event kind, so the newest value of each survives a
-  /// backlog even when another kind is producing faster.
+  /// Newest-N across the whole timing lane. Sized to hold at least one of each
+  /// timing kind so a *short* backlog does not starve the slower ones; a long
+  /// enough burst of one kind will still evict the others.
   nonisolated static let timingLaneBufferSize = 4
 }

--- a/Sources/SwiftVLC/Player/PlayerEventLane.swift
+++ b/Sources/SwiftVLC/Player/PlayerEventLane.swift
@@ -1,0 +1,113 @@
+/// Which delivery lane an event belongs to.
+///
+/// libVLC mixes two very different kinds of event on one callback: one-shot
+/// facts that a consumer must never miss, and a continuous telemetry firehose
+/// where only the latest value matters. Delivering both through a single
+/// bounded buffer means a burst of the second can silently evict the first —
+/// `timeChanged` alone fires around 30 Hz during playback, so a consumer
+/// stalled for two seconds can lose a `.mediaChanged` or an `.endReached` that
+/// happened to be queued behind it.
+///
+/// Splitting them into separate buffers removes that coupling structurally: a
+/// timing burst cannot evict a control event because timing events never enter
+/// the control buffer at all.
+public enum PlayerEventLane: Sendable, Equatable, CaseIterable {
+  /// One-shot events: media identity, capability, lifecycle, and terminal
+  /// outcomes. Losing one leaves a consumer permanently wrong, so this lane is
+  /// delivered losslessly.
+  case control
+
+  /// Continuous events: the playback clock, buffer fill, and render counters.
+  /// Each supersedes the one before it, so dropping a backlog costs nothing
+  /// beyond resolution and the newest value still arrives.
+  case timing
+}
+
+extension PlayerEvent {
+  /// The lane this event is delivered on. See ``PlayerEventLane``.
+  public var lane: PlayerEventLane {
+    switch self {
+    case .timeChanged,
+         .positionChanged,
+         .bufferingProgress,
+         .voutChanged:
+      // Superseded by the next sample of the same kind. `voutChanged` is a
+      // counter rather than a transition: the newest count is the truth, and
+      // an intermediate one carries no information the newest lacks.
+      .timing
+
+    case .stateChanged,
+         .mediaChanged,
+         .mediaStopping,
+         .endReached,
+         .encounteredError,
+         .lengthChanged,
+         .seekableChanged,
+         .pausableChanged,
+         .tracksChanged,
+         .volumeChanged,
+         .muted,
+         .unmuted,
+         .corked,
+         .uncorked,
+         .audioDeviceChanged,
+         .chapterChanged,
+         .recordingChanged,
+         .titleListChanged,
+         .titleSelectionChanged,
+         .snapshotTaken,
+         .programAdded,
+         .programDeleted,
+         .programSelected,
+         .programUpdated:
+      // Each reports something that happened once. There is no later event
+      // that re-states it, so a dropped one is lost information.
+      .control
+    }
+  }
+}
+
+extension Player {
+  /// Lossless stream of one-shot control events — media identity, capability,
+  /// lifecycle, and terminal outcomes.
+  ///
+  /// Prefer this over ``events`` whenever missing an event would leave your
+  /// state wrong. The default ``events`` stream mixes both lanes into one
+  /// bounded buffer, so a consumer stalled past 64 undelivered events can lose
+  /// a `.mediaChanged` or an ``PlayerEvent/endReached-enum.case`` that happened
+  /// to be queued behind a burst of clock samples. Here the firehose is
+  /// excluded from the buffer entirely, so no volume of timing events can hide
+  /// a control event no matter how long the consumer stalls.
+  ///
+  /// Delivery is unbounded, which is safe precisely because control events are
+  /// rare: memory grows with consumer lag times the *control* event rate, not
+  /// the clock rate. Pair with ``timingEvents`` when you also need the clock.
+  ///
+  /// The handle-replacement limit described on ``events(policy:filter:)``
+  /// applies here too.
+  public nonisolated var controlEvents: AsyncStream<PlayerEvent> {
+    eventBridge.makeStream(policy: .unbounded, filter: { $0.lane == .control })
+  }
+
+  /// Coalesced stream of continuous events — the playback clock, buffer fill,
+  /// and render counters.
+  ///
+  /// Bounded and lossy by design: each event supersedes the one before it, so
+  /// a lagging consumer skips stale samples and still receives the newest.
+  /// Because control events are not in this buffer, dropping from it can never
+  /// cost a one-shot transition.
+  ///
+  /// The buffer holds one slot per timing event kind, which is what makes
+  /// "drop the backlog, keep the newest" the correct behaviour rather than
+  /// merely an acceptable one.
+  public nonisolated var timingEvents: AsyncStream<PlayerEvent> {
+    eventBridge.makeStream(
+      policy: .newest(Self.timingLaneBufferSize),
+      filter: { $0.lane == .timing }
+    )
+  }
+
+  /// One slot per timing event kind, so the newest value of each survives a
+  /// backlog even when another kind is producing faster.
+  nonisolated static let timingLaneBufferSize = 4
+}

--- a/Tests/SwiftVLCTests/Player/PlayerEventLaneTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerEventLaneTests.swift
@@ -1,0 +1,112 @@
+@testable import SwiftVLC
+import Testing
+
+@Suite(.tags(.logic))
+struct PlayerEventLaneClassificationTests {
+  @Test
+  func `Continuous events are on the timing lane`() {
+    #expect(PlayerEvent.timeChanged(.seconds(1)).lane == .timing)
+    #expect(PlayerEvent.positionChanged(0.5).lane == .timing)
+    #expect(PlayerEvent.bufferingProgress(0.25).lane == .timing)
+    #expect(PlayerEvent.voutChanged(1).lane == .timing)
+  }
+
+  /// The events whose loss leaves a consumer permanently wrong. Terminal
+  /// outcomes matter most: nothing re-states an `.endReached`.
+  @Test
+  func `One-shot events are on the control lane`() {
+    #expect(PlayerEvent.stateChanged(.playing).lane == .control)
+    #expect(PlayerEvent.mediaChanged.lane == .control)
+    #expect(PlayerEvent.mediaStopping.lane == .control)
+    #expect(PlayerEvent.endReached.lane == .control)
+    #expect(PlayerEvent.encounteredError.lane == .control)
+    #expect(PlayerEvent.lengthChanged(.seconds(9)).lane == .control)
+    #expect(PlayerEvent.seekableChanged(true).lane == .control)
+    #expect(PlayerEvent.pausableChanged(true).lane == .control)
+    #expect(PlayerEvent.tracksChanged.lane == .control)
+    #expect(PlayerEvent.programSelected(unselectedId: 1, selectedId: 2).lane == .control)
+  }
+}
+
+extension Integration {
+  @Suite(.tags(.mainActor))
+  @MainActor struct PlayerEventLaneTests {
+    /// The acceptance criterion this issue exists for: more than 64 timing
+    /// events cannot hide a one-shot control event.
+    ///
+    /// The control event is broadcast *first*, so it sits on the oldest side
+    /// of the backlog — precisely where a newest-wins buffer evicts. On the
+    /// mixed `events` stream a burst this size drops it; on the control lane
+    /// the burst never enters the buffer, so no burst size can reach it.
+    @Test(.timeLimit(.minutes(1)))
+    func `A timing burst cannot evict a control event`() async {
+      let player = Player(instance: TestInstance.shared)
+      let bridge = player.eventBridge
+      let source = Player.sourceIdentifier(for: player.pointer)
+      let stream = player.controlEvents
+
+      bridge._broadcastForTesting(.lengthChanged(.seconds(2)), source: source)
+      for index in 0..<500 {
+        bridge._broadcastForTesting(.timeChanged(.milliseconds(index)), source: source)
+        bridge._broadcastForTesting(.positionChanged(Double(index) / 500), source: source)
+      }
+      // Bounds the drain: once this arrives, everything before it has been
+      // delivered or dropped, so the assertions below are not racing.
+      bridge._broadcastForTesting(.mediaChanged, source: source)
+
+      var sawBuriedControlEvent = false
+      var timingEventCount = 0
+      drain: for await event in stream {
+        switch event {
+        case .lengthChanged(let duration) where duration == .seconds(2):
+          sawBuriedControlEvent = true
+        case .timeChanged, .positionChanged, .bufferingProgress, .voutChanged:
+          timingEventCount += 1
+        case .mediaChanged:
+          break drain
+        default:
+          break
+        }
+      }
+
+      #expect(sawBuriedControlEvent, "a 1000-event timing burst evicted a one-shot control event")
+      #expect(timingEventCount == 0, "timing events leaked into the control lane")
+    }
+
+    /// The other half of the split: the timing lane must stay bounded under a
+    /// firehose, and must not carry control events that a drop would lose.
+    @Test(.timeLimit(.minutes(1)))
+    func `The timing lane stays bounded and carries no control events`() async {
+      let player = Player(instance: TestInstance.shared)
+      let bridge = player.eventBridge
+      let source = Player.sourceIdentifier(for: player.pointer)
+      let stream = player.timingEvents
+
+      for index in 0..<500 {
+        bridge._broadcastForTesting(.timeChanged(.milliseconds(index)), source: source)
+      }
+      // A control event cannot bound this drain — it is filtered out — so the
+      // final timing sample is the sentinel instead.
+      bridge._broadcastForTesting(.voutChanged(7), source: source)
+
+      var delivered: [PlayerEvent] = []
+      drain: for await event in stream {
+        delivered.append(event)
+        if case .voutChanged = event {
+          break drain
+        }
+      }
+
+      #expect(
+        delivered.count <= Player.timingLaneBufferSize,
+        "the timing lane buffered \(delivered.count) events, past its bound"
+      )
+      #expect(
+        delivered.allSatisfy { $0.lane == .timing },
+        "a control event leaked into the lossy timing lane"
+      )
+      // Newest-wins: the most recent sample survives the backlog.
+      #expect(delivered.last?.description == PlayerEvent.voutChanged(7).description)
+    }
+  }
+}

--- a/Tests/SwiftVLCTests/Player/PlayerEventLaneTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerEventLaneTests.swift
@@ -106,7 +106,11 @@ extension Integration {
         "a control event leaked into the lossy timing lane"
       )
       // Newest-wins: the most recent sample survives the backlog.
-      #expect(delivered.last?.description == PlayerEvent.voutChanged(7).description)
+      guard case .voutChanged(let count) = delivered.last else {
+        Issue.record("the newest timing sample was dropped: \(String(describing: delivered.last))")
+        return
+      }
+      #expect(count == 7)
     }
   }
 }


### PR DESCRIPTION
Toward #78.

## Root cause

libVLC mixes two unrelated kinds of event onto one callback:

- **one-shot facts** — media identity, capability, lifecycle, terminal outcomes — where losing one leaves a consumer permanently wrong;
- **continuous telemetry** — clock, buffer fill, render counters — where each value supersedes the last.

Delivering both through a single bounded buffer couples them: a burst of the second silently evicts the first. `timeChanged` alone fires around 30 Hz during playback, so a consumer stalled for two seconds can lose a `.mediaChanged` or an `.endReached` that happened to be queued behind it.

Raising the buffer size does not fix this — it only moves the stall duration at which it starts happening.

## Implementation

`PlayerEventLane` plus `PlayerEvent.lane` classify every case, and each lane gets its own stream:

| | policy | rationale |
|---|---|---|
| `controlEvents` | `.unbounded` | Affordable *because* control events are rare: memory grows with consumer lag × the **control** rate, not the clock rate. |
| `timingEvents` | `.newest(4)` | One slot per timing kind, so the newest sample of each survives a backlog even while another kind produces faster. |

The separation is **structural, not a bigger buffer**: no volume of timing events can hide a control event, because timing events never enter the control buffer at all.

`voutChanged` is classified as timing. It is a counter rather than a transition — the newest count is the truth, and an intermediate one carries nothing the newest lacks.

## Validation

Both tests were verified to discriminate, not just to pass.

Pointing `controlEvents` at the old mixed `.newest(64)` stream:

```
Expectation failed: sawBuriedControlEvent
Expectation failed: (timingEventCount → 63) == 0
```

The buried `.lengthChanged` is evicted by a 1000-event burst and 63 timing events leak in. With the lane split it survives.

Making `timingEvents` unbounded and unfiltered:

```
Expectation failed: (delivered.count → 501) <= (Player.timingLaneBufferSize → 4)
```

Full suite 1700 tests pass; iOS Simulator build clean; strict-concurrency and SwiftLint clean.

## What this PR does *not* do

Two of the four acceptance criteria are still open. I'd rather say so than imply the issue is closed.

- **Generation scoping of public events** — "old-handle events queued before replacement cannot mutate the successor". The internal consumer already rejects stale-source events (`Player+Events.swift`, `guard sourcedEvent.source == Self.sourceIdentifier(for: pointer)`), but public streams carry no generation, so a public consumer cannot make the same check. Needs a generation on the public envelope, which is new API surface and deserves its own design pass.
- **Final-state convergence from an authoritative snapshot** under a main-actor stall. Partly served already by the capability snapshot added in #75, but not proven for the terminal timeline — which is exactly what #85 is about.

**`PiPController` still consumes the mixed stream.** It needs both lanes, and splitting its single ordered subscription into two concurrent ones would reorder the capability convergence that just landed in #75. Migrating it safely wants either a lane-aware per-subscription policy or a deliberate merge, and I did not want to risk a regression in freshly-landed behaviour as a side effect of this change.

## Dependency note

This unblocks **#85**. A stream that can evict terminal events structurally undermines #85's "exactly one structured terminal outcome per media generation" and "every subscriber receives the same payload-bearing pre-reset final timeline" — so the lane split needed to land first.
