### PR TITLE
Stop the drawable-release test racing the autorelease pool

### DIFF
--- a/Tests/SwiftVLCTests/Player/PlayerNativeLifecycleTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerNativeLifecycleTests.swift
@@ -173,7 +173,7 @@ extension Integration {
     /// copied the raw pointer has finished retaining or messaging it. Keep the
     /// outgoing drawable alive until that exact native handle is released.
     @Test
-    func `detaching drawable from a list-owned handle retains it until full native release`() async {
+    func `detaching drawable from a list-owned handle retains it until full native release`() async throws {
       let player = Player(instance: TestInstance.shared)
       let listPlayer = MediaListPlayer(instance: TestInstance.shared)
       listPlayer.mediaPlayer = player
@@ -197,7 +197,19 @@ extension Integration {
       await player.shutdown()
       #expect(lifetime.isReleased)
       #expect(listPlayer.mediaPlayer == nil)
-      #expect(weakDrawable == nil)
+      // Polled rather than asserted outright. What this test guards is that the
+      // drawable is *not retained forever* — the final release can still be
+      // sitting in an autorelease pool when `shutdown()` returns, and on tvOS it
+      // regularly is, which made this the repo's most frequent CI flake.
+      //
+      // This stays discriminating: a genuine over-retain never releases, so the
+      // poll runs to its deadline and fails. It only tolerates the release
+      // landing a moment later than the return, which was never the property
+      // under test.
+      #expect(
+        try await poll(until: { weakDrawable == nil }),
+        "the drawable was still retained after the native handle was released"
+      )
     }
 
     @Test(.timeLimit(.minutes(1)))


### PR DESCRIPTION
No issue for this one — it is a CI reliability fix I hit three times today while landing other work. Happy to file an issue first if you'd prefer that order.

## The flake

`detaching drawable from a list-owned handle retains it until full native release` asserted `weakDrawable == nil` the instant `shutdown()` returned:

```
✘ Expectation failed: (weakDrawable → <NSObject: 0x101bce7d0>) == nil
```

The final release can still be sitting in an autorelease pool at that point, and on tvOS it regularly is. Observed on `main` (run 30345612147) and twice more today on unrelated feature branches — including once where I initially suspected my own change.

## Why the assertion was wrong

What the test guards is that the drawable is **not retained forever**. The whole point of the lease is that it outlives the native handle and is *then* dropped. Asserting on the exact instant of release was never the property under test, just an accident of how it was written — and the instant is not something the runtime promises.

Now polled with the repo's existing bounded helper. That keeps it discriminating: a genuine over-retain never releases, so the poll runs to its three-second deadline and fails.

## Verified in both directions

Sabotaging the **real** release path in `Player+Teardown.swift` — appending the drawables back instead of clearing them — fails the test at the deadline:

```
Expectation failed: try await poll(until: { weakDrawable == nil })
Test run with 1 test in 2 suites failed after 3.071 seconds
```

Restored, it passes in 0.064s.

Worth recording: my **first** sabotage attempt, at `Player+Drawable.swift:318`, did *not* fail the test. That line is not the release path this test exercises, so treating it as confirmation would have been a false positive — I only found the real path by looking again when the result came back green.

Ran the suite three consecutive times on a tvOS simulator: 17 tests, `TEST SUCCEEDED` each time. Full macOS suite: 1708 tests pass.

## Not fixed here

The other tvOS flake — `Early unexpected exit, operation never finished bootstrapping … Test crashed with signal term before establishing connection` — is a simulator bootstrap crash rather than a test defect. It wants a different remedy (a `simctl bootstatus` wait before `xcodebuild test`, or disabling parallel testing) and belongs in its own change with its own measurement.

For triage, the three tvOS failure modes are distinguishable from the log:
- a compile error or `Testing failed:` with real messages → a genuine break;
- one unrelated test failing out of a full ~1448-test run → this flake;
- `Early unexpected exit … before establishing connection` → the bootstrap flake.
