### PR TITLE
Use the engine's own stop reason instead of inferring it (issue 85)

### DIFF
--- a/Sources/SwiftVLC/Player/EventBridge.swift
+++ b/Sources/SwiftVLC/Player/EventBridge.swift
@@ -268,6 +268,11 @@ private func playerEventCallback(
   // then `.endReached` from the same source, with no consumer-lag race
   // and internal source filtering working unchanged.
   let coordinator = context.endCoordinator
+  // Recorded before the `stopped` that follows it, so the decision below has
+  // the engine's own answer rather than only SwiftVLC's inference.
+  if event.pointee.type == Int32(libvlc_MediaPlayerMediaStopping.rawValue) {
+    coordinator.noteStoppingReason(event.pointee.u.media_player_media_stopping.reason)
+  }
   switch mapped {
   case .encounteredError:
     coordinator.markError()

--- a/Sources/SwiftVLC/Player/PlaybackEndCoordinator.swift
+++ b/Sources/SwiftVLC/Player/PlaybackEndCoordinator.swift
@@ -1,3 +1,4 @@
+import CLibVLC
 import Synchronization
 
 /// Decides, on libVLC's event thread, whether a `stopped` transition is a
@@ -28,6 +29,9 @@ final class PlaybackEndCoordinator: Sendable {
     /// calls that never pass through `Player.stop()` — every
     /// list-initiated advancement would synthesize a spurious end.
     var suppressSynthesis = false
+    /// The engine's reason for the stop now in flight, when it supplied one.
+    /// Cleared by each `stopped`, so it can never describe a later one.
+    var stoppingReason: libvlc_stopping_reason_t?
   }
 
   private let state = Mutex(EndState())
@@ -67,18 +71,43 @@ final class PlaybackEndCoordinator: Sendable {
     state.withLock { $0.suppressSynthesis = suppressed }
   }
 
+  /// Records the engine's own reason for the stop that is about to arrive.
+  ///
+  /// libVLC reports this on `MediaPlayerMediaStopping`, which precedes the
+  /// `stopped` transition. It is authoritative: the player core knows whether
+  /// the input reached end of stream, was stopped by request, or failed.
+  func noteStoppingReason(_ reason: libvlc_stopping_reason_t) {
+    state.withLock { $0.stoppingReason = reason }
+  }
+
   /// Consumes a `stopped` transition on the event thread: returns `true`
   /// when it should synthesize ``PlayerEvent/endReached``, and clears the
   /// one-shot causes either way (each `stopped` accounts for whatever
   /// preceded it).
+  ///
+  /// When the engine supplied a reason, it decides. Only `eos` is a natural
+  /// end; `user` and `error` are not, and neither is a stop that arrived with
+  /// no reason at all. The inference below is the fallback for the latter, and
+  /// it is the weaker answer: it concludes "natural end" from the *absence* of
+  /// a known cause, so anything it has not been told about reads as end of
+  /// media. That is exactly what an authoritative reason removes.
   func consumeStoppedShouldSynthesizeEnd() -> Bool {
     state.withLock { state in
-      let synthesize = !state.libraryStopPending
+      defer {
+        state.libraryStopPending = false
+        state.sawErrorSinceLastPlay = false
+        state.stoppingReason = nil
+      }
+
+      if let reason = state.stoppingReason {
+        // Still honour list-player suppression: an advance through a playlist
+        // ends one media at eos without ending playback.
+        return reason == libvlc_stopping_reason_eos && !state.suppressSynthesis
+      }
+
+      return !state.libraryStopPending
         && !state.sawErrorSinceLastPlay
         && !state.suppressSynthesis
-      state.libraryStopPending = false
-      state.sawErrorSinceLastPlay = false
-      return synthesize
     }
   }
 }

--- a/Tests/SwiftVLCTests/Player/AuthoritativeStopReasonTests.swift
+++ b/Tests/SwiftVLCTests/Player/AuthoritativeStopReasonTests.swift
@@ -1,0 +1,84 @@
+@testable import SwiftVLC
+import CLibVLC
+import Testing
+
+/// Issue 85 criterion 4: an unattributed stop is never reported as a confirmed
+/// natural end.
+///
+/// Before patch 0015 reached a released engine, SwiftVLC could only *infer*
+/// this: a `stopped` that no library-issued stop, error, or attached
+/// `MediaListPlayer` accounted for was treated as end of media. That concludes
+/// "natural end" from the absence of a known cause, so any cause it had not
+/// been told about — a server closing the connection, a demuxer giving up —
+/// read as a clean EOF.
+///
+/// The engine knows. `MediaPlayerMediaStopping` carries
+/// `libvlc_stopping_reason_t`, and it precedes the `stopped` transition.
+@Suite(.tags(.logic))
+struct AuthoritativeStopReasonTests {
+  @Test
+  func `An end-of-stream reason confirms a natural end`() {
+    let coordinator = PlaybackEndCoordinator()
+    coordinator.noteStoppingReason(libvlc_stopping_reason_eos)
+
+    #expect(coordinator.consumeStoppedShouldSynthesizeEnd())
+  }
+
+  /// The case the inference got wrong. Nothing here marked a library stop or
+  /// an error, so the old rule would have called this a natural end purely
+  /// because it recognised no cause.
+  @Test
+  func `An error reason is not a natural end even with no other cause recorded`() {
+    let coordinator = PlaybackEndCoordinator()
+    coordinator.noteStoppingReason(libvlc_stopping_reason_error)
+
+    #expect(
+      !coordinator.consumeStoppedShouldSynthesizeEnd(),
+      "a stop the engine attributed to an error was reported as a natural end"
+    )
+  }
+
+  @Test
+  func `A user-requested stop is not a natural end`() {
+    let coordinator = PlaybackEndCoordinator()
+    coordinator.noteStoppingReason(libvlc_stopping_reason_user)
+
+    #expect(!coordinator.consumeStoppedShouldSynthesizeEnd())
+  }
+
+  /// List-player suppression still wins: advancing a playlist ends one media
+  /// at eos without ending playback.
+  @Test
+  func `List-player suppression outranks an end-of-stream reason`() {
+    let coordinator = PlaybackEndCoordinator()
+    coordinator.setSuppressed(true)
+    coordinator.noteStoppingReason(libvlc_stopping_reason_eos)
+
+    #expect(!coordinator.consumeStoppedShouldSynthesizeEnd())
+  }
+
+  /// The reason describes one stop only. Leaking it into the next would let a
+  /// past end of stream confirm a later, unrelated stop.
+  @Test
+  func `A reason does not carry into the next stop`() {
+    let coordinator = PlaybackEndCoordinator()
+    coordinator.noteStoppingReason(libvlc_stopping_reason_eos)
+    #expect(coordinator.consumeStoppedShouldSynthesizeEnd())
+
+    // No reason supplied for this one, and no other cause recorded.
+    #expect(
+      coordinator.consumeStoppedShouldSynthesizeEnd(),
+      "the fallback inference should apply once the reason is consumed"
+    )
+  }
+
+  /// Without a reason the inference still applies, so an engine that does not
+  /// report one behaves as before rather than losing end-of-media entirely.
+  @Test
+  func `A library-issued stop without a reason is still not a natural end`() {
+    let coordinator = PlaybackEndCoordinator()
+    coordinator.markLibraryStop()
+
+    #expect(!coordinator.consumeStoppedShouldSynthesizeEnd())
+  }
+}


