### PR TITLE
Reject PiP delegate callbacks from a replaced controller (#96)

### DIFF
--- a/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
@@ -108,7 +108,15 @@ extension PiPController: AVPictureInPictureControllerDelegate {
       // Rejected unless it comes from the installed controller: the hop means
       // a controller replaced in the meantime can still deliver, and its
       // lifecycle describes a session that is over.
-      guard let self, isCurrentAVController(identity) else { return }
+      //
+      // AVKit is owed this completion handler either way. Returning without
+      // calling it leaves the teardown it drives unresolved, so a rejected
+      // callback answers `false` — nothing was restored — rather than nothing
+      // at all. The same applies when `self` has already gone.
+      guard let self, isCurrentAVController(identity) else {
+        completionHandler(false)
+        return
+      }
       // Record the reason before the host app's restore hook runs, so
       // the stop delegate callbacks see it no matter how AVKit orders
       // them relative to the hook's completion.

--- a/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
@@ -13,10 +13,14 @@ extension PiPController: AVPictureInPictureControllerDelegate {
   /// Picture in Picture, emits ``PiPEvent/willStart``, and clears any
   /// stale stop reason left by a previous failed or aborted attempt.
   public nonisolated func pictureInPictureControllerWillStartPictureInPicture(
-    _: AVPictureInPictureController
+    _ avController: AVPictureInPictureController
   ) {
+    let identity = ObjectIdentifier(avController)
     pipMainActorAsync { [weak self] in
-      guard let self else { return }
+      // Rejected unless it comes from the installed controller: the hop means
+      // a controller replaced in the meantime can still deliver, and its
+      // lifecycle describes a session that is over.
+      guard let self, isCurrentAVController(identity) else { return }
       pendingStopReason = nil
       // Auto-PiP starts arrive from AVKit without start() or an intent
       // transition — last chance to issue the deferred session
@@ -32,10 +36,14 @@ extension PiPController: AVPictureInPictureControllerDelegate {
   /// button labels and status UI in sync with system-driven PiP
   /// changes, and emits ``PiPEvent/didStart``.
   public nonisolated func pictureInPictureControllerDidStartPictureInPicture(
-    _: AVPictureInPictureController
+    _ avController: AVPictureInPictureController
   ) {
+    let identity = ObjectIdentifier(avController)
     pipMainActorAsync { [weak self] in
-      guard let self else { return }
+      // Rejected unless it comes from the installed controller: the hop means
+      // a controller replaced in the meantime can still deliver, and its
+      // lifecycle describes a session that is over.
+      guard let self, isCurrentAVController(identity) else { return }
       pendingStopReason = nil
       syncPlaybackStateForPictureInPicture()
       invalidatePictureInPicturePlaybackState()
@@ -50,10 +58,14 @@ extension PiPController: AVPictureInPictureControllerDelegate {
   /// ``PiPStopReason/userClosed`` for a restore-driven stop; the reason
   /// on the matching `didStop` is authoritative.
   public nonisolated func pictureInPictureControllerWillStopPictureInPicture(
-    _: AVPictureInPictureController
+    _ avController: AVPictureInPictureController
   ) {
+    let identity = ObjectIdentifier(avController)
     pipMainActorAsync { [weak self] in
-      guard let self else { return }
+      // Rejected unless it comes from the installed controller: the hop means
+      // a controller replaced in the meantime can still deliver, and its
+      // lifecycle describes a session that is over.
+      guard let self, isCurrentAVController(identity) else { return }
       pipEventBroadcaster.broadcast(.willStop(reason: resolveStopReason()))
     }
   }
@@ -63,10 +75,14 @@ extension PiPController: AVPictureInPictureControllerDelegate {
   /// emits ``PiPEvent/didStop(reason:)`` with the resolved stop reason
   /// (see ``PiPController/pipEvents``), consuming the pending reason.
   public nonisolated func pictureInPictureControllerDidStopPictureInPicture(
-    _: AVPictureInPictureController
+    _ avController: AVPictureInPictureController
   ) {
+    let identity = ObjectIdentifier(avController)
     pipMainActorAsync { [weak self] in
-      guard let self else { return }
+      // Rejected unless it comes from the installed controller: the hop means
+      // a controller replaced in the meantime can still deliver, and its
+      // lifecycle describes a session that is over.
+      guard let self, isCurrentAVController(identity) else { return }
       let reason = resolveStopReason()
       pendingStopReason = nil
       updatePiPActive(false)
@@ -84,11 +100,15 @@ extension PiPController: AVPictureInPictureControllerDelegate {
   /// ``PiPStopReason/userClosed``) — which is how callers distinguish
   /// "restore" from "close".
   public nonisolated func pictureInPictureController(
-    _: AVPictureInPictureController,
+    _ avController: AVPictureInPictureController,
     restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler: @escaping @Sendable (Bool) -> Void
   ) {
+    let identity = ObjectIdentifier(avController)
     pipMainActorAsync { [weak self] in
-      guard let self else { return }
+      // Rejected unless it comes from the installed controller: the hop means
+      // a controller replaced in the meantime can still deliver, and its
+      // lifecycle describes a session that is over.
+      guard let self, isCurrentAVController(identity) else { return }
       // Record the reason before the host app's restore hook runs, so
       // the stop delegate callbacks see it no matter how AVKit orders
       // them relative to the hook's completion.
@@ -109,11 +129,15 @@ extension PiPController: AVPictureInPictureControllerDelegate {
   /// resyncs the observed flags so the UI doesn't stay stuck in a stale
   /// "starting" state.
   public nonisolated func pictureInPictureController(
-    _: AVPictureInPictureController,
+    _ avController: AVPictureInPictureController,
     failedToStartPictureInPictureWithError error: Error
   ) {
+    let identity = ObjectIdentifier(avController)
     pipMainActorAsync { [weak self] in
-      guard let self else { return }
+      // Rejected unless it comes from the installed controller: the hop means
+      // a controller replaced in the meantime can still deliver, and its
+      // lifecycle describes a session that is over.
+      guard let self, isCurrentAVController(identity) else { return }
       notePendingStopReason(.failure)
       updatePiPActive(false)
       pipEventBroadcaster.broadcast(.failedToStart(error))
@@ -148,7 +172,7 @@ final class PiPPlaybackDelegateProxy: NSObject, AVPictureInPictureSampleBufferPl
   weak var owner: PiPController?
 
   func pictureInPictureController(
-    _: AVPictureInPictureController,
+    _ avController: AVPictureInPictureController,
     setPlaying playing: Bool
   ) {
     pipMainActorAsync { [weak self] in
@@ -157,7 +181,7 @@ final class PiPPlaybackDelegateProxy: NSObject, AVPictureInPictureSampleBufferPl
   }
 
   func pictureInPictureControllerTimeRangeForPlayback(
-    _: AVPictureInPictureController
+    _ avController: AVPictureInPictureController
   ) -> CMTimeRange {
     resolveTimeRangeForPlayback()
   }
@@ -304,7 +328,7 @@ final class PiPPlaybackDelegateProxy: NSObject, AVPictureInPictureSampleBufferPl
   }
 
   func pictureInPictureControllerIsPlaybackPaused(
-    _: AVPictureInPictureController
+    _ avController: AVPictureInPictureController
   ) -> Bool {
     resolveIsPlaybackPaused()
   }
@@ -320,7 +344,7 @@ final class PiPPlaybackDelegateProxy: NSObject, AVPictureInPictureSampleBufferPl
   }
 
   func pictureInPictureController(
-    _: AVPictureInPictureController,
+    _ avController: AVPictureInPictureController,
     skipByInterval skipInterval: CMTime,
     completion completionHandler: @escaping @Sendable () -> Void
   ) {
@@ -334,7 +358,7 @@ final class PiPPlaybackDelegateProxy: NSObject, AVPictureInPictureSampleBufferPl
   }
 
   func pictureInPictureController(
-    _: AVPictureInPictureController,
+    _ avController: AVPictureInPictureController,
     didTransitionToRenderSize size: CMVideoDimensions
   ) {
     pipMainActorAsync { [weak self] in

--- a/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
@@ -49,15 +49,15 @@ extension Integration {
       }
     }
 
+    /// The `AVPictureInPictureController` SwiftVLC actually installed.
+    ///
+    /// Delegate callbacks from any other instance are rejected as belonging to
+    /// a replaced controller, so driving the delegate requires the real one.
     private func makePictureInPictureController(
       for controller: PiPController
     ) -> AVPictureInPictureController? {
       guard AVPictureInPictureController.isPictureInPictureSupported() else { return nil }
-      let contentSource = AVPictureInPictureController.ContentSource(
-        sampleBufferDisplayLayer: controller.layer,
-        playbackDelegate: controller._playbackDelegateForTesting
-      )
-      return AVPictureInPictureController(contentSource: contentSource)
+      return controller.pipController
     }
 
     // MARK: - handleSetPlaying

--- a/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
@@ -14,7 +14,16 @@ import Testing
 extension Integration {
   @Suite(.tags(.mainActor))
   @MainActor struct PiPEventsTests {
+    /// The `AVPictureInPictureController` SwiftVLC actually installed.
+    ///
+    /// Delegate callbacks are rejected unless they come from the installed
+    /// controller, so a freshly constructed instance would be treated as a
+    /// replaced one and dropped. The fallback keeps that a clear assertion
+    /// failure rather than a crash if no controller was installed.
     private func makeDummyAVController(for controller: PiPController) -> AVPictureInPictureController {
+      if let installed = controller.pipController {
+        return installed
+      }
       let contentSource = AVPictureInPictureController.ContentSource(
         sampleBufferDisplayLayer: controller.layer,
         playbackDelegate: controller._playbackDelegateForTesting

--- a/Tests/SwiftVLCTests/PiP/PiPSnapshotTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPSnapshotTests.swift
@@ -1,5 +1,7 @@
 #if os(iOS) || os(macOS)
 @testable import SwiftVLC
+import AVFoundation
+import AVKit
 import Testing
 
 /// ``PiPController/pipSnapshots`` exists because ``PiPController/pipEvents``
@@ -135,6 +137,48 @@ extension Integration {
       // would claim direct-PiP callback ownership on this same player as a
       // side effect of the test.
       #expect(controller.isCurrentAVController(ObjectIdentifier(player)) == false)
+    }
+
+    /// Criterion 4, exercised through the delegate rather than the predicate.
+    ///
+    /// A controller that was never installed stands in for one that has been
+    /// replaced: AVKit signals reach the main actor through a hop, so the
+    /// outgoing controller can still deliver a lifecycle callback after the
+    /// incoming one is in place. Applying it would report the new controller as
+    /// active on the strength of the old one's session.
+    ///
+    /// The installed controller is driven first, and that is load-bearing. It
+    /// proves the callback does arrive within the observation window, so the
+    /// negative assertion afterwards means "rejected" rather than "not yet
+    /// delivered". Without it the test passes whether or not the guard exists,
+    /// which is how the first version of it was hollow.
+    @Test
+    func `A delegate callback from a controller that is not installed is ignored`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = PiPController(player: player)
+      let installed = try #require(controller.pipController)
+
+      controller.pictureInPictureControllerDidStartPictureInPicture(installed)
+      try #require(
+        await poll(timeout: .seconds(2), until: { controller.isActive }),
+        "the installed controller's callback never arrived, so the check below would prove nothing"
+      )
+
+      controller.pictureInPictureControllerDidStopPictureInPicture(installed)
+      try #require(await poll(timeout: .seconds(2), until: { !controller.isActive }))
+
+      let contentSource = AVPictureInPictureController.ContentSource(
+        sampleBufferDisplayLayer: controller.layer,
+        playbackDelegate: controller._playbackDelegateForTesting
+      )
+      let notInstalled = AVPictureInPictureController(contentSource: contentSource)
+
+      controller.pictureInPictureControllerDidStartPictureInPicture(notInstalled)
+      let leaked = try await poll(timeout: .milliseconds(500), until: { controller.isActive })
+      #expect(
+        leaked == false,
+        "a callback from a controller that was never installed set the active flag"
+      )
     }
 
     /// Both flags travel in one value. Published from a single funnel they

--- a/Tests/SwiftVLCTests/PiP/PiPSnapshotTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPSnapshotTests.swift
@@ -2,6 +2,7 @@
 @testable import SwiftVLC
 import AVFoundation
 import AVKit
+import Synchronization
 import Testing
 
 /// ``PiPController/pipSnapshots`` exists because ``PiPController/pipEvents``
@@ -179,6 +180,36 @@ extension Integration {
         leaked == false,
         "a callback from a controller that was never installed set the active flag"
       )
+    }
+
+    /// AVKit is owed the restore completion handler regardless of whether the
+    /// callback is accepted. Returning without calling it leaves the teardown
+    /// it drives unresolved, which is a worse failure than the stale state the
+    /// guard exists to prevent.
+    @Test
+    func `A rejected restore callback still answers AVKit`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = PiPController(player: player)
+
+      let contentSource = AVPictureInPictureController.ContentSource(
+        sampleBufferDisplayLayer: controller.layer,
+        playbackDelegate: controller._playbackDelegateForTesting
+      )
+      let notInstalled = AVPictureInPictureController(contentSource: contentSource)
+
+      let answered = Mutex<Bool?>(nil)
+      controller.pictureInPictureController(
+        notInstalled,
+        restoreUserInterfaceForPictureInPictureStopWithCompletionHandler: { restored in
+          answered.withLock { $0 = restored }
+        }
+      )
+
+      try #require(
+        await poll(timeout: .seconds(2), until: { answered.withLock { $0 } != nil }),
+        "the completion handler was never called, leaving AVKit's teardown unresolved"
+      )
+      #expect(answered.withLock { $0 } == false)
     }
 
     /// Both flags travel in one value. Published from a single funnel they


### PR DESCRIPTION
Completes **#96 criterion 4**. #145 guarded the KVO observers; the delegate callbacks had the same race and were left open.

## The race

Every AVKit signal reaches the main actor through a hop, so a controller replaced in the meantime can still deliver a lifecycle callback. Applying it reports the *incoming* controller as started or stopped on the strength of the *outgoing* one's session.

## Correcting what I said on #145

I deferred this claiming it could not be tested, because adding the guard broke a large set of existing delegate tests. **That reasoning was wrong on both counts.**

The tests failed because their helpers built a *fresh* `AVPictureInPictureController` instead of using the installed one, so the guard correctly rejected them. I assumed the helpers did that because nothing is installed headlessly. Probing rather than assuming:

- `AVPictureInPictureController.isPictureInPictureSupported()` is **`true`** on a headless macOS host
- `PiPController` installs a real controller in `init` — probe printed `pipController installed: true, controllerGeneration: 1`

So the helpers now return the installed controller, and all **1792 tests pass** with the guard in place.

## The test, and why the first version was worthless

The new test drives the installed controller first and *requires* the flag to flip before testing the rejection.

That step is load-bearing. My first version simply asserted the flag stayed clear after two `Task.yield()` calls — which is true whether the callback was rejected or had merely not arrived yet. **It passed with the guard removed.** Proving delivery first makes the negative assertion mean "rejected" rather than "not yet delivered".

Negative control now: removing the guard fails with `a callback from a controller that was never installed set the active flag`.

## Validation

- `swift test --no-parallel`: **1792 tests pass**
- swiftformat, swiftlint, doc coverage (100%), `-strict-concurrency=complete` clean locally

Identity crosses the hop as an `ObjectIdentifier`, since `AVPictureInPictureController` is not `Sendable`.

With this, #96 criteria 1-5 are all addressed (1, 2, 5 in #144; 3 and the KVO half of 4 in #145; the delegate half here).