### PR TITLE
Cover HDR metadata invalidation in the format description cache (issue 94)

### DIFF
--- a/Tests/SwiftVLCTests/PiP/PixelBufferFormatDescriptionCacheTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferFormatDescriptionCacheTests.swift
@@ -171,10 +171,19 @@ extension Integration {
 
       // And back: dropping the metadata must not keep serving the HDR one.
       CVBufferRemoveAttachment(buffer, kCVImageBufferMasteringDisplayColorVolumeKey)
+      #expect(
+        !CMVideoFormatDescriptionMatchesImageBuffer(hdr, imageBuffer: buffer),
+        "the HDR description still matched after its metadata was removed"
+      )
+
       let backToSDR = try #require(
         renderer.formatDescription(for: buffer, generation: generation)
       )
       #expect(hdr !== backToSDR)
+      // Identity alone would also hold if the cache recreated needlessly or
+      // handed back something that does not describe this buffer.
+      #expect(CMVideoFormatDescriptionMatchesImageBuffer(backToSDR, imageBuffer: buffer))
+      expectNoDifference(sampleCreationStatus(buffer: buffer, description: backToSDR), noErr)
       expectNoDifference(
         renderer.state.withLock { $0.formatDescriptionCreationCount },
         UInt64(3)

--- a/Tests/SwiftVLCTests/PiP/PixelBufferFormatDescriptionCacheTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferFormatDescriptionCacheTests.swift
@@ -119,6 +119,68 @@ extension Integration {
       )
     }
 
+    /// Issue 94 names HDR metadata explicitly, and the attachment case above
+    /// only covers colour primaries.
+    ///
+    /// The buffer here is deliberately **not** IOSurface-backed, unlike
+    /// `makePixelBuffer`. Probing the two constructions directly:
+    /// `CVBufferSetAttachment` of `kCVImageBufferMasteringDisplayColorVolumeKey`
+    /// on an IOSurface-backed buffer never reaches the format description —
+    /// the description built from that buffer does not carry the extension at
+    /// all, so `CMVideoFormatDescriptionMatchesImageBuffer` has nothing to
+    /// disagree about and keeps matching. Colour primaries does propagate,
+    /// which is why the case above works on the shared helper.
+    ///
+    /// So an IOSurface-backed HDR case would assert on a buffer that is not
+    /// actually HDR and would pass for the wrong reason. Real HDR frames carry
+    /// the metadata on the surface from the decoder, which this process cannot
+    /// produce. This covers the cache's invalidation on an HDR extension
+    /// change; coverage of decoder-produced HDR surfaces needs a device.
+    @Test
+    func `HDR metadata changes replace the cached description`() throws {
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      var created: CVPixelBuffer?
+      expectNoDifference(
+        CVPixelBufferCreate(kCFAllocatorDefault, 16, 9, kCVPixelFormatType_32BGRA, nil, &created),
+        kCVReturnSuccess
+      )
+      let buffer = try #require(created)
+      let generation = renderer.state.withLock { $0.renderGeneration }
+
+      let sdr = try #require(
+        renderer.formatDescription(for: buffer, generation: generation)
+      )
+
+      CVBufferSetAttachment(
+        buffer,
+        kCVImageBufferMasteringDisplayColorVolumeKey,
+        Data(repeating: 0, count: 24) as CFData,
+        .shouldPropagate
+      )
+
+      #expect(
+        !CMVideoFormatDescriptionMatchesImageBuffer(sdr, imageBuffer: buffer),
+        "an SDR description still matched a buffer carrying HDR mastering metadata"
+      )
+
+      let hdr = try #require(
+        renderer.formatDescription(for: buffer, generation: generation)
+      )
+      #expect(sdr !== hdr, "the cache reused an SDR description for an HDR buffer")
+      #expect(CMVideoFormatDescriptionMatchesImageBuffer(hdr, imageBuffer: buffer))
+
+      // And back: dropping the metadata must not keep serving the HDR one.
+      CVBufferRemoveAttachment(buffer, kCVImageBufferMasteringDisplayColorVolumeKey)
+      let backToSDR = try #require(
+        renderer.formatDescription(for: buffer, generation: generation)
+      )
+      #expect(hdr !== backToSDR)
+      expectNoDifference(
+        renderer.state.withLock { $0.formatDescriptionCreationCount },
+        UInt64(3)
+      )
+    }
+
     @Test
     func `A generation change clears the cache and stale work cannot evict its successor`() throws {
       let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())


### PR DESCRIPTION
Criterion 3 of **issue 94** names HDR metadata explicitly. The existing attachment case only covered colour primaries, so this fills that gap.

## The interesting part: the first version was wrong

I wrote it using the shared `makePixelBuffer` helper and it **failed** — the cache returned the same description for an SDR and an HDR buffer. That looked like a real defect in the cache.

It was not. Probing the two buffer constructions directly:

```
IOSurface=false  sdr-matches-after-HDR: false   ← invalidates correctly
IOSurface=true   sdr-matches-after-HDR: true    ← keeps matching
HDR frame's own description carries mastering:  false
```

That last line settles it. `CVBufferSetAttachment` of `kCVImageBufferMasteringDisplayColorVolumeKey` on an **IOSurface-backed** buffer never reaches the format description — the description built from that buffer doesn't carry the extension at all. So `CMVideoFormatDescriptionMatchesImageBuffer` has nothing to disagree about and keeps matching. The synthetic buffer was never HDR from Core Media's point of view.

Colour primaries *does* propagate on IOSurface-backed buffers, which is why the existing case works on the shared helper. That asymmetry is what made the first version look like a product bug.

Had I shipped it as a "found defect", it would have been a false alarm; had I shipped it passing on the shared helper, it would have been a test that passes for the wrong reason.

## What this covers, and what it doesn't

**Covers:** the cache invalidating when an HDR extension appears and disappears, on a buffer where the attachment genuinely reaches the description.

**Does not cover:** decoder-produced HDR surfaces, which carry the metadata on the IOSurface itself. This process cannot produce one — that needs a device.

## Validation

- Negative control: making the cache's match check unconditional fails with `the cache reused an SDR description for an HDR buffer`
- `CI=true swift test --no-parallel`: **1794 tests pass**
- swiftformat, swiftlint clean

## Status of issue 94

No implementation was needed — the cache already existed and is generation-scoped. Criteria 2, 3 and 4 are satisfied by the implementation plus the now-six regression tests. Criterion 1, comparing allocation and CPU profiles at 24/30/60 fps across 720p/1080p/4K, is a measurement task that needs hardware.