### PR TITLE
Refuse to release an artifact without device qualification (issue 88)

### DIFF
--- a/scripts/check-qualification.sh
+++ b/scripts/check-qualification.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# check-qualification.sh — refuse to release an xcframework whose physical-device
+# qualification is missing, stale, or incomplete.
+#
+# Issue 88: simulator and wrapper-only coverage cannot validate system PiP,
+# native video output, audio teardown, or real libVLC playback. CI compiles the
+# iOS tests but never executes system PiP on hardware, and the sanitizer job
+# links a released xcframework rather than the engine under test. So the device
+# matrix is the acceptance gate, and nothing enforced it.
+#
+# This does not run the tests — a person does, on hardware. What it enforces is
+# that the results exist, that every required row was executed and passed, and
+# that they describe *this* artifact rather than an earlier one.
+#
+# The artifact is identified by a digest over its static libraries, computed
+# here rather than trusted from the record. A record can claim any digest; only
+# a recomputed one can contradict it.
+#
+# Usage:
+#   ./scripts/check-qualification.sh <version> [xcframework-path]
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+VERSION="${1:-}"
+XCFW="${2:-Vendor/libvlc.xcframework}"
+MATRIX="$SCRIPT_DIR/qualification/matrix.json"
+RECORD="$SCRIPT_DIR/qualification/${VERSION}.json"
+
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: $0 <version> [xcframework-path]" >&2
+  exit 2
+fi
+
+if [[ ! -d "$XCFW" ]]; then
+  echo "Error: $XCFW not found." >&2
+  exit 1
+fi
+
+if [[ ! -f "$MATRIX" ]]; then
+  echo "Error: $MATRIX not found; the required rows are undefined." >&2
+  exit 1
+fi
+
+# Digest over every slice's static library, in a stable order. Headers and
+# Info.plist are excluded: they carry no executable behaviour, and a header-only
+# change cannot invalidate a device run.
+artifact_digest() {
+  find "$XCFW" -name '*.a' -type f -print0 \
+    | sort -z \
+    | xargs -0 shasum -a 256 \
+    | shasum -a 256 \
+    | cut -d' ' -f1
+}
+
+DIGEST="$(artifact_digest)"
+
+if [[ ! -f "$RECORD" ]]; then
+  echo "Error: no device qualification record for $VERSION." >&2
+  echo "  Expected: $RECORD" >&2
+  echo "  Artifact digest: $DIGEST" >&2
+  echo "" >&2
+  echo "  The device matrix is the acceptance gate for system PiP; CI cannot" >&2
+  echo "  stand in for it. Run the matrix on hardware and record the results," >&2
+  echo "  then release. See scripts/qualification/README.md." >&2
+  exit 1
+fi
+
+python3 - "$MATRIX" "$RECORD" "$DIGEST" "$VERSION" <<'PY'
+import json
+import sys
+
+matrix_path, record_path, digest, version = sys.argv[1:5]
+
+try:
+    matrix = json.load(open(matrix_path))
+    record = json.load(open(record_path))
+except (OSError, ValueError) as error:
+    sys.exit(f"Error: cannot read qualification input: {error}")
+
+problems = []
+
+recorded = record.get("artifactDigest")
+if recorded != digest:
+    problems.append(
+        "the record describes a different artifact\n"
+        f"    recorded:   {recorded}\n"
+        f"    on disk:    {digest}\n"
+        "    A device run only qualifies the binary it was run against. Rebuild\n"
+        "    or re-run the matrix, whichever is actually stale."
+    )
+
+if record.get("version") != version:
+    problems.append(
+        f"the record is for version {record.get('version')!r}, not {version!r}"
+    )
+
+required = {
+    (s["id"], h["id"])
+    for s in matrix["scenarios"]
+    for h in matrix["hardware"]
+}
+
+executed = {}
+for row in record.get("rows", []):
+    key = (row.get("scenario"), row.get("hardware"))
+    executed[key] = row
+
+missing = sorted(required - set(executed))
+if missing:
+    listed = "\n".join(f"      {s} on {h}" for s, h in missing)
+    problems.append(f"{len(missing)} required row(s) were never executed:\n{listed}")
+
+failed = sorted(
+    key for key, row in executed.items()
+    if key in required and row.get("result") != "pass"
+)
+if failed:
+    listed = "\n".join(
+        f"      {s} on {h}: {executed[(s, h)].get('result')!r}" for s, h in failed
+    )
+    problems.append(f"{len(failed)} required row(s) did not pass:\n{listed}")
+
+# Fields the criteria call for on every row. A row missing them is not a record
+# of anything reproducible.
+for key in sorted(executed):
+    if key not in required:
+        continue
+    row = executed[key]
+    for field in ("device", "os", "fixture", "duration", "result"):
+        if not row.get(field):
+            problems.append(f"row {key[0]} on {key[1]} is missing {field!r}")
+
+if problems:
+    print(f"Error: {version} is not qualified for release.", file=sys.stderr)
+    for problem in problems:
+        print(f"  - {problem}", file=sys.stderr)
+    sys.exit(1)
+
+print(
+    f"Device qualification verified: {len(required)} rows executed and passing "
+    f"for artifact {digest[:12]}…"
+)
+PY

