### PR TITLE
Move cached PiP handles onto the successor before release (#86)

### DIFF
--- a/Sources/SwiftVLC/PiP/NativeHandleSnapshotObserver.swift
+++ b/Sources/SwiftVLC/PiP/NativeHandleSnapshotObserver.swift
@@ -1,0 +1,95 @@
+#if os(iOS) || os(macOS)
+
+/// A consumer that caches the player's native handle so callback threads can
+/// read it without touching the main actor.
+///
+/// AVKit and VLC's own PiP module ask synchronous questions from arbitrary
+/// threads, so the handle they interrogate is published into a lock rather
+/// than read through the main-actor `Player`. That makes the cached copy a
+/// *second* owner of a lifetime it does not control: ``Player`` replaces its
+/// native handle independently of its own identity — lazily when
+/// drawable-hosted playback stops, and on a renderer recast — and releases the
+/// outgoing one.
+///
+/// Nothing in the type system connects those two facts, which is how a freed
+/// handle survived in two separate snapshots. Conforming here is what makes
+/// the connection explicit: an observer is told to republish *after* the new
+/// handle is installed and *before* the old one is released, so no callback
+/// thread can ever observe a pointer that has been freed.
+/// The three transitions below mirror the direct-PiP callback hooks
+/// (`moveDirectPiPVideoCallbacks(to:)` / `retireDirectPiPVideoCallbacksForHandleEnd()`)
+/// one for one. Those cover the vout callback slot; these cover the cached
+/// handle the synchronous AVKit queries read. Any new handle transition needs
+/// an entry in both sets.
+@MainActor
+protocol NativeHandleSnapshotObserver: AnyObject {
+  /// Republish the cached handle from the player's current one.
+  func refreshNativeHandleSnapshot()
+
+  /// Publish "no handle": the player's native handle is ending with no
+  /// successor to move to, so the only safe cached value is none.
+  func invalidateNativeHandleSnapshot()
+}
+
+extension Player {
+  /// Registers a consumer to be refreshed on every native-handle replacement.
+  ///
+  /// Held weakly: observers are PiP controllers and media controllers whose
+  /// lifetime is owned by the view layer, and a strong reference here would
+  /// keep a dismissed screen's controller alive past its teardown — the exact
+  /// situation that produced the dangling pointer in the first place.
+  func registerNativeHandleSnapshotObserver(_ observer: NativeHandleSnapshotObserver) {
+    pruneNativeHandleSnapshotObservers()
+    guard !nativeHandleSnapshotObservers.contains(where: { $0.value === observer }) else {
+      return
+    }
+    nativeHandleSnapshotObservers.append(WeakNativeHandleSnapshotObserver(observer))
+  }
+
+  func unregisterNativeHandleSnapshotObserver(_ observer: NativeHandleSnapshotObserver) {
+    nativeHandleSnapshotObservers.removeAll { $0.value == nil || $0.value === observer }
+  }
+
+  /// Tells every live observer to republish.
+  ///
+  /// Call sites must invoke this *between* installing the successor handle and
+  /// releasing the predecessor. Refreshing earlier republishes the handle that
+  /// is about to be freed; refreshing later leaves a window in which a
+  /// callback thread reads freed memory.
+  func refreshNativeHandleSnapshots() {
+    pruneNativeHandleSnapshotObservers()
+    for box in nativeHandleSnapshotObservers {
+      box.value?.refreshNativeHandleSnapshot()
+    }
+  }
+
+  /// Tells every live observer that the handle is ending with no successor.
+  ///
+  /// Used by `deinit`, where there is nothing to republish: the player itself
+  /// is going away, so an observer that re-derived its cache from `self` would
+  /// be reading a half-destroyed object.
+  func invalidateNativeHandleSnapshots() {
+    pruneNativeHandleSnapshotObservers()
+    for box in nativeHandleSnapshotObservers {
+      box.value?.invalidateNativeHandleSnapshot()
+    }
+    nativeHandleSnapshotObservers.removeAll()
+  }
+
+  private func pruneNativeHandleSnapshotObservers() {
+    nativeHandleSnapshotObservers.removeAll { $0.value == nil }
+  }
+}
+
+/// Weak box. `NativeHandleSnapshotObserver` is a class-bound protocol, so this
+/// only needs to exist because Swift arrays cannot hold weak elements
+/// directly.
+struct WeakNativeHandleSnapshotObserver {
+  weak var value: (any NativeHandleSnapshotObserver)?
+
+  init(_ value: any NativeHandleSnapshotObserver) {
+    self.value = value
+  }
+}
+
+#endif

--- a/Sources/SwiftVLC/PiP/PiPCallbackSnapshot.swift
+++ b/Sources/SwiftVLC/PiP/PiPCallbackSnapshot.swift
@@ -42,7 +42,15 @@ struct PiPCallbackSnapshot: @unchecked Sendable {
   }
 }
 
