### PR TITLE
Surface engine patches the CI binary does not contain (#97)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,17 @@ jobs:
         timeout-minutes: 1
         run: ./scripts/verify-patch-manifest.sh >/dev/null
 
+      # Reports engine patches that are in the tree but not in the binary the
+      # test jobs link, which is the latest release's xcframework. Warns rather
+      # than fails: patches legitimately land before the release carrying them,
+      # so failing would wedge every PR. See the script header for the
+      # regression that made this worth surfacing.
+      - name: Engine patch coverage
+        timeout-minutes: 2
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/check-engine-coverage.sh
+
   # Showcase apps build gate. Catches API breakage that the SwiftVLC
   # test suite wouldn't notice — e.g. renaming a public symbol used
   # only by the Showcase, or breaking the Showcase's Mac/iOS/tvOS/visionOS

--- a/scripts/check-engine-coverage.sh
+++ b/scripts/check-engine-coverage.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# check-engine-coverage.sh — report which engine patches CI is not testing.
+#
+# CI does not build libVLC. `ci-use-released-xcframework.sh` rewrites
+# Package.swift to the latest release's url + checksum, so every test job links
+# the engine that was built when that release was cut. That is deliberate: it
+# is what downstream SPM consumers resolve.
+#
+# The consequence is easy to miss. A patch added to scripts/patches/ after that
+# release is present in the source tree and absent from the binary under test,
+# so it can change libVLC behaviour while every gate stays green.
+#
+# That already happened. Patch 0007 changed `libvlc_media_player_get_media()`
+# to report the media the player core is using rather than the one last set.
+# Three tests depended on the old semantics and passed CI for as long as the
+# gap existed, failing the moment the suite ran against the patched engine.
+#
+# Non-blocking by design. Patches legitimately land before the release that
+# carries them, so failing here would wedge every PR. This emits warning
+# annotations instead, so the divergence is visible on the PR rather than
+# silent.
+#
+# Usage:
+#   ./scripts/check-engine-coverage.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+PATCHES_DIR="scripts/patches"
+
+annotate() {
+  # GitHub renders `::warning::` on the PR; elsewhere it is just a line.
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    echo "::warning title=Engine patch not covered by CI::$1"
+  else
+    echo "WARNING: $1"
+  fi
+}
+
+tag=$(gh release view --json tagName -q .tagName 2>/dev/null || true)
+if [ -z "$tag" ]; then
+  echo "Could not resolve the latest release tag via gh; skipping coverage check." >&2
+  exit 0
+fi
+
+# Shallow CI checkouts do not fetch tags.
+git fetch origin "refs/tags/$tag:refs/tags/$tag" >/dev/null 2>&1 || true
+
+if ! git rev-parse -q --verify "$tag^{commit}" >/dev/null; then
+  echo "Tag $tag is not available locally; skipping coverage check." >&2
+  exit 0
+fi
+
+released=$(git ls-tree --name-only "$tag" "$PATCHES_DIR/" 2>/dev/null \
+  | grep '\.patch$' | xargs -n1 basename 2>/dev/null | sort || true)
+current=$(find "$PATCHES_DIR" -maxdepth 1 -name '*.patch' -exec basename {} \; | sort)
+
+uncovered=$(comm -13 <(printf '%s\n' "$released") <(printf '%s\n' "$current"))
+
+echo "Engine under test: $tag"
+echo "Patches in tree:   $(printf '%s\n' "$current" | grep -c . || true)"
+echo "Patches at $tag:   $(printf '%s\n' "$released" | grep -c . || true)"
+
+if [ -z "$uncovered" ]; then
+  echo "Every engine patch is covered by the release CI links."
+  exit 0
+fi
+
+count=$(printf '%s\n' "$uncovered" | grep -c .)
+echo
+echo "$count patch(es) are in the tree but not in the engine CI links:"
+printf '  %s\n' $uncovered
+
+annotate "$count engine patch(es) are not in the binary CI tests against ($tag). Behaviour they change is untested until a release carries them: $(printf '%s ' $uncovered)"
+
+# Always succeeds. See the header for why.
+exit 0

--- a/scripts/check-engine-coverage.sh
+++ b/scripts/check-engine-coverage.sh
@@ -55,9 +55,11 @@ if ! git rev-parse -q --verify "$tag^{commit}" >/dev/null; then
   exit 0
 fi
 
+# Basenames stripped in the pipeline rather than through `xargs basename`,
+# which needs a guard for empty input and is the only `xargs` in scripts/.
 released=$(git ls-tree --name-only "$tag" "$PATCHES_DIR/" 2>/dev/null \
-  | grep '\.patch$' | xargs -n1 basename 2>/dev/null | sort || true)
-current=$(find "$PATCHES_DIR" -maxdepth 1 -name '*.patch' -exec basename {} \; | sort)
+  | grep '\.patch$' | sed 's#.*/##' | sort || true)
+current=$(find "$PATCHES_DIR" -maxdepth 1 -type f -name '*.patch' | sed 's#.*/##' | sort)
 
 uncovered=$(comm -13 <(printf '%s\n' "$released") <(printf '%s\n' "$current"))
 
