### PR TITLE
Qualify VLCKit coexistence as ecosystem, not same-process (#98)

### DIFF
--- a/Sources/SwiftVLC/SwiftVLC.docc/ComparisonWithVLCKit.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/ComparisonWithVLCKit.md
@@ -174,7 +174,7 @@ Both are maintained, and choosing one does not deprecate the other.
 The two projects coexisting is a fact about the ecosystem, not about
 linking. **Do not link SwiftVLC and VLCKit into the same process.** Each
 ships its own complete
-libVLC, and a process that loads two of them is in undefined behavior:
+libVLC, and a process that loads two of them is undefined behavior:
 duplicate Objective-C classes resolved arbitrarily at launch, two plugin
 registries, and callbacks able to cross between two half-initialized
 runtimes. The libvlc archive has to exist exactly once among the images a

--- a/Sources/SwiftVLC/SwiftVLC.docc/ComparisonWithVLCKit.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/ComparisonWithVLCKit.md
@@ -165,6 +165,29 @@ requirements.
 - You want libVLC 4.0 APIs from a Swift package.
 - You're integrating through Swift Package Manager.
 
-The libraries coexist. SwiftVLC is not a fork of VLCKit or a replacement
-for it; it's a different set of trade-offs aimed at a different
-generation of Swift.
+SwiftVLC is not a fork of VLCKit or a replacement for it; it's a
+different set of trade-offs aimed at a different generation of Swift.
+Both are maintained, and choosing one does not deprecate the other.
+
+## Not in the same process
+
+The two projects coexisting is a fact about the ecosystem, not about
+linking. **Do not link SwiftVLC and VLCKit into the same process.** Each
+ships its own complete
+libVLC, and a process that loads two of them is in undefined behavior:
+duplicate Objective-C classes resolved arbitrarily at launch, two plugin
+registries, and callbacks able to cross between two half-initialized
+runtimes. The libvlc archive has to exist exactly once among the images a
+process loads — see <doc:IntegrationTopology> for the rule and the
+supported layered topology.
+
+Migrating is therefore a replacement rather than a gradual mix: move a
+target from one wrapper to the other, don't run both side by side inside
+one app. Two apps, two extensions, or an app and its extension are
+separate processes and are unaffected.
+
+Nothing here is a claim about same-process compatibility, and SwiftVLC
+does not test for it. If that ever becomes supported it will be backed
+by fixtures covering symbols, Objective-C classes, plugin registration,
+playback, and teardown on every platform — not by a sentence in a
+comparison guide.


### PR DESCRIPTION
Part of #98.

## The contradiction

`ComparisonWithVLCKit.md` ended on an unqualified claim:

> The libraries coexist.

`IntegrationTopology.md` says the opposite, and is right:

> The libvlc archive must therefore exist **exactly once** among the images a process loads.

VLCKit ships its own complete libVLC, so linking both wrappers is precisely the unsupported case: duplicate Objective-C classes resolved arbitrarily at launch, two plugin registries, and callbacks able to cross between two half-initialized runtimes.

Both statements were true of different things — ecosystem vs. linking — but only one of them said which, and the ambiguous one was the last line of the page a reader consults *while choosing a wrapper*.

## The fix

The comparison page now says what it means:

- the projects coexist **as projects**, and choosing one doesn't deprecate the other;
- **do not link both into one process**, with the one-line reason and a link to <doc:IntegrationTopology> for the rule rather than restating it;
- migration is a replacement, not a gradual mix — move a target, don't run both inside one app;
- separate processes (two apps, or an app and its extension) are explicitly unaffected, because that's the case someone will reasonably wonder about next.

It also records that same-process compatibility is **untested**, and what it would take to claim otherwise — fixtures for symbols, Objective-C classes, plugin registration, playback and teardown on every platform. That's #98's third criterion, and it means the next person tempted to add a reassuring sentence has to bring evidence with it.

## Validation

Documentation only; no code changes.

- The link target exists, and `SwiftVLC.md:76` already uses the identical `<doc:IntegrationTopology>` form, so the shape is proven resolvable rather than assumed.
- Checked the rest of the catalog for the same claim: `grep` for coexist / side-by-side / alongside finds no other instance, and the porting guide makes no incremental-mixing claim.
- Lint, format, 100% doc coverage, and target build all clean.