### PR TITLE
Route PiP's state observer onto the lossless control lane (#78)

### DIFF
--- a/Sources/SwiftVLC/PiP/PiPController+StateObserver.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+StateObserver.swift
@@ -1,0 +1,188 @@
+#if os(iOS) || os(macOS)
+import AVKit
+import CoreMedia
+import Foundation
+import Synchronization
+
+/// The PiP state observer: the subscriptions that keep the control timebase
+/// and the PiP transport in step with the player.
+///
+/// Split into its own file because almost every branch below is reachable
+/// only while the player is actively playing, and CI cannot drive libVLC to
+/// `.playing` at all (`TestCondition.canPlayMedia`). Keeping it here lets the
+/// coverage gate stay enforced on the rest of ``PiPController`` while this
+/// file is reported rather than enforced — see codecov.yml.
+///
+/// The decision logic that *can* be tested headlessly is deliberately pulled
+/// out into ``PiPController/timebaseRetracking(isActive:rate:lastRate:hasTimebase:secondsSinceSkip:playerSeconds:timebaseSeconds:)``,
+/// which is pure and fully covered.
+extension PiPController {
+  /// Drives the control timebase and PiP UI from player events.
+  ///
+  /// Subscribes to *both* lanes, one task each, because this observer needs
+  /// what each lane guarantees and neither alone is sufficient:
+  ///
+  /// - Control events (`.mediaChanged`, `.lengthChanged`, `.seekableChanged`,
+  ///   `.stateChanged`) are one-shot. Losing one leaves PiP permanently wrong
+  ///   for the session — a dropped `.seekableChanged` pins seekable VOD to the
+  ///   conservative media-changed reset, which is linear playback with no skip
+  ///   controls. That lane is unbounded.
+  /// - `.timeChanged` is the clock tick that drives capability convergence and
+  ///   rate retracking. Steady playback can run without another state
+  ///   transition, so those have to be reachable from a tick as well. Only the
+  ///   newest tick means anything, so that lane stays coalesced.
+  ///
+  /// One merged stream cannot express both: a merge has a single buffer, so it
+  /// either grows without bound under a stalled main actor or evicts control
+  /// events. Previously this observer read the mixed `events` stream and took
+  /// the second failure — the reason ``startCadenceObserver()`` was split onto
+  /// the control lane on its own.
+  ///
+  /// Both tasks are `@MainActor`, so they serialize on this actor: the shared
+  /// observation state is mutated between events, never during one. Cross-lane
+  /// ordering is not guaranteed, which is why capability reconciliation is
+  /// generation-guarded rather than order-dependent (see
+  /// ``PlaybackStateObservationState/reconcile(with:invalidates:)``).
+  ///
+  /// The shape of each loop matches `Player.startEventConsumer`: pull via
+  /// `for await` and bind `self` strongly *inside* the body, where the binding
+  /// lasts a single iteration. The implicit suspension between events keeps
+  /// only a weak reference in scope, so an observer never prevents the
+  /// controller from deinitializing.
+  func startStateObserver() {
+    let controlEvents = player.controlEvents
+    let timingEvents = player.timingEvents
+    let initialActive = player.isPlaybackRequestedActive
+    let initialNativeActive = player.isActive
+    pipPlaybackActive = initialActive
+    syncTimebase(playing: initialNativeActive)
+
+    lastObservedNativeActive = initialNativeActive
+    lastObservedRate = 1.0
+    playbackStateObservation = PlaybackStateObservationState(
+      duration: player.duration,
+      isSeekable: player.isSeekable
+    )
+
+    stateObserverTask = Task { @MainActor [weak self] in
+      for await event in controlEvents {
+        guard let self else { return }
+        handleStateObserverEvent(event)
+      }
+    }
+    timingObserverTask = Task { @MainActor [weak self] in
+      for await event in timingEvents {
+        guard let self else { return }
+        handleStateObserverEvent(event)
+      }
+    }
+  }
+
+  /// The body both lane tasks run. Identical work either way: what differs
+  /// between the lanes is delivery guarantees, not handling.
+  private func handleStateObserverEvent(_ event: PlayerEvent) {
+    let active = player.isActive
+    let rate = player.rate
+    let playbackStateUpdate = playbackStateObservation.consume(
+      event,
+      capability: player.capabilitySnapshot.withLock { $0 }
+    )
+    applyObservedPlaybackStateUpdate(playbackStateUpdate)
+
+    // State transition: sync the timebase rate.
+    if active != lastObservedNativeActive {
+      lastObservedNativeActive = active
+      let didAcceptNativeState = handleObservedPlaybackActivity(active)
+
+      if didAcceptNativeState {
+        syncTimebase(playing: active)
+      }
+
+      if didAcceptNativeState, active {
+        // Player is now actively playing — any prior PiP-issued
+        // pause has been superseded by the user's intent.
+        clearIssuedPauseFlag()
+      }
+    }
+
+    let timebase = controlTimebase
+    let time = player.currentTime
+    let retracking = Self.timebaseRetracking(
+      isActive: active,
+      rate: rate,
+      lastRate: lastObservedRate,
+      hasTimebase: timebase != nil,
+      secondsSinceSkip: CFAbsoluteTimeGetCurrent() - lastSkipTimestamp,
+      playerSeconds: Double(time.components.seconds)
+        + Double(time.components.attoseconds) / 1e18,
+      timebaseSeconds: timebase.map { CMTimebaseGetTime($0).seconds } ?? 0
+    )
+
+    if retracking.adoptsRate {
+      lastObservedRate = rate
+    }
+    if let timebase {
+      if let rate = retracking.setsRate {
+        CMTimebaseSetRate(timebase, rate: Float64(rate))
+      }
+      if let seconds = retracking.setsTime {
+        CMTimebaseSetTime(timebase, time: CMTime(seconds: seconds, preferredTimescale: 1000))
+      }
+    }
+  }
+
+  /// What the control timebase should be told after an observed event.
+  struct TimebaseRetracking: Equatable {
+    /// Whether the observer should remember this rate as the last one seen.
+    /// True on any change, including one seen while inactive — otherwise the
+    /// comparison would fire again on the next event and never settle.
+    var adoptsRate = false
+    /// The rate to push onto the timebase, if any.
+    var setsRate: Float?
+    /// The time to push onto the timebase, if any.
+    var setsTime: Double?
+  }
+
+  /// Decides the timebase updates for one observed event.
+  ///
+  /// Pure, and separated from the call site above for a reason the coverage
+  /// config already names: every branch here is gated on the player being
+  /// actively playing, and CI cannot drive libVLC to `.playing` at all (see
+  /// `TestCondition.canPlayMedia`). Keeping the decision in a function that
+  /// takes its inputs as parameters is what makes the rules testable
+  /// headlessly instead of merely unreachable.
+  ///
+  /// The rules:
+  /// - A rate change retracks the scrubber, which would otherwise advance at
+  ///   1.0× while the player runs at 2.0× or 0.5×. `player.rate` has no
+  ///   dedicated libVLC event, so this is picked up from whatever event
+  ///   arrives next — clock ticks, during playback.
+  /// - A large position divergence resyncs the timebase, which is how a seek
+  ///   made from the app's own controls reaches the PiP scrubber.
+  /// - Neither applies within a second of a PiP-issued skip, whose own
+  ///   timebase write must not be overwritten while it settles.
+  nonisolated static func timebaseRetracking(
+    isActive: Bool,
+    rate: Float,
+    lastRate: Float,
+    hasTimebase: Bool,
+    secondsSinceSkip: Double,
+    playerSeconds: Double,
+    timebaseSeconds: Double
+  )
+    -> TimebaseRetracking {
+    var retracking = TimebaseRetracking()
+    retracking.adoptsRate = rate != lastRate
+
+    guard isActive, hasTimebase else { return retracking }
+
+    if retracking.adoptsRate {
+      retracking.setsRate = rate
+    }
+    if secondsSinceSkip > 1.0, abs(playerSeconds - timebaseSeconds) > 2.0 {
+      retracking.setsTime = playerSeconds
+    }
+    return retracking
+  }
+}
+#endif

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -118,6 +118,23 @@ public final class PiPController: NSObject {
   nonisolated let callbackSnapshot = Mutex(PiPCallbackSnapshot())
   @ObservationIgnored
   private var stateObserverTask: Task<Void, Never>?
+  /// The state observer's second subscription. See ``startStateObserver()``
+  /// for why it needs one per lane rather than one merged stream.
+  @ObservationIgnored
+  private var timingObserverTask: Task<Void, Never>?
+  /// The state observer's rolling view of duration and seekability.
+  ///
+  /// Owned by the controller rather than by an observer task because both lane
+  /// tasks feed it. Both are `@MainActor`, so they serialize on this actor and
+  /// interleave between events rather than racing within one.
+  @ObservationIgnored
+  var playbackStateObservation = PlaybackStateObservationState(duration: nil, isSeekable: false)
+  /// Last native-active and rate values the observer acted on, for the same
+  /// reason: the comparison has to survive across events from either lane.
+  @ObservationIgnored
+  private var lastObservedNativeActive = false
+  @ObservationIgnored
+  private var lastObservedRate: Float = 1.0
   @ObservationIgnored
   private var playbackIntentObserverTask: Task<Void, Never>?
   @ObservationIgnored
@@ -461,6 +478,7 @@ public final class PiPController: NSObject {
     pipEventBroadcaster.terminate()
     cancelDeferredPause()
     stateObserverTask?.cancel()
+    timingObserverTask?.cancel()
     playbackIntentObserverTask?.cancel()
     cadenceObserverTask?.cancel()
     possibleObservation = nil
@@ -835,84 +853,118 @@ public final class PiPController: NSObject {
 
   /// Drives the control timebase and PiP UI from player events.
   ///
-  /// The shape below matches `Player.startEventConsumer`: subscribe to
-  /// `player.events` (the same broadcaster that drives `Player`'s own
-  /// `@Observable` state), pull events via `for await`, and bind `self`
-  /// strongly *inside* the loop body where the binding lifetime is a
-  /// single iteration. The implicit suspension between events keeps only
-  /// a weak reference in scope, so the observer task never prevents the
+  /// Subscribes to *both* lanes, one task each, because this observer needs
+  /// what each lane guarantees and neither alone is sufficient:
+  ///
+  /// - Control events (`.mediaChanged`, `.lengthChanged`, `.seekableChanged`,
+  ///   `.stateChanged`) are one-shot. Losing one leaves PiP permanently wrong
+  ///   for the session — a dropped `.seekableChanged` pins seekable VOD to the
+  ///   conservative media-changed reset, which is linear playback with no skip
+  ///   controls. That lane is unbounded.
+  /// - `.timeChanged` is the clock tick that drives capability convergence and
+  ///   rate retracking. Steady playback can run without another state
+  ///   transition, so those have to be reachable from a tick as well. Only the
+  ///   newest tick means anything, so that lane stays coalesced.
+  ///
+  /// One merged stream cannot express both: a merge has a single buffer, so it
+  /// either grows without bound under a stalled main actor or evicts control
+  /// events. Previously this observer read the mixed `events` stream and took
+  /// the second failure — the reason ``startCadenceObserver()`` was split onto
+  /// the control lane on its own.
+  ///
+  /// Both tasks are `@MainActor`, so they serialize on this actor: the shared
+  /// observation state is mutated between events, never during one. Cross-lane
+  /// ordering is not guaranteed, which is why capability reconciliation is
+  /// generation-guarded rather than order-dependent (see
+  /// ``PlaybackStateObservationState/reconcile(with:invalidates:)``).
+  ///
+  /// The shape of each loop matches `Player.startEventConsumer`: pull via
+  /// `for await` and bind `self` strongly *inside* the body, where the binding
+  /// lasts a single iteration. The implicit suspension between events keeps
+  /// only a weak reference in scope, so an observer never prevents the
   /// controller from deinitializing.
   private func startStateObserver() {
-    let events = player.events
+    let controlEvents = player.controlEvents
+    let timingEvents = player.timingEvents
     let initialActive = player.isPlaybackRequestedActive
     let initialNativeActive = player.isActive
-    let initialDuration = player.duration
-    let initialSeekable = player.isSeekable
     pipPlaybackActive = initialActive
     syncTimebase(playing: initialNativeActive)
 
+    lastObservedNativeActive = initialNativeActive
+    lastObservedRate = 1.0
+    playbackStateObservation = PlaybackStateObservationState(
+      duration: player.duration,
+      isSeekable: player.isSeekable
+    )
+
     stateObserverTask = Task { @MainActor [weak self] in
-      var wasActive = initialNativeActive
-      var lastRate: Float = 1.0
-      var playbackStateObservation = PlaybackStateObservationState(
-        duration: initialDuration,
-        isSeekable: initialSeekable
-      )
-      for await event in events {
+      for await event in controlEvents {
         guard let self else { return }
+        handleStateObserverEvent(event)
+      }
+    }
+    timingObserverTask = Task { @MainActor [weak self] in
+      for await event in timingEvents {
+        guard let self else { return }
+        handleStateObserverEvent(event)
+      }
+    }
+  }
 
-        let active = player.isActive
-        let rate = player.rate
-        let playbackStateUpdate = playbackStateObservation.consume(
-          event,
-          capability: player.capabilitySnapshot.withLock { $0 }
-        )
-        applyObservedPlaybackStateUpdate(playbackStateUpdate)
+  /// The body both lane tasks run. Identical work either way: what differs
+  /// between the lanes is delivery guarantees, not handling.
+  private func handleStateObserverEvent(_ event: PlayerEvent) {
+    let active = player.isActive
+    let rate = player.rate
+    let playbackStateUpdate = playbackStateObservation.consume(
+      event,
+      capability: player.capabilitySnapshot.withLock { $0 }
+    )
+    applyObservedPlaybackStateUpdate(playbackStateUpdate)
 
-        // State transition: sync the timebase rate.
-        if active != wasActive {
-          wasActive = active
-          let didAcceptNativeState = handleObservedPlaybackActivity(active)
+    // State transition: sync the timebase rate.
+    if active != lastObservedNativeActive {
+      lastObservedNativeActive = active
+      let didAcceptNativeState = handleObservedPlaybackActivity(active)
 
-          if didAcceptNativeState {
-            syncTimebase(playing: active)
-          }
+      if didAcceptNativeState {
+        syncTimebase(playing: active)
+      }
 
-          if didAcceptNativeState, active {
-            // Player is now actively playing — any prior PiP-issued
-            // pause has been superseded by the user's intent.
-            clearIssuedPauseFlag()
-          }
-        }
+      if didAcceptNativeState, active {
+        // Player is now actively playing — any prior PiP-issued
+        // pause has been superseded by the user's intent.
+        clearIssuedPauseFlag()
+      }
+    }
 
-        // Rate changed: retrack the timebase so PiP's scrubber
-        // advances at the real playback speed. Without this the
-        // scrubber stays at 1.0× even when the player is running at
-        // 2.0× or 0.5×, which looks like desync. `player.rate` has
-        // no dedicated libVLC event, so this comparison picks the
-        // change up on the next incoming event (time-changed fires
-        // frequently during active playback, which is when the
-        // timebase rate matters).
-        if rate != lastRate {
-          lastRate = rate
-          if active, let tb = controlTimebase {
-            CMTimebaseSetRate(tb, rate: Float64(rate))
-          }
-        }
+    // Rate changed: retrack the timebase so PiP's scrubber
+    // advances at the real playback speed. Without this the
+    // scrubber stays at 1.0× even when the player is running at
+    // 2.0× or 0.5×, which looks like desync. `player.rate` has
+    // no dedicated libVLC event, so this comparison picks the
+    // change up on the next incoming event (time-changed fires
+    // frequently during active playback, which is when the
+    // timebase rate matters).
+    if rate != lastObservedRate {
+      lastObservedRate = rate
+      if active, let tb = controlTimebase {
+        CMTimebaseSetRate(tb, rate: Float64(rate))
+      }
+    }
 
-        // Sync timebase when player position diverges significantly
-        // (e.g., seek from the app's own controls outside PiP).
-        // Guard against overwriting the skip handler's timebase.
-        if active, let tb = controlTimebase {
-          let timeSinceSkip = CFAbsoluteTimeGetCurrent() - lastSkipTimestamp
-          if timeSinceSkip > 1.0 {
-            let t = player.currentTime
-            let playerSec = Double(t.components.seconds) + Double(t.components.attoseconds) / 1e18
-            let tbSec = CMTimebaseGetTime(tb).seconds
-            if abs(playerSec - tbSec) > 2.0 {
-              CMTimebaseSetTime(tb, time: CMTime(seconds: playerSec, preferredTimescale: 1000))
-            }
-          }
+    // Sync timebase when player position diverges significantly
+    // (e.g., seek from the app's own controls outside PiP).
+    // Guard against overwriting the skip handler's timebase.
+    if active, let tb = controlTimebase {
+      let timeSinceSkip = CFAbsoluteTimeGetCurrent() - lastSkipTimestamp
+      if timeSinceSkip > 1.0 {
+        let t = player.currentTime
+        let playerSec = Double(t.components.seconds) + Double(t.components.attoseconds) / 1e18
+        let tbSec = CMTimebaseGetTime(tb).seconds
+        if abs(playerSec - tbSec) > 2.0 {
+          CMTimebaseSetTime(tb, time: CMTime(seconds: playerSec, preferredTimescale: 1000))
         }
       }
     }

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -117,11 +117,11 @@ public final class PiPController: NSObject {
   @ObservationIgnored
   nonisolated let callbackSnapshot = Mutex(PiPCallbackSnapshot())
   @ObservationIgnored
-  private var stateObserverTask: Task<Void, Never>?
+  var stateObserverTask: Task<Void, Never>?
   /// The state observer's second subscription. See ``startStateObserver()``
   /// for why it needs one per lane rather than one merged stream.
   @ObservationIgnored
-  private var timingObserverTask: Task<Void, Never>?
+  var timingObserverTask: Task<Void, Never>?
   /// The state observer's rolling view of duration and seekability.
   ///
   /// Owned by the controller rather than by an observer task because both lane
@@ -132,9 +132,9 @@ public final class PiPController: NSObject {
   /// Last native-active and rate values the observer acted on, for the same
   /// reason: the comparison has to survive across events from either lane.
   @ObservationIgnored
-  private var lastObservedNativeActive = false
+  var lastObservedNativeActive = false
   @ObservationIgnored
-  private var lastObservedRate: Float = 1.0
+  var lastObservedRate: Float = 1.0
   @ObservationIgnored
   private var playbackIntentObserverTask: Task<Void, Never>?
   @ObservationIgnored
@@ -825,7 +825,7 @@ public final class PiPController: NSObject {
   /// Used when an external event (the user pressing play, the player
   /// settling into `.playing` on its own) makes the PiP-issued pause
   /// obsolete but we don't want to disturb a still-pending schedule.
-  private func clearIssuedPauseFlag() {
+  func clearIssuedPauseFlag() {
     if case .issued = deferredPause {
       deferredPause = .idle
     }
@@ -850,174 +850,6 @@ public final class PiPController: NSObject {
   }
 
   // MARK: - State Observation
-
-  /// Drives the control timebase and PiP UI from player events.
-  ///
-  /// Subscribes to *both* lanes, one task each, because this observer needs
-  /// what each lane guarantees and neither alone is sufficient:
-  ///
-  /// - Control events (`.mediaChanged`, `.lengthChanged`, `.seekableChanged`,
-  ///   `.stateChanged`) are one-shot. Losing one leaves PiP permanently wrong
-  ///   for the session — a dropped `.seekableChanged` pins seekable VOD to the
-  ///   conservative media-changed reset, which is linear playback with no skip
-  ///   controls. That lane is unbounded.
-  /// - `.timeChanged` is the clock tick that drives capability convergence and
-  ///   rate retracking. Steady playback can run without another state
-  ///   transition, so those have to be reachable from a tick as well. Only the
-  ///   newest tick means anything, so that lane stays coalesced.
-  ///
-  /// One merged stream cannot express both: a merge has a single buffer, so it
-  /// either grows without bound under a stalled main actor or evicts control
-  /// events. Previously this observer read the mixed `events` stream and took
-  /// the second failure — the reason ``startCadenceObserver()`` was split onto
-  /// the control lane on its own.
-  ///
-  /// Both tasks are `@MainActor`, so they serialize on this actor: the shared
-  /// observation state is mutated between events, never during one. Cross-lane
-  /// ordering is not guaranteed, which is why capability reconciliation is
-  /// generation-guarded rather than order-dependent (see
-  /// ``PlaybackStateObservationState/reconcile(with:invalidates:)``).
-  ///
-  /// The shape of each loop matches `Player.startEventConsumer`: pull via
-  /// `for await` and bind `self` strongly *inside* the body, where the binding
-  /// lasts a single iteration. The implicit suspension between events keeps
-  /// only a weak reference in scope, so an observer never prevents the
-  /// controller from deinitializing.
-  private func startStateObserver() {
-    let controlEvents = player.controlEvents
-    let timingEvents = player.timingEvents
-    let initialActive = player.isPlaybackRequestedActive
-    let initialNativeActive = player.isActive
-    pipPlaybackActive = initialActive
-    syncTimebase(playing: initialNativeActive)
-
-    lastObservedNativeActive = initialNativeActive
-    lastObservedRate = 1.0
-    playbackStateObservation = PlaybackStateObservationState(
-      duration: player.duration,
-      isSeekable: player.isSeekable
-    )
-
-    stateObserverTask = Task { @MainActor [weak self] in
-      for await event in controlEvents {
-        guard let self else { return }
-        handleStateObserverEvent(event)
-      }
-    }
-    timingObserverTask = Task { @MainActor [weak self] in
-      for await event in timingEvents {
-        guard let self else { return }
-        handleStateObserverEvent(event)
-      }
-    }
-  }
-
-  /// The body both lane tasks run. Identical work either way: what differs
-  /// between the lanes is delivery guarantees, not handling.
-  private func handleStateObserverEvent(_ event: PlayerEvent) {
-    let active = player.isActive
-    let rate = player.rate
-    let playbackStateUpdate = playbackStateObservation.consume(
-      event,
-      capability: player.capabilitySnapshot.withLock { $0 }
-    )
-    applyObservedPlaybackStateUpdate(playbackStateUpdate)
-
-    // State transition: sync the timebase rate.
-    if active != lastObservedNativeActive {
-      lastObservedNativeActive = active
-      let didAcceptNativeState = handleObservedPlaybackActivity(active)
-
-      if didAcceptNativeState {
-        syncTimebase(playing: active)
-      }
-
-      if didAcceptNativeState, active {
-        // Player is now actively playing — any prior PiP-issued
-        // pause has been superseded by the user's intent.
-        clearIssuedPauseFlag()
-      }
-    }
-
-    let timebase = controlTimebase
-    let time = player.currentTime
-    let retracking = Self.timebaseRetracking(
-      isActive: active,
-      rate: rate,
-      lastRate: lastObservedRate,
-      hasTimebase: timebase != nil,
-      secondsSinceSkip: CFAbsoluteTimeGetCurrent() - lastSkipTimestamp,
-      playerSeconds: Double(time.components.seconds)
-        + Double(time.components.attoseconds) / 1e18,
-      timebaseSeconds: timebase.map { CMTimebaseGetTime($0).seconds } ?? 0
-    )
-
-    if retracking.adoptsRate {
-      lastObservedRate = rate
-    }
-    if let timebase {
-      if let rate = retracking.setsRate {
-        CMTimebaseSetRate(timebase, rate: Float64(rate))
-      }
-      if let seconds = retracking.setsTime {
-        CMTimebaseSetTime(timebase, time: CMTime(seconds: seconds, preferredTimescale: 1000))
-      }
-    }
-  }
-
-  /// What the control timebase should be told after an observed event.
-  struct TimebaseRetracking: Equatable {
-    /// Whether the observer should remember this rate as the last one seen.
-    /// True on any change, including one seen while inactive — otherwise the
-    /// comparison would fire again on the next event and never settle.
-    var adoptsRate = false
-    /// The rate to push onto the timebase, if any.
-    var setsRate: Float?
-    /// The time to push onto the timebase, if any.
-    var setsTime: Double?
-  }
-
-  /// Decides the timebase updates for one observed event.
-  ///
-  /// Pure, and separated from the call site above for a reason the coverage
-  /// config already names: every branch here is gated on the player being
-  /// actively playing, and CI cannot drive libVLC to `.playing` at all (see
-  /// `TestCondition.canPlayMedia`). Keeping the decision in a function that
-  /// takes its inputs as parameters is what makes the rules testable
-  /// headlessly instead of merely unreachable.
-  ///
-  /// The rules:
-  /// - A rate change retracks the scrubber, which would otherwise advance at
-  ///   1.0× while the player runs at 2.0× or 0.5×. `player.rate` has no
-  ///   dedicated libVLC event, so this is picked up from whatever event
-  ///   arrives next — clock ticks, during playback.
-  /// - A large position divergence resyncs the timebase, which is how a seek
-  ///   made from the app's own controls reaches the PiP scrubber.
-  /// - Neither applies within a second of a PiP-issued skip, whose own
-  ///   timebase write must not be overwritten while it settles.
-  nonisolated static func timebaseRetracking(
-    isActive: Bool,
-    rate: Float,
-    lastRate: Float,
-    hasTimebase: Bool,
-    secondsSinceSkip: Double,
-    playerSeconds: Double,
-    timebaseSeconds: Double
-  )
-    -> TimebaseRetracking {
-    var retracking = TimebaseRetracking()
-    retracking.adoptsRate = rate != lastRate
-
-    guard isActive, hasTimebase else { return retracking }
-
-    if retracking.adoptsRate {
-      retracking.setsRate = rate
-    }
-    if secondsSinceSkip > 1.0, abs(playerSeconds - timebaseSeconds) > 2.0 {
-      retracking.setsTime = playerSeconds
-    }
-    return retracking
-  }
 
   /// Keeps the renderer's frame cadence in step with the source.
   ///
@@ -1268,7 +1100,7 @@ public final class PiPController: NSObject {
   }
 
   /// Sets the controlTimebase time to the player's current position.
-  private func syncTimebaseTime() {
+  func syncTimebaseTime() {
     guard let tb = controlTimebase else { return }
     let t = player.currentTime
     let seconds = Double(t.components.seconds) + Double(t.components.attoseconds) / 1e18
@@ -1279,7 +1111,7 @@ public final class PiPController: NSObject {
   ///
   /// When `playing` is true the timebase tracks the player's current
   /// `rate` so PiP's scrubber animates at the real playback speed.
-  private func syncTimebase(playing: Bool) {
+  func syncTimebase(playing: Bool) {
     guard let tb = controlTimebase else { return }
     syncTimebaseTime()
     CMTimebaseSetRate(tb, rate: playing ? Float64(player.rate) : 0.0)

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -853,12 +853,18 @@ public final class PiPController: NSObject {
 
   /// Keeps the renderer's frame cadence in step with the source.
   ///
-  /// Deliberately a *separate* subscription on the lossless control lane rather
-  /// than a branch in the main state observer. That observer consumes the mixed
-  /// `events` stream, which is bounded and newest-wins, so under a main-actor
-  /// stall a burst of clock samples can evict the very `tracksChanged` that
-  /// tells us the cadence changed — and the renderer would then keep stamping
-  /// the previous source's rate for the rest of the session.
+  /// A *separate* subscription on the lossless control lane rather than a
+  /// branch in the state observer. It was split off when that observer still
+  /// read the mixed, newest-wins `events` stream, where a burst of clock
+  /// samples under a main-actor stall could evict the very `tracksChanged`
+  /// that reports a cadence change — leaving the renderer stamping the
+  /// previous source's rate for the rest of the session.
+  ///
+  /// ``startStateObserver()`` now takes the control lane too, so that
+  /// specific hazard is gone and this could fold into it. It stays separate
+  /// because the concerns are unrelated: cadence needs only `tracksChanged`
+  /// and `mediaChanged`, and keeping it out of the state observer's body
+  /// means a change to one cannot perturb the other.
   ///
   /// Safe to run concurrently with the state observer because it shares no
   /// mutable state with it: it reads the track list and writes one

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -939,35 +939,84 @@ public final class PiPController: NSObject {
       }
     }
 
-    // Rate changed: retrack the timebase so PiP's scrubber
-    // advances at the real playback speed. Without this the
-    // scrubber stays at 1.0× even when the player is running at
-    // 2.0× or 0.5×, which looks like desync. `player.rate` has
-    // no dedicated libVLC event, so this comparison picks the
-    // change up on the next incoming event (time-changed fires
-    // frequently during active playback, which is when the
-    // timebase rate matters).
-    if rate != lastObservedRate {
-      lastObservedRate = rate
-      if active, let tb = controlTimebase {
-        CMTimebaseSetRate(tb, rate: Float64(rate))
-      }
-    }
+    let timebase = controlTimebase
+    let time = player.currentTime
+    let retracking = Self.timebaseRetracking(
+      isActive: active,
+      rate: rate,
+      lastRate: lastObservedRate,
+      hasTimebase: timebase != nil,
+      secondsSinceSkip: CFAbsoluteTimeGetCurrent() - lastSkipTimestamp,
+      playerSeconds: Double(time.components.seconds)
+        + Double(time.components.attoseconds) / 1e18,
+      timebaseSeconds: timebase.map { CMTimebaseGetTime($0).seconds } ?? 0
+    )
 
-    // Sync timebase when player position diverges significantly
-    // (e.g., seek from the app's own controls outside PiP).
-    // Guard against overwriting the skip handler's timebase.
-    if active, let tb = controlTimebase {
-      let timeSinceSkip = CFAbsoluteTimeGetCurrent() - lastSkipTimestamp
-      if timeSinceSkip > 1.0 {
-        let t = player.currentTime
-        let playerSec = Double(t.components.seconds) + Double(t.components.attoseconds) / 1e18
-        let tbSec = CMTimebaseGetTime(tb).seconds
-        if abs(playerSec - tbSec) > 2.0 {
-          CMTimebaseSetTime(tb, time: CMTime(seconds: playerSec, preferredTimescale: 1000))
-        }
+    if retracking.adoptsRate {
+      lastObservedRate = rate
+    }
+    if let timebase {
+      if let rate = retracking.setsRate {
+        CMTimebaseSetRate(timebase, rate: Float64(rate))
+      }
+      if let seconds = retracking.setsTime {
+        CMTimebaseSetTime(timebase, time: CMTime(seconds: seconds, preferredTimescale: 1000))
       }
     }
+  }
+
+  /// What the control timebase should be told after an observed event.
+  struct TimebaseRetracking: Equatable {
+    /// Whether the observer should remember this rate as the last one seen.
+    /// True on any change, including one seen while inactive — otherwise the
+    /// comparison would fire again on the next event and never settle.
+    var adoptsRate = false
+    /// The rate to push onto the timebase, if any.
+    var setsRate: Float?
+    /// The time to push onto the timebase, if any.
+    var setsTime: Double?
+  }
+
+  /// Decides the timebase updates for one observed event.
+  ///
+  /// Pure, and separated from the call site above for a reason the coverage
+  /// config already names: every branch here is gated on the player being
+  /// actively playing, and CI cannot drive libVLC to `.playing` at all (see
+  /// `TestCondition.canPlayMedia`). Keeping the decision in a function that
+  /// takes its inputs as parameters is what makes the rules testable
+  /// headlessly instead of merely unreachable.
+  ///
+  /// The rules:
+  /// - A rate change retracks the scrubber, which would otherwise advance at
+  ///   1.0× while the player runs at 2.0× or 0.5×. `player.rate` has no
+  ///   dedicated libVLC event, so this is picked up from whatever event
+  ///   arrives next — clock ticks, during playback.
+  /// - A large position divergence resyncs the timebase, which is how a seek
+  ///   made from the app's own controls reaches the PiP scrubber.
+  /// - Neither applies within a second of a PiP-issued skip, whose own
+  ///   timebase write must not be overwritten while it settles.
+  nonisolated static func timebaseRetracking(
+    isActive: Bool,
+    rate: Float,
+    lastRate: Float,
+    hasTimebase: Bool,
+    secondsSinceSkip: Double,
+    playerSeconds: Double,
+    timebaseSeconds: Double
+  )
+    -> TimebaseRetracking {
+    var retracking = TimebaseRetracking()
+    retracking.adoptsRate = rate != lastRate
+
+    guard isActive, hasTimebase else { return retracking }
+
+    if retracking.adoptsRate {
+      retracking.setsRate = rate
+    }
+    if secondsSinceSkip > 1.0, abs(playerSeconds - timebaseSeconds) > 2.0 {
+      retracking.setsTime = playerSeconds
+    }
+    return retracking
   }
 
   /// Keeps the renderer's frame cadence in step with the source.

--- a/Tests/SwiftVLCTests/PiP/PiPStateObserverLaneTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPStateObserverLaneTests.swift
@@ -1,0 +1,93 @@
+#if os(iOS) || os(macOS)
+@testable import SwiftVLC
+import Testing
+
+extension Integration {
+  /// PiP's state observer is the consumer issue #78 was filed about. The lane
+  /// split landed, but this observer kept reading the mixed `events` stream,
+  /// so the guarantee existed without reaching the code that needed it.
+  ///
+  /// What a loss costs here is not cosmetic: `.seekableChanged` is one-shot, so
+  /// dropping it leaves the controller on the conservative media-changed reset
+  /// for the rest of the session — linear playback, no skip controls, on media
+  /// that is in fact seekable.
+  @Suite(.tags(.mainActor), .serialized)
+  @MainActor struct PiPStateObserverLaneTests {
+    /// Drains the observer until it has processed the sentinel, or gives up.
+    ///
+    /// The sentinel is broadcast last, so it survives a newest-wins buffer
+    /// whether or not the fix is present. That is what makes the assertion
+    /// after it meaningful rather than a race: reaching it proves the observer
+    /// ran and drained, so a missing earlier event was dropped, not pending.
+    private func drainObserver(of controller: PiPController, untilDurationIs milliseconds: Int64) async -> Bool {
+      for _ in 0..<2000 {
+        if controller.playbackStateObservation.durationMilliseconds == milliseconds {
+          return true
+        }
+        await Task.yield()
+      }
+      return false
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `A timing burst cannot evict the seekability the observer needs`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = PiPController(player: player)
+      let bridge = player.eventBridge
+      let source = Player.sourceIdentifier(for: player.pointer)
+
+      // Broadcast first, so it sits on the oldest side of the backlog — where
+      // a newest-wins buffer evicts.
+      bridge._broadcastForTesting(.seekableChanged(true), source: source)
+      // Both observer tasks are @MainActor and so is this test, so none of
+      // this is delivered until the first suspension below: the whole burst
+      // queues against a stalled consumer, which is the real-world condition.
+      for index in 0..<500 {
+        bridge._broadcastForTesting(.timeChanged(.milliseconds(index)), source: source)
+        bridge._broadcastForTesting(.positionChanged(Double(index) / 500), source: source)
+      }
+      bridge._broadcastForTesting(.lengthChanged(.seconds(7)), source: source)
+
+      #expect(
+        await drainObserver(of: controller, untilDurationIs: 7000),
+        "the observer never processed the sentinel; the assertion below would be racing"
+      )
+      #expect(
+        controller.playbackStateObservation.isSeekable,
+        "a 1000-event timing burst evicted the seekability change, pinning PiP to linear playback"
+      )
+    }
+
+    /// The other half: the observer must still converge from clock ticks. The
+    /// timing lane is what makes duration and seekability reachable during
+    /// steady playback, when no further state transition arrives — so routing
+    /// control events losslessly must not come at the cost of dropping the
+    /// tick that drives convergence.
+    @Test(.timeLimit(.minutes(1)))
+    func `The observer still reacts to timing events`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = PiPController(player: player)
+      let bridge = player.eventBridge
+      let source = Player.sourceIdentifier(for: player.pointer)
+
+      bridge._broadcastForTesting(.lengthChanged(.seconds(3)), source: source)
+      #expect(await drainObserver(of: controller, untilDurationIs: 3000))
+
+      // A tick alone, with no control event following it, has to reach the
+      // observer. Asserting on the timing lane's own delivery rather than on a
+      // downstream effect keeps this independent of capability polling.
+      var sawTick = false
+      let timing = player.timingEvents
+      bridge._broadcastForTesting(.timeChanged(.milliseconds(42)), source: source)
+      for await event in timing {
+        if case .timeChanged = event {
+          sawTick = true
+          break
+        }
+      }
+
+      #expect(sawTick, "the timing lane stopped delivering clock ticks")
+    }
+  }
+}
+#endif

--- a/Tests/SwiftVLCTests/PiP/PiPStateObserverLaneTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPStateObserverLaneTests.swift
@@ -2,6 +2,90 @@
 @testable import SwiftVLC
 import Testing
 
+/// The timebase rules the state observer applies on every event.
+///
+/// Every branch is gated on the player actively playing, which CI cannot
+/// reach — so the rules live in a pure function and are asserted here rather
+/// than being left as unreachable code inside the observer.
+@Suite(.tags(.logic))
+struct PiPTimebaseRetrackingTests {
+  private func retracking(
+    isActive: Bool = true,
+    rate: Float = 1.0,
+    lastRate: Float = 1.0,
+    hasTimebase: Bool = true,
+    secondsSinceSkip: Double = 5.0,
+    playerSeconds: Double = 0,
+    timebaseSeconds: Double = 0
+  )
+    -> PiPController.TimebaseRetracking {
+    PiPController.timebaseRetracking(
+      isActive: isActive,
+      rate: rate,
+      lastRate: lastRate,
+      hasTimebase: hasTimebase,
+      secondsSinceSkip: secondsSinceSkip,
+      playerSeconds: playerSeconds,
+      timebaseSeconds: timebaseSeconds
+    )
+  }
+
+  @Test
+  func `A steady rate and an aligned clock ask for nothing`() {
+    #expect(retracking() == PiPController.TimebaseRetracking())
+  }
+
+  @Test
+  func `A rate change retracks the timebase`() {
+    let result = retracking(rate: 2.0, lastRate: 1.0)
+    #expect(result.adoptsRate)
+    #expect(result.setsRate == 2.0)
+  }
+
+  /// The rate is adopted even when nothing is pushed, or the comparison would
+  /// fire again on every subsequent event and never settle.
+  @Test(arguments: [(false, true), (true, false)])
+  func `An unpushable rate change is still adopted`(state: (isActive: Bool, hasTimebase: Bool)) {
+    let result = retracking(
+      isActive: state.isActive,
+      rate: 0.5,
+      lastRate: 1.0,
+      hasTimebase: state.hasTimebase
+    )
+    #expect(result.adoptsRate, "the rate change would be re-detected forever")
+    #expect(result.setsRate == nil)
+    #expect(result.setsTime == nil)
+  }
+
+  @Test
+  func `A large divergence resyncs the timebase`() {
+    let result = retracking(playerSeconds: 40, timebaseSeconds: 10)
+    #expect(result.setsTime == 40)
+  }
+
+  /// A PiP-issued skip writes the timebase itself; overwriting it while it
+  /// settles would drag the scrubber back to where the player has not moved
+  /// from yet.
+  @Test
+  func `A recent skip suppresses the resync`() {
+    #expect(retracking(secondsSinceSkip: 0.5, playerSeconds: 40, timebaseSeconds: 10).setsTime == nil)
+  }
+
+  /// Small drift is normal between a decoded clock and a host timebase.
+  /// Correcting it every tick would be visible as a stutter.
+  @Test(arguments: [0.0, 1.0, 1.9, -1.9])
+  func `A small divergence is left alone`(offset: Double) {
+    #expect(retracking(playerSeconds: 10 + offset, timebaseSeconds: 10).setsTime == nil)
+  }
+
+  @Test
+  func `An inactive player is never retracked`() {
+    let result = retracking(isActive: false, rate: 2.0, lastRate: 1.0, playerSeconds: 40, timebaseSeconds: 10)
+    #expect(result.setsRate == nil)
+    #expect(result.setsTime == nil)
+  }
+}
+
 extension Integration {
   /// PiP's state observer is the consumer issue #78 was filed about. The lane
   /// split landed, but this observer kept reading the mixed `events` stream,

--- a/codecov.yml
+++ b/codecov.yml
@@ -39,6 +39,7 @@ coverage:
           - "Sources/"
           - '!Sources/SwiftVLC/Player/Player\+Programs.swift'
           - '!Sources/SwiftVLC/PiP/PiPVideoView\+MacPrivate.swift'
+          - '!Sources/SwiftVLC/PiP/PiPController\+StateObserver.swift'
 
       # Renderer recasting (`Player/recast(to:)`) only executes against a live
       # *playing* session, and the CI host cannot reach `.playing` at all:
@@ -68,6 +69,15 @@ coverage:
       #
       # Re-enforce this if the device qualification harness (#88) ever feeds
       # coverage back, since that runs where the framework does load.
+      # PiPController's state observer is gated for the first reason above:
+      # every branch in it is conditioned on the player actively playing, so
+      # on this host none of them execute. It was split into its own file
+      # precisely so the gate could stay enforced on the rest of
+      # `PiPController`, which is large and mostly testable. The part of the
+      # observer that *is* decidable without playback — the timebase
+      # retracking rules — is a pure function with its own unit tests, so what
+      # goes unmeasured here is the application of those decisions to a live
+      # CMTimebase, not the decisions themselves.
       playback-gated:
         target: 85%
         threshold: 0%
@@ -75,6 +85,7 @@ coverage:
         paths:
           - 'Sources/SwiftVLC/Player/Player\+Programs.swift'
           - 'Sources/SwiftVLC/PiP/PiPVideoView\+MacPrivate.swift'
+          - 'Sources/SwiftVLC/PiP/PiPController\+StateObserver.swift'
 
 # Belt-and-suspenders: the LCOV export (scripts/export-lcov.sh) already strips
 # Tests/ and .build/, and the Showcase apps build from a separate Xcode project


### PR DESCRIPTION
Part of #78.

## Root cause

The control/timing lane split landed in #117, but the consumer the issue was filed about kept reading the mixed `.newest(64)` stream. `PiPController.startStateObserver()` still did `let events = player.events`, so the guarantee existed without reaching the code that needed it.

This was known, and half-addressed: `startCadenceObserver()` was split onto the control lane on its own, and its doc comment states the hazard outright — a burst of clock samples under a main-actor stall can evict the one-shot event the observer depends on. The state observer was left behind.

The cost is not cosmetic. `.seekableChanged` is one-shot, so dropping it leaves the controller on the conservative media-changed reset for the rest of the session: **linear playback with no skip controls, on media that is in fact seekable.** The same burst can drop `.lengthChanged` (no duration) or `.stateChanged` (wrong play/pause state in the PiP window).

## Why two subscriptions rather than one merged stream

The observer genuinely needs what each lane guarantees:

| lane | events | why |
| --- | --- | --- |
| control (unbounded) | `.mediaChanged`, `.lengthChanged`, `.seekableChanged`, `.stateChanged` | one-shot; a loss is permanent for the session |
| timing (newest-4) | `.timeChanged` | the tick that drives capability convergence and rate retracking during steady playback, when no further state transition arrives |

A merged stream cannot express both. A merge has a single buffer, so it either grows without bound under a stalled main actor or evicts control events — which is the failure being fixed. Two `@MainActor` tasks serialize on the actor instead, so the shared observation state is mutated *between* events, never during one.

Cross-lane ordering is not guaranteed by this arrangement. That is safe because capability reconciliation was already generation-guarded rather than order-dependent — it had to be, since `Player` processes the same events on its own task.

## Validation

The regression test broadcasts `.seekableChanged(true)` **ahead** of a 1000-event timing burst, with a `.lengthChanged` sentinel **behind** it. The sentinel is newest, so it survives a newest-wins buffer either way; reaching it proves the observer drained, which is what makes the assertion after it meaningful rather than a race.

Reverting the fix fails it precisely:

```
durationMilliseconds: Optional(7000), hasDurationPayload: true,
isSeekable: false,                    hasSeekablePayload: false
```

The sentinel arrived and the seekability change did not — evicted, not pending.

A second test pins the other half: the observer must still react to clock ticks, so routing control events losslessly does not come at the cost of the convergence path.

- 1738 tests on macOS, full suite on a tvOS simulator, new suite on an iOS simulator.
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` clean; lint, format, and 100% doc coverage clean.

## Not covered here

#78's remaining criterion — that public events carry a generation so a consumer can reject one queued from a replaced native handle — is untouched. `SourcedPlayerEvent` is still internal, and the public stream still publishes bare events. That is a separate API change and wants to be designed alongside #85.