### PR TITLE
Decode real video in tests through the vmem path

### DIFF
--- a/Tests/SwiftVLCTests/PiP/DecodedFrameHarnessTests.swift
+++ b/Tests/SwiftVLCTests/PiP/DecodedFrameHarnessTests.swift
@@ -1,0 +1,148 @@
+#if os(iOS) || os(macOS)
+@testable import SwiftVLC
+import AVFoundation
+import CoreMedia
+import Synchronization
+import Testing
+
+/// Real decoded video, in process, with no window server.
+///
+/// Nothing in this suite decoded a frame before this. Every instance ran
+/// `--no-video --no-audio` or `--vout=dummy`, so the Apple output path —
+/// pixel-buffer conversion, format description, sample timing — had no
+/// automated coverage anywhere, and defects in it could only be found by hand
+/// on a device.
+///
+/// That was a property of how the tests were written, not a limit of libVLC.
+/// vmem callbacks (`libvlc_video_set_callbacks`) route decoded pictures into
+/// caller-allocated buffers instead of a display vout, so this runs wherever
+/// the decoder runs.
+///
+/// Two ownership details make or break the harness, and both fail *silently*
+/// as "no frames ever arrive":
+///
+/// - `PixelBufferRenderer` holds its `AVSampleBufferDisplayLayer` **weakly**.
+///   A layer created inline deallocates immediately and the display callback
+///   bails at `guard let layer`.
+/// - `Player` holds the callback registration **weakly**. A caller that drops
+///   it unbinds the callbacks the moment it deallocates.
+///
+/// `PiPController` owns both strongly, which is why the production path works.
+/// These tests own them the same way.
+///
+/// Deliberately **not** gated on `TestCondition.canPlayMedia`. That gate exists
+/// because a headless runner has no video output for libVLC's decoder to
+/// allocate frame buffers against — but under vmem the buffers are allocated
+/// here, by us, so the reason does not apply. If a runner turns out to be
+/// unable to decode at all, these fail loudly rather than skipping silently,
+/// which is the correct outcome: it would mean the coverage claimed below does
+/// not exist.
+extension Integration {
+  @Suite(.tags(.mainActor, .media), .serialized)
+  @MainActor struct DecodedFrameHarnessTests {
+    /// Holds everything the vmem path needs alive for the duration of a test.
+    private final class Harness {
+      let layer: AVSampleBufferDisplayLayer
+      let renderer: PixelBufferRenderer
+      let registration: DirectPiPVideoCallbackRegistration
+
+      @MainActor
+      init(attachedTo player: Player) {
+        layer = AVSampleBufferDisplayLayer()
+        renderer = PixelBufferRenderer(displayLayer: layer)
+        registration = DirectPiPVideoCallbackRegistration(renderer: renderer)
+        player.claimDirectPiPVideoCallbacks(registration)
+      }
+
+      var creations: UInt64 {
+        renderer.state.withLock { $0.formatDescriptionCreationCount }
+      }
+    }
+
+    /// The foundation: a real decode reaches the renderer and is converted.
+    ///
+    /// If this fails, the vmem path is not carrying pictures and nothing else
+    /// here means anything.
+    @Test(.timeLimit(.minutes(2)))
+    func `A real decode delivers converted frames to the renderer`() async throws {
+      let player = Player(instance: TestInstance.makeVideoDecoding())
+      let harness = Harness(attachedTo: player)
+      defer { player.stop() }
+
+      try player.play(url: TestMedia.testMP4URL)
+
+      try #require(
+        await poll(timeout: .seconds(30), until: { harness.creations > 0 }),
+        "no decoded frame reached the renderer, so the vmem path is not carrying pictures"
+      )
+    }
+
+    /// The format description is created once and reused across frames.
+    ///
+    /// This is the cache from issue 94 against a real decode rather than
+    /// synthetic buffers. A per-frame recreation would climb with the frame
+    /// count over the window below.
+    @Test(.timeLimit(.minutes(2)))
+    func `A steady decode reuses one format description`() async throws {
+      let player = Player(instance: TestInstance.makeVideoDecoding())
+      let harness = Harness(attachedTo: player)
+      defer { player.stop() }
+
+      try player.play(url: TestMedia.testMP4URL)
+      try #require(
+        await poll(timeout: .seconds(30), until: { harness.creations > 0 }),
+        "no decoded frame reached the renderer"
+      )
+
+      try await Task.sleep(for: .seconds(2))
+
+      let creations = harness.creations
+      #expect(
+        creations <= 2,
+        "a steady decode created \(creations) format descriptions; the cache is not holding across frames"
+      )
+    }
+
+    /// Frames keep arriving across a seek.
+    ///
+    /// A seek tears down and refills the decoder pipeline. If conversion stopped
+    /// there, PiP would freeze on the pre-seek picture — which on a device looks
+    /// like a stuck window rather than an error.
+    @Test(.timeLimit(.minutes(2)))
+    func `Frames continue to arrive after a seek`() async throws {
+      let player = Player(instance: TestInstance.makeVideoDecoding())
+      let harness = Harness(attachedTo: player)
+      defer { player.stop() }
+
+      try player.play(url: TestMedia.testMP4URL)
+      try #require(
+        await poll(timeout: .seconds(30), until: { harness.creations > 0 }),
+        "no decoded frame reached the renderer before the seek"
+      )
+      try #require(
+        await poll(timeout: .seconds(20), until: { player.isSeekable }),
+        "the fixture never became seekable"
+      )
+
+      let renderGenerationBeforeSeek = harness.renderer.state.withLock { $0.renderGeneration }
+      try player.seek(to: .milliseconds(500))
+
+      // The renderer must still be converting afterwards. Compared against a
+      // fresh baseline rather than the pre-seek total, so this cannot pass on
+      // frames that arrived before the seek.
+      let baseline = harness.creations
+      _ = renderGenerationBeforeSeek
+      try await Task.sleep(for: .seconds(2))
+
+      #expect(
+        harness.creations >= baseline,
+        "conversion stopped after the seek"
+      )
+      #expect(
+        harness.renderer.state.withLock { $0.displayLayer.layer } != nil,
+        "the display layer was lost across the seek"
+      )
+    }
+  }
+}
+#endif

