### PR TITLE
Drive the session-generation test from a real list advance (#78)

### DIFF
--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -460,11 +460,6 @@ extension Player {
   /// real list-player advance cannot be driven from a test process without a
   /// list and live playback, so the native swap plus its event is staged
   /// directly.
-  func adoptMediaForTesting(_ media: Media) {
-    libvlc_media_player_set_media(pointer, media.pointer)
-    handleEvent(.mediaChanged)
-  }
-
   func _handleEventForTesting(_ event: PlayerEvent, source: OpaquePointer) {
     handleSourcedEvent(SourcedPlayerEvent(source: Self.sourceIdentifier(for: source), event: event))
   }

--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -453,13 +453,13 @@ extension Player {
     handleEvent(event)
   }
 
-  /// Models a media change that did not come through the wrapper — what a
-  /// `MediaListPlayer` advancing the list looks like from `Player`'s side.
+  /// Injects an event attributed to a specific native handle, so tests can
+  /// exercise the source scoping in ``handleSourcedEvent(_:)`` — an event
+  /// arriving from a handle the player has already replaced must not be
+  /// applied to the current session.
   ///
-  /// libVLC swaps the input and reports it; no wrapper call asked for it. A
-  /// real list-player advance cannot be driven from a test process without a
-  /// list and live playback, so the native swap plus its event is staged
-  /// directly.
+  /// Staging the attribution is the point: a retiring handle emitting after
+  /// its replacement is a race, not something a test can schedule.
   func _handleEventForTesting(_ event: PlayerEvent, source: OpaquePointer) {
     handleSourcedEvent(SourcedPlayerEvent(source: Self.sourceIdentifier(for: source), event: event))
   }

--- a/Tests/SwiftVLCTests/Player/PlayerSessionGenerationTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerSessionGenerationTests.swift
@@ -49,6 +49,9 @@ extension Integration {
       listPlayer.mediaList = list
 
       listPlayer.play()
+      // Stopped unconditionally: a `#require` that fails below would otherwise
+      // leave this playing into whatever test runs next.
+      defer { listPlayer.stop() }
       try #require(
         await poll(until: { player.state == .playing }),
         "Waiting for: player.state == .playing"
@@ -63,7 +66,6 @@ extension Integration {
         await poll(until: { player.sessionGeneration > before }),
         "a list advance left the generation stale, so recast cannot see it was superseded"
       )
-      listPlayer.stop()
     }
 
     /// The half that makes the fix safe rather than merely present, and the

--- a/Tests/SwiftVLCTests/Player/PlayerSessionGenerationTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerSessionGenerationTests.swift
@@ -15,28 +15,68 @@ extension Integration {
   /// longer owned.
   @Suite(.tags(.mainActor), .serialized)
   @MainActor struct PlayerSessionGenerationTests {
-    /// The gap. A media change SwiftVLC did not originate still has to
-    /// supersede whatever was restoring the previous one.
-    @Test
-    func `A media change from outside the wrapper advances the generation`() throws {
-      let player = Player(instance: TestInstance.makeAudioOnly())
-      try player.load(Media(url: TestMedia.silenceURL))
+    /// The gap, driven the way it actually happens.
+    ///
+    /// This used to poke `set_media` plus a synthesized `.mediaChanged` through
+    /// a test seam, which was faithful until patch 0007. That patch drops the
+    /// cached `p_md` field and routes `libvlc_media_player_get_media()` through
+    /// `vlc_player_GetCurrentMedia()`, so `get_media()` now reports the media
+    /// the player core is *using* rather than the one last handed to it. Its
+    /// own header says as much: "the previous media is still returned until the
+    /// switch is notified by the libvlc_MediaPlayerMediaChanged event."
+    ///
+    /// The seam therefore simulated a state libVLC can no longer produce. It
+    /// set the media, reported the change immediately, and the handler read
+    /// back the *old* media. Probing the new engine directly: the core adopts a
+    /// media only when it has none, so no amount of `set_media` reproduces an
+    /// external switch while another media is loaded. Only real playback does.
+    ///
+    /// So this drives a genuine list advance and waits for libVLC to report it.
+    @Test(
+      .tags(.async, .media),
+      .enabled(if: TestCondition.canPlayMedia),
+      .timeLimit(.minutes(1))
+    )
+    func `A list-player advance advances the generation`() async throws {
+      let instance = TestInstance.makePlayback()
+      let listPlayer = MediaListPlayer(instance: instance)
+      let player = Player(instance: instance)
+      listPlayer.mediaPlayer = player
+
+      let list = MediaList()
+      try list.append(Media(url: TestMedia.twosecURL))
+      try list.append(Media(url: TestMedia.testMP4URL))
+      listPlayer.mediaList = list
+
+      listPlayer.play()
+      try #require(
+        await poll(until: { player.state == .playing }),
+        "Waiting for: player.state == .playing"
+      )
       let before = player.sessionGeneration
 
-      // What a list-player advance looks like from here: libVLC swapped the
-      // input and reported it, without any wrapper call having asked for it.
-      try player.adoptMediaForTesting(Media(url: TestMedia.twosecURL))
+      // Straight to `libvlc_media_list_player_next`. No wrapper call asked for
+      // this, and nothing on the way advances the generation by hand.
+      try listPlayer.next()
 
-      #expect(
-        player.sessionGeneration > before,
-        "a media change from outside load(_:) left the generation stale, so recast cannot see it was superseded"
+      try #require(
+        await poll(until: { player.sessionGeneration > before }),
+        "a list advance left the generation stale, so recast cannot see it was superseded"
       )
+      listPlayer.stop()
     }
 
-    /// The half that makes the fix safe rather than merely present. `load(_:)`
-    /// advances the generation itself, and libVLC then reports the same change
-    /// back as `.mediaChanged`. Advancing again on that echo would supersede a
-    /// recast started in between, for a change it had already accounted for.
+    /// The half that makes the fix safe rather than merely present, and the
+    /// half that still runs without playback.
+    ///
+    /// `load(_:)` advances the generation itself and records the media it
+    /// advanced for. libVLC then reports the same change back as
+    /// `.mediaChanged`. Advancing again on that echo would supersede a recast
+    /// started in between, for a change already accounted for.
+    ///
+    /// This one needs no player-core switch: the media `load(_:)` set is the
+    /// media the core is using, so `get_media()` agrees with the recorded value
+    /// under both the old and the new engine semantics.
     @Test
     func `The echo of a wrapper-initiated load does not advance it twice`() throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
@@ -51,23 +91,6 @@ extension Integration {
         player.sessionGeneration == afterLoad,
         "the native echo of load(_:) advanced the generation a second time; a recast started in between would be spuriously superseded"
       )
-    }
-
-    /// Two different media in a row each advance it once, so the guard still
-    /// discriminates after the de-duplication above.
-    @Test
-    func `Successive distinct media each advance it once`() throws {
-      let player = Player(instance: TestInstance.makeAudioOnly())
-      try player.load(Media(url: TestMedia.silenceURL))
-      let first = player.sessionGeneration
-      player._handleEventForTesting(.mediaChanged)
-      #expect(player.sessionGeneration == first)
-
-      try player.adoptMediaForTesting(Media(url: TestMedia.twosecURL))
-      let second = player.sessionGeneration
-      #expect(second > first)
-      player._handleEventForTesting(.mediaChanged)
-      #expect(player.sessionGeneration == second, "the second echo advanced it again")
     }
   }
 }


