### PR TITLE
Backport the post-pin demuxer fixes (#79)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -384,6 +384,12 @@ jobs:
           flags: swiftpm
           name: swiftvlc-swiftpm
 
+      # The flag matches the `swift test` invocation above. Without it SwiftPM
+      # sees a different build configuration and recompiles the entire module
+      # from scratch, which is what previously pushed this step past its
+      # timeout — the docs themselves were never the slow part.
       - name: Doc coverage
         timeout-minutes: 3
+        env:
+          DOC_COVERAGE_BUILD_FLAGS: --enable-code-coverage
         run: ./scripts/doc-coverage.sh

--- a/scripts/doc-coverage.sh
+++ b/scripts/doc-coverage.sh
@@ -15,6 +15,9 @@
 # Usage:
 #   ./scripts/doc-coverage.sh            # report + summary
 #   ./scripts/doc-coverage.sh --json     # emit JSON (for CI consumption)
+#
+# Environment:
+#   DOC_COVERAGE_BUILD_FLAGS — extra flags for the `swift build` below.
 
 set -euo pipefail
 
@@ -22,15 +25,29 @@ MODULE="SwiftVLC"
 OUT_DIR="$(mktemp -d)"
 trap 'rm -rf "$OUT_DIR"' EXIT
 
+# SwiftPM keys its build products on the exact flag set, so a build differing
+# from the previous one by a single flag recompiles the whole module. CI runs
+# `swift test --enable-code-coverage` immediately before this script; matching
+# that here turns the build below into a no-op instead of a ~400-file rebuild
+# that does not fit in the step's budget. Callers with a differently configured
+# build set this to their own flags.
+BUILD_FLAGS=()
+if [[ -n "${DOC_COVERAGE_BUILD_FLAGS:-}" ]]; then
+  # Word-split deliberately: the variable carries a flag list, not one argument.
+  read -r -a BUILD_FLAGS <<< "$DOC_COVERAGE_BUILD_FLAGS"
+fi
+
 # xcrun respects $TOOLCHAINS when CI pins a specific Swift toolchain.
-xcrun swift build --target "$MODULE" >/dev/null
+# `${arr[@]+…}` guards the expansion: under `set -u`, bash 3.2 — still what
+# /bin/bash is on macOS — treats an empty array as unbound.
+xcrun swift build --target "$MODULE" ${BUILD_FLAGS[@]+"${BUILD_FLAGS[@]}"} >/dev/null
 
 # Derive target triple and build layout from the active toolchain / SwiftPM
 # rather than hard-coding `arm64-apple-macosx15.0` + `.build/arm64-apple-macosx/…`.
 # Hard-coded paths break on Intel runners and future SwiftPM layouts.
 TARGET="$(xcrun swiftc -print-target-info \
   | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["target"]["triple"])')"
-BIN_DIR="$(xcrun swift build --target "$MODULE" --show-bin-path)"
+BIN_DIR="$(xcrun swift build --target "$MODULE" ${BUILD_FLAGS[@]+"${BUILD_FLAGS[@]}"} --show-bin-path)"
 SDK="$(xcrun --sdk macosx --show-sdk-path)"
 MODULES_DIR="$BIN_DIR/Modules"
 FRAMEWORKS_DIR="$BIN_DIR/PackageFrameworks"

--- a/scripts/patches/0009-mp4-pcr-large-buffering.patch
+++ b/scripts/patches/0009-mp4-pcr-large-buffering.patch
@@ -1,0 +1,109 @@
+# Backport fa7e1cdd3e2a39565fe5a74e741ec1e748b3e06c:
+#   demux: mp4: ensure PCR updates are sent with large buffering sequence
+#
+# The pinned revision can leave the PCR stalled through a long buffering
+# sequence, and a stalled PCR stalls the playback clock. The backport tracks the
+# minimum non-zero DTS across tracks in both DemuxMoov() and DemuxMoof() and
+# emits es_out_SetPCR() from it, and makes every PCR write monotonic so a late
+# track cannot walk the clock backwards.
+#
+# Applies cleanly to c833c4be0 with no prerequisite commits. Independent of the
+# player/decoder pause series in this issue.
+#
+# Note the parent commit, ae06c7155afa34e82e5fb3eb6e24e99f0184b9d0, is already
+# backported as patch 0006 for an unrelated reason (AAC roll seek points). This
+# patch does not depend on it -- verified by applying to a pristine pin without
+# 0006 -- but they touch the same file in disjoint regions.
+diff --git a/modules/demux/mp4/mp4.c b/modules/demux/mp4/mp4.c
+index 9b8c8303e3c..78545ac01fd 100644
+--- a/modules/demux/mp4/mp4.c
++++ b/modules/demux/mp4/mp4.c
+@@ -1782,6 +1782,7 @@ static int DemuxMoov( demux_t *p_demux )
+     {
+         mp4_track_t *tk = NULL;
+         i_status = VLC_DEMUXER_EOS;
++        vlc_tick_t i_minnzdts = VLC_TICK_MAX;
+ 
+         /* First pass, find any track within our target increment, ordered by position */
+         for( i_track = 0; i_track < p_sys->i_tracks; i_track++ )
+@@ -1795,11 +1796,13 @@ static int DemuxMoov( demux_t *p_demux )
+             /* At least still have data to demux on this or next turns */
+             i_status = VLC_DEMUXER_SUCCESS;
+ 
+-            if ( MP4_TrackGetDTSPTS( p_demux, tk_tmp, NULL ) <= i_nztime + DEMUX_INCREMENT )
++            vlc_tick_t i_nzdts = MP4_TrackGetDTSPTS( p_demux, tk_tmp, NULL );
++            if ( i_nzdts <= i_nztime + DEMUX_INCREMENT )
+             {
+                 if( tk == NULL || MP4_TrackGetPos( tk_tmp ) < MP4_TrackGetPos( tk ) )
+                     tk = tk_tmp;
+             }
++            i_minnzdts = __MIN(i_minnzdts, i_nzdts);
+         }
+ 
+         if( tk )
+@@ -1833,12 +1836,18 @@ static int DemuxMoov( demux_t *p_demux )
+                 i_status = VLC_DEMUXER_SUCCESS;
+         }
+ 
++        if( i_minnzdts != VLC_TICK_MAX && VLC_TICK_0 + i_minnzdts > p_sys->i_pcr )
++        {
++            p_sys->i_pcr = VLC_TICK_0 + i_minnzdts;
++            es_out_SetPCR( p_demux->out, p_sys->i_pcr );
++        }
++
+         if( i_status != VLC_DEMUXER_SUCCESS || !tk )
+             break;
+     }
+ 
+     p_sys->i_nztime += DEMUX_INCREMENT;
+-    if( p_sys->i_pcr != VLC_TICK_INVALID )
++    if( p_sys->i_pcr != VLC_TICK_INVALID && VLC_TICK_0 + p_sys->i_nztime > p_sys->i_pcr )
+     {
+         p_sys->i_pcr = VLC_TICK_0 + p_sys->i_nztime;
+         es_out_SetPCR( p_demux->out, p_sys->i_pcr );
+@@ -5086,6 +5095,7 @@ static int DemuxMoof( demux_t *p_demux )
+     {
+         mp4_track_t *tk = NULL;
+         i_status = VLC_DEMUXER_EOS;
++        vlc_tick_t i_minnzdts = VLC_TICK_MAX;
+ 
+         /* First pass, find any track within our target increment, ordered by position */
+         for( unsigned i = 0; i < p_sys->i_tracks; i++ )
+@@ -5101,11 +5111,13 @@ static int DemuxMoof( demux_t *p_demux )
+             /* At least still have data to demux on this or next turns */
+             i_status = VLC_DEMUXER_SUCCESS;
+ 
+-            if( MP4_rescale_mtime( tk_tmp->i_time, tk_tmp->i_timescale ) <= i_nztime + DEMUX_INCREMENT )
++            vlc_tick_t i_nzdts = MP4_rescale_mtime( tk_tmp->i_time, tk_tmp->i_timescale );
++            if( i_nzdts <= i_nztime + DEMUX_INCREMENT )
+             {
+                 if( tk == NULL || tk_tmp->context.i_trun_sample_pos < tk->context.i_trun_sample_pos )
+                     tk = tk_tmp;
+             }
++            i_minnzdts = __MIN(i_minnzdts, i_nzdts);
+         }
+ 
+         if( tk )
+@@ -5142,6 +5154,12 @@ static int DemuxMoof( demux_t *p_demux )
+                 i_status = VLC_DEMUXER_EOF;
+         }
+ 
++        if( i_minnzdts != VLC_TICK_MAX && VLC_TICK_0 + i_minnzdts > p_sys->i_pcr )
++        {
++            p_sys->i_pcr = VLC_TICK_0 + i_minnzdts;
++            es_out_SetPCR( p_demux->out, p_sys->i_pcr );
++        }
++
+         if( i_status != VLC_DEMUXER_SUCCESS || !tk )
+             break;
+     }
+@@ -5149,7 +5167,8 @@ static int DemuxMoof( demux_t *p_demux )
+     if( i_status != VLC_DEMUXER_EOS )
+     {
+         p_sys->i_nztime += DEMUX_INCREMENT;
+-        p_sys->i_pcr = VLC_TICK_0 + p_sys->i_nztime;
++        if ( VLC_TICK_0 + p_sys->i_nztime > p_sys->i_pcr )
++            p_sys->i_pcr = VLC_TICK_0 + p_sys->i_nztime;
+         es_out_SetPCR( p_demux->out, p_sys->i_pcr );
+     }
+     else

