### PR TITLE
Add a runtime probe for the stopping-reason patch (#85)

### DIFF
--- a/scripts/patches/0015-expose-stopping-reason.patch
+++ b/scripts/patches/0015-expose-stopping-reason.patch
@@ -38,7 +38,12 @@
 # rather than silently mislabelling every terminal event. Verified by doing
 # exactly that and watching lib/media_player.c:92 refuse to compile.
 #
-# Compile-gated against the pin with patches 0001-0015 applied.
+# Compile-gated against the pin with patches 0001-0015 applied, and
+# runtime-verified: because this patch is not verbatim upstream, a passing
+# static_assert only shows the enums line up, not that the reason reaches the
+# event with the right value. scripts/patches/validation/stopping-reason-probe.c
+# checks the latter against a local engine build -- a file played to its
+# natural end reports eos, the same file stopped explicitly reports user.
 #
 # Inert until the xcframework is rebuilt: the Swift side cannot read the new
 # field until Vendor/libvlc.xcframework carries these headers, so the wrapper

--- a/scripts/patches/validation/stopping-reason-probe.c
+++ b/scripts/patches/validation/stopping-reason-probe.c
@@ -1,0 +1,110 @@
+/* Runtime proof for patch 0015 (expose the media stopping reason).
+ *
+ * 0015 is the one patch in this directory that is not a verbatim upstream
+ * backport, so "it compiles and the static_assert holds" is a weaker claim
+ * here than elsewhere: it shows the enums line up, not that the reason
+ * actually reaches the event with the right value. This checks the latter.
+ *
+ * Plays a short file to its natural end and records the reason, then plays it
+ * again and stops it explicitly. Expects eos (1) then user (2). Without the
+ * patch the `reason` field does not exist and this fails to compile, which is
+ * itself a useful signal.
+ *
+ * Not wired into CI: it needs a libvlc built from a patched tree, which CI
+ * does not produce. Run it against a local engine build after changing 0015.
+ *
+ *   V=scripts/.build-libvlc/vlc
+ *   clang -o /tmp/stopping-reason-probe \
+ *     scripts/patches/validation/stopping-reason-probe.c \
+ *     -I "$V/include" -L "$V/build-asan-native/lib/.libs" -lvlc
+ *   VLC_PLUGIN_PATH="$V/build-asan-native/modules" \
+ *   DYLD_LIBRARY_PATH="$V/build-asan-native/src/.libs:$V/build-asan-native/lib/.libs" \
+ *     /tmp/stopping-reason-probe <some-short-media-file>
+ *
+ * Last run against the pin with patches 0001-0015 applied:
+ *   PASS eos    reason=eos  (1)
+ *   PASS user   reason=user (2)
+ */
+#include <vlc/vlc.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+
+static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+static int seen = 0;
+static libvlc_stopping_reason_t last_reason;
+
+static void on_event(const libvlc_event_t *ev, void *data)
+{
+    (void) data;
+    if (ev->type != libvlc_MediaPlayerMediaStopping)
+        return;
+    pthread_mutex_lock(&lock);
+    last_reason = ev->u.media_player_media_stopping.reason;
+    seen = 1;
+    pthread_cond_signal(&cond);
+    pthread_mutex_unlock(&lock);
+}
+
+static const char *name(libvlc_stopping_reason_t r)
+{
+    switch (r) {
+    case libvlc_stopping_reason_error: return "error";
+    case libvlc_stopping_reason_eos:   return "eos";
+    case libvlc_stopping_reason_user:  return "user";
+    }
+    return "?";
+}
+
+static int run(libvlc_instance_t *vlc, const char *path, int stop_early,
+               const char *expected)
+{
+    libvlc_media_t *m = libvlc_media_new_path(path);
+    if (!m) { fprintf(stderr, "cannot open %s\n", path); return 1; }
+    libvlc_media_player_t *mp = libvlc_media_player_new_from_media(vlc, m);
+    if (!mp) { fprintf(stderr, "cannot create player\n"); return 1; }
+
+    libvlc_event_manager_t *em = libvlc_media_player_event_manager(mp);
+    libvlc_event_attach(em, libvlc_MediaPlayerMediaStopping, on_event, NULL);
+
+    pthread_mutex_lock(&lock); seen = 0; pthread_mutex_unlock(&lock);
+    libvlc_media_player_play(mp);
+
+    if (stop_early) {
+        usleep(300 * 1000);
+        libvlc_media_player_stop_async(mp);
+    }
+
+    struct timespec ts; clock_gettime(CLOCK_REALTIME, &ts); ts.tv_sec += 15;
+    pthread_mutex_lock(&lock);
+    while (!seen && pthread_cond_timedwait(&cond, &lock, &ts) == 0) {}
+    int got = seen;
+    libvlc_stopping_reason_t r = last_reason;
+    pthread_mutex_unlock(&lock);
+
+    libvlc_media_player_release(mp);
+    libvlc_media_release(m);
+
+    if (!got) { printf("FAIL %-18s no MediaStopping event\n", expected); return 1; }
+    int ok = strcmp(name(r), expected) == 0;
+    printf("%s %-18s reason=%s (%d)\n", ok ? "PASS" : "FAIL", expected, name(r), (int) r);
+    return ok ? 0 : 1;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc < 2) { fprintf(stderr, "usage: %s <media>\n", argv[0]); return 2; }
+    const char *args[] = { "--no-audio", "--vout=dummy", "--aout=dummy" };
+    libvlc_instance_t *vlc = libvlc_new(3, args);
+    if (!vlc) { fprintf(stderr, "libvlc_new failed\n"); return 2; }
+
+    int rc = 0;
+    rc |= run(vlc, argv[1], 0, "eos");
+    rc |= run(vlc, argv[1], 1, "user");
+
+    libvlc_release(vlc);
+    printf(rc ? "\nRESULT: FAILED\n" : "\nRESULT: PASSED\n");
+    return rc;
+}