-extension PiPController {
+extension PiPController: NativeHandleSnapshotObserver {
+  func refreshNativeHandleSnapshot() {
+    refreshCallbackSnapshot()
+  }
+
+  func invalidateNativeHandleSnapshot() {
+    invalidateCallbackSnapshot()
+  }
+
   /// Republishes everything the callback threads read.
   ///
   /// Called from the main actor whenever the attached handle, the timebase or

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -342,6 +342,7 @@ public final class PiPController: NSObject {
     setupPiPController()
     startStateObserver()
     startPlaybackIntentObserver()
+    player.registerNativeHandleSnapshotObserver(self)
     startCadenceObserver()
   }
 
@@ -390,6 +391,7 @@ public final class PiPController: NSObject {
     updatePiPActive(nativeBackend.isActive)
     startStateObserver()
     startPlaybackIntentObserver()
+    player.registerNativeHandleSnapshotObserver(self)
   }
   #endif
 
@@ -419,6 +421,7 @@ public final class PiPController: NSObject {
     updatePiPActive(nativeBackend.isActive)
     startStateObserver()
     startPlaybackIntentObserver()
+    player.registerNativeHandleSnapshotObserver(self)
   }
   #endif
 
@@ -451,6 +454,7 @@ public final class PiPController: NSObject {
     setupPiPController()
     startStateObserver()
     startPlaybackIntentObserver()
+    player.registerNativeHandleSnapshotObserver(self)
   }
 
   isolated deinit {
@@ -471,6 +475,7 @@ public final class PiPController: NSObject {
     // Stop any in-flight AVKit query from interrogating a handle that is
     // about to be released. Cleared before the relinquish below, so the
     // window where a callback could see a dead pointer never opens.
+    player.unregisterNativeHandleSnapshotObserver(self)
     invalidateCallbackSnapshot()
     renderer.setDisplayLayer(nil)
     renderer.setTimebase(nil)

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -877,9 +877,22 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
   }
 }
 
+extension IOSNativePiPMediaController: NativeHandleSnapshotObserver {
+  func refreshNativeHandleSnapshot() {
+    refreshCallbackSnapshot()
+  }
+
+  func invalidateNativeHandleSnapshot() {
+    invalidateCallbackSnapshot()
+  }
+}
+
 final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling, @unchecked Sendable {
   weak var player: Player? {
-    didSet { publishCallbackSnapshot() }
+    didSet {
+      guard oldValue !== player else { return }
+      publishCallbackSnapshot(movingRegistrationFrom: oldValue, to: player)
+    }
   }
 
   /// What VLC's native PiP module reads instead of blocking on the main
@@ -888,13 +901,37 @@ final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling,
 
   /// Publishes without assuming the caller is already on the main actor.
   /// `assumeIsolated` would trap if this nominally nonisolated class is ever
-  /// mutated from a background thread.
-  private func publishCallbackSnapshot() {
+  /// mutated from a background thread — `IOSNativePiPBackend` is `@unchecked
+  /// Sendable` and attaches without an isolation guarantee.
+  ///
+  /// The players are passed rather than re-read on the main actor: on the
+  /// asynchronous path the property may already have moved on, and unhooking
+  /// the wrong player would leave the outgoing one still refreshing this
+  /// snapshot.
+  private func publishCallbackSnapshot(
+    movingRegistrationFrom outgoing: Player? = nil,
+    to incoming: Player? = nil
+  ) {
     if Thread.isMainThread {
-      MainActor.assumeIsolated { refreshCallbackSnapshot() }
+      MainActor.assumeIsolated {
+        moveSnapshotRegistration(from: outgoing, to: incoming)
+        refreshCallbackSnapshot()
+      }
     } else {
-      Task { @MainActor [weak self] in self?.refreshCallbackSnapshot() }
+      Task { @MainActor [weak self] in
+        self?.moveSnapshotRegistration(from: outgoing, to: incoming)
+        self?.refreshCallbackSnapshot()
+      }
     }
+  }
+
+  /// Follows the attachment: a handle replacement on the newly attached player
+  /// has to reach this snapshot, and the player being detached has to stop
+  /// refreshing a controller it no longer drives.
+  @MainActor
+  private func moveSnapshotRegistration(from outgoing: Player?, to incoming: Player?) {
+    outgoing?.unregisterNativeHandleSnapshotObserver(self)
+    incoming?.registerNativeHandleSnapshotObserver(self)
   }
 
   /// Republished whenever the attached player changes.
@@ -906,6 +943,18 @@ final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling,
         snapshot.generation &+= 1
       }
       snapshot.playerPointer = pointer
+    }
+  }
+
+  /// Clears the cached handle so in-flight callbacks stop interrogating one
+  /// that is being torn down with nothing to replace it.
+  @MainActor
+  func invalidateCallbackSnapshot() {
+    callbackSnapshot.withLock { snapshot in
+      if snapshot.playerPointer != nil {
+        snapshot.generation &+= 1
+      }
+      snapshot.playerPointer = nil
     }
   }
 

--- a/Sources/SwiftVLC/Player/Player+Drawable.swift
+++ b/Sources/SwiftVLC/Player/Player+Drawable.swift
@@ -315,6 +315,13 @@ extension Player {
     attachedMediaListPlayer?.rebindMediaPlayerHandle()
     applyAspectRatio()
 
+    #if os(iOS) || os(macOS)
+    // Between installing the successor and releasing the predecessor: any
+    // callback thread reading a cached handle must see the new one before the
+    // old one is freed.
+    refreshNativeHandleSnapshots()
+    #endif
+
     retainedDrawablesUntilNativePlayerRelease.removeAll()
     nativePlayerNeedsReplacementBeforePlayback = false
     needsDrawableRebindForPlayback = false

--- a/Sources/SwiftVLC/Player/Player+Teardown.swift
+++ b/Sources/SwiftVLC/Player/Player+Teardown.swift
@@ -241,6 +241,12 @@ extension Player {
     let replacementLifetime = NativePlayerHandleLifetime(pointer: replacement)
     pointer = replacement
     nativeHandleLifetime = replacementLifetime
+    #if os(iOS) || os(macOS)
+    // Between installing the inert successor and tearing the predecessor down
+    // below: a callback thread reading a cached handle must be moved onto the
+    // successor before `p` is released.
+    refreshNativeHandleSnapshots()
+    #endif
 
     await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
       DispatchQueue.global(qos: .utility).async {

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -429,6 +429,13 @@ public final class Player {
   /// for consumers that must not mistake the previous media's capability for
   /// the current one. See ``PlayerCapabilitySnapshot``.
   nonisolated let capabilitySnapshot = Mutex(PlayerCapabilitySnapshot())
+  #if os(iOS) || os(macOS)
+  /// Consumers caching the native handle for lock-free callback reads. See
+  /// ``NativeHandleSnapshotObserver``.
+  @ObservationIgnored
+  var nativeHandleSnapshotObservers: [WeakNativeHandleSnapshotObserver] = []
+  #endif
+
   /// Set while a multi-property capability change is in progress, so the
   /// per-property `didSet` publishes do not expose an intermediate mix of the
   /// outgoing and incoming media. See ``resetMediaDerivedState()``.
@@ -553,6 +560,10 @@ public final class Player {
     playbackIntentBridge.terminate()
     #if os(iOS) || os(macOS)
     retireDirectPiPVideoCallbacksForHandleEnd()
+    // No successor to move to here, unlike replacement and shutdown: the
+    // player itself is being destroyed, so the only cached handle that stays
+    // valid past this point is none.
+    invalidateNativeHandleSnapshots()
     #endif
     // Tell libVLC to forget the drawable *before* release so the
     // vout thread observes a nil pointer rather than dereferencing a

--- a/Tests/SwiftVLCTests/PiP/NativeHandleSnapshotObserverTests.swift
+++ b/Tests/SwiftVLCTests/PiP/NativeHandleSnapshotObserverTests.swift
@@ -1,0 +1,262 @@
+#if os(iOS) || os(macOS)
+@testable import SwiftVLC
+import Foundation
+import Synchronization
+import Testing
+
+/// Records what the player asks of an observer, and what the player's handle
+/// was at the moment it asked.
+@MainActor
+private final class RecordingSnapshotObserver: NativeHandleSnapshotObserver {
+  private(set) var refreshedHandles: [OpaquePointer] = []
+  private(set) var invalidateCount = 0
+  /// Weak, mirroring the real observers: a strong reference here would keep
+  /// the player alive and hide the very deinit path under test.
+  weak var player: Player?
+
+  init(player: Player) {
+    self.player = player
+  }
+
+  func refreshNativeHandleSnapshot() {
+    if let pointer = player?.pointer {
+      refreshedHandles.append(pointer)
+    }
+  }
+
+  func invalidateNativeHandleSnapshot() {
+    invalidateCount += 1
+  }
+}
+
+extension Integration {
+  /// A cached native handle is a second owner of a lifetime it does not
+  /// control. `Player` replaces its handle independently of its own identity
+  /// and releases the outgoing one, so every consumer holding a copy has to be
+  /// moved onto the successor *before* the predecessor is freed.
+  ///
+  /// Missing that is what produced #86: PiP kept answering AVKit's synchronous
+  /// queries from a snapshot taken before a replacement, and
+  /// `libvlc_media_player_get_length` was eventually handed a freed handle.
+  /// On device it surfaced as a `SIGBUS` inside `vlc_mutex_lock`, several
+  /// frames away from the actual defect.
+  @Suite(.tags(.mainActor, .async), .serialized)
+  @MainActor struct NativeHandleSnapshotObserverTests {
+    // MARK: - The real PiP path
+
+    /// The #86 regression. Replacement installs the successor and then releases
+    /// the predecessor; a PiP controller left pointing at the predecessor is
+    /// holding freed memory the moment that release lands.
+    @Test
+    func `A handle replacement moves the PiP snapshot onto the successor`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = PiPController(player: player)
+
+      let outgoing = player.pointer
+      #expect(controller.callbackSnapshot.withLock { $0.playerPointer } == outgoing)
+
+      try player.replaceNativePlayerForDrawablePlayback(target: nil)
+      let incoming = player.pointer
+
+      // The successor is allocated before the predecessor is released, so the
+      // two addresses can never alias and this comparison is exact.
+      #expect(incoming != outgoing, "the replacement did not install a new handle")
+      #expect(
+        controller.callbackSnapshot.withLock { $0.playerPointer } == incoming,
+        "the PiP snapshot still points at the released handle"
+      )
+
+      await player.shutdown()
+    }
+
+    /// Shutdown is the other replacement: it swaps in an inert handle and tears
+    /// the live one down off the main actor. Same hazard, different entry
+    /// point.
+    @Test
+    func `Shutdown moves the PiP snapshot off the retiring handle`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = PiPController(player: player)
+      let retiring = player.pointer
+
+      await player.shutdown()
+
+      #expect(
+        controller.callbackSnapshot.withLock { $0.playerPointer } != retiring,
+        "the PiP snapshot still points at the handle shutdown released"
+      )
+    }
+
+    /// Invalidation clears rather than re-derives. `PiPController` holds its
+    /// player strongly, so it always tears down before that player's `deinit`
+    /// and never reaches this through the registry today — but the conformance
+    /// is what the registry dispatches, and "clear" is the only answer that
+    /// stays correct once there is no successor handle to point at.
+    @Test
+    func `An invalidated PiP controller clears its cached handle`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = PiPController(player: player)
+      #expect(controller.callbackSnapshot.withLock { $0.playerPointer } != nil)
+
+      player.invalidateNativeHandleSnapshots()
+
+      #expect(controller.callbackSnapshot.withLock { $0.playerPointer } == nil)
+      await player.shutdown()
+    }
+
+    // MARK: - Ordering
+
+    /// The refresh has to land while the outgoing handle is still alive.
+    /// Republishing after the release would still leave the correct pointer
+    /// cached at the end, so an end-state assertion alone cannot tell a fix
+    /// from a race. Observing the handle *at callback time* can.
+    @Test
+    func `The successor is published before the predecessor is released`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let observer = RecordingSnapshotObserver(player: player)
+      player.registerNativeHandleSnapshotObserver(observer)
+
+      let outgoing = player.pointer
+      try player.replaceNativePlayerForDrawablePlayback(target: nil)
+      let incoming = player.pointer
+
+      #expect(incoming != outgoing)
+      #expect(
+        observer.refreshedHandles.contains(incoming),
+        "no refresh carried the successor handle"
+      )
+      #expect(
+        observer.refreshedHandles.allSatisfy { $0 != outgoing },
+        "a refresh published the handle that was about to be released"
+      )
+    }
+
+    // MARK: - Registry semantics
+
+    /// `deinit` has no successor to move to, so the only cached handle that
+    /// stays valid is none. Distinguished from replacement deliberately:
+    /// re-deriving a snapshot from a player that is mid-destruction is not a
+    /// safe thing to ask for.
+    @Test
+    func `Player deinit invalidates rather than refreshes`() async {
+      let observer: RecordingSnapshotObserver
+      let refreshesBeforeDeinit: Int
+      // Scoped so the player's last strong reference is gone at the closing
+      // brace. `isolated deinit` then runs synchronously here on the main
+      // actor, which is what makes the assertions below deterministic.
+      do {
+        let player = Player(instance: TestInstance.makeAudioOnly())
+        observer = RecordingSnapshotObserver(player: player)
+        player.registerNativeHandleSnapshotObserver(observer)
+        await player.shutdown()
+        refreshesBeforeDeinit = observer.refreshedHandles.count
+      }
+
+      #expect(observer.invalidateCount == 1, "deinit did not invalidate the cached handle")
+      #expect(
+        observer.refreshedHandles.count == refreshesBeforeDeinit,
+        "deinit re-derived a snapshot from a player being destroyed"
+      )
+    }
+
+    /// Registering twice must not double-notify. The PiP backends attach on
+    /// several paths and a duplicate entry would be invisible until it showed
+    /// up as a doubled generation bump.
+    @Test
+    func `Registering twice notifies once`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let observer = RecordingSnapshotObserver(player: player)
+      player.registerNativeHandleSnapshotObserver(observer)
+      player.registerNativeHandleSnapshotObserver(observer)
+
+      try player.replaceNativePlayerForDrawablePlayback(target: nil)
+
+      #expect(observer.refreshedHandles.count == 1)
+      await player.shutdown()
+    }
+
+    @Test
+    func `An unregistered observer stops being refreshed`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let observer = RecordingSnapshotObserver(player: player)
+      player.registerNativeHandleSnapshotObserver(observer)
+      player.unregisterNativeHandleSnapshotObserver(observer)
+
+      try player.replaceNativePlayerForDrawablePlayback(target: nil)
+
+      #expect(observer.refreshedHandles.isEmpty)
+      await player.shutdown()
+    }
+
+    /// Held weakly. The observers are view-layer controllers, and a strong
+    /// reference from the player would keep a dismissed screen's controller
+    /// alive past its own teardown — which is the situation that produced the
+    /// dangling pointer to begin with.
+    @Test
+    func `A released observer is dropped rather than kept alive`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      weak var probe: RecordingSnapshotObserver?
+      do {
+        let observer = RecordingSnapshotObserver(player: player)
+        probe = observer
+        player.registerNativeHandleSnapshotObserver(observer)
+      }
+
+      #expect(probe == nil, "the player kept the observer alive")
+
+      // The dead entry must not be dereferenced or left behind.
+      try player.replaceNativePlayerForDrawablePlayback(target: nil)
+      #expect(player.nativeHandleSnapshotObservers.isEmpty)
+
+      await player.shutdown()
+    }
+
+    #if os(iOS)
+
+    // MARK: - The path the device crash came through
+
+    /// `IOSNativePiPMediaController` is what libVLC's own PiP module calls, and
+    /// `mediaLength()` reaches straight into `libvlc_media_player_get_length`
+    /// with whatever handle the snapshot holds. This is the exact query that
+    /// faulted in #86.
+    @Test
+    func `A handle replacement moves the native media controller snapshot`() async throws {
+      let player = Player(instance: TestInstance.shared)
+      let mediaController = IOSNativePiPMediaController()
+      mediaController.player = player
+
+      let outgoing = player.pointer
+      #expect(mediaController.callbackSnapshot.withLock { $0.playerPointer } == outgoing)
+
+      try player.replaceNativePlayerForDrawablePlayback(target: nil)
+      let incoming = player.pointer
+
+      #expect(incoming != outgoing, "the replacement did not install a new handle")
+      #expect(
+        mediaController.callbackSnapshot.withLock { $0.playerPointer } == incoming,
+        "mediaLength() would interrogate the handle the replacement released"
+      )
+
+      await player.shutdown()
+    }
+
+    /// Detaching has to unhook the registration too, or a controller the view
+    /// layer has finished with keeps being refreshed by a player it no longer
+    /// represents.
+    @Test
+    func `Detaching the native media controller unhooks it from the player`() async {
+      let player = Player(instance: TestInstance.shared)
+      let mediaController = IOSNativePiPMediaController()
+      mediaController.player = player
+      #expect(player.nativeHandleSnapshotObservers.count == 1)
+
+      mediaController.player = nil
+
+      #expect(player.nativeHandleSnapshotObservers.isEmpty)
+      #expect(mediaController.callbackSnapshot.withLock { $0.playerPointer } == nil)
+
+      await player.shutdown()
+    }
+    #endif
+  }
+}
+#endif


