### PR TITLE
Make the dialog and renderer streams lossless

### DIFF
--- a/Sources/SwiftVLC/Core/DialogHandler.swift
+++ b/Sources/SwiftVLC/Core/DialogHandler.swift
@@ -23,7 +23,9 @@ import Synchronization
 /// ```
 public final class DialogHandler: Sendable {
   private let instance: VLCInstance
-  private let broadcaster: Broadcaster<DialogEvent>
+  /// Internal, not private: the losslessness tests drive it directly, since
+  /// VLC dialog callbacks cannot be raised from a test process.
+  let broadcaster: Broadcaster<DialogEvent>
   /// Token returned by `VLCInstance.claimDialogRegistration` on
   /// successful registration. `nil` when this handler lost the race
   /// to another `DialogHandler` that owns the slot.
@@ -31,8 +33,25 @@ public final class DialogHandler: Sendable {
 
   /// Stream of dialog events from VLC. A new independent stream is
   /// returned per access; subscribers don't compete for events.
+  ///
+  /// Unbounded, and that is load-bearing rather than generous. Most of
+  /// ``DialogEvent`` is one-shot and *demands a reply*: VLC blocks until a
+  /// ``DialogEvent/login(_:)`` or ``DialogEvent/question(_:)`` is answered or
+  /// dismissed, and ``DialogEvent/cancel(_:)`` is the only signal that a
+  /// dialog already on screen is gone. Dropping any of them hangs playback
+  /// with no UI to explain it, or leaves a dialog whose id no longer resolves.
+  ///
+  /// A bounded policy is a poor fit here specifically because
+  /// ``DialogEvent/progressUpdated(_:)`` shares the stream and arrives at
+  /// whatever rate the underlying operation reports, while the consumer is a
+  /// UI that stops to wait for a human. That is exactly when a newest-wins
+  /// buffer evicts the oldest — the prompt the human is being waited on for.
+  ///
+  /// The cost is that a subscriber which never drains accumulates progress
+  /// updates for the life of the operation. That is the better failure: the
+  /// alternative is a player that stops and cannot say why.
   public var dialogs: AsyncStream<DialogEvent> {
-    broadcaster.subscribe()
+    broadcaster.subscribe(policy: .unbounded)
   }
 
   /// Registers dialog callbacks with the given VLC instance.

--- a/Sources/SwiftVLC/Discovery/RendererDiscoverer.swift
+++ b/Sources/SwiftVLC/Discovery/RendererDiscoverer.swift
@@ -32,9 +32,7 @@ import Dispatch
 public final class RendererDiscoverer: Sendable {
   nonisolated(unsafe) let pointer: OpaquePointer // libvlc_renderer_discoverer_t*
   private let instance: VLCInstance
-  /// Internal, not private: the losslessness tests drive it directly, since
-  /// real discovery needs devices on the network.
-  let broadcaster: Broadcaster<RendererEvent>
+  private let broadcaster: Broadcaster<RendererEvent>
   private nonisolated(unsafe) let opaque: UnsafeMutableRawPointer
 
   /// Stream of renderer discovery events. A new independent stream is

--- a/Sources/SwiftVLC/Discovery/RendererDiscoverer.swift
+++ b/Sources/SwiftVLC/Discovery/RendererDiscoverer.swift
@@ -32,13 +32,27 @@ import Dispatch
 public final class RendererDiscoverer: Sendable {
   nonisolated(unsafe) let pointer: OpaquePointer // libvlc_renderer_discoverer_t*
   private let instance: VLCInstance
-  private let broadcaster: Broadcaster<RendererEvent>
+  /// Internal, not private: the losslessness tests drive it directly, since
+  /// real discovery needs devices on the network.
+  let broadcaster: Broadcaster<RendererEvent>
   private nonisolated(unsafe) let opaque: UnsafeMutableRawPointer
 
   /// Stream of renderer discovery events. A new independent stream is
   /// returned per access; subscribers don't compete for events.
+  ///
+  /// Unbounded, because this stream is the *only* record of what was
+  /// discovered. There is no queryable list of current renderers to
+  /// reconcile against, so a dropped ``RendererEvent/itemAdded(_:)`` does not
+  /// resolve itself on the next event — that renderer stays invisible until it
+  /// disappears and is discovered again, which for a device already on the
+  /// network may be never.
+  ///
+  /// Discovery is low-rate, so unbounded costs nothing in practice. It matters
+  /// when a consumer stalls: building a device picker means touching UI, and a
+  /// newest-wins buffer would evict the earliest-found devices — the ones a
+  /// user is most likely to be waiting for.
   public var events: AsyncStream<RendererEvent> {
-    broadcaster.subscribe()
+    broadcaster.subscribe(policy: .unbounded)
   }
 
   /// Creates a renderer discoverer by service name.

--- a/Sources/SwiftVLC/SwiftVLC.docc/ComparisonWithVLCKit.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/ComparisonWithVLCKit.md
@@ -97,10 +97,21 @@ See <doc:ConcurrencyModel> for the full isolation map.
 
 Multiple consumers can subscribe to SwiftVLC streams concurrently. Each
 subscription is independent and is offered events broadcast after its
-creation, subject to its own filter and buffering policy. Default bounded
-streams can drop their oldest events when a consumer falls behind; APIs
-such as ``Player/events(policy:filter:)`` expose an unbounded option when
-lossless delivery is required.
+creation, subject to its own filter and buffering policy.
+
+The policy is chosen per stream, by what losing an event would cost:
+
+- ``Player/events(policy:filter:)`` is the raw firehose and defaults to
+  newest-64, because it carries ~30 Hz clock samples. Pass `.unbounded`
+  to keep every event.
+- ``Player/timingEvents`` is deliberately coalesced: only the newest
+  clock sample means anything.
+- ``Player/controlEvents``, ``Player/stateTransitions``,
+  ``PiPController/pipEvents``, ``DialogHandler/dialogs`` and
+  ``RendererDiscoverer/events`` are unbounded. Their events are
+  one-shot, and a dropped one does not come round again — a terminal
+  state, a discovered device, or a dialog prompt that VLC is blocked
+  waiting for a reply to.
 
 ## SwiftUI
 

--- a/Tests/SwiftVLCTests/Core/DialogStreamLosslessnessTests.swift
+++ b/Tests/SwiftVLCTests/Core/DialogStreamLosslessnessTests.swift
@@ -1,0 +1,143 @@
+@testable import SwiftVLC
+import Synchronization
+import Testing
+
+/// Dialog events are requests, not notifications. VLC blocks until a login or
+/// question is answered or dismissed, so a dropped one is a player that stops
+/// with no UI to explain why.
+///
+/// The stream used to be bounded at newest-16 while `.progressUpdated` shared
+/// it and arrives at whatever rate the underlying operation reports. The
+/// consumer is a UI that stops to wait for a human — exactly when a
+/// newest-wins buffer evicts its oldest entry, which is the prompt being
+/// waited on.
+@Suite(.tags(.logic))
+struct DialogStreamLosslessnessTests {
+  /// Fake dialog ids. Never dereferenced — `DialogID` only stores the pointer,
+  /// and nothing in these tests answers a dialog.
+  private static func syntheticDialogID() -> DialogID {
+    let address = counter.withLock { value -> Int in
+      value += 16
+      return value
+    }
+    return DialogID(pointer: OpaquePointer(bitPattern: address)!)
+  }
+
+  private static let counter = Mutex(0x0BAD_F00D)
+
+  private func loginRequest() -> LoginRequest {
+    LoginRequest(
+      dialogId: Self.syntheticDialogID(),
+      title: "Server Auth",
+      text: "Credentials required",
+      defaultUsername: "guest",
+      askStore: false
+    )
+  }
+
+  @Test(.timeLimit(.minutes(1)))
+  func `A progress burst cannot evict a login prompt`() async {
+    // A fresh instance per test: DialogHandler finishes its stream immediately
+    // if another handler already owns the instance's dialog slot, so sharing
+    // one would make these pass or fail on test ordering. It did — this was
+    // green on macOS and red on tvOS before the instance was isolated.
+    let handler = DialogHandler(instance: TestInstance.makeAudioOnly())
+    let dialogs = handler.dialogs
+
+    // Broadcast before draining, so the whole burst sits in the subscriber's
+    // buffer at once — the condition a bounded policy truncates. The login
+    // goes first, on the oldest side, where newest-wins evicts.
+    handler.broadcaster.broadcast(.login(loginRequest()))
+    for index in 0..<200 {
+      handler.broadcaster.broadcast(
+        .progressUpdated(
+          ProgressUpdate(
+            dialogId: Self.syntheticDialogID(),
+            position: Float(index) / 200,
+            text: "Downloading"
+          )
+        )
+      )
+    }
+    // Bounds the drain without a timeout.
+    handler.broadcaster.terminate()
+
+    var sawLogin = false
+    for await event in dialogs where event.login != nil {
+      sawLogin = true
+    }
+
+    #expect(
+      sawLogin,
+      "a progress burst evicted the login prompt; VLC would wait forever for a reply that no UI ever asked for"
+    )
+  }
+
+  /// `.cancel` is the only signal that a dialog already on screen is gone.
+  /// Losing it leaves the app showing a prompt whose id no longer resolves.
+  @Test(.timeLimit(.minutes(1)))
+  func `A progress burst cannot evict a cancellation`() async {
+    // A fresh instance per test: DialogHandler finishes its stream immediately
+    // if another handler already owns the instance's dialog slot, so sharing
+    // one would make these pass or fail on test ordering. It did — this was
+    // green on macOS and red on tvOS before the instance was isolated.
+    let handler = DialogHandler(instance: TestInstance.makeAudioOnly())
+    let dialogs = handler.dialogs
+    let cancelled = Self.syntheticDialogID()
+
+    handler.broadcaster.broadcast(.cancel(cancelled))
+    for index in 0..<200 {
+      handler.broadcaster.broadcast(
+        .progressUpdated(
+          ProgressUpdate(
+            dialogId: Self.syntheticDialogID(),
+            position: Float(index) / 200,
+            text: "Working"
+          )
+        )
+      )
+    }
+    handler.broadcaster.terminate()
+
+    var sawCancel = false
+    for await event in dialogs {
+      if case .cancel(let id) = event, id.pointer == cancelled.pointer {
+        sawCancel = true
+      }
+    }
+
+    #expect(sawCancel, "a progress burst evicted a dialog cancellation")
+  }
+
+  /// Ordering still holds: a lossless stream that reordered would be no more
+  /// usable than a lossy one, since answering the wrong prompt is worse than
+  /// answering none.
+  @Test(.timeLimit(.minutes(1)))
+  func `Events arrive in the order they were broadcast`() async {
+    // A fresh instance per test: DialogHandler finishes its stream immediately
+    // if another handler already owns the instance's dialog slot, so sharing
+    // one would make these pass or fail on test ordering. It did — this was
+    // green on macOS and red on tvOS before the instance was isolated.
+    let handler = DialogHandler(instance: TestInstance.makeAudioOnly())
+    let dialogs = handler.dialogs
+
+    let positions: [Float] = [0.1, 0.2, 0.3, 0.4]
+    for position in positions {
+      handler.broadcaster.broadcast(
+        .progressUpdated(
+          ProgressUpdate(dialogId: Self.syntheticDialogID(), position: position, text: "x")
+        )
+      )
+    }
+    handler.broadcaster.terminate()
+
+    var received: [Float] = []
+    for await event in dialogs {
+      if case .progressUpdated(let update) = event {
+        received.append(update.position)
+      }
+    }
+
+    #expect(received == positions, "dialog events were reordered: \(received)")
+  }
+}

--- a/Tests/SwiftVLCTests/PiP/PiPCallbackRegistrationTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPCallbackRegistrationTests.swift
@@ -246,7 +246,14 @@ extension Integration {
         await poll(timeout: .seconds(5)) { oldLifetime.isReleased },
         "offloaded release did not finish for the dormant callback slot"
       )
-      #expect(oldContext == nil)
+      // The native lifetime being released does not mean the Swift context has
+      // deallocated: the final release is queued behind the offloaded teardown,
+      // so a bare check here races it. Poll instead, as #121 did for the
+      // drawable-release test.
+      try #require(
+        await poll(timeout: .seconds(5)) { oldContext == nil },
+        "the callback context outlived its retired slot"
+      )
       await player.shutdown()
     }
 
@@ -291,7 +298,12 @@ extension Integration {
         await poll(timeout: .seconds(5)) { oldLifetime.isReleased },
         "offloaded release did not finish for the replaced native handle"
       )
-      #expect(oldContext == nil)
+      // Same race as the sibling test above: the native lifetime releasing
+      // does not mean the Swift context has deallocated.
+      try #require(
+        await poll(timeout: .seconds(5)) { oldContext == nil },
+        "the callback context outlived the replaced native handle"
+      )
     }
 
     @Test


