### PR TITLE
Route PiP skip through the relative jump and reserve its timeline (#76)

### DIFF
--- a/Sources/SwiftVLC/PiP/PiPController+Skip.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Skip.swift
@@ -1,0 +1,60 @@
+#if os(iOS) || os(macOS)
+
+import CoreMedia
+
+extension PiPController {
+  /// How a PiP skip request finished.
+  ///
+  /// AVKit's contract is that the completion handler runs once the skip
+  /// operation finishes or fails — never twice, and never not at all. Naming
+  /// the outcomes makes "exactly once" checkable rather than assumed.
+  enum SkipOutcome: Equatable {
+    /// libVLC accepted the relative jump.
+    case issued
+    /// There was no session to seek in, or libVLC refused the request. The
+    /// published timeline is left exactly as it was.
+    case rejected
+    /// AVKit handed over an interval that cannot be expressed in libVLC's
+    /// millisecond unit — infinite, NaN, or out of range.
+    case unrepresentableInterval
+  }
+
+  /// Routes an AVKit skip through the player's relative jump.
+  ///
+  /// Every PiP backend funnels through here. Previously each of the three
+  /// converted the interval into an absolute target itself and issued a strict
+  /// seek, which has two problems:
+  ///
+  /// - The strict path needs a known duration and validates against it, so on
+  ///   live and timeshift media — exactly where a DVR skip is most useful —
+  ///   there is no target to derive. ``Player/jump(by:)`` jumps relative to the
+  ///   input's own clock and works there.
+  /// - Converting to an absolute target discards the interval AVKit asked for.
+  ///   Rounding through `currentTime`, which is itself an estimate between
+  ///   native clock samples, makes the skip land somewhere other than exactly
+  ///   the requested distance away.
+  ///
+  /// The interval is therefore preserved and handed to libVLC as a relative
+  /// offset.
+  @MainActor
+  static func performSkip(on player: Player, by interval: CMTime) -> SkipOutcome {
+    guard let offsetMilliseconds = skipOffsetMilliseconds(interval) else {
+      return .unrepresentableInterval
+    }
+    guard player.jump(by: .milliseconds(offsetMilliseconds)) else {
+      return .rejected
+    }
+    return .issued
+  }
+
+  /// Whether this outcome means the timeline actually moved.
+  ///
+  /// A rejected skip must not be reflected anywhere: publishing the requested
+  /// time as though it had landed puts the transport controls ahead of the
+  /// media, and the next native clock sample then yanks them back.
+  static func skipMovedTimeline(_ outcome: SkipOutcome) -> Bool {
+    outcome == .issued
+  }
+}
+
+#endif

--- a/Sources/SwiftVLC/PiP/PiPController+Testing.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Testing.swift
@@ -62,8 +62,29 @@ extension PiPController {
     controlTimebase.map { CMTimebaseGetRate($0) }
   }
 
+  func _controlTimebaseSecondsForTesting() -> Double? {
+    controlTimebase.map { CMTimebaseGetTime($0).seconds }
+  }
+
+  /// Non-zero once a skip has been accepted. The controller uses it to stop
+  /// the drift corrector from fighting a just-issued skip.
+  func _didRecordSkipForTesting() -> Bool {
+    lastSkipTimestamp != 0
+  }
+
   func _skipByIntervalForTesting(_ skipInterval: CMTime) {
     handleSkip(by: skipInterval) {}
+  }
+
+  /// Returns how many times the completion handler ran, so "exactly once" is
+  /// assertable rather than assumed.
+  func _skipCompletionCountForTesting(_ skipInterval: CMTime) -> Int {
+    // `handleSkip`'s completion is `@Sendable`, so the counter has to be
+    // shared state rather than a captured `var`. It is called synchronously on
+    // this actor today; the lock keeps the helper correct if that changes.
+    let count = Mutex(0)
+    handleSkip(by: skipInterval) { count.withLock { $0 += 1 } }
+    return count.withLock { $0 }
   }
 
   func _renderSizeForTesting() -> CMVideoDimensions? {

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -65,7 +65,10 @@ public final class PiPController: NSObject {
     let resume: @MainActor () -> Bool
     let cancelPendingPause: @MainActor () -> Void
     let shouldResume: @MainActor () -> Bool
-    let seek: @MainActor (Duration) -> Void
+    /// Relative rather than absolute: see ``PiPController/performSkip(on:by:)``
+    /// for why the interval AVKit requested is preserved instead of being
+    /// converted into a target.
+    let skip: @MainActor (CMTime) -> SkipOutcome
 
     static func live(player: Player) -> Self {
       Self(
@@ -73,7 +76,7 @@ public final class PiPController: NSObject {
         resume: { player.issueResume() },
         cancelPendingPause: { player.cancelPendingPause() },
         shouldResume: { player.shouldResumeForExternalPlayRequest },
-        seek: { try? player.seek(to: $0) }
+        skip: { PiPController.performSkip(on: player, by: $0) }
       )
     }
   }
@@ -262,7 +265,7 @@ public final class PiPController: NSObject {
   /// overwriting the skip handler's timebase position with stale
   /// `currentTime` data that hasn't caught up to the seek yet.
   @ObservationIgnored
-  private var lastSkipTimestamp: CFAbsoluteTime = 0
+  var lastSkipTimestamp: CFAbsoluteTime = 0
 
   /// Whether PiP can be started right now.
   ///
@@ -1071,26 +1074,26 @@ public final class PiPController: NSObject {
     // libVLC through a pause → seek → resume cycle.
     cancelDeferredPause()
 
-    let currentMs = player.currentTime.milliseconds
-    guard let offsetMs = Self.skipOffsetMilliseconds(skipInterval) else {
+    let outcome = playbackDriver.skip(skipInterval)
+
+    // A refused skip leaves the timeline untouched. Moving the timebase to a
+    // target the media never reached would put the transport controls ahead of
+    // playback until the next native clock sample yanked them back.
+    guard Self.skipMovedTimeline(outcome) else {
       completionHandler()
       return
     }
-    let targetMs = Self.clampedSkipTargetMilliseconds(
-      current: currentMs,
-      offset: offsetMs,
-      duration: player.duration?.milliseconds
-    )
-
-    playbackDriver.seek(.milliseconds(targetMs))
 
     lastSkipTimestamp = CFAbsoluteTimeGetCurrent()
 
     // Apple docs: "the control timebase should reflect the current
-    // playback time and rate when the closure is invoked"
+    // playback time and rate when the closure is invoked". Read it back from
+    // the player rather than from a locally computed target: `jump(by:)` has
+    // already published its own clamped estimate, and recomputing one here
+    // could disagree with it.
     if let tb = controlTimebase {
       CMTimebaseSetTime(tb, time: CMTime(
-        seconds: Double(targetMs) / 1000.0,
+        seconds: Double(player.currentTime.milliseconds) / 1000.0,
         preferredTimescale: 1000
       ))
       CMTimebaseSetRate(tb, rate: player.isActive ? Float64(player.rate) : 0.0)

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -1074,6 +1074,15 @@ public final class PiPController: NSObject {
     // libVLC through a pause → seek → resume cycle.
     cancelDeferredPause()
 
+    // Reject an interval that cannot be expressed in libVLC's millisecond unit
+    // here rather than inside the driver, so no driver — live or injected —
+    // is ever handed one. AVKit has no contract preventing it from passing an
+    // indefinite or infinite CMTime.
+    guard Self.skipOffsetMilliseconds(skipInterval) != nil else {
+      completionHandler()
+      return
+    }
+
     let outcome = playbackDriver.skip(skipInterval)
 
     // A refused skip leaves the timeline untouched. Moving the timebase to a

--- a/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
@@ -5,8 +5,10 @@
 // `PIP.framework`) reparents the real VLC drawable instead.
 
 #if os(macOS)
+
 import AppKit
 import CLibVLC
+import CoreMedia
 import Foundation
 import Synchronization
 
@@ -575,12 +577,15 @@ final class MacNativePiPMediaController: NSObject, @unchecked Sendable {
         return
       }
 
-      let target = PiPController.clampedSkipTargetMilliseconds(
-        current: player.currentTime.milliseconds,
-        offset: offset,
-        duration: player.duration?.milliseconds
+      // One relative-jump path for every PiP backend: see
+      // PiPController.performSkip(on:by:). The interval is preserved rather
+      // than converted to an absolute target, so live and timeshift DVR
+      // windows skip correctly, and completion runs exactly once whether the
+      // jump was accepted or refused.
+      _ = PiPController.performSkip(
+        on: player,
+        by: CMTime(value: offset, timescale: 1000)
       )
-      try? player.seek(to: .milliseconds(target))
       completion?()
     }
   }

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -940,12 +940,15 @@ final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling,
         return
       }
 
-      let target = PiPController.clampedSkipTargetMilliseconds(
-        current: player.currentTime.milliseconds,
-        offset: offset,
-        duration: player.duration?.milliseconds
+      // One relative-jump path for every PiP backend: see
+      // PiPController.performSkip(on:by:). The interval is preserved rather
+      // than converted to an absolute target, so live and timeshift DVR
+      // windows skip correctly, and completion runs exactly once whether the
+      // jump was accepted or refused.
+      _ = PiPController.performSkip(
+        on: player,
+        by: CMTime(value: offset, timescale: 1000)
       )
-      try? player.seek(to: .milliseconds(target))
       completion?()
     }
   }

--- a/Sources/SwiftVLC/Player/Player+Seek.swift
+++ b/Sources/SwiftVLC/Player/Player+Seek.swift
@@ -186,9 +186,19 @@ extension Player {
     guard let offsetMs = try? offset.checkedMilliseconds(parameter: "offset") else {
       return false
     }
+    // Reserved before the native call and adopted only once libVLC accepts,
+    // exactly as the absolute paths do. A relative jump needs this more than
+    // they do, not less: it is issued while playback is running and clock
+    // samples are in flight, so without it a sample produced just before the
+    // jump lands afterwards and snaps the published time back to where
+    // playback used to be. A refused jump must not consume the reservation,
+    // or every later sample would be judged stale against a revision nothing
+    // adopted.
+    let revision = eventBridge.advanceTimelineRevision()
     guard libvlc_media_player_jump_time(pointer, offsetMs) == 0 else {
       return false
     }
+    acceptedTimelineRevision = revision
     if let currentMs = try? currentTime.checkedMilliseconds(parameter: "currentTime") {
       let targetResult = currentMs.addingReportingOverflow(offsetMs)
       if !targetResult.overflow {

--- a/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 #if os(iOS) || os(macOS)
 @testable import SwiftVLC
 import AVFoundation
@@ -25,7 +24,8 @@ extension Integration {
       var pauseResult = true
       var shouldResume = false
       var resumeResult = true
-      var seekTargets: [Int64] = []
+      var skipIntervals: [CMTime] = []
+      var skipOutcome: PiPController.SkipOutcome = .issued
 
       var driver: PiPController.PlaybackDriver {
         .init(
@@ -41,7 +41,10 @@ extension Integration {
             self.cancelPendingPauseCount += 1
           },
           shouldResume: { self.shouldResume },
-          seek: { self.seekTargets.append($0.milliseconds) }
+          skip: { interval in
+            self.skipIntervals.append(interval)
+            return self.skipOutcome
+          }
         )
       }
     }
@@ -491,66 +494,6 @@ extension Integration {
       #expect(controller._pendingPiPPlaybackStateForTesting() == true)
     }
 
-    // MARK: - handleSkip boundary conditions
-
-    /// PiP skip at position 0 with a negative interval must clamp to 0,
-    /// not go negative. The clamp lives in `handleSkip`.
-    @Test
-    func `skip backwards from zero clamps to zero`() {
-      let player = Player(instance: TestInstance.shared)
-      let recorder = PlaybackRecorder()
-      let controller = PiPController(
-        player: player,
-        playbackDriver: recorder.driver,
-        pauseDebounce: .milliseconds(10)
-      )
-
-      controller._skipByIntervalForTesting(CMTime(seconds: -10, preferredTimescale: 1000))
-
-      expectNoDifference(recorder.seekTargets, [0])
-    }
-
-    /// Skip with a known duration must clamp at the upper bound when
-    /// the interval would overshoot the end of the media.
-    @Test
-    func `skip past duration clamps to duration`() {
-      let player = Player(instance: TestInstance.shared)
-      player._setStateForTesting(
-        currentTime: .seconds(9),
-        duration: .seconds(10)
-      )
-      let recorder = PlaybackRecorder()
-      let controller = PiPController(
-        player: player,
-        playbackDriver: recorder.driver,
-        pauseDebounce: .milliseconds(10)
-      )
-
-      controller._skipByIntervalForTesting(CMTime(seconds: 60, preferredTimescale: 1000))
-
-      expectNoDifference(recorder.seekTargets, [10000])
-    }
-
-    /// A mid-range skip with neither clamp fires just the intended seek.
-    @Test
-    func `skip within bounds passes through unclamped`() {
-      let player = Player(instance: TestInstance.shared)
-      player._setStateForTesting(
-        currentTime: .seconds(5),
-        duration: .seconds(60)
-      )
-      let recorder = PlaybackRecorder()
-      let controller = PiPController(
-        player: player,
-        playbackDriver: recorder.driver,
-        pauseDebounce: .milliseconds(10)
-      )
-
-      controller._skipByIntervalForTesting(CMTime(seconds: 3, preferredTimescale: 1000))
-
-      expectNoDifference(recorder.seekTargets, [8000])
-    }
-
     @Test
     func `skip interval conversion rejects nonnumeric Core Media times`() {
       #expect(PiPController.skipOffsetMilliseconds(.invalid) == nil)
@@ -621,7 +564,7 @@ extension Integration {
         didComplete.withLock { $0 = true }
       }
 
-      expectNoDifference(recorder.seekTargets, [7000])
+      expectNoDifference(recorder.skipIntervals.map(\.seconds), [2])
       #expect(didComplete.withLock { $0 })
     }
 

--- a/Tests/SwiftVLCTests/PiP/PiPControllerSkipTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerSkipTests.swift
@@ -1,0 +1,173 @@
+#if os(iOS) || os(macOS)
+@testable import SwiftVLC
+import AVKit
+import CoreMedia
+import CustomDump
+import Testing
+
+/// Covers PiP skip: how AVKit's requested interval reaches the player, and
+/// what happens when the resulting jump is refused.
+extension Integration {
+  @Suite(.tags(.mainActor))
+  @MainActor struct PiPControllerSkipTests {
+    @MainActor
+    final class PlaybackRecorder {
+      var skipIntervals: [CMTime] = []
+      var skipOutcome: PiPController.SkipOutcome = .issued
+
+      var driver: PiPController.PlaybackDriver {
+        .init(
+          pause: { true },
+          resume: { true },
+          cancelPendingPause: {},
+          shouldResume: { false },
+          skip: { interval in
+            self.skipIntervals.append(interval)
+            return self.skipOutcome
+          }
+        )
+      }
+    }
+
+    /// The interval AVKit asked for reaches the player unchanged.
+    ///
+    /// Bounds are deliberately *not* applied here any more. PiP used to
+    /// convert the interval into an absolute target and clamp it against
+    /// `currentTime` and `duration` before issuing a strict seek, which broke
+    /// exactly where a DVR skip matters most: live and timeshift media have no
+    /// duration to clamp against, and `currentTime` is itself an estimate
+    /// between native clock samples, so rounding through it landed the skip
+    /// somewhere other than the requested distance away. The relative jump is
+    /// resolved against the input's own clock instead, and bounds are libVLC's
+    /// to enforce.
+    @Test
+    func `A backwards skip from zero passes the interval through unclamped`() {
+      let player = Player(instance: TestInstance.shared)
+      let recorder = PlaybackRecorder()
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(10)
+      )
+
+      controller._skipByIntervalForTesting(CMTime(seconds: -10, preferredTimescale: 1000))
+
+      expectNoDifference(recorder.skipIntervals.map(\.seconds), [-10])
+    }
+
+    /// An overshoot past a known duration is libVLC's to bound, not PiP's.
+    @Test
+    func `A skip past duration passes the interval through unclamped`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(
+        currentTime: .seconds(9),
+        duration: .seconds(10)
+      )
+      let recorder = PlaybackRecorder()
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(10)
+      )
+
+      controller._skipByIntervalForTesting(CMTime(seconds: 60, preferredTimescale: 1000))
+
+      expectNoDifference(recorder.skipIntervals.map(\.seconds), [60])
+    }
+
+    /// A mid-range skip fires exactly one jump carrying the requested offset.
+    @Test
+    func `A skip within bounds issues one jump with the requested interval`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(
+        currentTime: .seconds(5),
+        duration: .seconds(60)
+      )
+      let recorder = PlaybackRecorder()
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(10)
+      )
+
+      controller._skipByIntervalForTesting(CMTime(seconds: 3, preferredTimescale: 1000))
+
+      expectNoDifference(recorder.skipIntervals.map(\.seconds), [3])
+    }
+
+    /// A refused jump must not be recorded as a skip that happened.
+    ///
+    /// The controller suppresses its timebase drift corrector for a second
+    /// after each skip, so that the corrector does not fight a seek that is
+    /// still settling. Arming that suppression for a skip libVLC refused blinds
+    /// the corrector for a second over a timeline that never moved — precisely
+    /// when it should be free to correct.
+    @Test
+    func `A rejected skip is not recorded as a skip`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(currentTime: .seconds(5), duration: .seconds(60))
+      let recorder = PlaybackRecorder()
+      recorder.skipOutcome = .rejected
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(10)
+      )
+
+      controller._skipByIntervalForTesting(CMTime(seconds: 30, preferredTimescale: 1000))
+
+      #expect(
+        controller._didRecordSkipForTesting() == false,
+        "a refused skip armed the drift-corrector suppression"
+      )
+    }
+
+    /// The accepted counterpart, so the test above is proving a difference
+    /// rather than an always-false property.
+    @Test
+    func `An accepted skip is recorded`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(currentTime: .seconds(5), duration: .seconds(60))
+      let recorder = PlaybackRecorder()
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(10)
+      )
+
+      controller._skipByIntervalForTesting(CMTime(seconds: 30, preferredTimescale: 1000))
+
+      #expect(controller._didRecordSkipForTesting())
+    }
+
+    /// AVKit's contract: the completion handler runs once the skip finishes or
+    /// fails. Never twice, and never not at all — a missing call leaves the PiP
+    /// transport spinning.
+    @Test
+    func `A skip calls its completion handler exactly once`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(currentTime: .seconds(5), duration: .seconds(60))
+      let recorder = PlaybackRecorder()
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(10)
+      )
+      let interval = CMTime(seconds: 3, preferredTimescale: 1000)
+
+      #expect(controller._skipCompletionCountForTesting(interval) == 1)
+
+      recorder.skipOutcome = .rejected
+      #expect(
+        controller._skipCompletionCountForTesting(interval) == 1,
+        "a refused skip must still complete, exactly once"
+      )
+
+      #expect(
+        controller._skipCompletionCountForTesting(.invalid) == 1,
+        "an unrepresentable interval must still complete, exactly once"
+      )
+    }
+  }
+}
+#endif

