### PR TITLE
Ship patch 0015's stopping reason in the vendored headers (#79)

### DIFF
--- a/Sources/CLibVLC/include/vlc/libvlc_events.h
+++ b/Sources/CLibVLC/include/vlc/libvlc_events.h
@@ -48,6 +48,22 @@ typedef struct libvlc_media_t libvlc_media_t;
 typedef struct libvlc_media_list_t libvlc_media_list_t;
 
 /**
+ * Enumeration of media stopping reasons
+ *
+ * Names and values match vlc_player_media_stopping_reason, and match the
+ * libvlc_stopping_reason_t that upstream later added for the
+ * libvlc_media_player_cbs API.
+ */
+typedef enum libvlc_stopping_reason_t {
+    /** media is stopping due to an error (default) */
+    libvlc_stopping_reason_error,
+    /** media has reached the end of stream */
+    libvlc_stopping_reason_eos,
+    /** media is stopping due to user request */
+    libvlc_stopping_reason_user,
+} libvlc_stopping_reason_t;
+
+/**
  * \ingroup libvlc_event
  * @{
  */
@@ -385,6 +401,7 @@ typedef struct libvlc_event_t
         struct
         {
             libvlc_media_t * media;
+            libvlc_stopping_reason_t reason;
         } media_player_media_stopping;
 
 

--- a/Tests/SwiftVLCTests/Core/VendoredHeaderParityTests.swift
+++ b/Tests/SwiftVLCTests/Core/VendoredHeaderParityTests.swift
@@ -1,0 +1,44 @@
+@testable import SwiftVLC
+import CLibVLC
+import Testing
+
+/// The xcframework ships headers from `Sources/CLibVLC/include`, **not** from
+/// the patched VLC source tree — `build-libvlc.sh` passes that directory to
+/// `xcodebuild -create-xcframework -headers`.
+///
+/// So an engine patch that changes a public libVLC header has to change the
+/// vendored copy too, or the change reaches the compiled library and never
+/// reaches consumers. Patch 0015 did exactly that: the built `libvlc.a`
+/// populated `media_player_media_stopping.reason`, while every shipped header
+/// still declared a struct without the field, leaving it invisible to Swift.
+///
+/// Nothing caught it. The patch applied, the engine compiled, and a runtime
+/// probe passed — because the probe compiled against the VLC source headers
+/// (`-I .build-libvlc/vlc/include`) rather than the ones actually shipped.
+///
+/// These tests reference the symbols through `CLibVLC`, so they fail to
+/// compile if the vendored header loses them.
+@Suite(.tags(.logic))
+struct VendoredHeaderParityTests {
+  /// Values must match `vlc_player_media_stopping_reason` in the engine, which
+  /// `lib/media_player.c` static_asserts. Pinning them here means a divergence
+  /// introduced on the vendored side alone still fails.
+  @Test
+  func `The stopping-reason enum is declared with upstream's values`() {
+    #expect(libvlc_stopping_reason_error.rawValue == 0)
+    #expect(libvlc_stopping_reason_eos.rawValue == 1)
+    #expect(libvlc_stopping_reason_user.rawValue == 2)
+  }
+
+  /// The field the whole patch exists to deliver. Without it in the vendored
+  /// header this does not compile, which is the point.
+  @Test
+  func `The media-stopping event carries a reason Swift can read`() {
+    var event = libvlc_event_t()
+    event.u.media_player_media_stopping.reason = libvlc_stopping_reason_eos
+    #expect(event.u.media_player_media_stopping.reason == libvlc_stopping_reason_eos)
+
+    event.u.media_player_media_stopping.reason = libvlc_stopping_reason_user
+    #expect(event.u.media_player_media_stopping.reason == libvlc_stopping_reason_user)
+  }
+}

--- a/scripts/build-libvlc.sh
+++ b/scripts/build-libvlc.sh
@@ -1329,6 +1329,20 @@ compile_libvlc_catalyst() {
     info "Finished ${ACTUAL_ARCH} (Mac Catalyst) in ${platform_mins}m$((platform_secs % 60))s"
 }
 
