### PR TITLE
Keep external subtitle files readable after the picker returns

### DIFF
--- a/Showcase/iOS/CaseStudies/05-Subtitles-External.swift
+++ b/Showcase/iOS/CaseStudies/05-Subtitles-External.swift
@@ -11,6 +11,7 @@ struct SubtitlesExternalCase: View {
   @State private var player = Player()
   @State private var isPickingFile = false
   @State private var loaded: URL?
+  @State private var failure: String?
 
   var body: some View {
     Form {
@@ -44,6 +45,14 @@ struct SubtitlesExternalCase: View {
             Text(loaded.lastPathComponent).foregroundStyle(.secondary)
           }
         }
+
+        if let failure {
+          HStack {
+            Text("Failed")
+            Spacer()
+            Text(failure).foregroundStyle(.secondary)
+          }
+        }
       }
     }
     .showcaseFormStyle()
@@ -58,6 +67,12 @@ struct SubtitlesExternalCase: View {
     }
   }
 
+  /// The picker returns a security-scoped URL, and `addExternalTrack` only
+  /// registers the URI with libVLC — the demuxer opens the file later, on its
+  /// own thread. By then this function has returned and the scope is closed,
+  /// so libVLC gets `Operation not permitted` and the track never appears.
+  /// Copying into the container while access is held gives libVLC a path it
+  /// can read whenever it gets around to it.
   private func fileImporterCompleted(_ result: Result<URL, any Error>) {
     guard case .success(let url) = result else { return }
     let isAccessible = url.startAccessingSecurityScopedResource()
@@ -66,7 +81,20 @@ struct SubtitlesExternalCase: View {
         url.stopAccessingSecurityScopedResource()
       }
     }
-    try? player.addExternalTrack(from: url, type: .subtitle, select: true)
-    loaded = url
+
+    do {
+      let local = URL.temporaryDirectory.appending(path: url.lastPathComponent)
+      try? FileManager.default.removeItem(at: local)
+      try FileManager.default.copyItem(at: url, to: local)
+      try player.addExternalTrack(from: local, type: .subtitle, select: true)
+      loaded = local
+      failure = nil
+    } catch {
+      // Surfaced rather than swallowed: the previous `try?` reported every
+      // load as successful, so a track that never loaded looked identical to
+      // one that did.
+      loaded = nil
+      failure = error.localizedDescription
+    }
   }
 }