--- a/Tests/SwiftVLCTests/PiP/PiPControllerSkipTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerSkipTests.swift
@@ -163,10 +163,58 @@ extension Integration {
         "a refused skip must still complete, exactly once"
       )
 
+      // Note: an unrepresentable interval cannot be covered through the stub
+      // driver, which returns a canned outcome without converting anything.
+      // `performSkip` classifies that case, and is tested directly below.
+    }
+
+    /// The interval classification lives in `performSkip`, so it is tested
+    /// against the real function rather than through the stub driver — the stub
+    /// returns a canned outcome and never converts an interval, so routing
+    /// these through it would assert nothing.
+    @Test
+    func `An unrepresentable interval is classified without reaching the player`() {
+      let player = Player(instance: TestInstance.shared)
+
+      #expect(PiPController.performSkip(on: player, by: .invalid) == .unrepresentableInterval)
+      #expect(PiPController.performSkip(on: player, by: .indefinite) == .unrepresentableInterval)
       #expect(
-        controller._skipCompletionCountForTesting(.invalid) == 1,
-        "an unrepresentable interval must still complete, exactly once"
+        PiPController.performSkip(on: player, by: .positiveInfinity) == .unrepresentableInterval
       )
+      #expect(
+        PiPController.performSkip(on: player, by: .negativeInfinity) == .unrepresentableInterval
+      )
+    }
+
+    /// A representable interval with no session to seek in is a rejection, not
+    /// an unrepresentable interval. Distinguishing the two is the point of the
+    /// typed outcome.
+    @Test
+    func `A representable interval without a session is rejected`() {
+      let player = Player(instance: TestInstance.shared)
+
+      let outcome = PiPController.performSkip(
+        on: player,
+        by: CMTime(seconds: 3, preferredTimescale: 1000)
+      )
+
+      #expect(outcome == .rejected)
+    }
+
+    /// Completion still has to run exactly once when the interval cannot be
+    /// converted — that path returns before the driver is consulted at all.
+    @Test
+    func `An unrepresentable interval still completes exactly once`() {
+      let player = Player(instance: TestInstance.shared)
+      let recorder = PlaybackRecorder()
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(10)
+      )
+
+      #expect(controller._skipCompletionCountForTesting(.invalid) == 1)
+      #expect(recorder.skipIntervals.isEmpty, "an unconvertible interval reached the driver")
     }
   }
 }