### PR DESCRIPTION
Part of #86 — deliberately not an auto-close: the device reproduction below is still outstanding.

## Root cause

PiP answers AVKit's and libVLC's synchronous queries from a snapshot that caches the native player handle, so callback threads never block on the main actor. That cache is a second owner of a lifetime it does not control: `Player` replaces its native handle independently of its own identity and releases the outgoing one.

Nothing in the type system connected those two facts. A snapshot taken before a replacement kept answering afterwards, and `libvlc_media_player_get_length` was eventually handed freed memory.

On device this surfaced as a `SIGBUS` inside `vlc_mutex_lock`, several frames and one AVKit callback away from the actual defect. It reproduces deterministically as a unit test: after a replacement the snapshot still holds the predecessor's address while the player has moved on.

## Implementation

`NativeHandleSnapshotObserver` makes the coupling explicit. Observers register weakly and are driven from the three handle transitions, mirroring the existing direct-PiP callback hooks one for one:

| transition | direct-PiP hook | snapshot hook |
| --- | --- | --- |
| drawable replacement | `moveDirectPiPVideoCallbacks(to:)` | `refreshNativeHandleSnapshots()` |
| shutdown | `retireDirectPiPVideoCallbacksForHandleEnd()` | `refreshNativeHandleSnapshots()` |
| deinit | `retireDirectPiPVideoCallbacksForHandleEnd()` | `invalidateNativeHandleSnapshots()` |