--- a/scripts/check-qualification.sh
+++ b/scripts/check-qualification.sh
@@ -57,6 +57,16 @@ artifact_digest() {
     | cut -d' ' -f1
 }
 
+# An xcframework with no static libraries would still produce a stable digest —
+# shasum of empty input — so a record could be written that "qualifies" an
+# artifact containing nothing. Refuse before computing anything.
+SLICE_COUNT=$(find "$XCFW" -name '*.a' -type f | grep -c . || true)
+if [[ "$SLICE_COUNT" -eq 0 ]]; then
+  echo "Error: $XCFW contains no static libraries." >&2
+  echo "  Nothing to qualify. Rebuild with ./scripts/build-libvlc.sh --all." >&2
+  exit 1
+fi
+
 DIGEST="$(artifact_digest)"
 
 if [[ ! -f "$RECORD" ]]; then
@@ -105,10 +115,29 @@ required = {
     for h in matrix["hardware"]
 }
 
+rows = record.get("rows")
+if not isinstance(rows, list):
+    sys.exit(f"Error: {record_path} has no 'rows' array.")
+
 executed = {}
-for row in record.get("rows", []):
+duplicates = []
+for index, row in enumerate(rows):
+    if not isinstance(row, dict):
+        problems.append(f"row {index} is not an object")
+        continue
     key = (row.get("scenario"), row.get("hardware"))
+    if key in executed:
+        # Last-wins would let a failing row be masked by appending a passing
+        # duplicate, which defeats the point of the gate.
+        duplicates.append(key)
     executed[key] = row
+
+if duplicates:
+    listed = "\n".join(f"      {s} on {h}" for s, h in sorted(set(duplicates)))
+    problems.append(
+        f"{len(set(duplicates))} row(s) appear more than once:\n{listed}\n"
+        "    A duplicate can hide an earlier failure behind a later pass."
+    )
 
 missing = sorted(required - set(executed))
 if missing:

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -1,0 +1,61 @@
+# Device qualification records
+
+System Picture in Picture, native video output, audio teardown and real libVLC
+playback cannot be validated by CI. It compiles the iOS tests but never executes
+system PiP on hardware, and the sanitizer job links a *released* xcframework
+rather than the engine under test. The physical-device matrix is therefore the
+acceptance gate, and `release.sh` refuses to package an artifact without one.
+
+## Running the matrix
+
+`matrix.json` lists the required scenarios and hardware. Every combination is
+required — 9 scenarios across 4 hardware rows. Simulator runs never satisfy a
+row: PiP is force-disabled there, and a simulator can report PiP active while
+its window stays black.
+
+Record the results as `scripts/qualification/<version>.json`:
+
+```json
+{
+  "version": "1.1.0",
+  "artifactDigest": "…",
+  "rows": [
+    {
+      "scenario": "vod-controls",
+      "hardware": "iphone-current",
+      "device": "iPhone 15 Pro",
+      "os": "iOS 27.0",
+      "fixture": "demo.mkv",
+      "duration": "2m14s",
+      "result": "pass",
+      "notes": "optional; put log excerpts or anomalies here"
+    }
+  ]
+}
+```
+
+`artifactDigest` is a SHA-256 over every slice's static library, in sorted
+order. Get it for the artifact you are about to qualify with:
+
+```bash
+find Vendor/libvlc.xcframework -name '*.a' -type f -print0 \
+  | sort -z | xargs -0 shasum -a 256 | shasum -a 256 | cut -d' ' -f1
+```
+
+Headers and `Info.plist` are excluded deliberately: they carry no executable
+behaviour, so a header-only change cannot invalidate a device run.
+
+## Checking before release
+
+```bash
+./scripts/check-qualification.sh 1.1.0
+```
+
+It fails when the record is absent, describes a different artifact, is for
+another version, omits a required row, contains a row that did not pass, or has
+a row missing any of `device`, `os`, `fixture`, `duration` or `result`.
+
+The digest is recomputed from the artifact on disk rather than trusted from the
+record — a record can claim any digest, and only a recomputed one can contradict
+it. That is what stops a stale qualification from carrying forward onto a
+rebuilt engine.

