### PR TITLE
Propagate source frame cadence into direct PiP sample timing (#102)

### DIFF
--- a/Sources/SwiftVLC/Media/FrameRateRatio.swift
+++ b/Sources/SwiftVLC/Media/FrameRateRatio.swift
@@ -1,0 +1,29 @@
+/// An exact frame rate as libVLC reported it, numerator over denominator.
+///
+/// A `Double` cannot represent the NTSC-derived rates: 24000/1001 becomes
+/// 23.976023976…, and a frame duration derived from that accumulates drift over
+/// a long playback. Consumers that need exact timing — sample-buffer durations,
+/// most of all — should use this rather than ``Track/frameRate``.
+public struct FrameRateRatio: Sendable, Hashable {
+  /// Frames per `denominator` seconds. For 23.976 fps this is `24000`.
+  public let numerator: UInt32
+
+  /// Seconds per `numerator` frames. For 23.976 fps this is `1001`.
+  public let denominator: UInt32
+
+  /// Creates a frame rate from libVLC's rational pair.
+  ///
+  /// - Returns: `nil` when either side is zero, which is how libVLC reports
+  ///   "not known" rather than a real rate.
+  public init?(numerator: UInt32, denominator: UInt32) {
+    guard numerator > 0, denominator > 0 else { return nil }
+    self.numerator = numerator
+    self.denominator = denominator
+  }
+
+  /// The rate as frames per second. Lossy for NTSC rates by construction —
+  /// prefer the rational form when the result feeds timing.
+  public var framesPerSecond: Double {
+    Double(numerator) / Double(denominator)
+  }
+}

--- a/Sources/SwiftVLC/Media/Track.swift
+++ b/Sources/SwiftVLC/Media/Track.swift
@@ -10,6 +10,30 @@ import CLibVLC
 ///     print("\(track.name) (\(track.language ?? "unknown"))")
 /// }
 /// ```
+/// An exact frame rate as libVLC reported it, numerator over denominator.
+///
+/// A `Double` cannot represent the NTSC-derived rates: 24000/1001 becomes
+/// 23.976023976..., and a frame duration derived from that accumulates drift.
+/// Consumers that need exact timing -- sample-buffer durations, most of all --
+/// should use this rather than ``Track/frameRate``.
+public struct FrameRateRatio: Sendable, Hashable {
+  public let numerator: UInt32
+  public let denominator: UInt32
+
+  /// Fails when either side is zero, which is how libVLC reports "not known"
+  /// rather than a real rate.
+  public init?(numerator: UInt32, denominator: UInt32) {
+    guard numerator > 0, denominator > 0 else { return nil }
+    self.numerator = numerator
+    self.denominator = denominator
+  }
+
+  /// The rate as frames per second. Lossy for NTSC rates by construction.
+  public var framesPerSecond: Double {
+    Double(numerator) / Double(denominator)
+  }
+}
+
 public struct Track: Sendable, Identifiable, Hashable {
   /// Stable string identifier from libVLC.
   public let id: String
@@ -58,6 +82,17 @@ public struct Track: Sendable, Identifiable, Hashable {
 
   /// Video frame rate in frames per second (`nil` for non-video tracks).
   public let frameRate: Double?
+
+  /// The frame rate as the exact rational libVLC reported, numerator over
+  /// denominator (`nil` for non-video tracks or when the source did not report
+  /// one).
+  ///
+  /// ``frameRate`` divides these into a `Double`, which cannot represent the
+  /// NTSC-derived rates exactly: 24000/1001 becomes 23.976023976..., and
+  /// deriving a frame duration from that accumulates drift. Consumers that
+  /// need exact timing -- sample-buffer durations, most of all -- should use
+  /// this instead.
+  public let frameRateRatio: FrameRateRatio?
 
   // MARK: - Subtitle
 
@@ -137,20 +172,24 @@ extension Track {
       let a = t.audio.pointee
       channels = Int(a.i_channels)
       sampleRate = Int(a.i_rate)
-      (width, height, frameRate, encoding) = (nil, nil, nil, nil)
+      (width, height, frameRate, frameRateRatio, encoding) = (nil, nil, nil, nil, nil)
     case libvlc_track_video where t.video != nil:
       let v = t.video.pointee
       width = Int(v.i_width)
       height = Int(v.i_height)
-      frameRate = v.i_frame_rate_den > 0
-        ? Double(v.i_frame_rate_num) / Double(v.i_frame_rate_den)
-        : nil
+      frameRateRatio = FrameRateRatio(
+        numerator: v.i_frame_rate_num,
+        denominator: v.i_frame_rate_den
+      )
+      frameRate = frameRateRatio?.framesPerSecond
       (channels, sampleRate, encoding) = (nil, nil, nil)
     case libvlc_track_text where t.subtitle != nil:
       encoding = t.subtitle.pointee.psz_encoding.map { String(cString: $0) }
-      (channels, sampleRate, width, height, frameRate) = (nil, nil, nil, nil, nil)
+      (channels, sampleRate, width, height, frameRate, frameRateRatio) =
+        (nil, nil, nil, nil, nil, nil)
     default:
-      (channels, sampleRate, width, height, frameRate, encoding) = (nil, nil, nil, nil, nil, nil)
+      (channels, sampleRate, width, height, frameRate, frameRateRatio, encoding) =
+        (nil, nil, nil, nil, nil, nil, nil)
     }
   }
 }

--- a/Sources/SwiftVLC/Media/Track.swift
+++ b/Sources/SwiftVLC/Media/Track.swift
@@ -10,30 +10,6 @@ import CLibVLC
 ///     print("\(track.name) (\(track.language ?? "unknown"))")
 /// }
 /// ```
-/// An exact frame rate as libVLC reported it, numerator over denominator.
-///
-/// A `Double` cannot represent the NTSC-derived rates: 24000/1001 becomes
-/// 23.976023976..., and a frame duration derived from that accumulates drift.
-/// Consumers that need exact timing -- sample-buffer durations, most of all --
-/// should use this rather than ``Track/frameRate``.
-public struct FrameRateRatio: Sendable, Hashable {
-  public let numerator: UInt32
-  public let denominator: UInt32
-
-  /// Fails when either side is zero, which is how libVLC reports "not known"
-  /// rather than a real rate.
-  public init?(numerator: UInt32, denominator: UInt32) {
-    guard numerator > 0, denominator > 0 else { return nil }
-    self.numerator = numerator
-    self.denominator = denominator
-  }
-
-  /// The rate as frames per second. Lossy for NTSC rates by construction.
-  public var framesPerSecond: Double {
-    Double(numerator) / Double(denominator)
-  }
-}
-
 public struct Track: Sendable, Identifiable, Hashable {
   /// Stable string identifier from libVLC.
   public let id: String

--- a/Sources/SwiftVLC/PiP/PiPController+Cadence.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Cadence.swift
@@ -1,0 +1,32 @@
+#if os(iOS) || os(macOS)
+
+import CoreMedia
+
+extension PiPController {
+  /// The duration of one frame at the selected video track's own cadence, or
+  /// `nil` when no track reports one.
+  ///
+  /// Prefers the selected track, since that is the one being decoded; falls
+  /// back to any video track that reports a cadence, because a track list can
+  /// briefly show nothing selected right after a media change.
+  ///
+  /// Returns `nil` rather than a default. Direct PiP used to stamp every frame
+  /// with exactly `1/30s` regardless of the source, which misdescribes 24, 25,
+  /// 50 and 60 fps content and every variable-frame-rate stream. Sample
+  /// duration is not decorative — AVFoundation uses it for scheduling, pacing
+  /// and backpressure — and a fabricated value is worse than none, because
+  /// nothing downstream can tell it was fabricated.
+  @MainActor
+  static func sourceFrameDuration(of player: Player) -> CMTime? {
+    let tracks = player.videoTracks
+    let ratio = tracks.first(where: { $0.isSelected })?.frameRateRatio
+      ?? tracks.lazy.compactMap(\.frameRateRatio).first
+    guard let ratio else { return nil }
+    return PixelBufferRenderer.frameDuration(
+      rateNumerator: ratio.numerator,
+      rateDenominator: ratio.denominator
+    )
+  }
+}
+
+#endif

--- a/Sources/SwiftVLC/PiP/PiPController+Cadence.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Cadence.swift
@@ -19,8 +19,16 @@ extension PiPController {
   @MainActor
   static func sourceFrameDuration(of player: Player) -> CMTime? {
     let tracks = player.videoTracks
-    let ratio = tracks.first(where: { $0.isSelected })?.frameRateRatio
-      ?? tracks.lazy.compactMap(\.frameRateRatio).first
+    let ratio: FrameRateRatio? = if let selected = tracks.first(where: \.isSelected) {
+      // The selected track is the one being decoded. If it reports no cadence,
+      // the answer is "unknown" — borrowing a sibling track's rate would be
+      // fabrication of a subtler kind than the 30 fps default this replaces.
+      selected.frameRateRatio
+    } else {
+      // Nothing selected yet, which a track list shows briefly right after a
+      // media change. Any track that reports a cadence is better than none.
+      tracks.lazy.compactMap(\.frameRateRatio).first
+    }
     guard let ratio else { return nil }
     return PixelBufferRenderer.frameDuration(
       rateNumerator: ratio.numerator,

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -845,6 +845,16 @@ public final class PiPController: NSObject {
         )
         applyObservedPlaybackStateUpdate(playbackStateUpdate)
 
+        // The source cadence is only knowable once the video track has been
+        // parsed, and it changes on media replacement and on an adaptive
+        // representation switch — both of which re-report tracks.
+        switch event {
+        case .tracksChanged, .mediaChanged:
+          renderer.setFrameDuration(Self.sourceFrameDuration(of: player))
+        default:
+          break
+        }
+
         // State transition: sync the timebase rate.
         if active != wasActive {
           wasActive = active

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -121,6 +121,8 @@ public final class PiPController: NSObject {
   @ObservationIgnored
   private var playbackIntentObserverTask: Task<Void, Never>?
   @ObservationIgnored
+  private var cadenceObserverTask: Task<Void, Never>?
+  @ObservationIgnored
   private var possibleObservation: NSKeyValueObservation?
   @ObservationIgnored
   private var activeObservation: NSKeyValueObservation?
@@ -340,6 +342,7 @@ public final class PiPController: NSObject {
     setupPiPController()
     startStateObserver()
     startPlaybackIntentObserver()
+    startCadenceObserver()
   }
 
   #if os(iOS)
@@ -455,6 +458,7 @@ public final class PiPController: NSObject {
     cancelDeferredPause()
     stateObserverTask?.cancel()
     playbackIntentObserverTask?.cancel()
+    cadenceObserverTask?.cancel()
     possibleObservation = nil
     activeObservation = nil
     // No explicit native-backend relinquish: the backend holds its `owner`
@@ -845,16 +849,6 @@ public final class PiPController: NSObject {
         )
         applyObservedPlaybackStateUpdate(playbackStateUpdate)
 
-        // The source cadence is only knowable once the video track has been
-        // parsed, and it changes on media replacement and on an adaptive
-        // representation switch — both of which re-report tracks.
-        switch event {
-        case .tracksChanged, .mediaChanged:
-          renderer.setFrameDuration(Self.sourceFrameDuration(of: player))
-        default:
-          break
-        }
-
         // State transition: sync the timebase rate.
         if active != wasActive {
           wasActive = active
@@ -899,6 +893,37 @@ public final class PiPController: NSObject {
               CMTimebaseSetTime(tb, time: CMTime(seconds: playerSec, preferredTimescale: 1000))
             }
           }
+        }
+      }
+    }
+  }
+
+  /// Keeps the renderer's frame cadence in step with the source.
+  ///
+  /// Deliberately a *separate* subscription on the lossless control lane rather
+  /// than a branch in the main state observer. That observer consumes the mixed
+  /// `events` stream, which is bounded and newest-wins, so under a main-actor
+  /// stall a burst of clock samples can evict the very `tracksChanged` that
+  /// tells us the cadence changed — and the renderer would then keep stamping
+  /// the previous source's rate for the rest of the session.
+  ///
+  /// Safe to run concurrently with the state observer because it shares no
+  /// mutable state with it: it reads the track list and writes one
+  /// lock-protected duration, and doing that twice for the same media is
+  /// indistinguishable from doing it once.
+  private func startCadenceObserver() {
+    let events = player.controlEvents
+    cadenceObserverTask = Task { @MainActor [weak self] in
+      for await event in events {
+        guard let self else { return }
+        switch event {
+        case .tracksChanged, .mediaChanged:
+          // Cadence is only knowable once the video track has been parsed, and
+          // it changes on media replacement and on an adaptive representation
+          // switch — both of which re-report tracks.
+          renderer.setFrameDuration(Self.sourceFrameDuration(of: player))
+        default:
+          break
         }
       }
     }

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer.swift
@@ -108,7 +108,13 @@ final class PixelBufferRenderer: Sendable {
   /// variable-frame-rate stream, and duration feeds AVFoundation's scheduling
   /// and backpressure rather than being decorative.
   func setFrameDuration(_ duration: CMTime?) {
-    let resolved = duration.flatMap { $0.isNumeric && $0.seconds > 0 ? $0 : nil } ?? .invalid
+    // Validated on the rational fields rather than through `seconds`, which
+    // converts to `Double` — the very conversion this whole path exists to
+    // avoid. A positive value over a positive timescale is exactly the
+    // condition, with no rounding in the way.
+    let resolved = duration.flatMap {
+      $0.isNumeric && $0.value > 0 && $0.timescale > 0 ? $0 : nil
+    } ?? .invalid
     state.withLock { $0.frameDuration = resolved }
   }
 
@@ -119,10 +125,12 @@ final class PixelBufferRenderer: Sendable {
   /// rates are precisely where a rounded duration accumulates drift.
   static func frameDuration(rateNumerator: UInt32, rateDenominator: UInt32) -> CMTime? {
     guard rateNumerator > 0, rateDenominator > 0 else { return nil }
-    return CMTime(
-      value: CMTimeValue(rateDenominator),
-      timescale: CMTimeScale(rateNumerator)
-    )
+    // `CMTimeScale` is `Int32`, so a numerator above its maximum would trap on
+    // conversion. libVLC reports this straight from container metadata, which
+    // is attacker-controllable in a malformed file, so an absurd rate has to
+    // read as "cadence unknown" rather than crash the decode thread.
+    guard let timescale = CMTimeScale(exactly: rateNumerator) else { return nil }
+    return CMTime(value: CMTimeValue(rateDenominator), timescale: timescale)
   }
 
   func setRenderSize(_ size: CMVideoDimensions?) {

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer.swift
@@ -51,6 +51,10 @@ final class PixelBufferRenderer: Sendable {
     /// stable home the runtime can track across struct copies.
     let displayLayer: DisplayLayerBox
     var timebase: CMTimebase?
+    /// Duration of one frame at the source's own cadence, or `.invalid` when
+    /// the cadence is not known. Never a fabricated default: see
+    /// ``PixelBufferRenderer/setFrameDuration(_:)``.
+    var frameDuration: CMTime = .invalid
 
     init(displayLayer: AVSampleBufferDisplayLayer?) {
       self.displayLayer = DisplayLayerBox(displayLayer)
@@ -92,6 +96,33 @@ final class PixelBufferRenderer: Sendable {
 
   func setTimebase(_ tb: CMTimebase?) {
     state.withLock { $0.timebase = tb }
+  }
+
+  /// Publishes the source's frame cadence for the sample timing of subsequent
+  /// frames.
+  ///
+  /// Pass `nil` when the cadence is unknown; the duration then becomes
+  /// `.invalid` and AVFoundation is told "no duration" rather than being handed
+  /// a fabricated one. Every frame used to carry exactly `1/30s` regardless of
+  /// the source, which misdescribes 24, 25, 50 and 60 fps content and every
+  /// variable-frame-rate stream, and duration feeds AVFoundation's scheduling
+  /// and backpressure rather than being decorative.
+  func setFrameDuration(_ duration: CMTime?) {
+    let resolved = duration.flatMap { $0.isNumeric && $0.seconds > 0 ? $0 : nil } ?? .invalid
+    state.withLock { $0.frameDuration = resolved }
+  }
+
+  /// Converts a rational frame rate into the duration of a single frame.
+  ///
+  /// Kept rational rather than going through a `Double`: 24000/1001 is exactly
+  /// representable this way, while `1.0 / 23.976...` is not, and NTSC-derived
+  /// rates are precisely where a rounded duration accumulates drift.
+  static func frameDuration(rateNumerator: UInt32, rateDenominator: UInt32) -> CMTime? {
+    guard rateNumerator > 0, rateDenominator > 0 else { return nil }
+    return CMTime(
+      value: CMTimeValue(rateDenominator),
+      timescale: CMTimeScale(rateNumerator)
+    )
   }
 
   func setRenderSize(_ size: CMVideoDimensions?) {
@@ -789,7 +820,9 @@ func pixelBufferDisplayCallback(
     let outputBuffer = output.buffer
     let renderGeneration = output.generation
 
-    let (timebase, layer) = renderer.state.withLock { ($0.timebase, $0.displayLayer.layer) }
+    let (timebase, layer, frameDuration) = renderer.state.withLock {
+      ($0.timebase, $0.displayLayer.layer, $0.frameDuration)
+    }
 
     guard let layer else { return }
     guard
@@ -814,7 +847,9 @@ func pixelBufferDisplayCallback(
     let displayImmediately = timebase.map { CMTimebaseGetRate($0) == 0 } ?? false
 
     var timingInfo = CMSampleTimingInfo(
-      duration: CMTime(value: 1, timescale: 30),
+      // `.invalid` when the source cadence is unknown. Inventing 30 fps here
+      // told AVFoundation something false about every non-30 fps source.
+      duration: frameDuration,
       presentationTimeStamp: pts,
       decodeTimeStamp: .invalid
     )

--- a/Tests/SwiftVLCTests/Media/TrackCodecStringTests.swift
+++ b/Tests/SwiftVLCTests/Media/TrackCodecStringTests.swift
@@ -30,6 +30,7 @@ extension Logic {
         width: nil,
         height: nil,
         frameRate: nil,
+        frameRateRatio: nil,
         encoding: nil
       )
     }

--- a/Tests/SwiftVLCTests/Media/TrackExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Media/TrackExtendedTests.swift
@@ -146,6 +146,7 @@ extension Integration {
         width: nil,
         height: nil,
         frameRate: nil,
+        frameRateRatio: nil,
         encoding: "UTF-8"
       )
       #expect(sub.channels == nil)
@@ -236,6 +237,7 @@ extension Integration {
         width: nil,
         height: nil,
         frameRate: nil,
+        frameRateRatio: nil,
         encoding: nil
       )
       #expect(track.language == "fr")
@@ -271,6 +273,7 @@ extension Integration {
         width: width,
         height: height,
         frameRate: frameRate,
+        frameRateRatio: nil,
         encoding: nil
       )
     }

--- a/Tests/SwiftVLCTests/Media/TrackTests.swift
+++ b/Tests/SwiftVLCTests/Media/TrackTests.swift
@@ -139,6 +139,7 @@ extension Logic {
         width: nil,
         height: nil,
         frameRate: nil,
+        frameRateRatio: nil,
         encoding: "UTF-8"
       )
       #expect(track.encoding == "UTF-8")
@@ -163,6 +164,7 @@ extension Logic {
         width: 1920,
         height: 1080,
         frameRate: 29.97,
+        frameRateRatio: nil,
         encoding: nil
       )
       #expect(track.frameRate != nil)
@@ -185,6 +187,7 @@ extension Logic {
         width: nil,
         height: nil,
         frameRate: nil,
+        frameRateRatio: nil,
         encoding: nil
       )
       #expect(track.language == "en")
@@ -209,6 +212,7 @@ extension Logic {
         width: nil,
         height: nil,
         frameRate: nil,
+        frameRateRatio: nil,
         encoding: "UTF-8"
       )
       #expect(track.encoding == "UTF-8")
@@ -259,6 +263,7 @@ extension Logic {
         width: width,
         height: height,
         frameRate: nil,
+        frameRateRatio: nil,
         encoding: nil
       )
     }

--- a/Tests/SwiftVLCTests/PiP/PixelBufferFrameCadenceTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferFrameCadenceTests.swift
@@ -1,0 +1,109 @@
+#if os(iOS) || os(macOS)
+@testable import SwiftVLC
+import CoreMedia
+import Synchronization
+import Testing
+
+/// Direct PiP stamped every frame with exactly `1/30s` regardless of the
+/// source. Sample duration is not decorative — AVFoundation uses it for
+/// scheduling, pacing and backpressure — so a fabricated value misdescribes
+/// every source that is not 30 fps, and nothing downstream can tell it was
+/// fabricated.
+@Suite(.tags(.logic))
+struct PixelBufferFrameCadenceTests {
+  /// The rates that matter, including the NTSC-derived ones a `Double` cannot
+  /// represent exactly. The duration must be the exact rational, not a rounded
+  /// reciprocal.
+  @Test(arguments: [
+    (num: UInt32(24000), den: UInt32(1001)),
+    (num: UInt32(24), den: UInt32(1)),
+    (num: UInt32(25), den: UInt32(1)),
+    (num: UInt32(30000), den: UInt32(1001)),
+    (num: UInt32(30), den: UInt32(1)),
+    (num: UInt32(50), den: UInt32(1)),
+    (num: UInt32(60000), den: UInt32(1001)),
+    (num: UInt32(60), den: UInt32(1))
+  ])
+  func `A rational frame rate becomes an exact frame duration`(rate: (num: UInt32, den: UInt32)) throws {
+    let duration = try #require(
+      PixelBufferRenderer.frameDuration(rateNumerator: rate.num, rateDenominator: rate.den)
+    )
+
+    #expect(duration.value == CMTimeValue(rate.den))
+    #expect(duration.timescale == CMTimeScale(rate.num))
+    // Exact: value/timescale reproduces the rate without floating-point loss.
+    #expect(duration.isNumeric)
+    #expect(CMTimeValue(rate.num) * duration.value == CMTimeValue(rate.den) * CMTimeValue(duration.timescale))
+  }
+
+  /// 23.976 is the rate whose reciprocal a `Double` cannot hold exactly, so it
+  /// is worth pinning that the rational survives into the `CMTime` untouched.
+  ///
+  /// Note the duration is carried in the source's *own* timescale. Rounding it
+  /// into a general-purpose timescale is where the precision actually goes:
+  /// 1001/24000 has no exact representation in the common 600 tick base, so a
+  /// duration that had been routed through one would no longer sum to whole
+  /// seconds over a long playback.
+  @Test
+  func `An NTSC rate keeps its exact rational form`() throws {
+    let duration = try #require(
+      PixelBufferRenderer.frameDuration(rateNumerator: 24000, rateDenominator: 1001)
+    )
+
+    #expect(duration == CMTime(value: 1001, timescale: 24000))
+    #expect(duration.timescale == 24000, "the source timescale was not preserved")
+
+    // 24000 frames of 1001/24000 is exactly 1001 seconds. A rounded duration
+    // would not close.
+    let oneThousandOneSeconds = CMTimeMultiply(duration, multiplier: 24000)
+    #expect(oneThousandOneSeconds == CMTime(value: 1001, timescale: 1))
+
+    // The same duration forced into a 600-tick base does not round-trip, which
+    // is what preserving the source timescale avoids.
+    let rounded = CMTimeConvertScale(duration, timescale: 600, method: .default)
+    #expect(CMTimeConvertScale(rounded, timescale: 24000, method: .default) != duration)
+  }
+
+  @Test(arguments: [
+    (num: UInt32(0), den: UInt32(1)),
+    (num: UInt32(30), den: UInt32(0)),
+    (num: UInt32(0), den: UInt32(0))
+  ])
+  func `An unreported cadence yields no duration`(rate: (num: UInt32, den: UInt32)) {
+    #expect(
+      PixelBufferRenderer.frameDuration(rateNumerator: rate.num, rateDenominator: rate.den) == nil
+    )
+  }
+
+  /// The invariant the issue turns on: unknown cadence must not receive
+  /// fabricated duration metadata.
+  @Test
+  func `An unknown cadence publishes an invalid duration, not a default`() {
+    let renderer = PixelBufferRenderer()
+
+    // Starts invalid rather than at some assumed rate.
+    #expect(renderer.state.withLock { $0.frameDuration }.isValid == false)
+
+    renderer.setFrameDuration(CMTime(value: 1001, timescale: 24000))
+    #expect(renderer.state.withLock { $0.frameDuration } == CMTime(value: 1001, timescale: 24000))
+
+    renderer.setFrameDuration(nil)
+    #expect(
+      renderer.state.withLock { $0.frameDuration }.isValid == false,
+      "clearing the cadence left a stale duration describing the previous source"
+    )
+  }
+
+  /// A nonsense duration is not better than none: zero or non-numeric values
+  /// would describe an infinite frame rate.
+  @Test(arguments: [CMTime.zero, CMTime.invalid, CMTime.indefinite, CMTime.positiveInfinity])
+  func `A degenerate duration is rejected`(candidate: CMTime) {
+    let renderer = PixelBufferRenderer()
+    renderer.setFrameDuration(CMTime(value: 1, timescale: 25))
+
+    renderer.setFrameDuration(candidate)
+
+    #expect(renderer.state.withLock { $0.frameDuration }.isValid == false)
+  }
+}
+#endif

--- a/Tests/SwiftVLCTests/PiP/PixelBufferFrameCadenceTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferFrameCadenceTests.swift
@@ -107,3 +107,95 @@ struct PixelBufferFrameCadenceTests {
   }
 }
 #endif
+
+/// Resolving the cadence from the player's track list, which is what feeds the
+/// renderer on `.tracksChanged` and `.mediaChanged`.
+extension Integration {
+  @Suite(.tags(.mainActor))
+  @MainActor struct PiPCadenceResolutionTests {
+    private func videoTrack(
+      id: String,
+      isSelected: Bool,
+      ratio: FrameRateRatio?
+    ) -> Track {
+      Track(
+        id: id,
+        type: .video,
+        name: "Video \(id)",
+        codec: 0,
+        language: nil,
+        trackDescription: nil,
+        isSelected: isSelected,
+        bitrate: 0,
+        channels: nil,
+        sampleRate: nil,
+        width: 1920,
+        height: 1080,
+        frameRate: ratio?.framesPerSecond,
+        frameRateRatio: ratio,
+        encoding: nil
+      )
+    }
+
+    @Test
+    func `No video tracks yields no cadence`() {
+      let player = Player(instance: TestInstance.shared)
+      #expect(PiPController.sourceFrameDuration(of: player) == nil)
+    }
+
+    /// A track list with no reported cadence must stay unknown rather than
+    /// falling back to an assumed rate.
+    @Test
+    func `A track without a reported cadence yields no cadence`() {
+      let player = Player(instance: TestInstance.shared)
+      player.videoTracks = [videoTrack(id: "v0", isSelected: true, ratio: nil)]
+
+      #expect(PiPController.sourceFrameDuration(of: player) == nil)
+    }
+
+    @Test
+    func `The selected track's cadence wins`() throws {
+      let player = Player(instance: TestInstance.shared)
+      player.videoTracks = [
+        videoTrack(id: "v0", isSelected: false, ratio: FrameRateRatio(numerator: 60, denominator: 1)),
+        videoTrack(id: "v1", isSelected: true, ratio: FrameRateRatio(numerator: 24000, denominator: 1001))
+      ]
+
+      let duration = try #require(PiPController.sourceFrameDuration(of: player))
+
+      #expect(duration == CMTime(value: 1001, timescale: 24000), "an unselected track's cadence won")
+    }
+
+    /// A track list can briefly show nothing selected right after a media
+    /// change, and an unknown cadence there would stamp `.invalid` on frames
+    /// whose rate the list already reports.
+    @Test
+    func `An unselected track's cadence is used when nothing is selected`() throws {
+      let player = Player(instance: TestInstance.shared)
+      player.videoTracks = [
+        videoTrack(id: "v0", isSelected: false, ratio: nil),
+        videoTrack(id: "v1", isSelected: false, ratio: FrameRateRatio(numerator: 25, denominator: 1))
+      ]
+
+      let duration = try #require(PiPController.sourceFrameDuration(of: player))
+
+      #expect(duration == CMTime(value: 1, timescale: 25))
+    }
+
+    /// A selected track that reports no cadence must not silently adopt another
+    /// track's rate — the selected one is what is being decoded.
+    @Test
+    func `A selected track without a cadence does not borrow another track's`() {
+      let player = Player(instance: TestInstance.shared)
+      player.videoTracks = [
+        videoTrack(id: "v0", isSelected: true, ratio: nil),
+        videoTrack(id: "v1", isSelected: false, ratio: FrameRateRatio(numerator: 50, denominator: 1))
+      ]
+
+      #expect(
+        PiPController.sourceFrameDuration(of: player) == nil,
+        "the decoded track reported no cadence but another track's rate was used"
+      )
+    }
+  }
+}

--- a/Tests/SwiftVLCTests/PiP/PixelBufferFrameCadenceTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferFrameCadenceTests.swift
@@ -106,7 +106,6 @@ struct PixelBufferFrameCadenceTests {
     #expect(renderer.state.withLock { $0.frameDuration }.isValid == false)
   }
 }
-#endif
 
 /// Resolving the cadence from the player's track list, which is what feeds the
 /// renderer on `.tracksChanged` and `.mediaChanged`.
@@ -199,3 +198,4 @@ extension Integration {
     }
   }
 }
+#endif

--- a/Tests/SwiftVLCTests/Player/PlayerBranchCoverageTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerBranchCoverageTests.swift
@@ -368,6 +368,7 @@ extension Integration {
         width: nil,
         height: nil,
         frameRate: nil,
+        frameRateRatio: nil,
         encoding: nil
       )
 

--- a/Tests/SwiftVLCTests/Player/PlayerRecastTrackMatchTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerRecastTrackMatchTests.swift
@@ -26,6 +26,7 @@ extension Integration {
         width: nil,
         height: nil,
         frameRate: nil,
+        frameRateRatio: nil,
         encoding: nil
       )
     }


### PR DESCRIPTION
Toward #102.

## Root cause

`PixelBufferRenderer` stamped every frame with a sample duration of exactly `CMTime(value: 1, timescale: 30)` — regardless of the source.

Sample duration is not decorative. AVFoundation uses it for scheduling, frame pacing and backpressure, so this actively misdescribed 24, 25, 50 and 60 fps content and every variable-frame-rate stream. Supplying a correct PTS does not make it harmless, because both timing fields are handed to the sample-buffer renderer together.

## Implementation

The renderer carries a frame duration published from the selected video track's cadence, and stamps `.invalid` when no track reports one. **Telling AVFoundation "unknown" is strictly better than telling it something false**, which is the acceptance criterion this issue turns on.

### Why an exact rational, not a `Double`

`Track` gains `frameRateRatio` alongside the existing `frameRate`. 24000/1001 is not representable as a `Double` — it becomes 23.976023976… — and a frame duration derived from that accumulates drift over a long playback.

The `CMTime` also keeps the *source's own* timescale rather than being normalised, for the same reason: 1001/24000 has no exact form in the common 600-tick base. There's a test for exactly this — 24000 frames of 1001/24000 must sum to exactly 1001 seconds, and a 600-tick round-trip must not survive.

`FrameRateRatio` is a struct rather than a tuple: `Track` is `Hashable` and a tuple property would have blocked synthesis. Its failable init treats a zero numerator or denominator as "not reported", which is how libVLC signals absence.

### When it is republished

On `.tracksChanged` and `.mediaChanged` — the cadence is only knowable once the video track is parsed, and it changes on media replacement and on an adaptive representation switch. Both are control-lane events, so they cannot be evicted by the clock firehose (#78).

## Validation

Verified the tests discriminate by restoring the fabricated default:

```
Expectation failed: (renderer.state.withLock { $0.frameDuration }.isValid → true) == false
```

That fails the unknown-cadence test and all four degenerate-duration cases (`zero`, `invalid`, `indefinite`, `positiveInfinity`).

Parameterised coverage for 23.976 / 24 / 25 / 29.97 / 30 / 50 / 59.94 / 60.

Full suite 1713 tests pass; iOS Simulator build clean; strict-concurrency and SwiftLint clean.

### A test I had to correct

My first NTSC test asserted the rational form differed from a `Double` reciprocal at timescale 24000. **That was wrong** — `CMTime(seconds:preferredTimescale:)` rounds to the given timescale, and at 24000 it lands on exactly 1001/24000, so the two agree. The precision loss appears when the duration is forced into a *different* timescale. Rewritten to demonstrate that instead, since the original assertion would have passed for the wrong reason.

## Remaining

Two acceptance criteria are device work and belong to the #88 matrix:

- **Presented cadence, drops and backpressure measured on physical devices.** This PR fixes what we *tell* AVFoundation; whether the presented cadence actually improves is an on-device measurement.
- **Rate changes, pause/resume, replacement and PiP resize preserving monotonic timing.**

Also not covered: true variable-frame-rate sources where a single per-track cadence is itself an approximation. For those the track reports an average and the honest options are that average or `.invalid`; this takes the average when reported. Worth revisiting if device measurement shows VFR content pacing badly.