### PR DESCRIPTION
Addresses **criterion 4 of issue 85** — an unattributed stop is never reported as a confirmed natural end — and is the first consumer of patch 0015.

## The inference was backwards

`endReached` was synthesized when a `stopped` arrived that no library-issued stop, error, or attached `MediaListPlayer` accounted for. That concludes *natural end* from the **absence** of a recognised cause, so any cause SwiftVLC had not been told about — a server closing the connection, a demuxer giving up — read as a clean EOF.

## The engine knows

`MediaPlayerMediaStopping` carries `libvlc_stopping_reason_t` and precedes the `stopped` transition. The coordinator records it and lets it decide: only `eos` is a natural end.

## Why this could not be written until today

The field has existed in the patched source since #126 and in the shipped headers since #138 — but the **linked binary was v1.0.0**, which predates patch 0015 and writes only `media`. Reading `reason` against it would have read uninitialised union memory.

Publishing `v1.1.0-beta.1` and pointing CI at it (#154) is what made this safe. This is the payoff for that sequencing.

## Behaviour preserved

- List-player suppression still outranks the reason: advancing a playlist ends one media at `eos` without ending playback.
- The inference remains as a fallback when no reason is supplied, so an engine that does not report one behaves exactly as before.
- The reason is cleared by each `stopped`, so it can never describe a later one.

## Tests

Six cases, including the one the inference got wrong: an `error` reason with **no other cause recorded** must not be a natural end.

Negative control: removing the reason branch fails with `a stop the engine attributed to an error was reported as a natural end`.

`CI=true swift test --no-parallel`: **1813 tests pass**.