### PR TITLE
Scope the recast playback wait by media generation (#89)

### DIFF
--- a/Sources/SwiftVLC/Player/Player+Programs.swift
+++ b/Sources/SwiftVLC/Player/Player+Programs.swift
@@ -124,7 +124,7 @@ extension Player {
 
     selectedRenderer = renderer
     nativePlayerNeedsReplacementBeforePlayback = true
-    let transitions = stateTransitions
+    let statuses = playbackStatus
     do {
       try play()
     } catch {
@@ -150,7 +150,7 @@ extension Player {
     publishPlaybackStatus()
     let generation = sessionGeneration
 
-    switch await Self.awaitPlaying(on: transitions) {
+    switch await Self.awaitPlaying(on: statuses, atLeast: self.generation) {
     case .playing:
       break
     case .failed:
@@ -281,21 +281,35 @@ extension Player {
   /// - Parameter timeout: The defensive ceiling. Injectable so the outcome
   ///   mapping is testable against a synthetic transition stream; CI cannot
   ///   drive a real session to `.playing` (see `TestCondition.canPlayMedia`).
+  /// Waits for the *replacement* session to reach `.playing`.
+  ///
+  /// Scoped by generation rather than matching any `.playing`. A recast
+  /// captures its stream before calling `play()`, and same-player media
+  /// replacement restarts a session on a repeated `.playing`, so the outgoing
+  /// session's own transition is indistinguishable from the incoming one's on
+  /// a stream of bare `PlayerState`. Accepting it would report a settled
+  /// recast before the replacement had started.
+  ///
+  /// `atLeast` is the generation the recast owns. Anything older belongs to a
+  /// session this recast has already superseded and is ignored, including
+  /// `.error`: a failure in the outgoing session is not this recast's failure.
   static func awaitPlaying(
-    on transitions: AsyncStream<PlayerState>,
+    on statuses: AsyncStream<PlaybackStatus>,
+    atLeast generation: PlaybackGeneration,
     timeout: Duration = .seconds(10)
   )
     async -> RecastPlaybackResult {
     await withTaskGroup(of: RecastPlaybackResult?.self) { group in
       group.addTask {
-        for await state in transitions {
+        for await status in statuses {
+          guard status.generation >= generation else { continue }
           // `.error` is reported rather than silently treated as arrival:
           // the caller needs to know the replacement session failed, not
           // that it is playing.
-          if state == .playing {
+          if status.state == .playing {
             return .playing
           }
-          if state == .error {
+          if status.state == .error {
             return .failed
           }
         }

--- a/Sources/SwiftVLC/Player/Player+Programs.swift
+++ b/Sources/SwiftVLC/Player/Player+Programs.swift
@@ -150,7 +150,11 @@ extension Player {
     publishPlaybackStatus()
     let generation = sessionGeneration
 
-    switch await Self.awaitPlaying(on: statuses, atLeast: self.generation) {
+    // Scoped to the generation this recast captured, not a re-read of the
+    // property. They are equal here, and keeping them textually the same value
+    // is what stops a later edit from silently scoping the wait to a session
+    // this recast no longer owns.
+    switch await Self.awaitPlaying(on: statuses, atLeast: PlaybackGeneration(generation)) {
     case .playing:
       break
     case .failed:

--- a/Tests/SwiftVLCTests/Player/PlayerRecastOutcomeTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerRecastOutcomeTests.swift
@@ -24,7 +24,7 @@ extension Integration {
     func `Reaching playing settles the wait`() async {
       let transitions = Self.stateStream([.opening, .buffering, .playing])
 
-      let result = await Player.awaitPlaying(on: transitions, timeout: .seconds(5))
+      let result = await Player.awaitPlaying(on: transitions, atLeast: PlaybackGeneration(1), timeout: .seconds(5))
 
       #expect(result == .playing)
     }
@@ -36,7 +36,7 @@ extension Integration {
     func `An error is reported as failed rather than arrival`() async {
       let transitions = Self.stateStream([.opening, .error])
 
-      let result = await Player.awaitPlaying(on: transitions, timeout: .seconds(5))
+      let result = await Player.awaitPlaying(on: transitions, atLeast: PlaybackGeneration(1), timeout: .seconds(5))
 
       #expect(result == .failed)
       #expect(result != .playing)
@@ -49,6 +49,7 @@ extension Integration {
 
       let result = await Player.awaitPlaying(
         on: transitions,
+        atLeast: PlaybackGeneration(1),
         timeout: .milliseconds(50)
       )
 
@@ -60,6 +61,7 @@ extension Integration {
     func `An empty transition stream times out`() async {
       let result = await Player.awaitPlaying(
         on: Self.stateStream([]),
+        atLeast: PlaybackGeneration(1),
         timeout: .milliseconds(50)
       )
 
@@ -71,9 +73,61 @@ extension Integration {
     func `Playing before an error settles`() async {
       let transitions = Self.stateStream([.playing, .error])
 
-      let result = await Player.awaitPlaying(on: transitions, timeout: .seconds(5))
+      let result = await Player.awaitPlaying(on: transitions, atLeast: PlaybackGeneration(1), timeout: .seconds(5))
 
       #expect(result == .playing)
+    }
+
+    /// #89 criterion 3. `recast(to:)` captures its stream before calling
+    /// `play()`, and same-player media replacement restarts a session on a
+    /// repeated `.playing`. On a stream of bare `PlayerState` the outgoing
+    /// session's own `.playing` is indistinguishable from the incoming one's,
+    /// so the wait would settle before the replacement had started.
+    @Test
+    func `A playing from the superseded generation does not settle the wait`() async {
+      // Generation 1 is the session being replaced; the recast owns 2.
+      let statuses = Self.statusStream([(.playing, 1), (.opening, 2), (.playing, 2)])
+
+      let result = await Player.awaitPlaying(
+        on: statuses,
+        atLeast: PlaybackGeneration(2),
+        timeout: .seconds(5)
+      )
+
+      #expect(result == .playing)
+    }
+
+    /// The half that makes the scoping load-bearing rather than incidental:
+    /// with nothing from the new generation, the stale `.playing` must not
+    /// stand in for one.
+    @Test
+    func `A stale playing alone times out rather than settling`() async {
+      let statuses = Self.statusStream([(.playing, 1), (.paused, 1)])
+
+      let result = await Player.awaitPlaying(
+        on: statuses,
+        atLeast: PlaybackGeneration(2),
+        timeout: .milliseconds(50)
+      )
+
+      #expect(
+        result == .timedOut,
+        "a .playing from the session being replaced settled a recast that owns a later generation"
+      )
+    }
+
+    /// A failure in the outgoing session is not this recast's failure.
+    @Test
+    func `An error from the superseded generation is ignored`() async {
+      let statuses = Self.statusStream([(.error, 1), (.playing, 2)])
+
+      let result = await Player.awaitPlaying(
+        on: statuses,
+        atLeast: PlaybackGeneration(2),
+        timeout: .seconds(5)
+      )
+
+      #expect(result == .playing, "an error from a superseded session failed the recast that replaced it")
     }
 
     // MARK: - Outcome surface
@@ -214,10 +268,34 @@ extension Integration {
     }
 
     /// Builds a finite stream of states, finishing after the last one.
-    private static func stateStream(_ states: [PlayerState]) -> AsyncStream<PlayerState> {
+    /// Builds a status stream at a single generation.
+    ///
+    /// The wait is generation-scoped, so a bare `PlayerState` is no longer
+    /// enough to describe an input. Cases that do not care about generation use
+    /// the one the wait is scoped to, which preserves their original meaning.
+    private static func stateStream(
+      _ states: [PlayerState],
+      generation: UInt64 = 1
+    ) -> AsyncStream<PlaybackStatus> {
       AsyncStream { continuation in
         for state in states {
-          continuation.yield(state)
+          continuation.yield(
+            PlaybackStatus(state: state, generation: PlaybackGeneration(generation))
+          )
+        }
+        continuation.finish()
+      }
+    }
+
+    /// Builds a stream whose elements carry differing generations.
+    private static func statusStream(
+      _ pairs: [(PlayerState, UInt64)]
+    ) -> AsyncStream<PlaybackStatus> {
+      AsyncStream { continuation in
+        for (state, generation) in pairs {
+          continuation.yield(
+            PlaybackStatus(state: state, generation: PlaybackGeneration(generation))
+          )
         }
         continuation.finish()
       }

--- a/Tests/SwiftVLCTests/Player/PlayerRecastOutcomeTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerRecastOutcomeTests.swift
@@ -267,8 +267,8 @@ extension Integration {
       #expect(result == .notReady)
     }
 
-    /// Builds a finite stream of states, finishing after the last one.
-    /// Builds a status stream at a single generation.
+    /// Builds a finite status stream at a single generation, finishing after
+    /// the last element.
     ///
     /// The wait is generation-scoped, so a bare `PlayerState` is no longer
     /// enough to describe an input. Cases that do not care about generation use

--- a/Tests/SwiftVLCTests/Player/PlayerStateTransitionCompletenessTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerStateTransitionCompletenessTests.swift
@@ -134,10 +134,13 @@ extension Integration {
       let player = Player(instance: TestInstance.shared)
       let bridge = player.eventBridge
       let source = Player.sourceIdentifier(for: player.pointer)
-      let transitions = player.stateTransitions
+      // The wait is generation-scoped now, so it consumes `playbackStatus`
+      // and is anchored to the player's current generation.
+      let statuses = player.playbackStatus
+      let generation = player.generation
 
       let result = Task {
-        await Player.awaitPlaying(on: transitions, timeout: .seconds(5))
+        await Player.awaitPlaying(on: statuses, atLeast: generation, timeout: .seconds(5))
       }
       // Give the wait a turn to subscribe before the error is broadcast.
       await Task.yield()


### PR DESCRIPTION
Addresses **criterion 3 of issue 89** — start the new generation without relying on a repeated raw `.playing`.

## Problem

`recast(to:)` captures its stream **before** calling `play()`, and same-player media replacement restarts a session on a repeated `.playing`. On a stream of bare `PlayerState`, the outgoing session's own `.playing` is indistinguishable from the incoming one's.

So the wait could settle before the replacement had started — and every restore step after it (seek to resume time, reapply audio and subtitle selection, re-pause) would then be applied to a session that was never established.

## Change

`awaitPlaying` now consumes `playbackStatus` and takes the generation the recast owns:

```swift
static func awaitPlaying(
  on statuses: AsyncStream<PlaybackStatus>,
  atLeast generation: PlaybackGeneration,
  timeout: Duration = .seconds(10)
) async -> RecastPlaybackResult
```

Anything older is ignored — including `.error`. A failure in the session being replaced is not this recast's failure.

The wait subscribes before `play()` and `playbackStatus` replays its latest element, so the first thing it sees is the pre-replacement status. The generation filter is exactly what makes that harmless.

## Existing callers

Six call sites move to the new signature. Their synthetic streams now carry a generation, defaulted to the one the wait is scoped to, so each case keeps its original meaning rather than being quietly re-specified.

## Tests

Three new cases, each with the negative control run:

| case | asserts |
|---|---|
| `.playing` at gen 1 then a full gen-2 sequence | settles on the new generation |
| `.playing` at gen 1 only, wait owns gen 2 | **times out** rather than settling |
| `.error` at gen 1 then `.playing` at gen 2 | settles; the stale error does not fail it |

Removing the generation filter fails the second and third with `a .playing from the session being replaced settled a recast that owns a later generation` and `an error from a superseded session failed the recast that replaced it`.

This is testable without playback because `awaitPlaying` is stream-driven and static — the criterion is exercised directly rather than through a live session CI cannot reach.

## Validation

- `CI=true swift test --no-parallel`: **1796 tests pass** (the configuration CI actually runs)
- swiftformat, swiftlint, doc coverage (100%), `-strict-concurrency=complete` clean

## Scope

With this, all four criteria of issue 89 are addressed: 1 and 4 by earlier work (`publishPlaybackState` is what puts `.error` and `.buffering` on the stream; `awaitPlaying` maps `.error` to `.failed`), 2 by #143, and 3 here. I will verify the set against `main` before closing it rather than closing on this PR.