--- a/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
@@ -16,7 +16,8 @@ extension Integration {
       var resumeCount = 0
       var cancelPendingPauseCount = 0
       var shouldResume = false
-      var seekTargets: [Int64] = []
+      var skipIntervals: [CMTime] = []
+      var skipOutcome: PiPController.SkipOutcome = .issued
       /// Models an input libVLC refuses to pause, so the deferred-pause retry
       /// bound can be exercised.
       var pauseSucceeds = true
@@ -35,7 +36,10 @@ extension Integration {
             self.cancelPendingPauseCount += 1
           },
           shouldResume: { self.shouldResume },
-          seek: { self.seekTargets.append($0.milliseconds) }
+          skip: { interval in
+            self.skipIntervals.append(interval)
+            return self.skipOutcome
+          }
         )
       }
     }
@@ -383,7 +387,7 @@ extension Integration {
       #expect(recorder.pauseCount == 0)
       #expect(recorder.resumeCount == 0)
       #expect(recorder.cancelPendingPauseCount == 1)
-      #expect(recorder.seekTargets.count == 1)
+      #expect(recorder.skipIntervals.count == 1)
     }
 
     @Test

--- a/Tests/SwiftVLCTests/Player/PlayerSeekAuthorityTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerSeekAuthorityTests.swift
@@ -196,5 +196,56 @@ extension Integration {
         "a clock sample from the previous media updated the new one's timeline"
       )
     }