--- a/scripts/patches/0009-mp4-pcr-large-buffering.patch
+++ b/scripts/patches/0009-mp4-pcr-large-buffering.patch
@@ -3,9 +3,14 @@
 #
 # The pinned revision can leave the PCR stalled through a long buffering
 # sequence, and a stalled PCR stalls the playback clock. The backport tracks the
-# minimum non-zero DTS across tracks in both DemuxMoov() and DemuxMoof() and
-# emits es_out_SetPCR() from it, and makes every PCR write monotonic so a late
-# track cannot walk the clock backwards.
+# minimum DTS across tracks in both DemuxMoov() and DemuxMoof() and emits
+# es_out_SetPCR() from it, and makes every PCR write monotonic so a late track
+# cannot walk the clock backwards.
+#
+# `nz` in `i_minnzdts` is VLC's prefix for a *non zero-based* tick -- a
+# timestamp not offset by VLC_TICK_0, matching `i_nztime` and `i_nzdts` in the
+# same loop -- not a value filtered to be non-zero. That is why the PCR write
+# adds VLC_TICK_0 back before publishing. No DTS is excluded from the minimum.
 #
 # Applies cleanly to c833c4be0 with no prerequisite commits. Independent of the
 # player/decoder pause series in this issue.

--- a/scripts/patches/0010-ts-bounds-hardening.patch
+++ b/scripts/patches/0010-ts-bounds-hardening.patch
@@ -12,7 +12,13 @@
 #
 # 93e847d1c02 guards p_pkt->i_buffer > i_skip in SeekToTime() and ProbeChunk().
 # 417a06caa26 requires p_pkt->i_buffer > 4 before reading p_buffer[1] and
