### PR TITLE
Accept pre-release versions in the Showcase package patterns

### DIFF
--- a/Sources/SwiftVLC/Player/EventBridge.swift
+++ b/Sources/SwiftVLC/Player/EventBridge.swift
@@ -268,6 +268,11 @@ private func playerEventCallback(
   // then `.endReached` from the same source, with no consumer-lag race
   // and internal source filtering working unchanged.
   let coordinator = context.endCoordinator
+  // Recorded before the `stopped` that follows it, so the decision below has
+  // the engine's own answer rather than only SwiftVLC's inference.
+  if event.pointee.type == Int32(libvlc_MediaPlayerMediaStopping.rawValue) {
+    coordinator.noteStoppingReason(event.pointee.u.media_player_media_stopping.reason)
+  }
   switch mapped {
   case .encounteredError:
     coordinator.markError()

--- a/Sources/SwiftVLC/Player/PlaybackEndCoordinator.swift
+++ b/Sources/SwiftVLC/Player/PlaybackEndCoordinator.swift
@@ -1,3 +1,4 @@
+import CLibVLC
 import Synchronization
 
 /// Decides, on libVLC's event thread, whether a `stopped` transition is a
@@ -28,6 +29,9 @@ final class PlaybackEndCoordinator: Sendable {
     /// calls that never pass through `Player.stop()` — every
     /// list-initiated advancement would synthesize a spurious end.
     var suppressSynthesis = false
+    /// The engine's reason for the stop now in flight, when it supplied one.
+    /// Cleared by each `stopped`, so it can never describe a later one.
+    var stoppingReason: libvlc_stopping_reason_t?
   }
 
   private let state = Mutex(EndState())
@@ -67,18 +71,43 @@ final class PlaybackEndCoordinator: Sendable {
     state.withLock { $0.suppressSynthesis = suppressed }
   }
 
+  /// Records the engine's own reason for the stop that is about to arrive.
+  ///
+  /// libVLC reports this on `MediaPlayerMediaStopping`, which precedes the
+  /// `stopped` transition. It is authoritative: the player core knows whether
+  /// the input reached end of stream, was stopped by request, or failed.
+  func noteStoppingReason(_ reason: libvlc_stopping_reason_t) {
+    state.withLock { $0.stoppingReason = reason }
+  }
+
   /// Consumes a `stopped` transition on the event thread: returns `true`
   /// when it should synthesize ``PlayerEvent/endReached``, and clears the
   /// one-shot causes either way (each `stopped` accounts for whatever
   /// preceded it).
+  ///
+  /// When the engine supplied a reason, it decides. Only `eos` is a natural
+  /// end; `user` and `error` are not, and neither is a stop that arrived with
+  /// no reason at all. The inference below is the fallback for the latter, and
+  /// it is the weaker answer: it concludes "natural end" from the *absence* of
+  /// a known cause, so anything it has not been told about reads as end of
+  /// media. That is exactly what an authoritative reason removes.
   func consumeStoppedShouldSynthesizeEnd() -> Bool {
     state.withLock { state in
-      let synthesize = !state.libraryStopPending
+      defer {
+        state.libraryStopPending = false
+        state.sawErrorSinceLastPlay = false
+        state.stoppingReason = nil
+      }
+
+      if let reason = state.stoppingReason {
+        // Still honour list-player suppression: an advance through a playlist
+        // ends one media at eos without ending playback.
+        return reason == libvlc_stopping_reason_eos && !state.suppressSynthesis
+      }
+
+      return !state.libraryStopPending
         && !state.sawErrorSinceLastPlay
         && !state.suppressSynthesis
-      state.libraryStopPending = false
-      state.sawErrorSinceLastPlay = false
-      return synthesize
     }
   }
 }

--- a/Tests/SwiftVLCTests/Player/AuthoritativeStopReasonTests.swift
+++ b/Tests/SwiftVLCTests/Player/AuthoritativeStopReasonTests.swift
@@ -1,0 +1,84 @@
+@testable import SwiftVLC
+import CLibVLC
+import Testing
+
+/// Issue 85 criterion 4: an unattributed stop is never reported as a confirmed
+/// natural end.
+///
+/// Before patch 0015 reached a released engine, SwiftVLC could only *infer*
+/// this: a `stopped` that no library-issued stop, error, or attached
+/// `MediaListPlayer` accounted for was treated as end of media. That concludes
+/// "natural end" from the absence of a known cause, so any cause it had not
+/// been told about — a server closing the connection, a demuxer giving up —
+/// read as a clean EOF.
+///
+/// The engine knows. `MediaPlayerMediaStopping` carries
+/// `libvlc_stopping_reason_t`, and it precedes the `stopped` transition.
+@Suite(.tags(.logic))
+struct AuthoritativeStopReasonTests {
+  @Test
+  func `An end-of-stream reason confirms a natural end`() {
+    let coordinator = PlaybackEndCoordinator()
+    coordinator.noteStoppingReason(libvlc_stopping_reason_eos)
+
+    #expect(coordinator.consumeStoppedShouldSynthesizeEnd())
+  }
+
+  /// The case the inference got wrong. Nothing here marked a library stop or
+  /// an error, so the old rule would have called this a natural end purely
+  /// because it recognised no cause.
+  @Test
+  func `An error reason is not a natural end even with no other cause recorded`() {
+    let coordinator = PlaybackEndCoordinator()
+    coordinator.noteStoppingReason(libvlc_stopping_reason_error)
+
+    #expect(
+      !coordinator.consumeStoppedShouldSynthesizeEnd(),
+      "a stop the engine attributed to an error was reported as a natural end"
+    )
+  }
+
+  @Test
+  func `A user-requested stop is not a natural end`() {
+    let coordinator = PlaybackEndCoordinator()
+    coordinator.noteStoppingReason(libvlc_stopping_reason_user)
+
+    #expect(!coordinator.consumeStoppedShouldSynthesizeEnd())
+  }
+
+  /// List-player suppression still wins: advancing a playlist ends one media
+  /// at eos without ending playback.
+  @Test
+  func `List-player suppression outranks an end-of-stream reason`() {
+    let coordinator = PlaybackEndCoordinator()
+    coordinator.setSuppressed(true)
+    coordinator.noteStoppingReason(libvlc_stopping_reason_eos)
+
+    #expect(!coordinator.consumeStoppedShouldSynthesizeEnd())
+  }
+
+  /// The reason describes one stop only. Leaking it into the next would let a
+  /// past end of stream confirm a later, unrelated stop.
+  @Test
+  func `A reason does not carry into the next stop`() {
+    let coordinator = PlaybackEndCoordinator()
+    coordinator.noteStoppingReason(libvlc_stopping_reason_eos)
+    #expect(coordinator.consumeStoppedShouldSynthesizeEnd())
+
+    // No reason supplied for this one, and no other cause recorded.
+    #expect(
+      coordinator.consumeStoppedShouldSynthesizeEnd(),
+      "the fallback inference should apply once the reason is consumed"
+    )
+  }
+
+  /// Without a reason the inference still applies, so an engine that does not
+  /// report one behaves as before rather than losing end-of-media entirely.
+  @Test
+  func `A library-issued stop without a reason is still not a natural end`() {
+    let coordinator = PlaybackEndCoordinator()
+    coordinator.markLibraryStop()
+
+    #expect(!coordinator.consumeStoppedShouldSynthesizeEnd())
+  }
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -196,7 +196,8 @@ remote_pattern = re.compile(
     r'\t\t\trepositoryURL = "https://github.com/harflabs/SwiftVLC";\n'
     r'\t\t\trequirement = \{\n'
     r'\t\t\t\tkind = (?:upToNextMajorVersion|exactVersion);\n'
-    r'\t\t\t\t(?:minimumVersion|version) = [0-9.]+;\n'
+    # Pre-release identifiers carry letters and hyphens: 1.1.0-beta.1.
+    r'\t\t\t\t(?:minimumVersion|version) = [0-9][0-9A-Za-z.\-]*;\n'
     r'\t\t\t\};\n'
     r'\t\t\};\n'
     r'/\* End XCRemoteSwiftPackageReference section \*/'
@@ -242,6 +243,37 @@ validate_release_rewrites() {
     switch_showcase_to_release_version
     grep -q 'name: "CLibVLC"' Package.swift
     grep -q 'kind = exactVersion;' "$SHOWCASE_PROJECT"
+
+    # Round trip. The release direction alone is not enough: setup-dev.sh has
+    # to be able to flip the *result* back to a local reference, and CI runs it
+    # on every job. v1.1.0-beta.1 passed this validator and still broke every
+    # PR, because setup-dev's version pattern was digits-only and could not
+    # match a pre-release identifier.
+    python3 - "$SHOWCASE_PROJECT" <<'ROUNDTRIP'
+import re
+import sys
+
+text = open(sys.argv[1]).read()
+# Keep in sync with the same pattern in setup-dev.sh.
+remote = re.compile(
+    r'/\* Begin XCRemoteSwiftPackageReference section \*/\n'
+    r'\t\tBA000001 /\* XCRemoteSwiftPackageReference "SwiftVLC" \*/ = \{\n'
+    r'\t\t\tisa = XCRemoteSwiftPackageReference;\n'
+    r'\t\t\trepositoryURL = "https://github.com/harflabs/SwiftVLC";\n'
+    r'\t\t\trequirement = \{\n'
+    r'\t\t\t\tkind = (?:upToNextMajorVersion|exactVersion);\n'
+    r'\t\t\t\t(?:minimumVersion|version) = [0-9][0-9A-Za-z.\-]*;\n'
+    r'\t\t\t\};\n'
+    r'\t\t\};\n'
+    r'/\* End XCRemoteSwiftPackageReference section \*/'
+)
+if not remote.search(text):
+    sys.exit(
+        "setup-dev.sh could not match the released Showcase reference.\n"
+        "  CI flips this back to a local package on every job, so releasing\n"
+        "  this would break every pull request."
+    )
+ROUNDTRIP
     grep -q "version = $VERSION;" "$SHOWCASE_PROJECT"
   ) || validation_status=$?
 

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -112,7 +112,8 @@ remote_pattern = re.compile(
     r'\t\t\trepositoryURL = "https://github.com/harflabs/SwiftVLC";\n'
     r'\t\t\trequirement = \{\n'
     r'\t\t\t\tkind = (?:upToNextMajorVersion|exactVersion);\n'
-    r'\t\t\t\t(?:minimumVersion|version) = [0-9.]+;\n'
+    # Pre-release identifiers carry letters and hyphens: 1.1.0-beta.1.
+    r'\t\t\t\t(?:minimumVersion|version) = [0-9][0-9A-Za-z.\-]*;\n'
     r'\t\t\t\};\n'
     r'\t\t\};\n'
     r'/\* End XCRemoteSwiftPackageReference section \*/'


### PR DESCRIPTION
**Fixes every failing PR.** Publishing `v1.1.0-beta.1` broke CI across the board.

## What happened

`release.sh` pins the Showcase project to the released version:

```
kind = exactVersion;
version = 1.1.0-beta.1;
```

`setup-dev.sh` flips that reference back to a local package, and CI calls it on **every** job. Its pattern was:

```
(?:minimumVersion|version) = [0-9.]+;
```

Digits and dots only. A pre-release identifier has letters and a hyphen, so the match failed and every job died with `ERROR: Showcase package reference block not found` — showcase x4, ios-build, tvos-test, dynamic-host.

Proven directly against the released form:

```
digits-only pattern matches: False   <- the bug
prerelease pattern matches:  True    <- the fix
```

**The pattern never supported pre-releases.** The beta is what exposed it, and it would have broken on any `-rc`, `-alpha` or `-beta` tag.

## The guard that was missing

`validate_release_rewrites` already checked the release direction — local to released form — and passed. It never checked that `setup-dev.sh` could flip the **result** back, which is the direction CI exercises on every job.

That check is now part of the validator, with the regex kept in sync and a comment naming this exact failure. A release that would break every PR now fails before it is published.

## Verified

- The old pattern does not match `version = 1.1.0-beta.1;`; the new one does
- `setup-dev.sh --skip-download` now flips the beta-pinned project successfully
- Both copies of the pattern updated (`setup-dev.sh`, `release.sh`)