+# Every slice below ships headers from ${REPO_ROOT}/Sources/CLibVLC/include --
+# a git-tracked copy of the libVLC public headers -- and NOT from the patched
+# ${VLC_SRC}/include. That same directory is what SwiftPM compiles against.
+#
+# So a patch in scripts/patches that changes a public header has to change the
+# vendored copy too, or the change reaches the compiled library and no consumer
+# can see it. Patch 0015 hit exactly that: it added a `reason` field that the
+# library populated while every shipped header still declared the struct
+# without it.
+#
+# The two trees are deliberately not byte-identical (the vendored copies carry
+# fuller doc comments), so there is no equality gate here. The guard is
+# Tests/SwiftVLCTests/Core/VendoredHeaderParityTests.swift, which reaches the
+# patched declarations through CLibVLC and stops compiling if they go missing.
 XCFRAMEWORK_ARGS=()
 
 if [ "$BUILD_IOS" = "yes" ]; then

--- a/scripts/patches/validation/stopping-reason-probe.c
+++ b/scripts/patches/validation/stopping-reason-probe.c
@@ -13,10 +13,18 @@
  * Not wired into CI: it needs a libvlc built from a patched tree, which CI
  * does not produce. Run it against a local engine build after changing 0015.
  *
+ * Compile against Sources/CLibVLC/include, NOT "$V/include". Those are the
+ * headers the xcframework ships and SwiftPM compiles against; the patched
+ * source tree's headers are not shipped anywhere. An earlier run used
+ * "$V/include" and passed while every shipped header still declared a
+ * `media_player_media_stopping` with no `reason` field, so the value reached
+ * the library and no consumer could read it. Using the vendored path makes
+ * this probe fail to compile in that situation, which is the point.
+ *
  *   V=scripts/.build-libvlc/vlc
  *   clang -o /tmp/stopping-reason-probe \
  *     scripts/patches/validation/stopping-reason-probe.c \
- *     -I "$V/include" -L "$V/build-asan-native/lib/.libs" -lvlc
+ *     -I Sources/CLibVLC/include -L "$V/build-asan-native/lib/.libs" -lvlc
  *   VLC_PLUGIN_PATH="$V/build-asan-native/modules" \
  *   DYLD_LIBRARY_PATH="$V/build-asan-native/src/.libs:$V/build-asan-native/lib/.libs" \
  *     /tmp/stopping-reason-probe <some-short-media-file>


### PR DESCRIPTION
## Problem

Patch `0015-expose-stopping-reason.patch` adds `libvlc_stopping_reason_t` and a `reason` field on `media_player_media_stopping` to the VLC source tree. The compiled library populates the field. No consumer could read it.

`build-libvlc.sh` assembles every xcframework slice with `-headers ${REPO_ROOT}/Sources/CLibVLC/include` — a git-tracked copy of the libVLC public headers, not the patched source tree. That same directory is what SwiftPM compiles against. So a patch touching a public header has to change the vendored copy too, and 0015 changed only one of the two.

Measured before this change: `libvlc_stopping_reason_t` appeared **0 times** in all 8 shipped `Headers/vlc/libvlc_events.h`, against 4 in the patched source.

## Why nothing caught it

The patch applied, the engine built, and `scripts/patches/validation/stopping-reason-probe.c` passed. The probe compiles with `-I "$V/include"`, so it exercised the patched *source* headers and never the ones actually shipped. It is repointed here at `Sources/CLibVLC/include`, where a missing declaration makes it fail to compile.

## Changes

- `Sources/CLibVLC/include/vlc/libvlc_events.h` — add the enum and the `reason` field, copied verbatim from the patched engine header so the `static_assert` in `lib/media_player.c` keeps the two enums pinned to each other.
- `scripts/patches/validation/stopping-reason-probe.c` — compile against the vendored headers, with the reason recorded.
- `scripts/build-libvlc.sh` — note the coupling once where `XCFRAMEWORK_ARGS` is built. Comment only.
- `Tests/SwiftVLCTests/Core/VendoredHeaderParityTests.swift` — new.

## Why a test and not an equality gate

The two header trees are deliberately not byte-identical: the vendored copies of `libvlc_media_player.h` and `swiftvlc_vmem.h` carry fuller doc comments than the patched source, and `libvlc.h` differs on an `__OS2__` guard. A `diff` gate would be noise. The parity test reaches the declarations through `CLibVLC` instead, so the suite stops compiling if the vendored copy loses them.

## Validation

- Negative control: with the header reverted, both tests fail to compile — `cannot find 'libvlc_stopping_reason_error' in scope`.
- `CI=true swift test --no-parallel` — 1767 tests pass.
- Rebuilt the engine for all 8 slices and confirmed each shipped `libvlc_events.h` now declares the enum and the field.

Contributes to #79. Does not close it: its first and fourth criteria need assertion-enabled and release engines exercised on a device.