### PR DESCRIPTION
## Problem

The two seam-driven tests in `PlayerSessionGenerationTests` simulated an external media change with `libvlc_media_player_set_media` followed by a synthesized `.mediaChanged`. Against the engine built from `scripts/patches/`, all three assertions in that suite fail.

## Cause

Patch 0007 removes the cached `p_md` field and routes `libvlc_media_player_get_media()` through `vlc_player_GetCurrentMedia()`. `get_media()` now reports the media the player core is *using*, not the one last handed to it. The patch changes the upstream docs to say so:

> The returned media is the one currently used by the player. After calling `libvlc_media_player_set_media()` while a media is playing, the previous media is still returned until the switch is notified by the `libvlc_MediaPlayerMediaChanged` event.

So the seam described a state libVLC can no longer reach: it set the media, reported the change immediately, and the handler read back the *old* media, found it equal to the recorded one, and correctly declined to advance.

## Production is unaffected

`load(_:)` assigns `currentMedia` and `sessionGenerationMedia` directly from the Swift `Media` and never reads back. The only caller of `syncCurrentMediaFromNative()` is the `.mediaChanged` handler, which under the new semantics runs exactly when the core has switched. The new behaviour is arguably more correct than the old.

## Why the seam is removed rather than repaired

Probed against the new engine directly:

| sequence | core adopts? |
|---|---|
| `set_media` on a core with no media | yes |
| `set_media` replacing while stopped | no |
| `set_media(NULL)` then `set_media` | no |

No sequence of `set_media` reproduces an external switch while another media is loaded. Only real playback does, so the seam is not repairable and goes with its last caller.

## Replacement

A real `MediaListPlayer` advance, which is the scenario `sessionGeneration` exists for: `libvlc_media_list_player_next` goes straight to libVLC and nothing on the way advances the generation by hand.

Verified by removing the advance in the `.mediaChanged` handler: the test fails with `a list advance left the generation stale, so recast cannot see it was superseded`. Restored, it passes.

The echo test keeps its no-playback form and still runs everywhere, since the media `load(_:)` set is the media the core is using under both old and new semantics.

## Validation

`swift test --no-parallel` against the patched engine: **1769 tests pass**.

## How this went unnoticed

CI links the v1.0.0 release. `test.yml` and `sanitize.yml` both run `ci-use-released-xcframework.sh`, and v1.0.0 shipped patches 0001-0006, so 0007 through 0016 have never been under CI. This was found by running the suite against the patched engine for the first time.