### PR TITLE
Make the PiP restore completion once-only and bounded (issue 84)

### DIFF
--- a/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
@@ -151,13 +151,24 @@ extension PiPController: AVPictureInPictureControllerDelegate {
       let answer: @MainActor @Sendable (Bool) -> Void = { restored in
         guard !answered.value else { return }
         answered.value = true
+        // Nothing left to bound. Without this the sleeping task, and the
+        // completion closure it retains, stay alive for the full timeout after
+        // even an immediate restore.
+        answered.timeout?.cancel()
+        answered.timeout = nil
         completionHandler(restored)
       }
 
       onRestoreUserInterface(answer)
 
-      Task { @MainActor in
+      // A hook that answered synchronously needs no timeout at all; starting
+      // one here would create a task whose only job is to wake up and find the
+      // latch already closed.
+      guard !answered.value else { return }
+
+      answered.timeout = Task { @MainActor in
         try? await Task.sleep(for: Self.restoreCompletionTimeout)
+        guard !Task.isCancelled else { return }
         // `false`: the interface was not restored within the bound. Reporting
         // success would tell AVKit a restore happened that did not.
         answer(false)
@@ -490,6 +501,10 @@ func pipMainActorAsync(_ body: @escaping @MainActor @Sendable () -> Void) {
 @MainActor
 final class RestoreAnswerLatch {
   var value = false
+  /// The bounded wait, held so the first answer can cancel it rather than
+  /// leaving it sleeping — and retaining the completion closure — for the full
+  /// timeout.
+  var timeout: Task<Void, Never>?
 }
 
 #endif

--- a/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
@@ -90,6 +90,18 @@ extension PiPController: AVPictureInPictureControllerDelegate {
     }
   }
 
+  /// How long ``PiPController/onRestoreUserInterface`` has to answer before
+  /// AVKit is told the restore did not complete.
+  ///
+  /// The hook is host application code performing a UI transition, so it should
+  /// answer in well under this. The bound exists so a hook that never answers
+  /// cannot stall PiP teardown indefinitely, not to police a slow one — hence a
+  /// ceiling generous enough that a legitimate restore is never cut short.
+  ///
+  /// Overridable so the bound itself can be tested without a ten second wait.
+  /// Production never changes it.
+  static var restoreCompletionTimeout: Duration = .seconds(10)
+
   /// Called when the user taps the PiP window's restore ("return to app")
   /// control. Forwards to ``PiPController/onRestoreUserInterface`` so the
   /// host app can bring its player UI back, then completes the AVKit
@@ -125,8 +137,30 @@ extension PiPController: AVPictureInPictureControllerDelegate {
         completionHandler(true)
         return
       }
-      onRestoreUserInterface { restored in
+
+      // AVKit's handler must run exactly once. The hook is host application
+      // code: it can answer twice, or never. Answering twice invokes a system
+      // completion handler more than once; never answering leaves PiP teardown
+      // waiting with no way out, which is the worse of the two because nothing
+      // surfaces it.
+      //
+      // The latch is read and written only on the main actor — both the hook's
+      // callback and the timeout below are `@MainActor` — so a plain box is
+      // enough.
+      let answered = RestoreAnswerLatch()
+      let answer: @MainActor @Sendable (Bool) -> Void = { restored in
+        guard !answered.value else { return }
+        answered.value = true
         completionHandler(restored)
+      }
+
+      onRestoreUserInterface(answer)
+
+      Task { @MainActor in
+        try? await Task.sleep(for: Self.restoreCompletionTimeout)
+        // `false`: the interface was not restored within the bound. Reporting
+        // success would tell AVKit a restore happened that did not.
+        answer(false)
       }
     }
   }
@@ -445,6 +479,17 @@ func pipMainActorAsync(_ body: @escaping @MainActor @Sendable () -> Void) {
   DispatchQueue.main.async {
     MainActor.assumeIsolated(body)
   }
+}
+
+/// A once-only latch for AVKit's restore completion handler.
+///
+/// Confined to the main actor: both writers — the host's restore hook callback
+/// and the timeout — are `@MainActor`, so no synchronisation is needed beyond
+/// that isolation. A class rather than a captured `var` because two closures
+/// share it.
+@MainActor
+final class RestoreAnswerLatch {
+  var value = false
 }
 
 #endif

--- a/Tests/SwiftVLCTests/PiP/PiPSnapshotTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPSnapshotTests.swift
@@ -212,6 +212,103 @@ extension Integration {
       #expect(answered.withLock { $0 } == false)
     }
 
+    /// Criterion 3 of issue 84: restore completes exactly once.
+    ///
+    /// `onRestoreUserInterface` is host application code holding an escaping
+    /// callback. Nothing stops it answering twice, and AVKit's completion
+    /// handler must run once — invoking a system completion handler more than
+    /// once is undefined.
+    @Test
+    func `A restore hook that answers twice invokes AVKit once`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = PiPController(player: player)
+      let installed = try #require(controller.pipController)
+
+      controller.onRestoreUserInterface = { completion in
+        completion(true)
+        completion(true)
+        completion(false)
+      }
+
+      let answers = Mutex<[Bool]>([])
+      controller.pictureInPictureController(
+        installed,
+        restoreUserInterfaceForPictureInPictureStopWithCompletionHandler: { restored in
+          answers.withLock { $0.append(restored) }
+        }
+      )
+
+      try #require(await poll(timeout: .seconds(2), until: { !answers.withLock { $0 }.isEmpty }))
+      #expect(
+        answers.withLock { $0 } == [true],
+        "a restore hook answering repeatedly invoked AVKit's completion handler more than once"
+      )
+    }
+
+    /// The other half of criterion 3: or a documented timeout.
+    ///
+    /// A hook that never answers would otherwise leave PiP teardown waiting
+    /// with nothing to surface it. The bound reports `false`, since claiming a
+    /// restore that did not happen is worse than reporting none.
+    ///
+    /// The bound is shortened here rather than waiting out the real one. An
+    /// earlier version of this test only asserted the constant's value and that
+    /// nothing had fired yet, which would have held whether or not the timeout
+    /// was ever wired up.
+    @Test
+    func `A restore hook that never answers is bounded`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = PiPController(player: player)
+      let installed = try #require(controller.pipController)
+
+      let original = PiPController.restoreCompletionTimeout
+      PiPController.restoreCompletionTimeout = .milliseconds(50)
+      defer { PiPController.restoreCompletionTimeout = original }
+
+      // Swallows the callback entirely.
+      controller.onRestoreUserInterface = { _ in }
+
+      let answered = Mutex<Bool?>(nil)
+      controller.pictureInPictureController(
+        installed,
+        restoreUserInterfaceForPictureInPictureStopWithCompletionHandler: { restored in
+          answered.withLock { $0 = restored }
+        }
+      )
+
+      try #require(
+        await poll(timeout: .seconds(2), until: { answered.withLock { $0 } != nil }),
+        "a restore hook that never answered left AVKit's completion handler unresolved"
+      )
+      #expect(answered.withLock { $0 } == false)
+    }
+
+    /// The bound must not pre-empt a hook that does answer, or every slow but
+    /// legitimate restore would be reported as a failure.
+    @Test
+    func `A hook answering within the bound wins over the timeout`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = PiPController(player: player)
+      let installed = try #require(controller.pipController)
+
+      let original = PiPController.restoreCompletionTimeout
+      PiPController.restoreCompletionTimeout = .seconds(5)
+      defer { PiPController.restoreCompletionTimeout = original }
+
+      controller.onRestoreUserInterface = { completion in completion(true) }
+
+      let answers = Mutex<[Bool]>([])
+      controller.pictureInPictureController(
+        installed,
+        restoreUserInterfaceForPictureInPictureStopWithCompletionHandler: { restored in
+          answers.withLock { $0.append(restored) }
+        }
+      )
+
+      try #require(await poll(timeout: .seconds(2), until: { !answers.withLock { $0 }.isEmpty }))
+      #expect(answers.withLock { $0 } == [true], "the timeout overrode a hook that answered in time")
+    }
+
     /// Both flags travel in one value. Published from a single funnel they
     /// could otherwise describe a pair that was never simultaneously true.
     @Test