The refresh sits between installing the successor and releasing the predecessor. Earlier republishes the handle about to be freed; later leaves a window where a callback thread reads freed memory.

`deinit` invalidates rather than refreshes: there is no successor to point at, and re-deriving a snapshot from a player that is mid-destruction is not a safe thing to ask for.

Registration is weak because the observers are view-layer controllers. A strong reference from the player would keep a dismissed screen's controller alive past its own teardown, which is the situation that produced the dangling pointer to begin with.

## Scope note

The shutdown path was a second hole found while auditing for the first, not part of the original report. It replaces `pointer` with an inert handle and tears the live one down off the main actor, with exactly the same hazard. Removing that hook fails its own test with the retiring address printed.

## Validation

- 1736 tests on macOS, the full suite on a tvOS simulator, and the new suite on an iOS simulator (the two iOS-only tests cover `IOSNativePiPMediaController.mediaLength()`, the query that actually faulted).
- Each of the three hooks reverted individually to confirm the tests discriminate. Every one fails with the stale pointer in the failure message.
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` clean, lint and format clean, doc coverage 100%.
- Showcase iOS scheme builds against the local checkout.

## Still needs a device

The unit tests pin the invariant, not the system behaviour. PiP is force-disabled in the simulator, so the original reproduction (start PiP, background, foreground, dismiss the hosting screen, start PiP again) still wants a run on hardware before this is called closed.