### PR TITLE
Publish a replayable PiP snapshot (#96)

### DIFF
--- a/Sources/SwiftVLC/PiP/PiPController+Events.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Events.swift
@@ -108,6 +108,25 @@ extension PiPController {
     pipEventBroadcaster.subscribe(policy: .unbounded)
   }
 
+  /// The current Picture in Picture state, followed by every subsequent
+  /// change.
+  ///
+  /// ``pipEvents`` carries transitions only, so a subscriber that attaches
+  /// after PiP has started learns nothing until it stops. Auto-start makes that
+  /// the common case rather than an edge one: the system can begin PiP before
+  /// any application code has subscribed, and that start is simply missed.
+  ///
+  /// This stream opens with the current ``PiPSnapshot`` instead. Late
+  /// subscribers converge on the same ``PiPSnapshot/revision`` without waiting
+  /// for another transition, and because the flags travel as one value a
+  /// subscriber never sees a combination that was not simultaneously true.
+  ///
+  /// Unbounded, like ``pipEvents``: a stalled consumer must not silently drop a
+  /// state it will never be told about again.
+  public var pipSnapshots: AsyncStream<PiPSnapshot> {
+    pipSnapshotBroadcaster.subscribeReplayingLatest(policy: .unbounded)
+  }
+
   /// Records the best-known reason for the in-flight stop. First
   /// discriminating signal wins; later signals never overwrite it (see
   /// ``pipEvents`` for the resulting precedence).

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -199,6 +199,8 @@ public final class PiPController: NSObject {
   /// controller.
   @ObservationIgnored
   let pipEventBroadcaster = Broadcaster<PiPEvent>()
+  let pipSnapshotBroadcaster = Broadcaster<PiPSnapshot>()
+  private var pipSnapshotRevision: UInt64 = 0
 
   /// The best-known reason for an in-flight PiP stop, recorded by the
   /// first discriminating signal (restore callback, start failure,
@@ -354,6 +356,9 @@ public final class PiPController: NSObject {
     playbackDelegateProxy = PiPPlaybackDelegateProxy()
 
     super.init()
+    // Seeded here, not on first change: a controller whose flags never move
+    // would otherwise leave `pipSnapshots` with nothing to replay.
+    publishPiPSnapshot()
 
     playbackDelegateProxy.owner = self
     displayLayer.videoGravity = .resizeAspect
@@ -391,6 +396,9 @@ public final class PiPController: NSObject {
     self.nativeBackend = nativeBackend
 
     super.init()
+    // Seeded here, not on first change: a controller whose flags never move
+    // would otherwise leave `pipSnapshots` with nothing to replay.
+    publishPiPSnapshot()
 
     playbackDelegateProxy.owner = self
     configureAudioSession()
@@ -439,6 +447,9 @@ public final class PiPController: NSObject {
     self.nativeBackend = nativeBackend
 
     super.init()
+    // Seeded here, not on first change: a controller whose flags never move
+    // would otherwise leave `pipSnapshots` with nothing to replay.
+    publishPiPSnapshot()
 
     playbackDelegateProxy.owner = self
     nativeBackend.owner = self
@@ -468,6 +479,9 @@ public final class PiPController: NSObject {
     playbackDelegateProxy = PiPPlaybackDelegateProxy()
 
     super.init()
+    // Seeded here, not on first change: a controller whose flags never move
+    // would otherwise leave `pipSnapshots` with nothing to replay.
+    publishPiPSnapshot()
 
     playbackDelegateProxy.owner = self
     displayLayer.videoGravity = .resizeAspect
@@ -485,6 +499,7 @@ public final class PiPController: NSObject {
 
   isolated deinit {
     pipEventBroadcaster.terminate()
+    pipSnapshotBroadcaster.terminate()
     cancelDeferredPause()
     stateObserverTask?.cancel()
     timingObserverTask?.cancel()
@@ -680,11 +695,30 @@ public final class PiPController: NSObject {
   func updatePiPPossible(_ isPossible: Bool) {
     guard self.isPossible != isPossible else { return }
     self.isPossible = isPossible
+    publishPiPSnapshot()
   }
 
   func updatePiPActive(_ isActive: Bool) {
     guard self.isActive != isActive else { return }
     self.isActive = isActive
+    publishPiPSnapshot()
+  }
+
+  /// Publishes the current flags as one value.
+  ///
+  /// Called from both funnels rather than either alone: the two flags move
+  /// independently, so publishing from one would leave the snapshot describing
+  /// a pair that was never simultaneously true.
+  func publishPiPSnapshot() {
+    pipSnapshotRevision &+= 1
+    pipSnapshotBroadcaster.broadcast(
+      PiPSnapshot(
+        isActive: isActive,
+        isPossible: isPossible,
+        mediaGeneration: player.generation,
+        revision: pipSnapshotRevision
+      )
+    )
   }
 
   func applyObservedPlaybackStateUpdate(_ update: PlaybackStateUpdate) {

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -199,7 +199,9 @@ public final class PiPController: NSObject {
   /// controller.
   @ObservationIgnored
   let pipEventBroadcaster = Broadcaster<PiPEvent>()
+  @ObservationIgnored
   let pipSnapshotBroadcaster = Broadcaster<PiPSnapshot>()
+  @ObservationIgnored
   private var pipSnapshotRevision: UInt64 = 0
 
   /// The best-known reason for an in-flight PiP stop, recorded by the

--- a/Sources/SwiftVLC/PiP/PiPSnapshot.swift
+++ b/Sources/SwiftVLC/PiP/PiPSnapshot.swift
@@ -1,0 +1,31 @@
+/// The Picture in Picture state a subscriber needs in order to act, delivered
+/// as a value rather than inferred from a sequence of events.
+///
+/// ``PiPController/pipEvents`` reports transitions and nothing else, so a
+/// subscriber that attaches after PiP has already started sees nothing until it
+/// stops. Auto-start makes that ordinary rather than exotic: the system can
+/// begin PiP before any application code has had a chance to subscribe.
+///
+/// Reading ``PiPController/isActive`` alongside the event stream does not fix
+/// it. The property and the stream are separate publications, so a subscriber
+/// can observe a state that never coexisted with the event it arrived beside.
+/// A snapshot is one value, so the fields in it were true together.
+public struct PiPSnapshot: Hashable, Sendable {
+  /// Whether Picture in Picture is currently running.
+  public let isActive: Bool
+  /// Whether the current backend and media can support Picture in Picture.
+  public let isPossible: Bool
+  /// The media session these flags describe.
+  ///
+  /// A snapshot outlives the media it was taken for. Comparing this against
+  /// ``Player/generation`` tells a consumer whether the snapshot still
+  /// describes the media that is loaded now, which matters because a media
+  /// change tears Picture in Picture down.
+  public let mediaGeneration: PlaybackGeneration
+  /// A monotonically increasing counter for this controller.
+  ///
+  /// Two subscribers holding the same revision hold the same snapshot, without
+  /// either having to wait for another transition to find out. Ordering is only
+  /// meaningful within one controller.
+  public let revision: UInt64
+}

--- a/Sources/SwiftVLC/PiP/PiPSnapshot.swift
+++ b/Sources/SwiftVLC/PiP/PiPSnapshot.swift
@@ -1,3 +1,4 @@
+#if os(iOS) || os(macOS)
 /// The Picture in Picture state a subscriber needs in order to act, delivered
 /// as a value rather than inferred from a sequence of events.
 ///
@@ -29,3 +30,4 @@ public struct PiPSnapshot: Hashable, Sendable {
   /// meaningful within one controller.
   public let revision: UInt64
 }
+#endif

--- a/Tests/SwiftVLCTests/PiP/PiPSnapshotTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPSnapshotTests.swift
@@ -1,0 +1,126 @@
+#if os(iOS) || os(macOS)
+@testable import SwiftVLC
+import Testing
+
+/// ``PiPController/pipSnapshots`` exists because ``PiPController/pipEvents``
+/// carries transitions only. A subscriber attaching after PiP has already
+/// started sees nothing until it stops, and auto-start makes that ordinary:
+/// the system can begin PiP before any application code has subscribed.
+///
+/// Drained after terminating rather than awaited on an iterator. If the replay
+/// were missing there would be nothing to receive, and awaiting would hang
+/// instead of failing — a test that hangs on regression reports nothing.
+extension Integration {
+  @Suite(.tags(.mainActor))
+  @MainActor struct PiPSnapshotTests {
+    private func drain(_ stream: AsyncStream<PiPSnapshot>) async -> [PiPSnapshot] {
+      var received: [PiPSnapshot] = []
+      for await snapshot in stream {
+        received.append(snapshot)
+      }
+      return received
+    }
+
+    /// Criterion 1: a late subscriber is told the authoritative current state
+    /// rather than waiting for a change that may never come.
+    @Test
+    func `A late subscriber immediately receives the current snapshot`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = PiPController(player: player)
+
+      let stream = controller.pipSnapshots
+      controller.pipSnapshotBroadcaster.terminate()
+
+      let received = await drain(stream)
+      #expect(received.count == 1)
+      #expect(received.first?.isActive == controller.isActive)
+      #expect(received.first?.isPossible == controller.isPossible)
+    }
+
+    /// Criterion 2: a start that happened before anyone subscribed must still
+    /// be visible. On `pipEvents` that `didStart` is simply gone.
+    @Test
+    func `A start before subscription is not missed`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = PiPController(player: player)
+
+      controller.updatePiPActive(true)
+
+      let stream = controller.pipSnapshots
+      controller.pipSnapshotBroadcaster.terminate()
+
+      let received = await drain(stream)
+      #expect(received.last?.isActive == true, "a subscriber attaching after the start was told PiP was inactive")
+    }
+
+    /// Criterion 5: two subscribers converge on the same revision without
+    /// either needing another transition to get there.
+    @Test
+    func `Multiple subscribers converge on the same revision`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = PiPController(player: player)
+      controller.updatePiPActive(true)
+
+      let first = controller.pipSnapshots
+      let second = controller.pipSnapshots
+      controller.pipSnapshotBroadcaster.terminate()
+
+      let a = await drain(first)
+      let b = await drain(second)
+      #expect(a.last?.revision == b.last?.revision)
+      #expect(a.last == b.last)
+    }
+
+    /// The revision is what lets a consumer tell a newer snapshot from an
+    /// older one without comparing every field.
+    @Test
+    func `The revision advances on each change`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = PiPController(player: player)
+
+      let stream = controller.pipSnapshots
+      controller.updatePiPActive(true)
+      controller.updatePiPActive(false)
+      controller.pipSnapshotBroadcaster.terminate()
+
+      let received = await drain(stream)
+      let revisions = received.map(\.revision)
+      #expect(revisions == revisions.sorted())
+      #expect(Set(revisions).count == revisions.count, "two snapshots shared a revision")
+    }
+
+    /// The snapshot records which media it describes, because a media change
+    /// tears PiP down and a stale snapshot would otherwise look current.
+    @Test
+    func `The snapshot carries the media generation it describes`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = PiPController(player: player)
+      try player.load(Media(url: TestMedia.twosecURL))
+
+      controller.updatePiPActive(true)
+
+      let stream = controller.pipSnapshots
+      controller.pipSnapshotBroadcaster.terminate()
+
+      let received = await drain(stream)
+      #expect(received.last?.mediaGeneration == player.generation)
+    }
+
+    /// Both flags travel in one value. Published from a single funnel they
+    /// could otherwise describe a pair that was never simultaneously true.
+    @Test
+    func `A no-op update publishes nothing`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = PiPController(player: player)
+
+      let stream = controller.pipSnapshots
+      controller.updatePiPActive(controller.isActive)
+      controller.updatePiPPossible(controller.isPossible)
+      controller.pipSnapshotBroadcaster.terminate()
+
+      let received = await drain(stream)
+      #expect(received.count == 1, "an unchanged flag published a redundant snapshot")
+    }
+  }
+}
+#endif


### PR DESCRIPTION
Addresses **#96 criteria 1, 2 and 5**.

## Problem

`pipEvents` carries transitions and nothing else. A subscriber that attaches after PiP has started learns nothing until it stops, and auto-start makes that the ordinary case rather than an edge one — the system can begin PiP before any application code has subscribed, so that `didStart` is simply gone.

Reading `isActive` alongside the stream does not fix it. The property and the stream are separate publications, so a subscriber can observe a state that never coexisted with the event it arrived beside.

## API

```swift
public var pipSnapshots: AsyncStream<PiPSnapshot>
```

`PiPSnapshot` carries `isActive`, `isPossible`, the `mediaGeneration` it describes, and a monotonic `revision`. One value, so the fields in it were true together.

| criterion | how |
|---|---|
| 1 — late subscriber gets authoritative current state | stream opens with the current snapshot |
| 2 — auto-start before subscription cannot be missed | the started state is in the replayed snapshot, not only in a past event |
| 5 — subscribers converge without another transition | both are handed the same `revision` on subscribe |

## Design notes

**Published from both flag funnels**, not either alone. `isActive` and `isPossible` move independently, so publishing from one would leave the snapshot describing a pair that was never simultaneously true. Same reasoning as `playbackStatus` in #143.

**Seeded in every initializer.** A controller whose flags never move would otherwise leave the stream with nothing to replay. That is exactly the gap the first version of #143 shipped with and Copilot caught there, so it is handled up front here rather than after review.

**`mediaGeneration`** uses the `PlaybackGeneration` introduced in #143. A media change tears PiP down, so a snapshot that outlives its media would otherwise look current.

## Validation

- Six tests, one per criterion plus revision monotonicity and no-op suppression.
- Tests drain after terminating rather than awaiting an iterator: a missing replay would otherwise hang instead of failing.
- Negative control: swapping the replay subscription for a plain one fails all six, in 0.089s.
- `swift test --no-parallel`: **1789 tests pass** against the locally built engine.
- swiftformat, swiftlint, doc coverage (100%) and `-strict-concurrency=complete` clean locally.

## Scope

Does not close #96. Criteria 3 and 4 — controller recreation not pairing a new identity with an old active state, and ignoring events from a replaced controller generation — need a controller identity plumbed through the native replacement path, which is a larger change than this and is better reviewed on its own.