--- a/scripts/qualification/matrix.json
+++ b/scripts/qualification/matrix.json
@@ -1,0 +1,20 @@
+{
+  "description": "Physical-device rows that must be executed and passing before an xcframework can be released. Derived from the acceptance criteria of issue 88. Simulator runs never satisfy a row.",
+  "scenarios": [
+    { "id": "vod-controls",        "summary": "Finite VOD: play, pause, scrub, skip forward and back from the PiP controls" },
+    { "id": "live-media",          "summary": "Live stream with indefinite duration: PiP controls reflect an unbounded range" },
+    { "id": "restore",             "summary": "Restore from the PiP window back into the app" },
+    { "id": "close",               "summary": "Close the PiP window with the X control" },
+    { "id": "failed-start",        "summary": "PiP start refused or failing, surfaced rather than silent" },
+    { "id": "replacement",         "summary": "Same-player media replacement while PiP is active" },
+    { "id": "interruptions",       "summary": "Phone call or Siri interruption, and a route change such as Bluetooth disconnect" },
+    { "id": "background-audio",    "summary": "Audio continues with the app backgrounded" },
+    { "id": "long-stall",          "summary": "Sustained network stall and recovery while in PiP" }
+  ],
+  "hardware": [
+    { "id": "iphone-minimum", "summary": "iPhone on the minimum supported OS" },
+    { "id": "iphone-current", "summary": "iPhone on the current supported OS" },
+    { "id": "ipad-minimum",   "summary": "iPad on the minimum supported OS" },
+    { "id": "ipad-current",   "summary": "iPad on the current supported OS" }
+  ]
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -425,6 +425,13 @@ if ! verify_artifact_provenance; then
   exit 1
 fi
 
+# Device qualification. CI cannot execute system PiP on hardware, so the matrix
+# in scripts/qualification is the acceptance gate. Refusing here is the point of
+# issue 88: nothing previously stopped an unqualified artifact being published.
+if ! "$SCRIPT_DIR/check-qualification.sh" "$VERSION" "$XCFW_PATH"; then
+  exit 1
+fi
+
 # ── Strip ─────────────────────────────────────────────────────────────────────
 
 WORK_DIR=$(make_temp_dir)


### PR DESCRIPTION
Addresses **criteria 3 and 4 of issue 88**.

## Why a gate

System PiP, native video output, audio teardown and real libVLC playback cannot be validated by CI:

- `test.yml` compiles the iOS tests but never executes system PiP on hardware
- `sanitize.yml` links a *released* xcframework, so the engine under test is never sanitizer-instrumented
- PiP is force-disabled in the simulator, and a simulator can report PiP active while its window stays black

So the physical-device matrix is the acceptance gate. Nothing enforced it — an unqualified artifact could be published with everything green.

## What this adds

- `scripts/qualification/matrix.json` — the required rows, 9 scenarios across 4 hardware configurations, taken from criteria 1 and 2
- `scripts/check-qualification.sh` — verifies a recorded result set against the matrix
- `release.sh` calls it before packaging
- `scripts/qualification/README.md` — the operator flow

**It runs nothing.** A person runs the matrix on hardware. This enforces that the results exist, that every required row was executed and passed, that each carries `device`, `os`, `fixture`, `duration` and `result` (criterion 3), and that they describe *this* artifact (criterion 4).

## The digest is recomputed, not trusted

The artifact is identified by a SHA-256 over every slice's static library, computed from the xcframework on disk rather than read from the record. A record can claim any digest; only a recomputed one can contradict it. That is what stops a stale qualification carrying forward onto a rebuilt engine.

Headers and `Info.plist` are excluded deliberately — they carry no executable behaviour, so a header-only change cannot invalidate a device run.

## Exercised, not assumed

All failure modes run against fixtures:

| case | result |
|---|---|
| no record | refuses, prints the digest to record against |
| digest mismatch | refuses, shows recorded vs on-disk |
| wrong version | refuses |
| 31 of 36 rows missing | refuses, lists them |
| one row `"fail"` | refuses, names scenario and hardware |
| row missing `os` | refuses, names the field |
| complete and matching | **exit 0** |

End to end: `./scripts/release.sh 1.1.0 --dry-run` now passes provenance and then stops with `no device qualification record for 1.1.0`.

## Scope

Criteria 1 and 2 are the device runs themselves — this makes them mandatory rather than performing them. Once a matrix has been run, dropping the record in `scripts/qualification/1.1.0.json` satisfies the gate.