### PR TITLE
Clear the stop reason on handle replacement (issue 85)

### DIFF
--- a/Sources/SwiftVLC/Player/PlaybackEndCoordinator.swift
+++ b/Sources/SwiftVLC/Player/PlaybackEndCoordinator.swift
@@ -62,6 +62,11 @@ final class PlaybackEndCoordinator: Sendable {
     state.withLock {
       $0.libraryStopPending = false
       $0.sawErrorSinceLastPlay = false
+      // A reason recorded on the outgoing handle describes a stop that will
+      // never arrive here. Left behind, it would classify the *successor's*
+      // first stop — `MediaPlayerMediaStopping` can precede a replacement that
+      // lands before the matching `stopped` is observed.
+      $0.stoppingReason = nil
     }
   }
 
@@ -85,12 +90,15 @@ final class PlaybackEndCoordinator: Sendable {
   /// one-shot causes either way (each `stopped` accounts for whatever
   /// preceded it).
   ///
-  /// When the engine supplied a reason, it decides. Only `eos` is a natural
-  /// end; `user` and `error` are not, and neither is a stop that arrived with
-  /// no reason at all. The inference below is the fallback for the latter, and
-  /// it is the weaker answer: it concludes "natural end" from the *absence* of
-  /// a known cause, so anything it has not been told about reads as end of
-  /// media. That is exactly what an authoritative reason removes.
+  /// When the engine supplied a reason, it decides: only `eos` is a natural
+  /// end, and `user` and `error` are not.
+  ///
+  /// When it supplied none, the inference below applies unchanged — an engine
+  /// that does not report a reason must keep working, not lose end-of-media
+  /// entirely. That fallback is the weaker answer, and knowing why matters: it
+  /// concludes "natural end" from the *absence* of a known cause, so anything
+  /// it has not been told about reads as end of media. Supplying a reason is
+  /// what removes the guesswork, not the fallback itself.
   func consumeStoppedShouldSynthesizeEnd() -> Bool {
     state.withLock { state in
       defer {

--- a/Tests/SwiftVLCTests/Player/AuthoritativeStopReasonTests.swift
+++ b/Tests/SwiftVLCTests/Player/AuthoritativeStopReasonTests.swift
@@ -81,4 +81,24 @@ struct AuthoritativeStopReasonTests {
 
     #expect(!coordinator.consumeStoppedShouldSynthesizeEnd())
   }
+
+  /// A reason belongs to the handle that produced it.
+  ///
+  /// `MediaPlayerMediaStopping` can precede a handle replacement that lands
+  /// before the matching `stopped` is observed. Carrying the reason across
+  /// would let the outgoing session's end of stream confirm the successor's
+  /// first stop as a natural end.
+  @Test
+  func `A reason does not survive a handle replacement`() {
+    let coordinator = PlaybackEndCoordinator()
+    coordinator.noteStoppingReason(libvlc_stopping_reason_eos)
+
+    coordinator.clearForHandleReplacement()
+    coordinator.markLibraryStop()
+
+    #expect(
+      !coordinator.consumeStoppedShouldSynthesizeEnd(),
+      "an end-of-stream reason from a replaced handle confirmed the successor's stop as a natural end"
+    )
+  }
 }


### PR DESCRIPTION
Two defects found in review of #156, which carried the stop-reason work by mistake.

## The leak

`clearForHandleReplacement()` cleared the other one-shot causes but not `stoppingReason`.

`MediaPlayerMediaStopping` can precede a handle replacement that lands **before** the matching `stopped` is observed. The reason then survives into the successor, so an end of stream belonging to a session that is gone confirms a natural end for one that just began — exactly the misclassification the authoritative reason was added to prevent.

Negative control: removing the clear fails with `an end-of-stream reason from a replaced handle confirmed the successor's stop as a natural end`.

## The contradictory doc

The comment claimed a stop with no reason is not a natural end, while the implementation deliberately falls back to inference so an engine that reports no reason keeps working. The code was right; the comment described behaviour it did not have.

## On the scope mistake

I branched the version-pattern fix from the stop-reason branch instead of `main`, so #156 carried both and merging it landed the player change under a PR titled and described as a tooling fix. Copilot flagged the mismatch. #155 is closed as superseded and this cleans up after it.

That is the second time this session a branch has been cut from the wrong base — the first swept `release.sh` changes into #137. Worth checking `git log main..HEAD` before opening a PR rather than trusting the working tree.

## Validation

`CI=true swift test --no-parallel`: **1814 tests pass**. swiftformat and swiftlint clean.