### PR TITLE
Test against the newest release, pre-releases included

### DIFF
--- a/scripts/check-engine-coverage.sh
+++ b/scripts/check-engine-coverage.sh
@@ -41,7 +41,18 @@ annotate() {
   fi
 }
 
-tag=$(gh release view --json tagName -q .tagName 2>/dev/null || true)
+# The newest published release, pre-releases included.
+#
+# `gh release view` with no tag returns the latest *non*-prerelease. During a
+# beta cycle that is the wrong artifact: it would keep CI on the previous
+# stable engine while the beta — the thing actually being validated — is tested
+# by nothing. Ordering is by creation date, so the newest wins whatever its
+# kind.
+newest_release_tag() {
+  gh release list --limit 1 --exclude-drafts --json tagName -q '.[0].tagName'
+}
+
+tag=$(newest_release_tag) 2>/dev/null || true
 if [ -z "$tag" ]; then
   echo "Could not resolve the latest release tag via gh; skipping coverage check." >&2
   exit 0

--- a/scripts/ci-use-released-xcframework.sh
+++ b/scripts/ci-use-released-xcframework.sh
@@ -19,7 +19,18 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT_DIR"
 
-tag=$(gh release view --json tagName -q .tagName)
+# The newest published release, pre-releases included.
+#
+# `gh release view` with no tag returns the latest *non*-prerelease. During a
+# beta cycle that is the wrong artifact: it would keep CI on the previous
+# stable engine while the beta — the thing actually being validated — is tested
+# by nothing. Ordering is by creation date, so the newest wins whatever its
+# kind.
+newest_release_tag() {
+  gh release list --limit 1 --exclude-drafts --json tagName -q '.[0].tagName'
+}
+
+tag=$(newest_release_tag)
 if [ -z "$tag" ]; then
   echo "Error: could not resolve latest release tag via gh." >&2
   exit 1


### PR DESCRIPTION
Closes the engine coverage gap this milestone has carried since patch 0007 landed.

## The problem the beta exposed

Publishing `v1.1.0-beta.1` should have put the patched engine under CI. It did not.

`gh release view` with no tag returns the latest **non**-prerelease, so `ci-use-released-xcframework.sh` kept rewriting `Package.swift` back to `v1.0.0`. The beta — the artifact actually being validated — was tested by nothing, which defeats the point of publishing it.

I only caught this because `check-engine-coverage.sh` (added in #141 for exactly this class of blindness) still reported `Engine under test: v1.0.0` after the release.

## Change

Both scripts now resolve the newest published release regardless of kind, ordered by creation date.

```
before:  Engine under test: v1.0.0          10 patches uncovered
after:   Engine under test: v1.1.0-beta.1    every engine patch covered
```

## Verified end to end

Pinned to the beta and ran the full suite: **1807 tests pass against a binary containing patches 0007-0016**.

That is the first time in this milestone the tests have run against the engine they are meant to validate. Every green run before this was against v1.0.0, which has none of those patches — which is how the patch-0007 `get_media` semantic change reached `main` and only surfaced when the suite was finally run against a locally built engine.

## Why pre-releases should count

During a beta cycle the newest artifact is the one under validation. Excluding pre-releases keeps CI on the previous stable engine and leaves the candidate untested, which is precisely backwards.