+
+    /// `jump(by:)` is the seek entry point PiP skip controls route through, so
+    /// it needs the same protection the absolute paths already have. It is
+    /// also the one most exposed to it: a relative jump is issued while
+    /// playback is running and clock samples are in flight, rather than from a
+    /// settled scrubber drag.
+    @Test
+    func `A clock sample predating an accepted jump does not snap the timeline back`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      // `jump(by:)` gates on a live session; the intent flag is the
+      // synchronous signal that gate reads.
+      player._setStateForTesting(
+        state: .paused,
+        isPlaybackRequestedActive: true,
+        currentTime: .seconds(10),
+        duration: .seconds(100),
+        isSeekable: true
+      )
+
+      // Produced by libVLC before the jump, still queued behind it.
+      let stale = SourcedPlayerEvent(
+        source: Player.sourceIdentifier(for: player.pointer),
+        event: .timeChanged(.seconds(10)),
+        timelineRevision: player.acceptedTimelineRevision
+      )
+
+      #expect(player.jump(by: .seconds(30)))
+      #expect(player.currentTime == .seconds(40))
+
+      player.handleSourcedEvent(stale)
+
+      #expect(
+        player.currentTime == .seconds(40),
+        "a pre-jump clock sample overwrote the accepted jump target"
+      )
+    }
+
+    /// A refused jump must not consume the reservation, or every later clock
+    /// sample would be judged stale against a revision nothing ever adopted
+    /// and the published time would freeze.
+    @Test
+    func `A rejected jump leaves the accepted timeline revision alone`() {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      // No media, so there is no session to jump in and the call is refused.
+      let before = player.acceptedTimelineRevision
+
+      #expect(player.jump(by: .seconds(5)) == false)
+
+      #expect(player.acceptedTimelineRevision == before)
+    }
   }
 }


