### PR TITLE
Add an opt-in replay-latest subscription to Broadcaster

### DIFF
--- a/Sources/SwiftVLC/Core/Broadcaster.swift
+++ b/Sources/SwiftVLC/Core/Broadcaster.swift
@@ -46,6 +46,11 @@ final class Broadcaster<Element: Sendable>: Sendable {
     /// `subscribe(...)` calls return immediately-finished streams and
     /// `broadcast(_:)` is a no-op. Set by ``terminate()``.
     var terminated: Bool = false
+    /// The most recent broadcast element, retained solely for
+    /// ``subscribeReplayingLatest(policy:filter:)``. Recorded even when there
+    /// are no subscribers, because the whole point is to serve a subscriber
+    /// that arrives afterwards.
+    var latest: Element?
   }
 
   private let state = Mutex(State())
@@ -88,9 +93,29 @@ final class Broadcaster<Element: Sendable>: Sendable {
   ///     broadcaster's default size with the newest-wins policy.
   ///   - filter: Optional per-subscriber predicate. Only elements for
   ///     which `filter` returns `true` are yielded to this stream.
-  func subscribe(
+  /// Like ``subscribe(policy:filter:)``, but the stream begins with the most
+  /// recent element already broadcast, if there is one.
+  ///
+  /// For state a late subscriber must know rather than wait for: it cannot
+  /// learn the current value from a stream that only carries transitions, and
+  /// polling a separate property races the stream it is trying to align with.
+  ///
+  /// Opt-in on purpose. Replay is wrong for any consumer that subscribes in
+  /// order to await the *next* occurrence of something. ``Player/recast(to:)``
+  /// is exactly that: it captures the transition stream before calling
+  /// `play()`, so a replayed `.playing` from the outgoing session would let it
+  /// report success before the replacement session ever started.
+  func subscribeReplayingLatest(
     policy: EventBufferingPolicy? = nil,
     filter: Filter? = nil
+  ) -> AsyncStream<Element> {
+    subscribe(policy: policy, filter: filter, replayingLatest: true)
+  }
+
+  func subscribe(
+    policy: EventBufferingPolicy? = nil,
+    filter: Filter? = nil,
+    replayingLatest: Bool = false
   ) -> AsyncStream<Element> {
     // `bufferingNewest(0)` (or a negative count) silently drops every
     // element yielded while no consumer is suspended in `next()` —
@@ -115,6 +140,14 @@ final class Broadcaster<Element: Sendable>: Sendable {
       let id = state.nextID
       state.nextID += 1
       state.subscribers[id] = Subscriber(continuation: continuation, filter: filter)
+      // Replayed under the same lock that registers the subscriber, not after
+      // it. Yielding outside would let a `broadcast(_:)` that acquires the lock
+      // behind us deliver a newer element first, so the stream would open with
+      // the stale value second. Yielding is a buffer append on a continuation
+      // nobody else can reach yet, so it does not block under the lock.
+      if replayingLatest, let latest = state.latest, filter?(latest) ?? true {
+        continuation.yield(latest)
+      }
       if state.subscribers.count == 1 {
         scheduleReconciliation()
       }
@@ -145,7 +178,12 @@ final class Broadcaster<Element: Sendable>: Sendable {
   func broadcast(_ element: Element) {
     let interval = Signposts.signposter.beginInterval("Broadcaster.broadcast")
     let snapshot = state.withLock { state -> Snapshot in
-      guard !state.terminated, !state.subscribers.isEmpty else { return .none }
+      guard !state.terminated else { return .none }
+      // Recorded before the empty-subscribers bail-out: a replaying subscriber
+      // that arrives later still needs the element broadcast while nobody was
+      // listening, which is the case that motivates keeping it at all.
+      state.latest = element
+      guard !state.subscribers.isEmpty else { return .none }
       if state.subscribers.count == 1, let only = state.subscribers.values.first {
         return .single(only)
       }

--- a/Tests/SwiftVLCTests/Core/BroadcasterReplayTests.swift
+++ b/Tests/SwiftVLCTests/Core/BroadcasterReplayTests.swift
@@ -1,0 +1,133 @@
+@testable import SwiftVLC
+import Testing
+
+extension Integration {
+  /// ``Broadcaster/subscribeReplayingLatest(policy:filter:)`` exists for state a
+  /// late subscriber has to know rather than wait for. A transitions-only stream
+  /// cannot tell it the current value, and reading a separate property races the
+  /// stream it is trying to line up with.
+  @Suite(.tags(.logic))
+  struct BroadcasterReplayTests {
+    @Test
+    func `A late subscriber receives the most recent element first`() async {
+      let broadcaster = Broadcaster<Int>()
+      broadcaster.broadcast(1)
+      broadcaster.broadcast(2)
+
+      let stream = broadcaster.subscribeReplayingLatest(policy: .unbounded)
+      broadcaster.broadcast(3)
+      broadcaster.terminate()
+
+      var received: [Int] = []
+      for await value in stream { received.append(value) }
+
+      // 2 replayed, then 3 live. 1 is gone: this replays the latest, not a log.
+      #expect(received == [2, 3])
+    }
+
+    /// The case that motivates retaining the element at all. Recording it only
+    /// when someone is listening would leave the first subscriber with nothing,
+    /// which is precisely the subscriber that needs it.
+    @Test
+    func `An element broadcast with no subscribers is still replayed`() async {
+      let broadcaster = Broadcaster<Int>()
+      broadcaster.broadcast(7)
+
+      let stream = broadcaster.subscribeReplayingLatest(policy: .unbounded)
+      broadcaster.terminate()
+
+      var received: [Int] = []
+      for await value in stream { received.append(value) }
+
+      #expect(received == [7])
+    }
+
+    @Test
+    func `Replay yields nothing when nothing has been broadcast`() async {
+      let broadcaster = Broadcaster<Int>()
+      let stream = broadcaster.subscribeReplayingLatest(policy: .unbounded)
+      broadcaster.terminate()
+
+      var received: [Int] = []
+      for await value in stream { received.append(value) }
+
+      #expect(received.isEmpty)
+    }
+
+    /// A replayed element the filter rejects must not be smuggled past it. The
+    /// filter is the subscriber's statement about what it can handle, and it
+    /// does not stop applying because an element arrived by replay.
+    @Test
+    func `The subscriber filter applies to the replayed element`() async {
+      let broadcaster = Broadcaster<Int>()
+      broadcaster.broadcast(1)
+
+      let stream = broadcaster.subscribeReplayingLatest(
+        policy: .unbounded,
+        filter: { $0.isMultiple(of: 2) }
+      )
+      broadcaster.broadcast(4)
+      broadcaster.terminate()
+
+      var received: [Int] = []
+      for await value in stream { received.append(value) }
+
+      #expect(received == [4])
+    }
+
+    /// The default path is unchanged. Replay is opt-in because it is actively
+    /// wrong for a consumer awaiting the *next* occurrence of something:
+    /// `recast(to:)` captures the transition stream before `play()`, and a
+    /// replayed `.playing` from the outgoing session would let it report
+    /// success before the replacement ever started.
+    @Test
+    func `A plain subscriber receives no replay`() async {
+      let broadcaster = Broadcaster<Int>()
+      broadcaster.broadcast(1)
+
+      let stream = broadcaster.subscribe(policy: .unbounded)
+      broadcaster.broadcast(2)
+      broadcaster.terminate()
+
+      var received: [Int] = []
+      for await value in stream { received.append(value) }
+
+      #expect(received == [2])
+    }
+
+    /// Every subscriber converges on the same value without waiting for another
+    /// transition, which is what makes this usable for shared state.
+    @Test
+    func `Multiple replaying subscribers all see the same latest element`() async {
+      let broadcaster = Broadcaster<Int>()
+      broadcaster.broadcast(42)
+
+      let first = broadcaster.subscribeReplayingLatest(policy: .unbounded)
+      let second = broadcaster.subscribeReplayingLatest(policy: .unbounded)
+      broadcaster.terminate()
+
+      var a: [Int] = []
+      for await value in first { a.append(value) }
+      var b: [Int] = []
+      for await value in second { b.append(value) }
+
+      #expect(a == [42])
+      #expect(b == [42])
+    }
+
+    /// A terminated broadcaster hands back a finished stream, replay or not.
+    @Test
+    func `A replaying subscriber to a terminated broadcaster gets nothing`() async {
+      let broadcaster = Broadcaster<Int>()
+      broadcaster.broadcast(1)
+      broadcaster.terminate()
+
+      var received: [Int] = []
+      for await value in broadcaster.subscribeReplayingLatest(policy: .unbounded) {
+        received.append(value)
+      }
+
+      #expect(received.isEmpty)
+    }
+  }
+}

--- a/Tests/SwiftVLCTests/Core/BroadcasterReplayTests.swift
+++ b/Tests/SwiftVLCTests/Core/BroadcasterReplayTests.swift
@@ -19,7 +19,9 @@ extension Integration {
       broadcaster.terminate()
 
       var received: [Int] = []
-      for await value in stream { received.append(value) }
+      for await value in stream {
+        received.append(value)
+      }
 
       // 2 replayed, then 3 live. 1 is gone: this replays the latest, not a log.
       #expect(received == [2, 3])
@@ -37,7 +39,9 @@ extension Integration {
       broadcaster.terminate()
 
       var received: [Int] = []
-      for await value in stream { received.append(value) }
+      for await value in stream {
+        received.append(value)
+      }
 
       #expect(received == [7])
     }
@@ -49,7 +53,9 @@ extension Integration {
       broadcaster.terminate()
 
       var received: [Int] = []
-      for await value in stream { received.append(value) }
+      for await value in stream {
+        received.append(value)
+      }
 
       #expect(received.isEmpty)
     }
@@ -70,7 +76,9 @@ extension Integration {
       broadcaster.terminate()
 
       var received: [Int] = []
-      for await value in stream { received.append(value) }
+      for await value in stream {
+        received.append(value)
+      }
 
       #expect(received == [4])
     }
@@ -90,7 +98,9 @@ extension Integration {
       broadcaster.terminate()
 
       var received: [Int] = []
-      for await value in stream { received.append(value) }
+      for await value in stream {
+        received.append(value)
+      }
 
       #expect(received == [2])
     }
@@ -107,9 +117,13 @@ extension Integration {
       broadcaster.terminate()
 
       var a: [Int] = []
-      for await value in first { a.append(value) }
+      for await value in first {
+        a.append(value)
+      }
       var b: [Int] = []
-      for await value in second { b.append(value) }
+      for await value in second {
+        b.append(value)
+      }
 
       #expect(a == [42])
       #expect(b == [42])


### PR DESCRIPTION
## Why

Four milestone issues want the same primitive: a subscriber that arrives late must be able to learn the current state instead of waiting for the next transition.

- **#81** — stall and recovery events "paired and replayable to late subscribers"
- **#85** — "every subscriber receives the same payload-bearing pre-reset final timeline"
- **#89** — "a late subscriber immediately receives current media generation and state"
- **#96** — "multiple subscribers converge to the same revision without requiring another transition"

A transitions-only stream cannot answer that, and reading a separate property races the stream it is meant to line up with. This lands the shared piece once rather than four times.

## API

```swift
func subscribeReplayingLatest(policy:filter:) -> AsyncStream<Element>
```

Opens the stream with the most recent broadcast element, if there is one. Then behaves exactly like `subscribe`.

## Why opt-in and not the default

Replay is actively wrong for a consumer that subscribes in order to await the *next* occurrence of something.

`Player.recast(to:)` is exactly that. It captures `stateTransitions` **before** calling `play()` (`Player+Programs.swift:127`), so a replayed `.playing` from the outgoing session would satisfy `awaitPlaying` immediately and let the recast report success before the replacement session ever started. That is a correctness regression, not a nuisance, and it is why this is not simply switched on for existing streams.

Every existing subscriber keeps its current behaviour.

## Two load-bearing details

**The element is recorded before `broadcast(_:)` returns early on an empty subscriber set.** Recording it only when someone is listening would leave the first subscriber with nothing, and that is precisely the subscriber this exists for. Covered by `An element broadcast with no subscribers is still replayed`.

**The replay is yielded under the same lock that registers the subscriber.** Yielding after unlocking would let a `broadcast(_:)` that acquires the lock behind us deliver a newer element first, so the stream would open with the stale value second. The yield is a buffer append on a continuation nothing else can reach yet, so it does not block while the lock is held.

## Tests

Seven cases: replay ordering, the no-subscribers case, nothing-broadcast, filter application to the replayed element, plain subscribers getting no replay, multi-subscriber convergence, and a terminated broadcaster.

Verified by removing the yield: four of the seven fail.

`swift test --no-parallel`: **1776 tests pass** against the locally built engine.

## Scope

Infrastructure only. No issue closes here; this is the foundation the four above build on.