### PR TITLE
Handle audio-session interruptions and route loss (#87)

### DIFF
--- a/Sources/SwiftVLC/PiP/PiPController+AudioSession.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+AudioSession.swift
@@ -59,6 +59,217 @@ extension PiPController {
       // interruption). Leave the state unset so the next signal retries.
     }
   }
+
+  // MARK: - Session disruption
+
+  /// A disruption to the shared audio session that the managed path reacts to.
+  ///
+  /// Modelled as a value rather than read from `Notification` at the decision
+  /// point so the policy below can be exercised without an `AVAudioSession` —
+  /// there is none on macOS, and CI cannot produce a real interruption on any
+  /// platform.
+  enum AudioSessionDisruption: Equatable, Sendable {
+    /// The system took audio focus away. It has already deactivated our
+    /// session; nothing needs deactivating in response.
+    case interruptionBegan
+    /// Focus was returned. `shouldResume` mirrors AVKit's
+    /// `.shouldResume` option, which is the system's opinion — not consent.
+    case interruptionEnded(shouldResume: Bool)
+    /// The route the audio was playing out of went away, e.g. headphones
+    /// unplugged or Bluetooth disconnected.
+    case routeLost
+    /// The media server restarted. Every session object is invalid and the
+    /// category has to be set again from scratch.
+    case mediaServicesReset
+  }
+
+  /// What a disruption implies for the managed session.
+  struct AudioSessionReaction: Equatable, Sendable {
+    /// Clear ``hasActivatedAudioSession`` so a later signal can reactivate.
+    /// Without this the latch is permanent and audio never returns.
+    var clearsActivationLatch = false
+    /// Reconfigure the category before reactivating.
+    var reconfiguresCategory = false
+    /// Reactivate the session now.
+    var reactivates = false
+    /// Pause playback, because continuing would be wrong rather than merely
+    /// silent.
+    var pausesPlayback = false
+  }
+
+  /// Decides the response to a session disruption.
+  ///
+  /// Pure, and separated from the notification plumbing because every input
+  /// here originates in an `AVAudioSession` notification that no test on this
+  /// host can raise. The rules follow Apple's documented handling rather than
+  /// being invented:
+  ///
+  /// - An interruption deactivates the session on our behalf, so the only
+  ///   thing to undo is the latch. Reactivating here would fight whatever took
+  ///   focus.
+  /// - Resuming afterwards needs *both* the system's `.shouldResume` hint and
+  ///   the user's playback intent. The hint alone is not enough: someone who
+  ///   paused before the call must not find playback running after it.
+  /// - Losing the output route pauses. This is the headphone-unplug rule —
+  ///   continuing would move the audio to the speaker, which is the one
+  ///   outcome the user certainly did not ask for.
+  /// - A media-services reset invalidates everything, so the category must be
+  ///   set again before activation, and only if playback was wanted.
+  ///
+  /// With ``managesAudioSession`` disabled every reaction is empty: a library
+  /// that was told not to touch the session must not touch it on the way out
+  /// either.
+  nonisolated static func reaction(
+    to disruption: AudioSessionDisruption,
+    isPlaybackIntentActive: Bool,
+    managesAudioSession: Bool
+  )
+    -> AudioSessionReaction {
+    guard managesAudioSession else { return AudioSessionReaction() }
+
+    switch disruption {
+    case .interruptionBegan:
+      return AudioSessionReaction(clearsActivationLatch: true)
+
+    case .interruptionEnded(let shouldResume):
+      let resumes = shouldResume && isPlaybackIntentActive
+      return AudioSessionReaction(clearsActivationLatch: !resumes, reactivates: resumes)
+
+    case .routeLost:
+      // The session itself is still valid, so the latch stands.
+      return AudioSessionReaction(pausesPlayback: true)
+
+    case .mediaServicesReset:
+      return AudioSessionReaction(
+        clearsActivationLatch: !isPlaybackIntentActive,
+        reconfiguresCategory: true,
+        reactivates: isPlaybackIntentActive
+      )
+    }
+  }
+
+  /// Applies a decided reaction. Split from ``reaction(to:isPlaybackIntentActive:managesAudioSession:)``
+  /// so the rules stay testable and only the effects need a live session.
+  func apply(_ reaction: AudioSessionReaction) {
+    if reaction.clearsActivationLatch {
+      hasActivatedAudioSession = false
+    }
+    if reaction.reconfiguresCategory {
+      configureAudioSession()
+    }
+    if reaction.reactivates {
+      // Reactivation goes through the same one-shot machine as the first
+      // activation, so a failure here leaves the latch clear and the next
+      // playback signal retries — rather than latching a session that is not
+      // actually active.
+      hasActivatedAudioSession = false
+      activateAudioSessionIfNeeded()
+    }
+    if reaction.pausesPlayback {
+      _ = playbackDriver.pause()
+    }
+  }
+
+  #if os(iOS)
+  /// Subscribes to the session disruptions the managed path reacts to.
+  ///
+  /// Only when ``managesAudioSession`` is set: with it clear the library must
+  /// not observe the session either, since reacting would mean mutating a
+  /// session the host app owns.
+  func startAudioSessionObservers() {
+    guard managesAudioSession else { return }
+    let center = NotificationCenter.default
+    let session = AVAudioSession.sharedInstance()
+
+    audioSessionObservers = [
+      center.addObserver(
+        forName: AVAudioSession.interruptionNotification,
+        object: session,
+        queue: .main
+      ) { [weak self] notification in
+        let raw = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt
+        let options = notification.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt
+        MainActor.assumeIsolated {
+          self?.handleInterruption(rawType: raw, rawOptions: options)
+        }
+      },
+      center.addObserver(
+        forName: AVAudioSession.routeChangeNotification,
+        object: session,
+        queue: .main
+      ) { [weak self] notification in
+        let raw = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt
+        MainActor.assumeIsolated {
+          self?.handleRouteChange(rawReason: raw)
+        }
+      },
+      center.addObserver(
+        forName: AVAudioSession.mediaServicesWereResetNotification,
+        object: session,
+        queue: .main
+      ) { [weak self] _ in
+        MainActor.assumeIsolated {
+          self?.react(to: .mediaServicesReset)
+        }
+      }
+    ]
+  }
+
+  func stopAudioSessionObservers() {
+    for observer in audioSessionObservers {
+      NotificationCenter.default.removeObserver(observer)
+    }
+    audioSessionObservers.removeAll()
+  }
+
+  private func handleInterruption(rawType: UInt?, rawOptions: UInt?) {
+    guard let rawType, let type = AVAudioSession.InterruptionType(rawValue: rawType) else { return }
+    switch type {
+    case .began:
+      react(to: .interruptionBegan)
+    case .ended:
+      let options = AVAudioSession.InterruptionOptions(rawValue: rawOptions ?? 0)
+      react(to: .interruptionEnded(shouldResume: options.contains(.shouldResume)))
+    @unknown default:
+      break
+    }
+  }
+
+  private func handleRouteChange(rawReason: UInt?) {
+    guard
+      let rawReason,
+      let reason = AVAudioSession.RouteChangeReason(rawValue: rawReason),
+      reason == .oldDeviceUnavailable
+    else { return }
+    react(to: .routeLost)
+  }
+  #endif
+
+  /// Platform-neutral entry points, so the shared initializers and `deinit`
+  /// do not need their own `#if`. macOS has no `AVAudioSession` and nothing to
+  /// observe.
+  func startAudioSessionObserversIfManaged() {
+    #if os(iOS)
+    startAudioSessionObservers()
+    #endif
+  }
+
+  func stopAudioSessionObserversIfManaged() {
+    #if os(iOS)
+    stopAudioSessionObservers()
+    #endif
+  }
+
+  /// Resolves and applies the reaction for a disruption.
+  func react(to disruption: AudioSessionDisruption) {
+    apply(
+      Self.reaction(
+        to: disruption,
+        isPlaybackIntentActive: player.isPlaybackRequestedActive,
+        managesAudioSession: managesAudioSession
+      )
+    )
+  }
 }
 
 #endif

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -84,7 +84,7 @@ public final class PiPController: NSObject {
   @ObservationIgnored
   let player: Player
   @ObservationIgnored
-  private let playbackDriver: PlaybackDriver
+  let playbackDriver: PlaybackDriver
   @ObservationIgnored
   private let pauseDebounce: Duration
   @ObservationIgnored
@@ -187,6 +187,12 @@ public final class PiPController: NSObject {
   /// issued. One-shot per controller; see ``managesAudioSession``.
   @ObservationIgnored
   var hasActivatedAudioSession = false
+
+  /// Notification tokens for the managed session's disruption observers.
+  /// Empty when ``managesAudioSession`` is `false` — nothing is observed
+  /// because nothing may be changed. See `startAudioSessionObservers()`.
+  @ObservationIgnored
+  var audioSessionObservers: [any NSObjectProtocol] = []
 
   /// Broadcasts ``PiPEvent``s to every ``pipEvents`` subscriber.
   /// Terminated in deinit so subscribers' streams finish with the
@@ -354,6 +360,7 @@ public final class PiPController: NSObject {
     displayLayer.backgroundColor = CGColor(red: 0, green: 0, blue: 0, alpha: 1)
 
     configureAudioSession()
+    startAudioSessionObserversIfManaged()
     setupControlTimebase()
     attachCallbacks()
     setupPiPController()
@@ -387,6 +394,7 @@ public final class PiPController: NSObject {
 
     playbackDelegateProxy.owner = self
     configureAudioSession()
+    startAudioSessionObserversIfManaged()
     nativeBackend.setStartsAutomaticallyFromInline(startsAutomaticallyFromInline)
 
     // The native AVPictureInPictureController already belongs to the open
@@ -466,6 +474,7 @@ public final class PiPController: NSObject {
     displayLayer.backgroundColor = CGColor(red: 0, green: 0, blue: 0, alpha: 1)
 
     configureAudioSession()
+    startAudioSessionObserversIfManaged()
     setupControlTimebase()
     attachCallbacks()
     setupPiPController()
@@ -483,6 +492,7 @@ public final class PiPController: NSObject {
     cadenceObserverTask?.cancel()
     possibleObservation = nil
     activeObservation = nil
+    stopAudioSessionObserversIfManaged()
     // No explicit native-backend relinquish: the backend holds its `owner`
     // weakly, so ARC clears the back-reference as this controller is torn
     // down. A player swap (`updateUIView`/`updateNSView`) reassigns `owner`

--- a/Tests/SwiftVLCTests/PiP/PiPAudioSessionDisruptionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPAudioSessionDisruptionTests.swift
@@ -1,0 +1,198 @@
+#if os(iOS) || os(macOS)
+@testable import SwiftVLC
+import Testing
+
+/// What a managed audio session does when the system takes it away.
+///
+/// The bug this exists for is small and total: `hasActivatedAudioSession`
+/// latched on the first success and was never cleared, so after any
+/// interruption `activateAudioSessionIfNeeded()` no-oped forever. Take a phone
+/// call during PiP and the audio never comes back for the rest of that
+/// controller's life.
+///
+/// Every input here arrives as an `AVAudioSession` notification, which no test
+/// on this host can raise — there is no `AVAudioSession` on macOS at all. So
+/// the policy is a pure function and these are its rules.
+@Suite(.tags(.logic))
+struct PiPAudioSessionDisruptionTests {
+  private func reaction(
+    _ disruption: PiPController.AudioSessionDisruption,
+    playing: Bool = true,
+    managed: Bool = true
+  )
+    -> PiPController.AudioSessionReaction {
+    PiPController.reaction(
+      to: disruption,
+      isPlaybackIntentActive: playing,
+      managesAudioSession: managed
+    )
+  }
+
+  /// The regression itself. An interruption must release the latch, or nothing
+  /// can ever reactivate.
+  @Test
+  func `An interruption releases the activation latch`() {
+    let result = reaction(.interruptionBegan)
+    #expect(result.clearsActivationLatch)
+    // The system already deactivated us; reactivating here would fight
+    // whatever took focus.
+    #expect(!result.reactivates)
+    #expect(!result.pausesPlayback)
+  }
+
+  @Test
+  func `An interruption ending while playing reactivates`() {
+    let result = reaction(.interruptionEnded(shouldResume: true))
+    #expect(result.reactivates)
+    #expect(!result.clearsActivationLatch, "reactivating and clearing the latch would fight each other")
+  }
+
+  /// The criterion that matters most for trust: someone who paused before the
+  /// call must not find playback running after it. The system's `.shouldResume`
+  /// is a hint about the interruption, not consent from the user.
+  @Test
+  func `An interruption ending does not resume playback the user paused`() {
+    let result = reaction(.interruptionEnded(shouldResume: true), playing: false)
+    #expect(!result.reactivates, "an interruption ending resumed playback the user had paused")
+    #expect(result.clearsActivationLatch, "a later play must still be able to activate")
+  }
+
+  @Test
+  func `An interruption ending without the resume hint does not reactivate`() {
+    let result = reaction(.interruptionEnded(shouldResume: false))
+    #expect(!result.reactivates)
+    #expect(result.clearsActivationLatch)
+  }
+
+  /// Apple's headphone-unplug rule. Continuing would move the audio to the
+  /// speaker, which is the one outcome the user certainly did not ask for.
+  @Test
+  func `Losing the route pauses rather than rerouting`() {
+    let result = reaction(.routeLost)
+    #expect(result.pausesPlayback)
+    // The session is still valid, so the latch stands.
+    #expect(!result.clearsActivationLatch)
+    #expect(!result.reactivates)
+  }
+
+  /// A media-services reset invalidates every session object, so the category
+  /// has to be set again before anything else.
+  @Test
+  func `A media services reset reconfigures before reactivating`() {
+    let result = reaction(.mediaServicesReset)
+    #expect(result.reconfiguresCategory)
+    #expect(result.reactivates)
+  }
+
+  @Test
+  func `A media services reset while paused reconfigures without reactivating`() {
+    let result = reaction(.mediaServicesReset, playing: false)
+    #expect(result.reconfiguresCategory, "the category is gone regardless of intent")
+    #expect(!result.reactivates, "a reset must not take audio focus for a paused player")
+    #expect(result.clearsActivationLatch)
+  }
+
+  /// A library told not to manage the session must not manage it on the way
+  /// out either — including not pausing the host app's playback.
+  @Test(arguments: [
+    PiPController.AudioSessionDisruption.interruptionBegan,
+    .interruptionEnded(shouldResume: true),
+    .routeLost,
+    .mediaServicesReset
+  ])
+  func `An unmanaged session is never touched`(disruption: PiPController.AudioSessionDisruption) {
+    #expect(
+      reaction(disruption, managed: false) == PiPController.AudioSessionReaction(),
+      "managesAudioSession == false still produced a session mutation"
+    )
+  }
+}
+
+extension Integration {
+  /// The effects side. The rules above decide *what* should happen; these
+  /// check the controller actually does it — in particular that the latch is
+  /// released, which is the whole bug.
+  @Suite(.tags(.mainActor), .serialized)
+  @MainActor struct PiPAudioSessionEffectTests {
+    @MainActor
+    final class PauseRecorder {
+      var pauseCount = 0
+
+      var driver: PiPController.PlaybackDriver {
+        .init(
+          pause: {
+            self.pauseCount += 1
+            return true
+          },
+          resume: { true },
+          cancelPendingPause: {},
+          shouldResume: { false },
+          skip: { _ in .issued }
+        )
+      }
+    }
+
+    private func makeController(
+      player: Player,
+      recorder: PauseRecorder,
+      managesAudioSession: Bool = true
+    )
+      -> PiPController {
+      PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(10),
+        managesAudioSession: managesAudioSession
+      )
+    }
+
+    /// The regression, end to end at the controller: before this, a latched
+    /// controller stayed latched through an interruption and could never
+    /// activate again.
+    @Test
+    func `An interruption clears the latch so a later signal can reactivate`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = PauseRecorder()
+      let controller = makeController(player: player, recorder: recorder)
+      controller.hasActivatedAudioSession = true
+
+      controller.react(to: .interruptionBegan)
+
+      #expect(
+        !controller.hasActivatedAudioSession,
+        "the activation latch survived an interruption; audio can never come back"
+      )
+      await player.shutdown()
+    }
+
+    @Test
+    func `Losing the route pauses playback`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = PauseRecorder()
+      let controller = makeController(player: player, recorder: recorder)
+
+      controller.react(to: .routeLost)
+
+      #expect(recorder.pauseCount == 1, "unplugging the output did not pause playback")
+      await player.shutdown()
+    }
+
+    /// Criterion 4, at the effect level rather than the policy level: an
+    /// unmanaged controller must not pause the host app's playback either.
+    @Test
+    func `An unmanaged controller neither pauses nor unlatches`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = PauseRecorder()
+      let controller = makeController(player: player, recorder: recorder, managesAudioSession: false)
+      controller.hasActivatedAudioSession = true
+
+      controller.react(to: .routeLost)
+      controller.react(to: .interruptionBegan)
+
+      #expect(recorder.pauseCount == 0, "an unmanaged controller paused the host app's playback")
+      #expect(controller.hasActivatedAudioSession)
+      await player.shutdown()
+    }
+  }
+}
+#endif