### PR DESCRIPTION
Toward #76.

## Root cause

Three PiP backends — `PiPController`, `PiPVideoView+iOSNative`, `PiPVideoView+MacPrivate` — each independently converted AVKit's skip interval into an absolute target, clamped it, and issued a **strict** seek with the error discarded.

That is wrong in two ways, both of which bite hardest on live and timeshift media:

- The strict path needs a known duration and validates against it. Live and DVR media have no duration, so there is nothing to derive a target from — exactly where a skip control is most useful.
- Converting to an absolute target discards the interval AVKit asked for. It rounds through `currentTime`, which is itself an estimate between native clock samples, so the skip lands somewhere other than the requested distance away.

Completion was also reported when the seek was *dispatched*, not when it was accepted or refused, and a refused seek still moved PiP's state as though it had landed.

## Implementation

All three funnel through `PiPController.performSkip(on:by:)`, which hands the interval to `Player.jump(by:)` **unchanged**. `jump_time` resolves it against the input's own clock, so bounds become libVLC's to enforce rather than PiP's to guess.

`SkipOutcome` (`.issued` / `.rejected` / `.unrepresentableInterval`) replaces the previous `Void`, so a refused jump is distinguishable — and the completion handler runs **exactly once** on every path.

A refused skip no longer arms the timebase drift-corrector suppression. The controller silences that corrector for one second after each skip so it cannot fight a seek still settling; arming it for a skip libVLC refused blinds it for a second over a timeline that never moved.

