### PR TITLE
Advance the session generation on media changes from outside (#78)

### DIFF
--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -151,6 +151,18 @@ extension Player {
 
     case .mediaChanged:
       syncCurrentMediaFromNative()
+      // A media change the wrapper did not initiate still has to supersede
+      // whatever was restoring the previous session: a `MediaListPlayer`
+      // advancing the list calls `libvlc_media_list_player_next` directly, so
+      // `load(_:)` never runs and nothing else advances the generation.
+      // Compared by native identity rather than bumped unconditionally,
+      // because libVLC echoes the wrapper's own load back through here and a
+      // second advance would supersede a `recast(to:)` for a change it had
+      // already accounted for.
+      if currentMedia?.pointer != sessionGenerationMedia {
+        sessionGeneration &+= 1
+        sessionGenerationMedia = currentMedia?.pointer
+      }
       resetMediaDerivedState()
       refreshTracks()
       notifyMediaDependentObservables()
@@ -439,6 +451,18 @@ extension Player {
 
   func _handleEventForTesting(_ event: PlayerEvent) {
     handleEvent(event)
+  }
+
+  /// Models a media change that did not come through the wrapper — what a
+  /// `MediaListPlayer` advancing the list looks like from `Player`'s side.
+  ///
+  /// libVLC swaps the input and reports it; no wrapper call asked for it. A
+  /// real list-player advance cannot be driven from a test process without a
+  /// list and live playback, so the native swap plus its event is staged
+  /// directly.
+  func adoptMediaForTesting(_ media: Media) {
+    libvlc_media_player_set_media(pointer, media.pointer)
+    handleEvent(.mediaChanged)
   }
 
   func _handleEventForTesting(_ event: PlayerEvent, source: OpaquePointer) {

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -526,6 +526,15 @@ public final class Player {
   /// session, rather than reapplying stale tracks or transport state to
   /// someone else's media.
   var sessionGeneration: UInt64 = 0
+  /// The native media the generation was last advanced for.
+  ///
+  /// libVLC reports a media change back as `.mediaChanged` whether or not the
+  /// wrapper initiated it, so the handler cannot tell the two apart by the
+  /// event alone. Comparing identity does: a change this player asked for has
+  /// already advanced the generation and records itself here, while one that
+  /// arrives from elsewhere — a ``MediaListPlayer`` advancing the list through
+  /// libVLC directly — does not match and advances it.
+  var sessionGenerationMedia: OpaquePointer?
   let instance: VLCInstance
 
   // MARK: - Lifecycle
@@ -626,6 +635,9 @@ public final class Player {
     // Any recast still restoring the outgoing session no longer owns it.
     sessionGeneration &+= 1
     currentMedia = media
+    // Recorded so libVLC echoing this same change back as `.mediaChanged`
+    // does not advance the generation a second time.
+    sessionGenerationMedia = media.pointer
     resetMediaDerivedState()
     // No `markLibraryStop()` here: setting media on a *started* handle
     // replaces the input seamlessly — libVLC 4 emits `MediaStopping` for
@@ -671,6 +683,7 @@ public final class Player {
       // without going through it.
       sessionGeneration &+= 1
       currentMedia = media
+      sessionGenerationMedia = media.pointer
       // No `notifyMediaDependentObservables()` here: the swap already issued
       // it, and the keypaths it refreshes read from the native handle rather
       // than from `currentMedia`, so a second pass is pure churn.

--- a/Tests/SwiftVLCTests/Player/PlayerSessionGenerationTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerSessionGenerationTests.swift
@@ -1,0 +1,73 @@
+@testable import SwiftVLC
+import Testing
+
+extension Integration {
+  /// `sessionGeneration` is what ``Player/recast(to:)`` uses to notice it no
+  /// longer owns the session. It re-checks after each of its six suspension
+  /// points and stops mutating once the check fails, so anything that changes
+  /// the media has to advance it.
+  ///
+  /// It was advanced only by `load(_:)`, by the replacement branch of
+  /// `play(_:)`, and by `recast` itself. A `MediaListPlayer` advancing the list
+  /// calls `libvlc_media_list_player_next` directly and goes nowhere near it,
+  /// so a playlist advance during an in-flight recast was invisible: the recast
+  /// carried on reapplying track selection and transport state to media it no
+  /// longer owned.
+  @Suite(.tags(.mainActor), .serialized)
+  @MainActor struct PlayerSessionGenerationTests {
+    /// The gap. A media change SwiftVLC did not originate still has to
+    /// supersede whatever was restoring the previous one.
+    @Test
+    func `A media change from outside the wrapper advances the generation`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.silenceURL))
+      let before = player.sessionGeneration
+
+      // What a list-player advance looks like from here: libVLC swapped the
+      // input and reported it, without any wrapper call having asked for it.
+      try player.adoptMediaForTesting(Media(url: TestMedia.twosecURL))
+
+      #expect(
+        player.sessionGeneration > before,
+        "a media change from outside load(_:) left the generation stale, so recast cannot see it was superseded"
+      )
+    }
+
+    /// The half that makes the fix safe rather than merely present. `load(_:)`
+    /// advances the generation itself, and libVLC then reports the same change
+    /// back as `.mediaChanged`. Advancing again on that echo would supersede a
+    /// recast started in between, for a change it had already accounted for.
+    @Test
+    func `The echo of a wrapper-initiated load does not advance it twice`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let media = try Media(url: TestMedia.twosecURL)
+      player.load(media)
+      let afterLoad = player.sessionGeneration
+
+      // The native echo of that same load.
+      player._handleEventForTesting(.mediaChanged)
+
+      #expect(
+        player.sessionGeneration == afterLoad,
+        "the native echo of load(_:) advanced the generation a second time; a recast started in between would be spuriously superseded"
+      )
+    }
+
+    /// Two different media in a row each advance it once, so the guard still
+    /// discriminates after the de-duplication above.
+    @Test
+    func `Successive distinct media each advance it once`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.silenceURL))
+      let first = player.sessionGeneration
+      player._handleEventForTesting(.mediaChanged)
+      #expect(player.sessionGeneration == first)
+
+      try player.adoptMediaForTesting(Media(url: TestMedia.twosecURL))
+      let second = player.sessionGeneration
+      #expect(second > first)
+      player._handleEventForTesting(.mediaChanged)
+      #expect(player.sessionGeneration == second, "the second echo advanced it again")
+    }
+  }
+}