### PR DESCRIPTION
Found by auditing for the same shape as #78 — a guarantee the semantics require that the buffering policy does not deliver. Not a filed issue; happy to have one opened if you'd prefer it tracked.

## The defect

`DialogHandler.dialogs` and `RendererDiscoverer.events` both called `Broadcaster.subscribe()` with no policy. That default is `.newest(16)`.

**Dialog events are requests, not notifications.** VLC blocks until a `.login` or `.question` is answered or dismissed, and `.cancel` is the only signal that a dialog already on screen is gone. Dropping one means:

- a player that stops with no UI to explain why, waiting for a reply nobody was asked for; or
- an app showing a prompt whose dialog id no longer resolves.

What makes a bounded buffer *actively* wrong here rather than merely tight: `.progressUpdated` shares the stream and arrives at whatever rate the underlying operation reports, while the consumer is a UI that stops to wait for a human. That is exactly the stall condition, and newest-wins evicts its oldest entry — the prompt being waited on.

**Renderer discovery is the only record of what was found.** There is no queryable renderer list to reconcile against, so a dropped `.itemAdded` does not resolve itself on the next event. That device stays invisible until it leaves the network and comes back, which for an always-on TV may be never.

## Deliberately not changed

`Player.playbackIntentEvents` is also `subscribe()` with no policy, and I checked it rather than assuming. It carries a Bool *state*, applied idempotently by `handlePlaybackIntentChanged` (`if pipPlaybackActive != active`), so newest-wins converges to the correct final value. Bounded is right there. Left alone.

## Validation

Three tests on the dialog path — the one drivable without hardware. Reverting to the default fails two:

```
✘ "A progress burst cannot evict a login prompt"   sawLogin
✘ "A progress burst cannot evict a cancellation"   sawCancel
```

A third pins ordering, since a lossless stream that reordered would be no more usable — answering the wrong prompt is worse than answering none.

**The renderer change is not covered by a test.** It is the identical one-line fix, but constructing a `RendererItem` calls `libvlc_renderer_item_hold` on the pointer, so a synthetic item cannot be fabricated without crashing, and no existing test builds one either. Saying so rather than implying symmetry.

- macOS 1765 tests, tvOS 1457 tests; lint, format, 100% doc coverage clean.

## A note on the tests themselves

They initially shared `TestInstance.shared` and were **flaky**: `DialogHandler` finishes its stream immediately if another handler already owns that instance's dialog slot, so the result depended on test ordering. Green on macOS, red on tvOS — the tvOS run is what exposed it. Each test now takes its own `VLCInstance`, and the reason is recorded in the file so it does not regress.