### PR TITLE
Refuse to package a stale xcframework (#97)

### DIFF
--- a/scripts/build-libvlc.sh
+++ b/scripts/build-libvlc.sh
@@ -1450,6 +1450,38 @@ find "${OUTPUT_DIR}/libvlc.xcframework" -name "CLibVLC.h" -delete
 
 info "Created: ${OUTPUT_DIR}/libvlc.xcframework"
 
+# --- Step 4b: Record what produced it ---
+#
+# `release.sh` packages whatever xcframework is sitting in Vendor/. Without a
+# record of the inputs it cannot tell a fresh build from one made months ago
+# against a different pin or patch set, so a stale binary could be published as
+# a new release and nothing would notice. That is issue #97's second acceptance
+# criterion.
+#
+# Written last, after every slice succeeded, so a partial build leaves no
+# provenance rather than provenance describing an artifact that was never
+# finished.
+PROVENANCE_FILE="${OUTPUT_DIR}/libvlc-provenance.json"
+manifest_digest="none"
+if [ -n "${PATCHES_DIR}" ] && [ -f "${PATCHES_DIR}/manifest.sha256" ]; then
+    manifest_digest=$(shasum -a 256 "${PATCHES_DIR}/manifest.sha256" | cut -d' ' -f1)
+fi
+slice_list=$(find "${OUTPUT_DIR}/libvlc.xcframework" -maxdepth 1 -mindepth 1 -type d \
+    -exec basename {} \; | sort | paste -sd, -)
+
+cat > "${PROVENANCE_FILE}" <<PROVENANCE
+{
+  "vlcSourceRevision": "${SOURCE_SHA}",
+  "pinnedRevision": "${VLC_HASH}",
+  "patchManifestDigest": "${manifest_digest}",
+  "assertionsEnabled": "${WITH_ASSERTS}",
+  "slices": "${slice_list}",
+  "xcodeBuildVersion": "$(xcodebuild -version 2>/dev/null | head -1)",
+  "builtAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+PROVENANCE
+info "Recorded build provenance: ${PROVENANCE_FILE}"
+
 # --- Step 5: Verify ---
 #
 # Fail the build if any object file in the xcframework has an LC_BUILD_VERSION

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -355,6 +355,54 @@ echo "Validating release manifest rewrites..."
 validate_release_rewrites
 echo "Release rewrite validation passed."
 
+# ── Artifact freshness ────────────────────────────────────────────────────────
+#
+# Everything below packages whatever xcframework is in Vendor/. Nothing so far
+# has established that it was built from the sources this release will claim,
+# so a binary produced months ago against a different pin or patch set would be
+# published as new and nothing would notice (#97, second criterion).
+#
+# The build records its inputs beside the artifact; this compares them with what
+# the repository says now. It is not a reproducibility proof — two builds of the
+# same inputs are not yet compared — but it does refuse a demonstrably stale one.
+verify_artifact_provenance() {
+  local provenance="Vendor/libvlc-provenance.json"
+
+  if [[ ! -f "$provenance" ]]; then
+    echo "Error: $provenance not found." >&2
+    echo "  The xcframework in Vendor/ was built before provenance was recorded," >&2
+    echo "  so its inputs cannot be established. Rebuild with:" >&2
+    echo "    ./scripts/build-libvlc.sh --all" >&2
+    return 1
+  fi
+
+  local recorded_pin recorded_manifest current_pin current_manifest
+  recorded_pin=$(/usr/bin/python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["pinnedRevision"])' "$provenance")
+  recorded_manifest=$(/usr/bin/python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["patchManifestDigest"])' "$provenance")
+  current_pin=$(sed -n 's/^VLC_HASH="\(.*\)"$/\1/p' "$SCRIPT_DIR/build-libvlc.sh" | head -1)
+  current_manifest=$(shasum -a 256 "$SCRIPT_DIR/patches/manifest.sha256" | cut -d' ' -f1)
+
+  if [[ "$recorded_pin" != "$current_pin" ]]; then
+    echo "Error: the xcframework was built from a different engine pin." >&2
+    echo "  artifact: $recorded_pin" >&2
+    echo "  repo:     $current_pin" >&2
+    return 1
+  fi
+  if [[ "$recorded_manifest" != "$current_manifest" ]]; then
+    echo "Error: the xcframework was built from a different patch series." >&2
+    echo "  artifact manifest: $recorded_manifest" >&2
+    echo "  repo manifest:     $current_manifest" >&2
+    echo "  Rebuild so the shipped binary contains the patches this release claims." >&2
+    return 1
+  fi
+
+  echo "Artifact provenance verified: pin $current_pin, patch manifest ${current_manifest:0:12}…"
+}
+
+if ! verify_artifact_provenance; then
+  exit 1
+fi
+
 # ── Strip ─────────────────────────────────────────────────────────────────────
 
 WORK_DIR=$(make_temp_dir)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -366,19 +366,41 @@ echo "Release rewrite validation passed."
 # the repository says now. It is not a reproducibility proof — two builds of the
 # same inputs are not yet compared — but it does refuse a demonstrably stale one.
 verify_artifact_provenance() {
-  local provenance="Vendor/libvlc-provenance.json"
+  # Derived from XCFW_PATH rather than hard-coded, so the provenance always
+  # describes the artifact actually being packaged even if Vendor/ moves.
+  local provenance="$(dirname "$XCFW_PATH")/libvlc-provenance.json"
 
   if [[ ! -f "$provenance" ]]; then
     echo "Error: $provenance not found." >&2
-    echo "  The xcframework in Vendor/ was built before provenance was recorded," >&2
-    echo "  so its inputs cannot be established. Rebuild with:" >&2
+    echo "  $XCFW_PATH was built before provenance was recorded, so its inputs" >&2
+    echo "  cannot be established. Rebuild with:" >&2
     echo "    ./scripts/build-libvlc.sh --all" >&2
     return 1
   fi
 
+  # `python3` from PATH, not /usr/bin/python3: the rest of this script already
+  # relies on PATH, and a Homebrew-only Python would otherwise fail here while
+  # everything around it worked.
+  read_provenance() {
+    local key="$1"
+    local value
+    if ! value=$(python3 -c 'import json,sys
+try:
+    print(json.load(open(sys.argv[1]))[sys.argv[2]])
+except (OSError, ValueError) as error:
+    sys.exit(f"cannot read {sys.argv[1]}: {error}")
+except KeyError:
+    sys.exit(f"{sys.argv[1]} has no {sys.argv[2]!r} key")' "$provenance" "$key" 2>&1); then
+      echo "Error: $value" >&2
+      echo "  Rebuild to regenerate provenance: ./scripts/build-libvlc.sh --all" >&2
+      return 1
+    fi
+    printf '%s' "$value"
+  }
+
   local recorded_pin recorded_manifest current_pin current_manifest
-  recorded_pin=$(/usr/bin/python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["pinnedRevision"])' "$provenance")
-  recorded_manifest=$(/usr/bin/python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["patchManifestDigest"])' "$provenance")
+  recorded_pin=$(read_provenance pinnedRevision) || return 1
+  recorded_manifest=$(read_provenance patchManifestDigest) || return 1
   current_pin=$(sed -n 's/^VLC_HASH="\(.*\)"$/\1/p' "$SCRIPT_DIR/build-libvlc.sh" | head -1)
   current_manifest=$(shasum -a 256 "$SCRIPT_DIR/patches/manifest.sha256" | cut -d' ' -f1)
 


### PR DESCRIPTION
#97's **second** acceptance criterion. Follows #133, which covered the first.

## The gap

`release.sh` copies whatever xcframework is in `Vendor/` and publishes it:

```bash
cp -R "$XCFW_PATH" "$WORK_DIR/libvlc.xcframework"
```

Nothing established that the binary was built from the sources the release claims. An xcframework produced months ago, against a different engine pin or a different patch series, would ship as new — and nothing would notice.

That is not hypothetical: **the artifact currently in `Vendor/` predates every patch merged this week.** Releasing today would publish a binary without the #122, #124 and #126 fixes while the release notes said otherwise.

## The gate

The build records its inputs beside the artifact — VLC revision, pinned revision, patch-manifest digest, assertion setting, slices, Xcode version, timestamp — written **after every slice succeeds**, so a partial build leaves no provenance rather than provenance describing something unfinished.

`release.sh` compares the pin and the patch digest against what the repository says now, and refuses a mismatch with both values printed.

All four outcomes were produced, not reasoned about:

```
1. no provenance          → "built before provenance was recorded … Rebuild with:"
2. different pin          → artifact: deadbeef   repo: c833c4be0
3. different patch series → artifact manifest: 0000   repo manifest: 13e1a2f88c9a…
4. match                  → "Artifact provenance verified: pin c833c4be0, patch manifest 13e1a2f88c9a…"
```

## What this means for the next release

Case 1 is today's state, so **the next release will require an engine rebuild.** That rebuild is already necessary for the merged patches to exist in the shipped binary at all — the gate isn't adding work, it's refusing to let the omission pass silently.

## Deliberately not claimed

This is **not** reproducibility. Two builds of the same inputs are still not compared, and per-slice inputs — contrib hashes, configure flags, SDK versions — are not yet recorded. Those are #97's third and fourth criteria and remain open. The provenance file is the first piece of that record, shaped so it can grow into it.