--- a/Showcase/iOS/CaseStudies/05-Subtitles-External.swift
+++ b/Showcase/iOS/CaseStudies/05-Subtitles-External.swift
@@ -83,8 +83,13 @@ struct SubtitlesExternalCase: View {
     }
 
     do {
-      let local = URL.temporaryDirectory.appending(path: url.lastPathComponent)
-      try? FileManager.default.removeItem(at: local)
+      // A fresh directory per load. A name-based path would let a second
+      // subtitle with the same filename overwrite the file libVLC is still
+      // reading for the track already added, so each track keeps its own
+      // immutable backing file for as long as the player holds it.
+      let directory = URL.temporaryDirectory.appending(path: UUID().uuidString)
+      try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+      let local = directory.appending(path: url.lastPathComponent)
       try FileManager.default.copyItem(at: url, to: local)
       try player.addExternalTrack(from: local, type: .subtitle, select: true)
       loaded = local

--- a/Showcase/macOS/CaseStudies/05-Subtitles-External.swift
+++ b/Showcase/macOS/CaseStudies/05-Subtitles-External.swift
@@ -64,8 +64,11 @@ struct MacSubtitlesExternalCase: View {
     }
 
     do {
-      let local = URL.temporaryDirectory.appending(path: url.lastPathComponent)
-      try? FileManager.default.removeItem(at: local)
+      // Per-load directory, for the reason given in the iOS case: a name-based
+      // path lets a same-named reload overwrite a file libVLC is still reading.
+      let directory = URL.temporaryDirectory.appending(path: UUID().uuidString)
+      try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+      let local = directory.appending(path: url.lastPathComponent)
       try FileManager.default.copyItem(at: url, to: local)
       try player.addExternalTrack(from: local, type: .subtitle, select: true)
       loadedURL = local

--- a/Showcase/macOS/CaseStudies/05-Subtitles-External.swift
+++ b/Showcase/macOS/CaseStudies/05-Subtitles-External.swift
@@ -6,6 +6,7 @@ struct MacSubtitlesExternalCase: View {
   @State private var player = Player()
   @State private var isPickingFile = false
   @State private var loadedURL: URL?
+  @State private var failure: String?
 
   private let subtitleTypes = [UTType(filenameExtension: "srt") ?? .plainText, .plainText, .text]
 
@@ -24,6 +25,8 @@ struct MacSubtitlesExternalCase: View {
             Text(loadedURL.lastPathComponent)
               .foregroundStyle(.secondary)
               .textSelection(.enabled)
+          } else if let failure {
+            MacPlaceholderRow(text: "Failed: \(failure)")
           } else {
             MacPlaceholderRow(text: "Choose an .srt or text subtitle file.")
           }
@@ -47,6 +50,10 @@ struct MacSubtitlesExternalCase: View {
     .onDisappear { player.stop() }
   }
 
+  /// See the iOS case for the full reasoning: `addExternalTrack` only registers
+  /// the URI, so libVLC opens the file on the demuxer thread after this
+  /// function has returned and the security scope has closed. Copy into the
+  /// container while access is held and hand libVLC the local path.
   private func fileImporterCompleted(_ result: Result<[URL], any Error>) {
     guard let url = try? result.get().first else { return }
     let isAccessible = url.startAccessingSecurityScopedResource()
@@ -55,7 +62,17 @@ struct MacSubtitlesExternalCase: View {
         url.stopAccessingSecurityScopedResource()
       }
     }
-    try? player.addExternalTrack(from: url, type: .subtitle, select: true)
-    loadedURL = url
+
+    do {
+      let local = URL.temporaryDirectory.appending(path: url.lastPathComponent)
+      try? FileManager.default.removeItem(at: local)
+      try FileManager.default.copyItem(at: url, to: local)
+      try player.addExternalTrack(from: local, type: .subtitle, select: true)
+      loadedURL = local
+      failure = nil
+    } catch {
+      loadedURL = nil
+      failure = error.localizedDescription
+    }
   }
 }


### PR DESCRIPTION
## Problem

Found on a physical iPhone. Picking an external `.srt` through the document picker reported success in the UI while libVLC never read the file:

```
libvlc access error: cannot open file /private/var/mobile/Library/Mobile Documents/
com~apple~CloudDocs/Downloads/demo-sidecar.srt (Operation not permitted)
```

## Cause

The case studies took a security-scoped URL from `fileImporter`, opened access, called `addExternalTrack(from:)`, and released access in a `defer` on the way out.

`addExternalTrack` only registers the URI with libVLC. The demuxer opens the file later, on its own thread, by which point the scope is closed.

Two failures compounded:

1. The scope was gone before libVLC ever tried to read.
2. `try?` discarded the error and the "Loaded" row was set unconditionally, so a track that never loaded looked identical to one that did. That is how it survived this long, and it is why the first device report was "loaded fine" while the console said otherwise.

## Fix

Copy into the app container while access is still held, hand libVLC a path it can read whenever it gets to it, and surface a failure instead of swallowing it.

## Validation

- **iOS: confirmed fixed on device.** Same file, same picker, subtitle now renders.
- macOS carries the identical defect and the identical fix, verified only by building.
- tvOS is untouched: it loads a bundled URL with no picker and no security scope, so it has nothing to fix.

No test could have caught this. The suite never renders video and never runs a file picker.

Related to #95: this case study could not demonstrate the PiP subtitle behaviour at all while every external load was failing silently.