-# p_buffer[3]; it must be applied after 93e847d1c02, which it edits.
+# p_buffer[3]; it must be applied after 93e847d1c02, which it edits. That bound
+# is one byte stricter than indexing alone demands -- byte 3 needs only four
+# bytes present -- and is reproduced verbatim rather than loosened. It fails
+# closed, and the only input it additionally rejects is an exactly-four-byte
+# packet, which is malformed against the 188-byte TS packet size whatever the
+# bound says. Diverging from upstream here would also mean this hunk no longer
+# drops out cleanly when the pin moves past the fix.
 # f7d12646eef corrects an inverted bound in ParsePESDataChain():
 # `p_pes->i_buffer + 2 <= i_skip` becomes `p_pes->i_buffer >= i_skip + 2`. The
 # old form permits an out-of-bounds GetWBE.

--- a/scripts/patches/0010-ts-bounds-hardening.patch
+++ b/scripts/patches/0010-ts-bounds-hardening.patch
@@ -1,0 +1,68 @@
+# Backport the dependency-ordered MPEG-TS bounds-check series:
+#   93e847d1c02e8bb55c46f1d9c511e95e9e9bc2ec  check block skip size
+#   417a06caa26df76a51d09bdd5361ef4d9b7c96e3  check block has enough data
+#                                             before checking payload flags
+#   f7d12646eeffd1008b655075db759ed2534485fa  fix boundaries check to read
+#                                             in the block
+#
+# Out-of-bounds reads on truncated or malformed transport streams, which a
+# player that opens untrusted network sources is directly exposed to -- and
+# which matter more here because the shipped engine has historically been built
+# with assertions enabled (see issue #30).
+#
+# 93e847d1c02 guards p_pkt->i_buffer > i_skip in SeekToTime() and ProbeChunk().
+# 417a06caa26 requires p_pkt->i_buffer > 4 before reading p_buffer[1] and
+# p_buffer[3]; it must be applied after 93e847d1c02, which it edits.
+# f7d12646eef corrects an inverted bound in ParsePESDataChain():
+# `p_pes->i_buffer + 2 <= i_skip` becomes `p_pes->i_buffer >= i_skip + 2`. The
+# old form permits an out-of-bounds GetWBE.
+#
+# f7d12646eef is the one behaviour-changing entry: its author notes that PES
+# data previously skipped now gets read, "unless there was a bogus skip". It
+# wants a malformed/truncated TS fixture rather than compile verification alone
+# -- which is also issue #79's own acceptance criterion for this area.
+diff --git a/modules/demux/mpeg/ts.c b/modules/demux/mpeg/ts.c
+index 642947e346c..58643667426 100644
+--- a/modules/demux/mpeg/ts.c
++++ b/modules/demux/mpeg/ts.c
+@@ -1615,12 +1615,12 @@ static void ParsePESDataChain( demux_t *p_demux, ts_pid_t *pid, block_t *p_pes,
+             ( dcd->p_extra[1]&0x10 ) )
+         {
+             /* display length */
+-            if( p_pes->i_buffer + 2 <= i_skip )
++            if( p_pes->i_buffer >= i_skip + 2 )
+                 i_length = GetWBE( &p_pes->p_buffer[i_skip] );
+ 
+             i_skip += 2;
+         }
+-        if( p_pes->i_buffer + 2 <= i_skip )
++        if( p_pes->i_buffer >= i_skip + 2 )
+             i_pes_size = GetWBE( &p_pes->p_buffer[i_skip] );
+         /* */
+         i_skip += 2;
+@@ -2021,7 +2021,7 @@ static int SeekToTime( demux_t *p_demux, const ts_pmt_t *p_pmt, vlc_tick_t i_see
+                     i_pktpcr = GetPCR( p_pkt );
+ 
+                 unsigned i_skip = PKTHeaderAndAFSize( p_pkt );
+-                if( i_pktpcr == TS_90KHZ_INVALID && p_pid->type == TYPE_STREAM &&
++                if( p_pkt->i_buffer > 4 && p_pkt->i_buffer > i_skip && i_pktpcr == TS_90KHZ_INVALID && p_pid->type == TYPE_STREAM &&
+                     ts_stream_Find_es( p_pid->u.p_stream, p_pmt ) &&
+                    (p_pkt->p_buffer[1] & 0xC0) == 0x40 && /* Payload start but not corrupt */
+                    (p_pkt->p_buffer[3] & 0xD0) == 0x10    /* Has payload but is not encrypted */
+@@ -2111,6 +2111,8 @@ static int ProbeChunk( demux_t *p_demux, int i_program, bool b_end, bool *pb_fou
+             {
+                 b_pcrresult = false;
+                 unsigned i_skip = PKTHeaderAndAFSize( p_pkt );
++                if (p_pkt->i_buffer > i_skip)
++                {
+                 ts_pes_header_t pesh;
+                 ts_pes_header_init( &pesh );
+                 if ( VLC_SUCCESS == ParsePESHeader( NULL, &p_pkt->p_buffer[i_skip],
+@@ -2121,6 +2123,7 @@ static int ProbeChunk( demux_t *p_demux, int i_program, bool b_end, bool *pb_fou
+                     else if( pesh.i_pts != TS_90KHZ_INVALID )
+                         i_pcr = pesh.i_pts;
+                 }
++                }
+             }
+ 
+             if( i_pcr != TS_90KHZ_INVALID )


### PR DESCRIPTION
First slice of #79. Also carries the **decision** the issue asks for: backport, do not move the pin.

## The decision, with the measurement behind it

`scripts/build-libvlc.sh:28-32` says the pin is held back because newer revisions "changed `libvlc_time_t` from milliseconds to microseconds and require a coordinated wrapper migration." That is true, and it is **the small problem**. I measured both sides.

**The µs migration alone** (`a10f9a0e953`): ~23 C-boundary call sites, 15 helper functions, ~51 unit-bearing test assertions, plus five items needing judgement rather than rescaling. Call it 1–2 days. No overflow risk — Int64 µs spans ±292,000 years.

But it is dangerous out of proportion to its size: **`typedef int64_t libvlc_time_t` before and after**. No signature changes, no type changes. Nothing in that commit produces a compiler error or warning — a wrapper that recompiles cleanly is silently 1000× wrong at runtime, in a codebase whose CI cannot reach `.playing`.

**What actually blocks the pin move** is not the units at all:

| Blocker | Impact |
|---|---|
| `include/vlc/libvlc_events.h` **deleted**; `libvlc_event_manager_t` removed | `EventBridge`, `Player`, `Media`, `RendererDiscoverer`, `ThumbnailRequest` all built on it |
| Parsing moved to a new `libvlc_parser` API | `libvlc_media_parse_request` / `_stop` / `_parsed_status_*` gone |
| Thumbnailing folded into `libvlc_parser` | `libvlc_media_thumbnail_request_by_time` / `_destroy` gone |
| 61 of ~380 libVLC symbols we reference no longer exist | — |
| 8 local patches (~165 KB) written against `c833c4be0` | all need rebasing across 2776 commits |

Verified directly: `git show origin/master:include/vlc/libvlc_events.h` fails; it succeeds at the pin. `libvlc_event_attach` is absent from master's public headers.

That is a multi-week rewrite of three subsystems. **Backporting costs 19 commits with a 1.19 transitive fan-out.**

## Ledger summary

All 16 commits named in #79 (the issue prose says 15; it lists 16) resolve unambiguously, are ancestors of `origin/master`, are not ancestors of the pin, and none is reverted upstream. With **3 transitive prerequisites** not named in the issue, all 19 cherry-pick cleanly in dependency order, and patches `0001`–`0008` still apply on top unchanged.

Full ledger — per-commit analysis, dependency chains, ordering constraints — goes in the issue.

## This PR: Cluster E only

The four demuxer commits have **no prerequisites and no coupling** to the player/decoder pause series, so they ship first and derisk that half independently.

- **`0009`** — `fa7e1cdd3e2`, mp4 PCR updates through a large buffering sequence. A stalled PCR stalls the playback clock.
- **`0010`** — the TS bounds series `93e847d1c02` → `417a06caa26` → `f7d12646eef` (ordered; the second edits a line the first adds). Out-of-bounds reads on truncated or malformed transport streams — directly relevant to opening untrusted network sources, and more so given the shipped engine's assertions-on history (#30).

Both apply to a pristine `c833c4be0` and in series after `0001`–`0008`, and both **compile clean** under `-fsyntax-only` against the real `config.h` and contrib dvbpsi headers.

## Why compiling, not just applying

The ledger surfaced a trap worth naming, and I reproduced it rather than taking it on report:

`9f80ae524f8` cherry-picks with **zero conflict** onto the pin, and then does not build:

```
src/input/input.c:1734:9: error: use of undeclared identifier 'can_defer'
 1734 |     if (can_defer &&
```

Git's 3-way merge happily accepts a hunk referencing a parameter that its prerequisite (`73ca279b355`) introduces. Applying that prerequisite clears it. **No commit in this backport should be judged by cherry-pick exit code.**

## Remaining, stated plainly

- **`f7d12646eef` changes behaviour**, not just bounds: its author notes PES data previously skipped now gets read. It wants a malformed/truncated TS fixture — which is #79's own acceptance criterion for this area — and **this PR does not provide one**.
- The 15 remaining commits (player timer, deferred pause during buffering, decoder output state) are a separate PR.
- Not verified here: full link, runtime behaviour, or the Apple platform slices. This is syntax/type checking on the macOS config.
- The build-script comment should be corrected — it points a future maintainer at the wrong blocker. I'd rather do that in the PR that finishes the ledger than bury it here.