--- a/Tests/SwiftVLCTests/PiP/PiPSnapshotTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPSnapshotTests.swift
@@ -309,6 +309,43 @@ extension Integration {
       #expect(answers.withLock { $0 } == [true], "the timeout overrode a hook that answered in time")
     }
 
+    /// A hook that answers immediately must not leave the bounded wait running.
+    /// Without cancellation the sleeping task — and the completion closure it
+    /// retains — stays alive for the full timeout after every restore, which is
+    /// invisible in behaviour and only shows up as retention.
+    ///
+    /// The bound is stretched well past the assertion so a leaked task would
+    /// still be sleeping when it is checked.
+    @Test
+    func `An immediate answer leaves no bounded wait running`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = PiPController(player: player)
+      let installed = try #require(controller.pipController)
+
+      let original = PiPController.restoreCompletionTimeout
+      PiPController.restoreCompletionTimeout = .seconds(30)
+      defer { PiPController.restoreCompletionTimeout = original }
+
+      controller.onRestoreUserInterface = { completion in completion(true) }
+
+      weak var leaked: AnyObject?
+      do {
+        let probe = RestoreRetentionProbe()
+        leaked = probe
+        controller.pictureInPictureController(
+          installed,
+          restoreUserInterfaceForPictureInPictureStopWithCompletionHandler: { _ in
+            _ = probe
+          }
+        )
+      }
+
+      try #require(
+        await poll(timeout: .seconds(2), until: { leaked == nil }),
+        "the completion closure was still retained after an immediate answer, so the bounded wait outlived it"
+      )
+    }
+
     /// Both flags travel in one value. Published from a single funnel they
     /// could otherwise describe a pair that was never simultaneously true.
     @Test
