### PR TITLE
Drop native PiP transport commands issued for a replaced session (#82)

### DIFF
--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -960,9 +960,20 @@ final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling,
 
   weak var owner: PiPController?
 
+  /// The generation the callback snapshot is currently on.
+  ///
+  /// Every mutating callback below hops to the main actor, and the attached
+  /// player can be replaced during that hop. Comparing the generation captured
+  /// at entry against the one on arrival is how a command issued for the
+  /// previous session is kept from being applied to its successor.
+  var callbackGeneration: UInt64 {
+    callbackSnapshot.withLock { $0.generation }
+  }
+
   @objc func play() {
+    let issued = callbackGeneration
     Task { @MainActor [weak self] in
-      guard let self, let player else { return }
+      guard let self, callbackGeneration == issued, let player else { return }
       // A cold start after playback ended is not a resume — begin afresh.
       if player.state == .idle || player.state == .stopped {
         try? player.play()
@@ -981,8 +992,9 @@ final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling,
   }
 
   @objc func pause() {
+    let issued = callbackGeneration
     Task { @MainActor [weak self] in
-      guard let self else { return }
+      guard let self, callbackGeneration == issued else { return }
       if let owner {
         owner.handleNativePictureInPictureSetPlaying(false)
       } else {
@@ -994,8 +1006,13 @@ final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling,
   @objc(seekBy:completion:)
   func seek(by offset: Int64, completion: (() -> Void)?) {
     nonisolated(unsafe) let completion = completion
+    let issued = callbackGeneration
     Task { @MainActor [weak self] in
-      guard let player = self?.player else {
+      // The completion is owed to VLC's PiP module whether or not the seek is
+      // applied. Dropping it on a superseded generation would leave the skip
+      // it drives unresolved, which is worse than the stale seek being
+      // rejected.
+      guard let self, callbackGeneration == issued, let player else {
         completion?()
         return
       }

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -966,7 +966,7 @@ final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling,
   /// player can be replaced during that hop. Comparing the generation captured
   /// at entry against the one on arrival is how a command issued for the
   /// previous session is kept from being applied to its successor.
-  var callbackGeneration: UInt64 {
+  private var callbackGeneration: UInt64 {
     callbackSnapshot.withLock { $0.generation }
   }
 

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewIOSNativeTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewIOSNativeTests.swift
@@ -3,6 +3,7 @@
 import CLibVLC
 import CustomDump
 import SwiftUI
+import Synchronization
 import Testing
 import UIKit
 
@@ -13,12 +14,73 @@ extension Integration {
       libvlc_media_player_get_nsobject(player.pointer)
     }
 
-    /// Pinned libVLC copies `drawable-nsobject` into
-    /// `VLCVideoUIView._viewContainer` once, when the vout opens. Replacing
-    /// the player's variable cannot move that already-open vout. This probe
-    /// models the strong, immutable container reference so the representable
-    /// lifecycle regression is deterministic without relying on decoder
-    /// timing.
+    // Pinned libVLC copies `drawable-nsobject` into
+    // `VLCVideoUIView._viewContainer` once, when the vout opens. Replacing
+    // the player's variable cannot move that already-open vout. This probe
+    // models the strong, immutable container reference so the representable
+    // lifecycle regression is deterministic without relying on decoder
+    // timing.
+
+    /// #82 criterion 3. VLC's native PiP module issues transport commands from
+    /// its own threads, and each hops to the main actor before it acts. The
+    /// attached player can be replaced during that hop, so a command issued for
+    /// one session would otherwise be applied to its successor.
+    ///
+    /// The command is issued and the swap performed before the hop can run, so
+    /// the queued `pause()` arrives on a generation that has moved. Asserting
+    /// on the successor's intent rather than on the generation counter is
+    /// deliberate: the counter advancing proves only that the snapshot was
+    /// republished, not that anything consults it.
+    @Test
+    func `a transport command issued for a replaced session is dropped`() async throws {
+      let first = Player(instance: TestInstance.shared)
+      let controller = IOSNativePiPMediaController()
+      controller.player = first
+
+      // Issued against `first`, capturing its generation synchronously.
+      controller.pause()
+
+      // The session moves on before the queued command can run.
+      let second = Player(instance: TestInstance.shared)
+      controller.player = second
+      // `.paused` with intent active is the state in which `pause()` actually
+      // moves something: on an idle player `issuePause()` returns early, so the
+      // assertion below would hold whether or not the command was dropped.
+      second._setStateForTesting(state: .paused, isPlaybackRequestedActive: true)
+
+      // Give the queued hop every chance to land.
+      try await Task.sleep(for: .milliseconds(200))
+
+      #expect(
+        second.isPlaybackRequestedActive,
+        "a pause issued for the previous session paused its successor"
+      )
+    }
+
+    /// The completion is owed to VLC's PiP module whether or not the seek is
+    /// applied. Dropping it on a superseded generation would leave the skip it
+    /// drives unresolved, which is worse than refusing a stale seek — the same
+    /// mistake made and fixed on the AVKit delegate in #146.
+    @Test
+    func `a seek for a replaced session still runs its completion`() async throws {
+      let first = Player(instance: TestInstance.shared)
+      let controller = IOSNativePiPMediaController()
+      controller.player = first
+
+      let second = Player(instance: TestInstance.shared)
+      controller.player = second
+
+      let completed = Mutex(false)
+      controller.seek(by: 5000) {
+        completed.withLock { $0 = true }
+      }
+
+      try #require(
+        await poll(timeout: .seconds(2), until: { completed.withLock { $0 } }),
+        "the seek completion never ran, leaving VLC's skip unresolved"
+      )
+    }
+
     @Test
     func `same-player make before dismantle reparents the vout-latched attachment`() throws {
       let player = Player(instance: TestInstance.shared)

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewIOSNativeTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewIOSNativeTests.swift
@@ -48,8 +48,16 @@ extension Integration {
       // assertion below would hold whether or not the command was dropped.
       second._setStateForTesting(state: .paused, isPlaybackRequestedActive: true)
 
-      // Give the queued hop every chance to land.
-      try await Task.sleep(for: .milliseconds(200))
+      // Wait on a marker enqueued after the command rather than on the clock.
+      // Main-actor work runs in enqueue order, so the marker completing means
+      // the queued `pause()` has already had its turn. A fixed sleep would be
+      // both slower and flakier under load.
+      let drained = Mutex(false)
+      Task { @MainActor in drained.withLock { $0 = true } }
+      try #require(
+        await poll(timeout: .seconds(2), until: { drained.withLock { $0 } }),
+        "the main actor never drained, so the assertion below would prove nothing"
+      )
 
       #expect(
         second.isPlaybackRequestedActive,


### PR DESCRIPTION
Addresses **#82 criterion 3** — "No stale controller callback mutates the successor session" — on the native drawable path.

## The race

VLC's native PiP module issues `play`, `pause` and `seekBy:completion:` from its own threads. Each hops to the main actor before acting:

```swift
@objc func pause() {
  Task { @MainActor [weak self] in
    guard let self else { return }
    ...  // reads self.player — whichever player is attached *now*
  }
}
```

The attached player can be replaced during that hop, so a command issued for one session was applied to whatever session was current when it landed.

`callbackSnapshot` already carried a `generation` that advances whenever the attached player changes. Nothing consulted it. Each command now captures it synchronously at entry and drops on arrival if it no longer matches.

## The completion handler, up front this time

`seek` still runs its completion when rejected. VLC's module is owed that callback whether or not the seek is applied, and dropping it would leave the skip unresolved.

That is the same mistake I made on the AVKit delegate in #146 and had to be told about; applied here without waiting to be told.

## Verified on a simulator, not just built

These paths are `#if os(iOS)`, so the macOS suite never compiles them and CI's `ios-build` job only builds. I ran them on an iOS simulator: **33 tests pass**, and removing the three guards fails with `a pause issued for the previous session paused its successor`.

## Two hollow versions of that test, both caught by the negative control

1. Asserting the generation counter advanced. That only proved `refreshCallbackSnapshot` works — it passed with the guards removed.
2. Asserting on the successor's playback intent while the player was idle. `issuePause()` returns early for `.idle` and never touches intent, so the assertion held whether or not the command was dropped. Also passed with the guards removed.

The successor is now placed in `.paused` with intent active, a state where `pause()` actually moves something. Only then does the control fail.

## Validation

- iOS simulator: 33 tests pass; negative control fails with the intended message
- `swift test --no-parallel`: 1793 tests pass
- swiftformat, swiftlint, doc coverage (100%), `-strict-concurrency=complete` clean

## Scope

Does not close #82. Criterion 1 (VOD/live × seekable/unseekable determinism) and criterion 4 (recorded device runs) need hardware. Criterion 2 — time, duration and seekability belonging to one generation — is analysed but not fixed here: `mediaLength()`, `mediaTime()` and `isMediaSeekable()` are three separate callbacks each reading libVLC independently, and the two candidate fixes (cache a coherent sample, or extend the engine's atomic snapshot patch) trade coherence against scrubber freshness in a way I cannot judge without a device.