### PR DESCRIPTION
Part of #87.

## Root cause

`hasActivatedAudioSession` latched on the first successful activation and was never cleared:

```swift
func activateAudioSessionIfNeeded(using activate: () throws -> Void) {
  guard managesAudioSession, !hasActivatedAudioSession else { return }
  ...
```

An interruption — a phone call, Siri — leaves iOS having deactivated the session on our behalf. `activateAudioSessionIfNeeded()` then sees the latch and no-ops. **Audio never returns for the rest of that controller's life.** Nothing observed `interruptionNotification`, `routeChangeNotification`, or `mediaServicesWereResetNotification` at all.

## Policy

A pure function, because every input arrives as an `AVAudioSession` notification: there is no `AVAudioSession` on macOS, and CI cannot raise a real interruption on any platform. The rules follow Apple's documented handling rather than being invented:

| disruption | reaction |
| --- | --- |
| interruption began | clear the latch only — the system already deactivated us, and reactivating would fight whatever took focus |
| interruption ended | reactivate **only** if `.shouldResume` **and** playback intent is still active |
| route lost | pause |
| media services reset | reconfigure the category, then reactivate only if playback was wanted |

Two of these deserve calling out:

**Resuming needs consent, not just the hint.** `.shouldResume` is the system's opinion about the interruption, not the user's about playback. Someone who paused before the call must not find playback running after it — that is #87's third criterion, and it has its own test.

**Route loss pauses rather than reroutes.** The headphone-unplug rule: continuing would move audio to the speaker, which is the one outcome the user certainly did not ask for.

With `managesAudioSession` false, nothing is observed and every reaction is empty. A library told not to manage the session must not manage it on the way out either — including not pausing the host app's playback.

## Validation

Eleven tests: eight on the rules, three on the effects at the controller.

Reverting the latch clearing and the pause fails the two that matter — the first with the latch still `true` after an interruption, which is the shipped bug exactly.

- macOS 1761 tests, tvOS 1453 tests, and the new suites on an iOS simulator, where the notification wiring actually compiles.
- Strict-concurrency build clean; lint, format, and 100% doc coverage clean.

## Scope

Not covered here, from #87's first criterion: **device lock** and **background-without-PiP** behaviour. Both are lifecycle questions rather than session-disruption ones — they need `UIApplication` state observation and a decision about what PiP-less backgrounding should do to audio, which is a larger policy question than the disruptions handled here. The bounded-reactivation criterion is satisfied for the paths above: reactivation reuses the existing one-shot machine, so a failure leaves the latch clear and the next playback signal retries rather than latching an inactive session.