## A second bug found while wiring this up

`jump(by:)` was **the one seek entry point that never reserved a timeline revision.** `Player+Seek.swift` lines 33, 94 and 146 all do; the jump path did not.

That reservation is what stops a clock sample produced *before* a seek from landing afterwards and snapping the published time back — the guarantee added in #77. A relative jump needs it more than the absolute paths do, not less: it is issued while playback is running and samples are in flight, rather than from a settled scrubber drag.

**Routing PiP skip through `jump(by:)` without fixing this would have reintroduced the #77 bug on the skip path.** Reserved before the native call and adopted only on acceptance, so a refused jump does not consume the reservation and freeze every later sample against a revision nothing adopted.

## Validation

Each fix was reverted to confirm the tests catch it.

Without the revision reservation:
```
Expectation failed: (player.currentTime → 10.0 seconds) == (.seconds(40) → 40.0 seconds)
```
The jump moves time to 40s, then a stale pre-jump sample snaps it back to 10s.

Without the rejection guard:
```
Expectation failed: (controller._didRecordSkipForTesting() → true) == false
```

Full suite 1701 tests pass; iOS Simulator build clean; strict-concurrency and SwiftLint clean.

### One test I had to throw away

My first version of the rejected-skip test asserted on `player.currentTime` and **passed with the fix reverted** — the stub driver never moves `currentTime`, so it was proving nothing. Replaced with the drift-corrector assertion above, which does discriminate. Flagging it because the first version looked perfectly reasonable.

## Behaviour change

PiP no longer clamps the interval before seeking. Three tests that asserted clamped absolute targets (`[0]`, `[10000]`, `[8000]`) now assert interval pass-through. `clampedSkipTargetMilliseconds` is retained and still directly tested, but is no longer on the skip path.

## Remaining

- **Criterion 1 is only partly met.** Completion now runs exactly once on a bounded terminal result, but "after landing" is not implemented: an accepted jump completes once libVLC has *accepted* it, not once it has settled. A true settle-wait needs a bounded wait on the next native clock sample, with a paused player short-circuiting it — otherwise a paused skip would always sit out the full timeout before the PiP transport unfroze. Worth doing deliberately rather than bolted on here.
- **Criteria 3 and 4 are device work** — rapid alternating jumps while playing, paused, buffering and inside a live DVR window, and confirming no jump leaves playback paused or muted after the AVKit transport sequence. These belong to the #88 qualification matrix.