### PR DESCRIPTION
Found while investigating whether a public media generation could be built on `sessionGeneration` — five issues want one (#78 criterion 2, #81, #85 criterion 3, #89 criterion 3, #96 criterion 4). It turned out to be incomplete in a way that looks usable, which mattered more than the abstract question.

## The bug

`recast(to:)` re-checks `generation == sessionGeneration` after each of its **six** suspension points, and documents that it must stop mutating once it no longer owns the session. Three things advanced that counter: `load(_:)`, the replacement branch of `play(_:)`, and recast itself.

A playlist advance is not one of them. `MediaListPlayer.next()` / `previous()` call `libvlc_media_list_player_next/previous` directly — `load(_:)` never runs, and the `.mediaChanged` handler didn't touch the counter either.

So a list advance during an in-flight recast was **invisible to the guard**: the recast kept reapplying track selection, seek position and pause state to media it no longer owned. Reachable in ordinary use — an app calling `next()` in any of six await windows.

## Why the obvious fix is wrong

Bumping unconditionally in `.mediaChanged` looks right and isn't. libVLC echoes the wrapper's *own* `load(_:)` back through the same event, so the counter would advance twice for one change — superseding a recast that started in between, for something already accounted for.

So `load(_:)` and the replacement branch record the native media they advanced for, and the handler advances only when what arrived differs.

## Both halves proven load-bearing

Each was removed to confirm it matters:

```
remove the advance           → "a media change from outside" fails: (1) > (1)
                               (the shipped bug, reproduced)
advance unconditionally      → "the echo … does not advance it twice" fails: (2) == (1)
                               (the naive fix, reproduced)
```

A third test pins that two *distinct* media still advance it once each, so de-duplication didn't cost the guard its discrimination.

## Validation

- macOS 1768 tests, tvOS 1460 tests.
- Strict-concurrency build clean; lint, format, 100% doc coverage clean.

## Note on scope

This does **not** close #78 — its criterion 2 asks for old-handle events to be rejectable by a *public* consumer, which still needs a generation attached to public events. This fixes the internal counter those criteria would be built on, so that work starts from something correct.

The test seam `adoptMediaForTesting` stages the native swap plus its event, because a real list-player advance needs a list and live playback that a test process cannot drive.