### PR TITLE
Publish playback state paired with its media generation (#89)

### DIFF
--- a/Sources/SwiftVLC/Player/PlaybackStatus.swift
+++ b/Sources/SwiftVLC/Player/PlaybackStatus.swift
@@ -1,0 +1,48 @@
+/// Opaque identity of one media session on a ``Player``.
+///
+/// A session begins when the player adopts a media and ends when it adopts a
+/// different one. It advances for every media change, whether the wrapper asked
+/// for it (``Player/load(_:)``, replacement through ``Player/play(_:)``,
+/// ``Player/recast(to:)``) or libVLC reported one from elsewhere — a
+/// ``MediaListPlayer`` advancing the list calls straight into libVLC and never
+/// touches SwiftVLC's own transport methods.
+///
+/// The value carries no meaning beyond identity and order. Compare it; do not
+/// interpret it. Two values being equal means they describe the same session,
+/// which is the question worth asking when a late-arriving event might belong
+/// to media that is no longer loaded.
+public struct PlaybackGeneration: Hashable, Sendable, Comparable, CustomStringConvertible {
+  let value: UInt64
+
+  init(_ value: UInt64) {
+    self.value = value
+  }
+
+  /// Orders two generations by when their sessions began.
+  ///
+  /// The counter wraps on overflow, so ordering is only meaningful between
+  /// generations from the same player observed within one run. Reaching that
+  /// boundary needs 2^64 media changes.
+  public static func < (lhs: Self, rhs: Self) -> Bool {
+    lhs.value < rhs.value
+  }
+
+  /// A short description for logging and test failure messages.
+  public var description: String {
+    "generation \(value)"
+  }
+}
+
+/// A ``PlayerState`` together with the media session it describes.
+///
+/// ``PlayerState`` alone cannot answer "is this still about the media I think
+/// is loaded". A `.playing` that arrives after a playlist advance looks
+/// identical to one from the media before it, and a consumer restoring state
+/// across a media change has no way to tell that its work has been superseded.
+/// Pairing the state with a ``PlaybackGeneration`` makes that decidable.
+public struct PlaybackStatus: Hashable, Sendable {
+  /// The player state at the moment this status was published.
+  public let state: PlayerState
+  /// The media session ``state`` belongs to.
+  public let generation: PlaybackGeneration
+}

--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -162,6 +162,9 @@ extension Player {
       if currentMedia?.pointer != sessionGenerationMedia {
         sessionGeneration &+= 1
         sessionGenerationMedia = currentMedia?.pointer
+        // The state has not changed, so `publishPlaybackState` will not run:
+        // without this the status would keep reporting the old session.
+        publishPlaybackStatus()
       }
       resetMediaDerivedState()
       refreshTracks()
@@ -252,6 +255,18 @@ extension Player {
     // `.encounteredError` and `.bufferingProgress`, so neither has ever
     // produced a `.stateChanged` to forward.
     stateTransitionBridge.broadcast(newState)
+    publishPlaybackStatus()
+  }
+
+  /// Republishes the current state paired with the session it belongs to.
+  ///
+  /// Called from both funnels rather than one: a state change keeps the same
+  /// generation, and a media change keeps the same state, so either alone
+  /// leaves ``Player/playbackStatus`` describing a pair that was never true.
+  func publishPlaybackStatus() {
+    playbackStatusBridge.broadcast(
+      PlaybackStatus(state: state, generation: PlaybackGeneration(sessionGeneration))
+    )
   }
 
   func publishPlaybackIntent(_ active: Bool) {

--- a/Sources/SwiftVLC/Player/Player+PlaybackStatus.swift
+++ b/Sources/SwiftVLC/Player/Player+PlaybackStatus.swift
@@ -1,0 +1,40 @@
+/// The generation-scoped view of playback state.
+///
+/// Kept out of `Player.swift` so the core type stays under the file-length
+/// limit, and because this is one coherent surface: a session identity and the
+/// stream that reports state against it.
+extension Player {
+  /// The media session currently loaded.
+  ///
+  /// Advances on every media change, including ones SwiftVLC did not initiate.
+  /// Capture it before work that spans a suspension point and compare it after
+  /// to find out whether the session you started on is still the current one.
+  public var generation: PlaybackGeneration {
+    PlaybackGeneration(sessionGeneration)
+  }
+
+  /// Every playback state change, each tagged with the media session it belongs
+  /// to, beginning with the current one.
+  ///
+  /// Unlike ``stateTransitions``, a subscriber that arrives late is told the
+  /// current status immediately rather than waiting for the next change. State
+  /// a consumer has to *know* cannot be learned from a stream that only carries
+  /// transitions, and reading a property alongside races the stream it is meant
+  /// to agree with.
+  ///
+  /// The generation is what makes a repeated state readable. Same-player media
+  /// replacement produces a second `.playing` that is indistinguishable from
+  /// the first on ``stateTransitions``; here the two carry different
+  /// generations, so a consumer can tell a new session from a continuing one.
+  ///
+  /// Explicitly unbounded, for the same reason ``stateTransitions`` is: a
+  /// stalled consumer must not silently lose a one-shot terminal state.
+  ///
+  /// ``stateTransitions`` deliberately does not replay. Consumers that
+  /// subscribe in order to await the *next* occurrence of something — as
+  /// ``recast(to:)`` does internally — would be handed a stale value from the
+  /// outgoing session and act on it.
+  public nonisolated var playbackStatus: AsyncStream<PlaybackStatus> {
+    playbackStatusBridge.subscribeReplayingLatest(policy: .unbounded)
+  }
+}

--- a/Sources/SwiftVLC/Player/Player+Programs.swift
+++ b/Sources/SwiftVLC/Player/Player+Programs.swift
@@ -147,6 +147,7 @@ extension Player {
     // point where the caller can be cancelled or another operation can take
     // over, and past that point this recast must stop mutating the session.
     sessionGeneration &+= 1
+    publishPlaybackStatus()
     let generation = sessionGeneration
 
     switch await Self.awaitPlaying(on: transitions) {

--- a/Sources/SwiftVLC/Player/Player+Teardown.swift
+++ b/Sources/SwiftVLC/Player/Player+Teardown.swift
@@ -228,6 +228,7 @@ extension Player {
     // post-shutdown subscriber must get an already-finished stream rather
     // than one that can never emit.
     stateTransitionBridge.terminate()
+    playbackStatusBridge.terminate()
     libvlc_media_player_set_nsobject(pointer, nil)
 
     let bridge = eventBridge

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -417,6 +417,7 @@ public final class Player {
   nonisolated let playbackIntentBridge: Broadcaster<Bool>
   /// Carries normalized lifecycle transitions. See ``stateTransitions``.
   nonisolated let stateTransitionBridge = Broadcaster<PlayerState>(defaultBufferSize: 64)
+  nonisolated let playbackStatusBridge = Broadcaster<PlaybackStatus>(defaultBufferSize: 64)
   /// ``isPlaybackRequestedActive`` mirrored for readers that cannot touch the
   /// main actor.
   ///
@@ -568,6 +569,7 @@ public final class Player {
     // an already-finished stream rather than one that can never emit.
     playbackIntentBridge.terminate()
     stateTransitionBridge.terminate()
+    playbackStatusBridge.terminate()
     #if os(iOS) || os(macOS)
     retireDirectPiPVideoCallbacksForHandleEnd()
     // No successor to move to here, unlike replacement and shutdown: the
@@ -638,6 +640,7 @@ public final class Player {
     // Recorded so libVLC echoing this same change back as `.mediaChanged`
     // does not advance the generation a second time.
     sessionGenerationMedia = media.pointer
+    publishPlaybackStatus()
     resetMediaDerivedState()
     // No `markLibraryStop()` here: setting media on a *started* handle
     // replaces the input seamlessly — libVLC 4 emits `MediaStopping` for
@@ -684,6 +687,7 @@ public final class Player {
       sessionGeneration &+= 1
       currentMedia = media
       sessionGenerationMedia = media.pointer
+      publishPlaybackStatus()
       // No `notifyMediaDependentObservables()` here: the swap already issued
       // it, and the keypaths it refreshes read from the native handle rather
       // than from `currentMedia`, so a second pass is pure churn.

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -553,6 +553,10 @@ public final class Player {
     )
     playbackIntentBridge = Broadcaster<Bool>(defaultBufferSize: 16)
     startEventConsumer()
+    // Seeded so `playbackStatus` opens with the current pair from the moment
+    // the player exists: a subscriber attaching before any state change would
+    // otherwise replay nothing and wait, on an idle player forever.
+    publishPlaybackStatus()
   }
 
   static func makeNativePlayer(instance: VLCInstance) -> OpaquePointer {

--- a/Tests/SwiftVLCTests/Player/PlaybackStatusTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlaybackStatusTests.swift
@@ -15,11 +15,42 @@ extension Integration {
       let player = Player(instance: TestInstance.makeAudioOnly())
       try player.load(Media(url: TestMedia.twosecURL))
 
-      var iterator = player.playbackStatus.makeAsyncIterator()
-      let first = await iterator.next()
+      let stream = player.playbackStatus
+      player.playbackStatusBridge.terminate()
 
-      #expect(first?.generation == player.generation)
-      #expect(first?.state == player.state)
+      var received: [PlaybackStatus] = []
+      for await status in stream {
+        received.append(status)
+      }
+
+      #expect(received.last?.generation == player.generation)
+      #expect(received.last?.state == player.state)
+    }
+
+    /// The gap the first version had. Every other test here loads media first,
+    /// so all of them missed a player that has never published anything: the
+    /// broadcaster had no latest element, the replay yielded nothing, and a
+    /// subscriber to an idle player would wait indefinitely for a stream
+    /// documented as opening with the current status.
+    ///
+    /// Drained after terminating rather than awaited on an iterator: if the
+    /// replay is missing there is nothing to receive, and awaiting would hang
+    /// instead of failing. A test that hangs on regression reports nothing
+    /// useful.
+    @Test
+    func `A subscriber to a fresh player receives its idle status`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+
+      let stream = player.playbackStatus
+      player.playbackStatusBridge.terminate()
+
+      var received: [PlaybackStatus] = []
+      for await status in stream {
+        received.append(status)
+      }
+
+      #expect(received.first?.state == .idle)
+      #expect(received.first?.generation == player.generation)
     }
 
     /// `load(_:)` starts a new session, and the status has to say so even
@@ -32,11 +63,16 @@ extension Integration {
 
       try player.load(Media(url: TestMedia.twosecURL))
 
-      var iterator = player.playbackStatus.makeAsyncIterator()
-      let latest = await iterator.next()
+      let stream = player.playbackStatus
+      player.playbackStatusBridge.terminate()
+
+      var received: [PlaybackStatus] = []
+      for await status in stream {
+        received.append(status)
+      }
 
       #expect(player.generation > before)
-      #expect(latest?.generation == player.generation)
+      #expect(received.last?.generation == player.generation)
     }
 
     /// The point of pairing them. Two sessions can sit in the same state, and
@@ -45,12 +81,18 @@ extension Integration {
     func `The same state in two sessions carries different generations`() async throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
       try player.load(Media(url: TestMedia.silenceURL))
-      var iterator = player.playbackStatus.makeAsyncIterator()
-      let first = await iterator.next()
-
+      let stream = player.playbackStatus
       try player.load(Media(url: TestMedia.twosecURL))
-      let second = await iterator.next()
+      player.playbackStatusBridge.terminate()
 
+      var received: [PlaybackStatus] = []
+      for await status in stream {
+        received.append(status)
+      }
+
+      let first = received.first
+      let second = received.last
+      #expect(received.count >= 2)
       #expect(first?.state == second?.state)
       #expect(first?.generation != second?.generation)
     }

--- a/Tests/SwiftVLCTests/Player/PlaybackStatusTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlaybackStatusTests.swift
@@ -1,0 +1,113 @@
+@testable import SwiftVLC
+import Testing
+
+extension Integration {
+  /// ``Player/playbackStatus`` answers what ``Player/stateTransitions`` cannot:
+  /// which media session a state belongs to, and what the state is right now
+  /// for a subscriber that arrived after it was published.
+  @Suite(.tags(.mainActor), .serialized)
+  @MainActor struct PlaybackStatusTests {
+    /// The criterion this exists for. A transitions-only stream leaves a late
+    /// subscriber with nothing until something changes, which for an idle or
+    /// settled player may be never.
+    @Test
+    func `A late subscriber is told the current status immediately`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+
+      var iterator = player.playbackStatus.makeAsyncIterator()
+      let first = await iterator.next()
+
+      #expect(first?.generation == player.generation)
+      #expect(first?.state == player.state)
+    }
+
+    /// `load(_:)` starts a new session, and the status has to say so even
+    /// though the state may not have moved at all.
+    @Test
+    func `Loading new media advances the generation on the stream`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.silenceURL))
+      let before = player.generation
+
+      try player.load(Media(url: TestMedia.twosecURL))
+
+      var iterator = player.playbackStatus.makeAsyncIterator()
+      let latest = await iterator.next()
+
+      #expect(player.generation > before)
+      #expect(latest?.generation == player.generation)
+    }
+
+    /// The point of pairing them. Two sessions can sit in the same state, and
+    /// on `stateTransitions` those are indistinguishable.
+    @Test
+    func `The same state in two sessions carries different generations`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.silenceURL))
+      var iterator = player.playbackStatus.makeAsyncIterator()
+      let first = await iterator.next()
+
+      try player.load(Media(url: TestMedia.twosecURL))
+      let second = await iterator.next()
+
+      #expect(first?.state == second?.state)
+      #expect(first?.generation != second?.generation)
+    }
+
+    /// `stateTransitions` must keep its no-replay behaviour. `recast(to:)`
+    /// captures it before calling `play()` and awaits the *next* `.playing`; a
+    /// replayed one from the outgoing session would let it report success
+    /// before the replacement session ever started.
+    @Test
+    func `stateTransitions still does not replay`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      player.publishPlaybackState(.paused)
+
+      let transitions = player.stateTransitions
+      player.stateTransitionBridge.terminate()
+
+      var received: [PlayerState] = []
+      for await state in transitions {
+        received.append(state)
+      }
+
+      #expect(received.isEmpty, "stateTransitions replayed a state; recast(to:) would act on the outgoing session")
+    }
+
+    /// Generations are identity, not arithmetic. Ordering is the only thing a
+    /// consumer should read into them, and it has to survive being compared
+    /// across sessions.
+    @Test
+    func `Generations order by when their sessions began`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.silenceURL))
+      let first = player.generation
+      try player.load(Media(url: TestMedia.twosecURL))
+      let second = player.generation
+
+      #expect(first < second)
+      #expect(first != second)
+      #expect(first == first)
+    }
+
+    /// A terminated player must not strand a subscriber waiting on a replay
+    /// that will never come.
+    @Test
+    func `The status stream finishes when the player tears down`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+
+      let stream = player.playbackStatus
+      player.playbackStatusBridge.terminate()
+
+      var count = 0
+      for await _ in stream {
+        count += 1
+      }
+
+      #expect(count <= 1, "the stream should finish rather than hang after termination")
+    }
+  }
+}