--- a/scripts/patches/validation/stopping-reason-probe.c
+++ b/scripts/patches/validation/stopping-reason-probe.c
@@ -27,6 +27,7 @@
  */
 #include <vlc/vlc.h>
 #include <stdio.h>
+#include <time.h>
 #include <string.h>
 #include <unistd.h>
 #include <pthread.h>
@@ -64,7 +65,11 @@ static int run(libvlc_instance_t *vlc, const char *path, int stop_early,
     libvlc_media_t *m = libvlc_media_new_path(path);
     if (!m) { fprintf(stderr, "cannot open %s\n", path); return 1; }
     libvlc_media_player_t *mp = libvlc_media_player_new_from_media(vlc, m);
-    if (!mp) { fprintf(stderr, "cannot create player\n"); return 1; }
+    if (!mp) {
+        fprintf(stderr, "cannot create player\n");
+        libvlc_media_release(m);
+        return 1;
+    }
 
     libvlc_event_manager_t *em = libvlc_media_player_event_manager(mp);
     libvlc_event_attach(em, libvlc_MediaPlayerMediaStopping, on_event, NULL);


### PR DESCRIPTION
Part of #85. Follow-up to #126.

## Why

Patch `0015` is the only patch in `scripts/patches/` that is **not** a verbatim upstream backport. For the others, "applies cleanly and compiles" is close to sufficient — the behaviour is upstream's and has been reviewed there. For a divergent patch it is not.

I described `0015` as compile-gated with a load-bearing `static_assert`, and that was true. But it understates what still needed checking: the assert proves the two enums line up, not that the reason actually reaches the event with the right value. Those are different claims, and I had only established the first.

## What this adds

A small C probe that plays a file to its natural end, then plays the same file and stops it explicitly, asserting the reason each time:

```
PASS eos                reason=eos (1)
PASS user               reason=user (2)
RESULT: PASSED
```

Run against the pin with `0001-0015` applied. So the primitive #85's fourth criterion depends on is real, not merely well-typed — an unattributed stop can be distinguished from a confirmed natural end once the engine ships.

Without the patch the `reason` field does not exist and the probe fails to compile, which is itself a useful signal.

## Not in CI

Deliberately. CI builds against the released xcframework, not a patched tree, so it cannot run this. The file carries its own build and run commands in its header, so anyone reviewing `0015` can reproduce the result instead of taking it on trust.

The `0015` header now records the runtime verification alongside the compile gate.

## Validation

All fifteen patches still apply cleanly, in order, to a pristine `c833c4be0` after the header edit. Lint and format clean.