### PR TITLE
Identify which AVKit controller a PiP snapshot describes (#96)

### DIFF
--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -203,6 +203,11 @@ public final class PiPController: NSObject {
   let pipSnapshotBroadcaster = Broadcaster<PiPSnapshot>()
   @ObservationIgnored
   private var pipSnapshotRevision: UInt64 = 0
+  /// Advances every time a new `AVPictureInPictureController` is installed, so
+  /// a snapshot can say which controller its flags describe and a late callback
+  /// from a replaced one can be told apart from a current one.
+  @ObservationIgnored
+  private(set) var pipControllerGeneration: UInt64 = 0
 
   /// The best-known reason for an in-flight PiP stop, recorded by the
   /// first discriminating signal (restore callback, start failure,
@@ -666,6 +671,7 @@ public final class PiPController: NSObject {
     #if os(iOS)
     controller.canStartPictureInPictureAutomaticallyFromInline = startsAutomaticallyFromInline
     #endif
+    pipControllerGeneration &+= 1
     pipController = controller
     updatePiPPossible(controller.isPictureInPicturePossible)
     updatePiPActive(controller.isPictureInPictureActive)
@@ -678,8 +684,13 @@ public final class PiPController: NSObject {
       options: [.initial, .new]
     ) { [weak self] controller, _ in
       let isPossible = controller.isPictureInPicturePossible
+      let identity = ObjectIdentifier(controller)
       Task { @MainActor [weak self] in
-        self?.updatePiPPossible(isPossible)
+        // The hop means the controller can be replaced before this runs.
+        // Without the identity check a flag from the outgoing controller
+        // would be applied to the incoming one.
+        guard let self, isCurrentAVController(identity) else { return }
+        updatePiPPossible(isPossible)
       }
     }
 
@@ -688,10 +699,24 @@ public final class PiPController: NSObject {
       options: [.initial, .new]
     ) { [weak self] controller, _ in
       let isActive = controller.isPictureInPictureActive
+      let identity = ObjectIdentifier(controller)
       Task { @MainActor [weak self] in
-        self?.updatePiPActive(isActive)
+        guard let self, isCurrentAVController(identity) else { return }
+        updatePiPActive(isActive)
       }
     }
+  }
+
+  /// Whether `controller` is the one currently installed.
+  ///
+  /// Every AVKit signal reaches the main actor through a hop, so a controller
+  /// replaced in the meantime can still deliver. Its state describes a session
+  /// that is over.
+  /// Taken as an `ObjectIdentifier` rather than the controller itself:
+  /// `AVPictureInPictureController` is not `Sendable`, so it cannot cross the
+  /// hop, while its identity can.
+  func isCurrentAVController(_ identity: ObjectIdentifier) -> Bool {
+    pipController.map(ObjectIdentifier.init) == identity
   }
 
   func updatePiPPossible(_ isPossible: Bool) {
@@ -718,6 +743,7 @@ public final class PiPController: NSObject {
         isActive: isActive,
         isPossible: isPossible,
         mediaGeneration: player.generation,
+        controllerGeneration: pipControllerGeneration,
         revision: pipSnapshotRevision
       )
     )

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -707,14 +707,18 @@ public final class PiPController: NSObject {
     }
   }
 
-  /// Whether `controller` is the one currently installed.
+  /// Whether the identified controller is the one currently installed.
   ///
   /// Every AVKit signal reaches the main actor through a hop, so a controller
   /// replaced in the meantime can still deliver. Its state describes a session
   /// that is over.
-  /// Taken as an `ObjectIdentifier` rather than the controller itself:
+  ///
+  /// Takes an `ObjectIdentifier` rather than the controller itself:
   /// `AVPictureInPictureController` is not `Sendable`, so it cannot cross the
   /// hop, while its identity can.
+  ///
+  /// `nil` never matches. With no controller installed there is nothing for a
+  /// callback to be current with respect to.
   func isCurrentAVController(_ identity: ObjectIdentifier) -> Bool {
     pipController.map(ObjectIdentifier.init) == identity
   }

--- a/Sources/SwiftVLC/PiP/PiPSnapshot.swift
+++ b/Sources/SwiftVLC/PiP/PiPSnapshot.swift
@@ -23,6 +23,13 @@ public struct PiPSnapshot: Hashable, Sendable {
   /// describes the media that is loaded now, which matters because a media
   /// change tears Picture in Picture down.
   public let mediaGeneration: PlaybackGeneration
+  /// Which `AVPictureInPictureController` these flags describe.
+  ///
+  /// The underlying AVKit controller is recreated when the backend is rebuilt.
+  /// A snapshot taken before a recreation describes a controller that no longer
+  /// exists, and pairing its active state with the new controller's identity is
+  /// exactly the confusion this distinguishes.
+  public let controllerGeneration: UInt64
   /// A monotonically increasing counter for this controller.
   ///
   /// Two subscribers holding the same revision hold the same snapshot, without

--- a/Tests/SwiftVLCTests/PiP/PiPSnapshotTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPSnapshotTests.swift
@@ -106,6 +106,36 @@ extension Integration {
       #expect(received.last?.mediaGeneration == player.generation)
     }
 
+    /// Criterion 3: a snapshot taken before the AVKit controller was recreated
+    /// describes a controller that no longer exists. Pairing its active state
+    /// with the new controller's identity is the confusion being prevented.
+    @Test
+    func `The snapshot names which controller its flags describe`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = PiPController(player: player)
+
+      let stream = controller.pipSnapshots
+      controller.updatePiPActive(true)
+      controller.pipSnapshotBroadcaster.terminate()
+
+      let received = await drain(stream)
+      #expect(received.allSatisfy { $0.controllerGeneration == controller.pipControllerGeneration })
+    }
+
+    /// Criterion 4: every AVKit signal reaches the main actor through a hop, so
+    /// a controller replaced in the meantime can still deliver. Its state
+    /// describes a session that is over and must not be applied.
+    @Test
+    func `A signal from a replaced controller is rejected`() {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = PiPController(player: player)
+
+      // An identity that is not, and never was, the installed controller.
+      let other = PiPController(player: player)
+      let stale = ObjectIdentifier(other)
+      #expect(controller.isCurrentAVController(stale) == false)
+    }
+
     /// Both flags travel in one value. Published from a single funnel they
     /// could otherwise describe a pair that was never simultaneously true.
     @Test

--- a/Tests/SwiftVLCTests/PiP/PiPSnapshotTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPSnapshotTests.swift
@@ -130,10 +130,11 @@ extension Integration {
       let player = Player(instance: TestInstance.makeAudioOnly())
       let controller = PiPController(player: player)
 
-      // An identity that is not, and never was, the installed controller.
-      let other = PiPController(player: player)
-      let stale = ObjectIdentifier(other)
-      #expect(controller.isCurrentAVController(stale) == false)
+      // Any identity that is not the installed controller will do. The player
+      // is reused rather than constructing a second `PiPController`, which
+      // would claim direct-PiP callback ownership on this same player as a
+      // side effect of the test.
+      #expect(controller.isCurrentAVController(ObjectIdentifier(player)) == false)
     }
 
     /// Both flags travel in one value. Published from a single funnel they


### PR DESCRIPTION
Addresses **#96 criterion 3**, and part of criterion 4. Builds on #144.

## The race

Every AVKit signal reaches the main actor through a hop. A controller replaced in the meantime can still deliver, and its state describes a session that is over.

The KVO observers took the flag from the reporting controller and applied it unconditionally:

```swift
let isActive = controller.isPictureInPictureActive
Task { @MainActor in self?.updatePiPActive(isActive) }   // whose controller?
```

So a stale `isPictureInPictureActive` from an outgoing controller could be written as the state of the incoming one — exactly what criterion 3 says must not happen.

## Changes

- `pipControllerGeneration` advances whenever a new `AVPictureInPictureController` is installed.
- `PiPSnapshot` carries it, so a snapshot states which controller its flags describe instead of leaving the consumer to assume the current one.
- The KVO observers reject callbacks whose controller is no longer installed.

Identity crosses the hop as an `ObjectIdentifier`, not the controller. `AVPictureInPictureController` is not `Sendable`, and `-strict-concurrency=complete` refuses to send it — correctly, since that is the same reference the replacing code is mutating.

## What this does not do, and why

**The delegate callbacks have the same race and are deliberately left unguarded.**

I implemented the guard there too and reverted it. It breaks a large set of existing tests in `PiPControllerInteractionTests` and `PiPEventsTests`, which invoke delegate methods with a dummy `AVPictureInPictureController` that was never installed — the guard rejects them and the state never moves. One run also exited with signal 5.

Those tests are not wrong; they are testing delegate behaviour headlessly, which is reasonable. Making them drive the installed controller instead is a larger change that deserves its own review rather than riding along with this one. Criterion 4 is therefore only partly addressed here.

## Validation

- 8 tests in `PiPSnapshotTests`, two new: the snapshot naming its controller generation, and the identity predicate rejecting a controller that was never installed.
- `swift test --no-parallel`: **1791 tests pass**.
- swiftformat, swiftlint, doc coverage (100%) and `-strict-concurrency=complete` clean locally.

Honest limitation: the new tests cover the predicate and the snapshot field. The KVO call sites themselves are verified by build and inspection, because reproducing a real AVKit controller replacement headlessly is what the deferred test work above is about.