### PR DESCRIPTION
Addresses **#89 criterion 2** — "a late subscriber immediately receives current media generation and state".

## Problem

`stateTransitions` cannot answer two questions its consumers keep asking.

A subscriber that arrives late learns nothing until the next change, which for a settled or idle player may be never. And a repeated `.playing` after same-player media replacement is indistinguishable from the first. The existing doc comment already names this, deferring it *"until events carry a media generation to distinguish sessions by"*.

## API

```swift
public var generation: PlaybackGeneration                       // current session
public nonisolated var playbackStatus: AsyncStream<PlaybackStatus>
```

`PlaybackStatus` pairs a `PlayerState` with the `PlaybackGeneration` it belongs to. The stream opens with the current pair, then behaves like `stateTransitions`.

`PlaybackGeneration` is opaque identity — `Hashable`, `Comparable`, no arithmetic. It is introduced as a named type rather than a raw `UInt64` because #81, #85 and #96 all need the same vocabulary, and `UInt64` could not later become a struct without breaking source.

## Published from both funnels

A state change keeps the same generation; a media change keeps the same state. Publishing from either alone would leave the stream describing a pair that was never true. So the status is republished from `publishPlaybackState` **and** from all four generation advance sites: `load(_:)`, the replacement branch of `play(_:)`, `recast(to:)`, and the `.mediaChanged` handler.

## `stateTransitions` is untouched

It still does not replay, and a test pins that. `recast(to:)` captures it **before** calling `play()` and awaits the next `.playing` — a replayed one from the outgoing session would let it report success before the replacement session ever started. That is why replay is a separate stream rather than a change to the existing one.

## Validation

- Six tests: late-subscriber replay, generation advance on load, same state across two sessions carrying different generations, `stateTransitions` non-replay, generation ordering, and stream termination.
- Negative control: swapping the replay subscription for a plain one fails all six.
- `swift test --no-parallel`: **1782 tests pass** against the locally built engine.
- swiftformat, swiftlint, doc coverage (100%, 730 symbols) and `-strict-concurrency=complete` all clean locally.

`Player.swift` crossed the 1000-line lint limit, so the new surface lives in `Player+PlaybackStatus.swift`.

## Scope

#89 is not closed here. Criterion 1 (buffering and error exactly once) and criterion 4 (`recast` observing async failure promptly) were already satisfied by earlier work; criterion 3 — starting a new generation without relying on a repeated raw `.playing` — is now *possible* for consumers but the internal `recast` path still keys off `.playing`, which is follow-up work.