@@ -73,9 +75,19 @@ fi
 count=$(printf '%s\n' "$uncovered" | grep -c .)
 echo
 echo "$count patch(es) are in the tree but not in the engine CI links:"
-printf '  %s\n' $uncovered
 
-annotate "$count engine patch(es) are not in the binary CI tests against ($tag). Behaviour they change is untested until a release carries them: $(printf '%s ' $uncovered)"
+# Read loop rather than an unquoted expansion: word splitting and globbing
+# would mangle any patch name containing whitespace or a glob character.
+names=""
+while IFS= read -r patch; do
+  [ -n "$patch" ] || continue
+  echo "  $patch"
+  names="${names:+$names }$patch"
+done <<EOF
+$uncovered
+EOF
+
+annotate "$count engine patch(es) are not in the binary CI tests against ($tag). Behaviour they change is untested until a release carries them: $names"
 
 # Always succeeds. See the header for why.
 exit 0


### PR DESCRIPTION
## Problem

CI does not build libVLC. `ci-use-released-xcframework.sh` rewrites `Package.swift` to the latest release's url and checksum, so every test job links the engine built when that release was cut.

That is deliberate and documented in ARCHITECTURE.md: published `main` resolves what downstream SPM consumers resolve. The problem is not the design, it is that the resulting gap is invisible.

A patch added to `scripts/patches/` after that release is present in the source tree and absent from the binary under test. It can change libVLC behaviour while every gate stays green.

## It already happened

Patch 0007 removes libVLC's cached `p_md` field and routes `libvlc_media_player_get_media()` through `vlc_player_GetCurrentMedia()`, so `get_media()` reports the media the player core is *using* rather than the one last set. Three tests depended on the old semantics. They passed CI for as long as the gap existed and failed the moment the suite was run against the patched engine (fixed in #139).

Ten patches, **0007 through 0016**, are outside CI's binary right now. v1.0.0 shipped 0001-0006.

## Approach

A check in the `lint` job that resolves the latest release tag, lists the patches present at that tag, and diffs against the tree.

**It warns, it does not fail.** Patches legitimately land before the release that carries them, so failing would wedge every PR, including this one. It emits a GitHub Actions warning annotation naming the uncovered patches, so the divergence appears on the pull request instead of nowhere.

Local run against current `main`:

```
Engine under test: v1.0.0
Patches in tree:   16
Patches at v1.0.0: 6

10 patch(es) are in the tree but not in the engine CI links:
  0007-rapid-set-media-ownership.patch
  ...
  0016-skip-vlc-test-subdir.patch
```

## Scope

Contributes to #97, does not close it. The remaining criterion there is a two clean build checksum comparison, and genuinely closing this coverage gap means shipping a release built from the patched tree, which is a release-policy decision rather than a code change.

Worth stating plainly: this makes the gap visible. It does not test the patches.