@@ -327,3 +364,8 @@ extension Integration {
   }
 }
 #endif
+
+/// Stands in for anything the completion closure captures, so retention of the
+/// closure is observable. `Sendable` because the closure it rides in is
+/// `@Sendable`; it carries no state to race over.
+private final class RestoreRetentionProbe: @unchecked Sendable {}


### PR DESCRIPTION
Addresses **criterion 3 of issue 84** — "Restore completes exactly once after readiness or a documented timeout". Neither half held.

## Problem

`onRestoreUserInterface` is host application code holding an escaping callback:

```swift
onRestoreUserInterface { restored in
  completionHandler(restored)   // however many times the host calls it
}
```

Nothing stopped the host **answering twice**, which invokes an AVKit completion handler more than once. Nothing stopped it **never answering**, which leaves PiP teardown waiting with nothing to surface it.

The second is the worse failure precisely because it is silent — the same class of bug as the one Copilot caught in #146, where a rejected callback returned without answering at all.

## Change

- A once-only latch guards the handler.
- A bounded wait answers `false` if the hook has not responded within `restoreCompletionTimeout` (10s, documented). Reporting success there would tell AVKit a restore happened that did not.

The latch is main-actor confined — both writers, the hook's callback and the timeout, are `@MainActor` — so no synchronisation beyond that isolation is needed.

## The bound is testable, deliberately

`restoreCompletionTimeout` is a `static var` so the timeout can be exercised without a ten second wait.

That matters: my first version of the timeout test only asserted the constant's value and that nothing had fired *yet*. That would have passed whether or not the timeout was ever wired up — the same tautology trap as asserting a counter incremented. It now shortens the bound and waits for the completion to actually fire.

## Tests

Three, each with its own negative control:

| test | control |
|---|---|
| hook answers three times → AVKit sees one | removing the latch fails "invoked AVKit's completion handler more than once" |
| hook never answers → bounded, reports `false` | removing the timeout fails "left AVKit's completion handler unresolved" |
| hook answers in time → wins over the bound | guards against a timeout that pre-empts legitimate slow restores |

## Validation

- `CI=true swift test --no-parallel`: **1796 tests pass**
- swiftformat, swiftlint, doc coverage 100%, `-strict-concurrency=complete` clean

Doc coverage caught a real slip here: my first insertion put the new property between the delegate method's doc comment and its declaration, silently transferring the docs to the property. The gate flagged it at 99.9%.

## Scope

Criterion 1 (device event ordering) and criterion 2 (authoritative stop reasons) remain. Criterion 2 is blocked the same way issue 85 is — the engine-authoritative reason from patch 0015 cannot be read until a release ships the patched engine.