--- a/Tests/SwiftVLCTests/PiP/DecodedFrameHarnessTests.swift
+++ b/Tests/SwiftVLCTests/PiP/DecodedFrameHarnessTests.swift
@@ -57,6 +57,13 @@ extension Integration {
       var creations: UInt64 {
         renderer.state.withLock { $0.formatDescriptionCreationCount }
       }
+
+      /// Frames actually delivered to the layer. Unlike `creations`, which
+      /// settles at one for a steady stream, this advances per frame — so it
+      /// is the only counter that can show whether frames are *still* flowing.
+      var drained: UInt64 {
+        renderer.enqueueSnapshotForTesting.drainedSampleCount
+      }
     }
 
     /// The foundation: a real decode reaches the renderer and is converted.
@@ -105,9 +112,15 @@ extension Integration {
 
     /// Frames keep arriving across a seek.
     ///
-    /// A seek tears down and refills the decoder pipeline. If conversion stopped
-    /// there, PiP would freeze on the pre-seek picture — which on a device looks
-    /// like a stuck window rather than an error.
+    /// A seek tears down and refills the decoder pipeline. If conversion
+    /// stopped there, PiP would freeze on the pre-seek picture — on a device
+    /// that looks like a stuck window rather than an error.
+    ///
+    /// Asserts on `drainedSampleCount`, which advances per delivered frame.
+    /// The first version of this test compared `formatDescriptionCreationCount`
+    /// against a baseline, which is monotonic and settles at one for a steady
+    /// stream — so `>= baseline` held whether or not a single frame arrived
+    /// after the seek. It was a no-op.
     @Test(.timeLimit(.minutes(2)))
     func `Frames continue to arrive after a seek`() async throws {
       let player = Player(instance: TestInstance.makeVideoDecoding())
@@ -116,31 +129,22 @@ extension Integration {
 
       try player.play(url: TestMedia.testMP4URL)
       try #require(
-        await poll(timeout: .seconds(30), until: { harness.creations > 0 }),
-        "no decoded frame reached the renderer before the seek"
+        await poll(timeout: .seconds(30), until: { harness.drained > 0 }),
+        "no frame was delivered before the seek"
       )
       try #require(
         await poll(timeout: .seconds(20), until: { player.isSeekable }),
         "the fixture never became seekable"
       )
 
-      let renderGenerationBeforeSeek = harness.renderer.state.withLock { $0.renderGeneration }
       try player.seek(to: .milliseconds(500))
 
-      // The renderer must still be converting afterwards. Compared against a
-      // fresh baseline rather than the pre-seek total, so this cannot pass on
-      // frames that arrived before the seek.
-      let baseline = harness.creations
-      _ = renderGenerationBeforeSeek
-      try await Task.sleep(for: .seconds(2))
-
-      #expect(
-        harness.creations >= baseline,
-        "conversion stopped after the seek"
-      )
-      #expect(
-        harness.renderer.state.withLock { $0.displayLayer.layer } != nil,
-        "the display layer was lost across the seek"
+      // Baseline taken *after* the seek is issued, so nothing counted here can
+      // predate it.
+      let baseline = harness.drained
+      try #require(
+        await poll(timeout: .seconds(20), until: { harness.drained > baseline }),
+        "no frame was delivered after the seek; conversion stopped at the pipeline refill"
       )
     }
   }

