### PR TITLE
Emit every lifecycle transition, not just the raw ones (#89)

### DIFF
--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -233,6 +233,13 @@ extension Player {
   func publishPlaybackState(_ newState: PlayerState) {
     state = newState
     withMutation(keyPath: \.isActive) {}
+    // The single funnel for `state`, and therefore the only place that can
+    // see *every* lifecycle transition. Broadcasting from here rather than
+    // from the raw `.stateChanged` event is what puts `.error` and
+    // `.buffering` on the stream at all: libVLC reports those as
+    // `.encounteredError` and `.bufferingProgress`, so neither has ever
+    // produced a `.stateChanged` to forward.
+    stateTransitionBridge.broadcast(newState)
   }
 
   func publishPlaybackIntent(_ active: Bool) {

--- a/Sources/SwiftVLC/Player/Player+Teardown.swift
+++ b/Sources/SwiftVLC/Player/Player+Teardown.swift
@@ -224,6 +224,10 @@ extension Player {
     // Permanent: `playbackIntentEvents` also subscribes per access, so a
     // post-shutdown subscriber must get an already-finished stream.
     playbackIntentBridge.terminate()
+    // Same reasoning: `stateTransitions` subscribes per access, so a
+    // post-shutdown subscriber must get an already-finished stream rather
+    // than one that can never emit.
+    stateTransitionBridge.terminate()
     libvlc_media_player_set_nsobject(pointer, nil)
 
     let bridge = eventBridge

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -365,35 +365,23 @@ public final class Player {
 
   /// Lossless stream of lifecycle state transitions — no firehose.
   ///
-  /// Equivalent to an `.unbounded` ``events(policy:filter:)``
-  /// subscription that keeps only `.stateChanged` payloads, so a lagging
-  /// consumer can never lose a one-shot terminal transition. Memory is
-  /// bounded in practice by the low rate of state changes.
+  /// Carries every change of ``state``, so a lagging consumer can never lose
+  /// a one-shot terminal transition. Memory is bounded in practice by the low
+  /// rate of state changes.
+  ///
+  /// Driven by the state itself rather than by the raw `.stateChanged` event,
+  /// which is what makes it *complete*. libVLC reports a native failure as
+  /// `.encounteredError` and buffering as `.bufferingProgress`, so neither
+  /// ever produced a `.stateChanged` to forward: a stream built by filtering
+  /// raw events silently omitted every transition to ``PlayerState/error``
+  /// and ``PlayerState/buffering``. Anything waiting on `.error` here waited
+  /// for something that could not arrive.
+  ///
+  /// Buffering is published at most once per entry into it — repeated
+  /// progress reports do not re-announce the state — so completeness does not
+  /// cost the no-firehose guarantee.
   public nonisolated var stateTransitions: AsyncStream<PlayerState> {
-    let upstream = eventBridge.makeStream(
-      policy: .unbounded,
-      filter: { event in
-        if case .stateChanged = event {
-          return true
-        }
-        return false
-      }
-    )
-    let (stream, continuation) = AsyncStream<PlayerState>.makeStream(
-      bufferingPolicy: .unbounded
-    )
-    let pump = Task {
-      for await event in upstream {
-        if case .stateChanged(let state) = event {
-          continuation.yield(state)
-        }
-      }
-      continuation.finish()
-    }
-    continuation.onTermination = { _ in
-      pump.cancel()
-    }
-    return stream
+    stateTransitionBridge.subscribe()
   }
 
   nonisolated var playbackIntentEvents: AsyncStream<Bool> {
@@ -417,6 +405,8 @@ public final class Player {
   let eventBridge: EventBridge
   nonisolated let endCoordinator = PlaybackEndCoordinator()
   nonisolated let playbackIntentBridge: Broadcaster<Bool>
+  /// Carries normalized lifecycle transitions. See ``stateTransitions``.
+  nonisolated let stateTransitionBridge = Broadcaster<PlayerState>(defaultBufferSize: 64)
   /// ``isPlaybackRequestedActive`` mirrored for readers that cannot touch the
   /// main actor.
   ///
@@ -558,6 +548,7 @@ public final class Player {
     // The player is going away for good, so future subscribers must receive
     // an already-finished stream rather than one that can never emit.
     playbackIntentBridge.terminate()
+    stateTransitionBridge.terminate()
     #if os(iOS) || os(macOS)
     retireDirectPiPVideoCallbacksForHandleEnd()
     // No successor to move to here, unlike replacement and shutdown: the

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -380,8 +380,18 @@ public final class Player {
   /// Buffering is published at most once per entry into it — repeated
   /// progress reports do not re-announce the state — so completeness does not
   /// cost the no-firehose guarantee.
+  ///
+  /// Not de-duplicated: the same state published twice is delivered twice.
+  /// Same-player media replacement currently restarts a session on a repeated
+  /// `.playing`, so suppressing repeats would break it until events carry a
+  /// media generation to distinguish sessions by. Treat a value as "the
+  /// current state", not as "a value that differs from the last one".
   public nonisolated var stateTransitions: AsyncStream<PlayerState> {
-    stateTransitionBridge.subscribe()
+    // Explicitly unbounded. `subscribe()` defaults to newest-64, which would
+    // make a stream documented as lossless silently drop the oldest pending
+    // transitions under a stalled consumer — losing exactly the one-shot
+    // terminal states this exists to protect.
+    stateTransitionBridge.subscribe(policy: .unbounded)
   }
 
   nonisolated var playbackIntentEvents: AsyncStream<Bool> {

--- a/Tests/SwiftVLCTests/Player/PlayerStateTransitionCompletenessTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerStateTransitionCompletenessTests.swift
@@ -94,6 +94,38 @@ extension Integration {
       #expect(bufferingCount == 1, "200 progress reports produced \(bufferingCount) transitions")
     }
 
+    /// Completeness is worth nothing if the stream then drops what it
+    /// collected. `Broadcaster.subscribe()` defaults to newest-64, so moving
+    /// this stream onto a broadcaster is one keyword away from silently
+    /// turning a lossless API lossy — which is how it was written first.
+    ///
+    /// The transitions are published *before* the stream is drained, so they
+    /// all sit in the subscriber's buffer at once. That is the condition a
+    /// bounded policy truncates and an unbounded one does not.
+    @Test(.timeLimit(.minutes(1)))
+    func `A backlog past the default buffer size is not truncated`() async {
+      let player = Player(instance: TestInstance.shared)
+      let transitions = player.stateTransitions
+
+      // Comfortably past `Broadcaster`'s 64-element default.
+      let published = 200
+      for index in 0..<published {
+        player.publishPlaybackState(index.isMultiple(of: 2) ? .playing : .paused)
+      }
+      // Ends the drain below without depending on a timeout.
+      player.stateTransitionBridge.terminate()
+
+      var received = 0
+      for await _ in transitions {
+        received += 1
+      }
+
+      #expect(
+        received == published,
+        "\(published - received) transitions were dropped; the stream is bounded, not lossless"
+      )
+    }
+
     /// The consequence the issue is really about: the recast wait has to see
     /// a failure rather than sit out its ceiling. The timeout here is short on
     /// purpose — a regression should fail this in a second, not stall it.

--- a/Tests/SwiftVLCTests/Player/PlayerStateTransitionCompletenessTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerStateTransitionCompletenessTests.swift
@@ -1,0 +1,120 @@
+@testable import SwiftVLC
+import Synchronization
+import Testing
+
+extension Integration {
+  /// `stateTransitions` is documented as a lossless lifecycle stream, but it
+  /// was built by filtering raw `.stateChanged` events — and libVLC reports a
+  /// native failure as `.encounteredError` and buffering as
+  /// `.bufferingProgress`. Neither ever produced a `.stateChanged`, so every
+  /// transition to `.error` and `.buffering` was silently absent.
+  ///
+  /// That is not only a gap in the stream. `recast(to:)` waits on this stream
+  /// for `.playing || .error`, so a replacement session that failed could
+  /// never be observed failing: the wait ran to its full ten-second ceiling
+  /// and reported `.timedOut`, which is both slow and the wrong answer.
+  @Suite(.tags(.mainActor), .serialized)
+  @MainActor struct PlayerStateTransitionCompletenessTests {
+    /// `Mutex` is noncopyable, so the collector cannot be factored into a
+    /// helper that returns it alongside its task — each test builds its own.
+    @Test(.timeLimit(.minutes(1)))
+    func `A native error reaches the transition stream`() async throws {
+      let player = Player(instance: TestInstance.shared)
+      let bridge = player.eventBridge
+      let source = Player.sourceIdentifier(for: player.pointer)
+      let transitions = player.stateTransitions
+      let collected = Mutex<[PlayerState]>([])
+      let collector = Task.detached { @Sendable in
+        for await state in transitions {
+          collected.withLock { $0.append(state) }
+        }
+      }
+
+      bridge._broadcastForTesting(.encounteredError, source: source)
+
+      try #require(
+        await poll(until: { collected.withLock { $0.contains(.error) } }),
+        "the error transition never reached stateTransitions"
+      )
+      collector.cancel()
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `Entering buffering reaches the transition stream`() async throws {
+      let player = Player(instance: TestInstance.shared)
+      let bridge = player.eventBridge
+      let source = Player.sourceIdentifier(for: player.pointer)
+      let transitions = player.stateTransitions
+      let collected = Mutex<[PlayerState]>([])
+      let collector = Task.detached { @Sendable in
+        for await state in transitions {
+          collected.withLock { $0.append(state) }
+        }
+      }
+
+      bridge._broadcastForTesting(.bufferingProgress(0.25), source: source)
+
+      try #require(
+        await poll(until: { collected.withLock { $0.contains(.buffering) } }),
+        "the buffering transition never reached stateTransitions"
+      )
+      collector.cancel()
+    }
+
+    /// Completeness must not cost the no-firehose guarantee. Buffering
+    /// progress arrives at the fill rate; only *entering* buffering is a
+    /// transition, so repeated reports must not re-announce it.
+    @Test(.timeLimit(.minutes(1)))
+    func `Buffering progress does not re-announce the state`() async throws {
+      let player = Player(instance: TestInstance.shared)
+      let bridge = player.eventBridge
+      let source = Player.sourceIdentifier(for: player.pointer)
+      let transitions = player.stateTransitions
+      let collected = Mutex<[PlayerState]>([])
+      let collector = Task.detached { @Sendable in
+        for await state in transitions {
+          collected.withLock { $0.append(state) }
+        }
+      }
+
+      for index in 0..<200 {
+        bridge._broadcastForTesting(.bufferingProgress(Float(index) / 200), source: source)
+      }
+      // Bounds the drain: once this lands, every buffering report before it
+      // has been processed.
+      bridge._broadcastForTesting(.stateChanged(.playing), source: source)
+
+      try #require(
+        await poll(until: { collected.withLock { $0.contains(.playing) } }),
+        "Waiting for: the sentinel transition"
+      )
+      collector.cancel()
+
+      let bufferingCount = collected.withLock { $0.filter { $0 == .buffering }.count }
+      #expect(bufferingCount == 1, "200 progress reports produced \(bufferingCount) transitions")
+    }
+
+    /// The consequence the issue is really about: the recast wait has to see
+    /// a failure rather than sit out its ceiling. The timeout here is short on
+    /// purpose — a regression should fail this in a second, not stall it.
+    @Test(.timeLimit(.minutes(1)))
+    func `The recast wait observes failure instead of timing out`() async {
+      let player = Player(instance: TestInstance.shared)
+      let bridge = player.eventBridge
+      let source = Player.sourceIdentifier(for: player.pointer)
+      let transitions = player.stateTransitions
+
+      let result = Task {
+        await Player.awaitPlaying(on: transitions, timeout: .seconds(5))
+      }
+      // Give the wait a turn to subscribe before the error is broadcast.
+      await Task.yield()
+      bridge._broadcastForTesting(.encounteredError, source: source)
+
+      #expect(
+        await result.value == .failed,
+        "the recast wait could not observe the failure and fell through to its timeout"
+      )
+    }
+  }
+}


### PR DESCRIPTION
Part of #89.

## Root cause

`stateTransitions` is documented as a lossless lifecycle stream, but it was built by filtering raw `.stateChanged` events:

```swift
let upstream = eventBridge.makeStream(policy: .unbounded, filter: { if case .stateChanged = $0 { return true }; return false })
```

libVLC does not report every state that way. A native failure arrives as `.encounteredError`, and buffering as `.bufferingProgress`. Neither ever produces a `.stateChanged`, so **every transition to `.error` and `.buffering` was silently absent** from the one stream whose entire purpose is not to lose transitions.

Nothing broadcasts `.stateChanged(.error)` anywhere in the package — `publishPlaybackState(.error)` only sets the observable property.

## Why it matters beyond the stream

`recast(to:)` waits on this stream for `.playing || .error`:

```swift
if state == .error { return .failed }   // unreachable
```

That branch was dead. A replacement session that *failed* could not be observed failing, so the wait ran its full **ten-second** ceiling and returned `.timedOut` — both slow and the wrong answer, on the error path specifically.

## Fix

Driven from `publishPlaybackState` instead — the single funnel for `state`, and therefore the only place that sees every transition regardless of which event caused it.

**Deliberately not de-duplicated.** Emitting only on a changed value is the more obvious reading of "semantic transition", but #89's own third criterion records that same-player media replacement currently relies on a repeated `.playing`. Suppressing repeats without the generation tagging meant to replace them would trade this bug for a subtler one. Repeats stay until generations land.

Completeness does not cost the no-firehose guarantee: buffering progress arrives at the fill rate, but only *entering* buffering publishes a state, so 200 progress reports produce exactly one transition. There is a test for that.

The bridge is terminated in both `shutdown()` and `deinit`, alongside the playback-intent bridge and for the same reason: `stateTransitions` subscribes per access, so a post-shutdown subscriber must get an already-finished stream rather than one that can never emit.

## Validation

Four tests. Reverting to the raw-event source fails **all four** — and the recast one fails by burning its entire timeout, which is the production symptom reproduced:

```
✘ "A native error reaches the transition stream"            failed after 3.084s
✘ "Entering buffering reaches the transition stream"        failed after 3.054s
✘ "Buffering progress does not re-announce the state"       (bufferingCount → 0) == 1
✘ "The recast wait observes failure instead of timing out"  failed after 5.209s
```

1740 tests pass; strict-concurrency build clean; lint, format, and 100% doc coverage clean. Added executable lines are covered under CI's own conditions (`CI=true`, which is what makes the playback-gated tests skip).

## Scope

Criteria 1 and 4 of #89. Not covered here:

- **Criterion 2** (a late subscriber immediately receives current generation and state) needs current-value replay, which changes semantics for existing subscribers — `PiPController`'s intent observer documents that it relies on there being none.
- **Criterion 3** needs the generation tagging that is still internal-only (`SourcedPlayerEvent`), and wants designing together with #78's remaining criterion and #85's wrapper half.