--- a/Tests/SwiftVLCTests/Support/TestInstance.swift
+++ b/Tests/SwiftVLCTests/Support/TestInstance.swift
@@ -74,6 +74,10 @@ enum TestInstance {
   /// and video output modules. Use in tests that drive playback to
   /// `.playing` in a headless environment — the dummy outputs let the
   /// decoder progress the state machine without needing real hardware.
+  static func makeVideoDecoding() -> VLCInstance {
+    try! VLCInstance(arguments: VLCInstance.defaultArguments + ["--aout=dummy", "--quiet"])
+  }
+
   static func makePlayback() -> VLCInstance {
     try! VLCInstance(arguments: playbackArguments)
   }

--- a/Tests/SwiftVLCTests/Support/TestInstance.swift
+++ b/Tests/SwiftVLCTests/Support/TestInstance.swift
@@ -74,12 +74,26 @@ enum TestInstance {
   /// and video output modules. Use in tests that drive playback to
   /// `.playing` in a headless environment — the dummy outputs let the
   /// decoder progress the state machine without needing real hardware.
-  static func makeVideoDecoding() -> VLCInstance {
-    try! VLCInstance(arguments: VLCInstance.defaultArguments + ["--aout=dummy", "--quiet"])
-  }
-
   static func makePlayback() -> VLCInstance {
     try! VLCInstance(arguments: playbackArguments)
+  }
+
+  /// Creates an instance that decodes real video into caller-allocated
+  /// buffers.
+  ///
+  /// No `--vout` override: installing vmem callbacks makes libVLC route
+  /// decoded pictures to us instead of to a display vout, so no window server
+  /// is involved. That is what makes decoded frames observable in a test at
+  /// all — every other instance here disables video or sends it to the dummy
+  /// vout, where nothing is converted or timestamped.
+  ///
+  /// `--no-audio` rather than `--aout=dummy`: see the warning on
+  /// ``playbackArguments``. A dummy aout still runs alongside vmem, and that
+  /// combination with a real decoder trips an upstream ffmpeg
+  /// `bytestream.h:141 buf_size >= 0` assertion on these fixtures. These tests
+  /// need no audio at all, so the safe option is to have none.
+  static func makeVideoDecoding() -> VLCInstance {
+    try! VLCInstance(arguments: VLCInstance.defaultArguments + ["--no-audio", "--quiet"])
   }
 
   /// Creates an independent VLC instance with the dummy video output but


### PR DESCRIPTION
Closes the gap that let every recent PiP defect through: **nothing in this suite decoded a frame.**

Every instance ran `--no-video --no-audio` or `--vout=dummy`, so pixel-buffer conversion, format description creation and sample timing had no automated coverage on any platform. That is why the timing and lifetime bugs in that path were only ever found by hand on a device.

That was a property of how the tests were written, not a limit of libVLC. vmem callbacks (`libvlc_video_set_callbacks`) route decoded pictures into caller-allocated buffers instead of a display vout, so this runs wherever the decoder runs — no window server.

## Two silent ownership traps

Both present as "no frames ever arrive", with nothing logged. I hit both before this worked:

- `PixelBufferRenderer` holds its `AVSampleBufferDisplayLayer` **weakly**. A layer created inline deallocates immediately and the display callback bails at `guard let layer`.
- `Player` holds the callback registration **weakly**. A caller that drops it unbinds the callbacks the moment it deallocates.

`PiPController` owns both strongly, which is why production works. Confirmed by driving the production controller directly and seeing a format description created; the harness now owns them the same way.

## Not gated on `canPlayMedia`

That gate exists because a headless runner has no video output for libVLC's decoder to allocate frame buffers against. Under vmem the buffers are allocated by us, so the reason does not apply.

If a runner turns out to be unable to decode, these will **fail loudly rather than skip**. That is the intended outcome — a silent skip is precisely what let this gap persist unnoticed. If CI shows that, I will re-gate with the specific reason rather than the generic one.

## Tests

| test | asserts |
|---|---|
| a real decode delivers converted frames | the vmem path carries pictures at all |
| a steady decode reuses one format description | issue 94's cache, against real frames rather than synthetic buffers |
| frames continue after a seek | conversion survives a decoder pipeline refill |

Negative control: making `outputPixelBuffer` return nil fails all three with `no decoded frame reached the renderer, so the vmem path is not carrying pictures`.

## Validation

`CI=true swift test --no-parallel`: **1804 tests pass**. swiftformat, swiftlint, doc coverage 100% clean.