### PR TITLE
Make v1.1.0 artifact validation trustworthy

### DIFF
--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -50,7 +50,7 @@ jobs:
         timeout-minutes: 5
         with:
           path: Vendor
-          key: libvlc-xcf-vendor-${{ hashFiles('Package.swift') }}
+          key: libvlc-xcf-vendor-v2-${{ hashFiles('Package.swift') }}
           enableCrossOsArchive: false
 
       # Download the libvlc xcframework + flip Package.swift to the local

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -64,7 +64,7 @@ jobs:
         timeout-minutes: 1
         run: xcrun --toolchain "$TOOLCHAINS" swift --version
 
-      - name: Point Package.swift at last released xcframework
+      - name: Select declared libvlc release
         id: xcf
         timeout-minutes: 1
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
   # warnings are treated as errors.
   lint:
     runs-on: macos-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
         timeout-minutes: 2
@@ -55,8 +55,14 @@ jobs:
         timeout-minutes: 1
         run: ./scripts/verify-patch-manifest.sh >/dev/null
 
-      # Reports engine patches that are in the tree but not in the binary the
-      # test jobs link, which is the latest release's xcframework. Warns rather
+      - name: Release integrity
+        timeout-minutes: 2
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/tests/release-integrity.sh
+
+      # Reports engine patches that are in the tree but not in the exact binary
+      # release declared by the checkout. Warns rather
       # than fails: patches legitimately land before the release carrying them,
       # so failing would wedge every PR. See the script header for the
       # regression that made this worth surfacing.
@@ -116,7 +122,7 @@ jobs:
         timeout-minutes: 5
         with:
           path: Vendor
-          key: libvlc-xcf-vendor-${{ hashFiles('Package.swift') }}
+          key: libvlc-xcf-vendor-v2-${{ hashFiles('Package.swift') }}
           enableCrossOsArchive: false
 
       # Download the libvlc xcframework + flip the Showcase project to
@@ -169,7 +175,7 @@ jobs:
         timeout-minutes: 5
         with:
           path: Vendor
-          key: libvlc-xcf-vendor-${{ hashFiles('Package.swift') }}
+          key: libvlc-xcf-vendor-v2-${{ hashFiles('Package.swift') }}
           enableCrossOsArchive: false
 
       - name: Set up Vendor + local Swift package
@@ -219,7 +225,7 @@ jobs:
         timeout-minutes: 5
         with:
           path: Vendor
-          key: libvlc-xcf-vendor-${{ hashFiles('Package.swift') }}
+          key: libvlc-xcf-vendor-v2-${{ hashFiles('Package.swift') }}
           enableCrossOsArchive: false
 
       - name: Set up Vendor + local Swift package
@@ -308,12 +314,12 @@ jobs:
         timeout-minutes: 1
         run: xcrun --toolchain "$TOOLCHAINS" swift --version
 
-      # CI should always test against the last published xcframework (what
-      # SPM consumers get), regardless of whether the checkout currently
-      # points at Vendor/ for local dev or already carries a release URL.
+      # CI tests the exact published xcframework declared by this checkout (or
+      # SWIFTVLC_RELEASE_TAG), regardless of whether a developer had previously
+      # flipped Package.swift to Vendor/ locally.
       # Only the libvlc binaryTarget is rewritten; other Package.swift
       # edits are preserved.
-      - name: Point Package.swift at last released xcframework
+      - name: Select declared libvlc release
         id: xcf
         timeout-minutes: 1
         env:

--- a/.github/workflows/vendor-manifest.yml
+++ b/.github/workflows/vendor-manifest.yml
@@ -46,11 +46,11 @@ jobs:
         timeout-minutes: 5
         with:
           path: Vendor
-          key: libvlc-xcf-vendor-${{ hashFiles('Package.swift') }}
+          key: libvlc-xcf-vendor-v2-${{ hashFiles('Package.swift') }}
           enableCrossOsArchive: false
 
-      # Download the latest released libvlc xcframework into Vendor/
-      # (setup-dev.sh resolves it via gh release).
+      # Download the exact released libvlc xcframework declared by Package.swift
+      # into Vendor/. setup-dev.sh verifies the tag and GitHub asset digest.
       - name: Set up Vendor + local Swift package
         timeout-minutes: 5
         env:

--- a/README.md
+++ b/README.md
@@ -196,11 +196,14 @@ cd SwiftVLC
 swift test
 ```
 
-`main` tracks the latest released `url + checksum` form of the libVLC binary target. `setup-dev.sh` downloads `libvlc.xcframework.zip` into `Vendor/` and idempotently flips `Package.swift` plus the Showcase package reference to repo-local sources so package development and Showcase builds use the checkout on disk.
+`main` records an exact libVLC release URL and checksum. `setup-dev.sh` verifies
+that tag against the GitHub asset digest, downloads that exact artifact into
+`Vendor/`, and flips `Package.swift` plus the Showcase package reference to
+repo-local sources. It never follows GitHub's mutable “latest” pointer.
 
 | `setup-dev.sh` flag | Effect |
 |---|---|
-| *(none)* | Download the latest release if `Vendor/` is empty; otherwise keep existing. |
+| *(none)* | Install the exact release declared by `Package.swift`; replace an unverified or stale `Vendor/` copy. |
 | `vX.Y.Z` *(positional)* | Pin to a specific release tag. |
 | `--force` | Re-download even if `Vendor/` already exists. |
 | `--skip-download` | Only flip local references (`Package.swift` and the Showcase app). Expects `Vendor/` to already exist, which is useful after running `build-libvlc.sh`. |
@@ -254,26 +257,36 @@ The script also applies these checked-in VLC source patches in order:
 
 ## Releasing
 
-Releases advance `main`: `release.sh` rewrites `Package.swift` to the new remote xcframework URL + checksum, pins the Showcase app to that exact SwiftVLC version, tags that commit, uploads the zip as a GitHub Release asset, and then pushes `main` to that same commit. `setup-dev.sh` is what flips a working checkout back to local sources for day-to-day development.
+Releases advance `main`, but stable releases can only consume an immutable,
+previously prepared and device-qualified candidate. `setup-dev.sh` flips a
+working checkout back to local sources for day-to-day development.
 
 ```bash
 ./scripts/build-libvlc.sh --all          # produces Vendor/libvlc.xcframework
 ./scripts/release.sh X.Y.Z --dry-run     # strip + zip + checksum, no push
-./scripts/release.sh X.Y.Z               # cut the release
+./scripts/release.sh X.Y.Z --prepare /absolute/path/to/candidate
+./scripts/check-qualification.sh X.Y.Z /absolute/path/to/candidate/libvlc.xcframework
+./scripts/release.sh X.Y.Z --candidate /absolute/path/to/candidate
 ```
 
 What `release.sh` does:
 
 1. Verifies all eight platform slices are present in the xcframework.
-2. Copies it to a temp dir, strips debug symbols, zips with `ditto`.
-3. Computes SHA-256 via `swift package compute-checksum`.
-4. Rewrites `Package.swift` to the remote URL and checksum, and pins the Showcase app to `SwiftVLC` exact version `X.Y.Z`.
-5. Commits that change and tags it as `vX.Y.Z`.
-6. Pushes the tag first so GitHub can attach the release asset to that exact commit.
-7. Uploads the zip to a new GitHub Release.
-8. Pushes `main` to the same commit, so `main` always references the latest published xcframework and Showcase package version.
+2. In `--prepare` mode, strips and zips once, then records complete-tree, zip,
+   and provenance digests in an immutable candidate directory.
+3. Requires physical-device qualification to name that complete post-strip
+   tree; a stable run refuses to rebuild or mutate it.
+4. Verifies the prepared zip expands to the qualified XCFramework and that all
+   candidate/provenance checksums still match.
+5. Rewrites `Package.swift` to the remote URL and checksum, pins the Showcase
+   app to exact version `X.Y.Z`, commits, and tags the result.
+6. Uploads the zip, provenance, and candidate manifest to a draft release.
+7. Advances `origin/main`; only after that succeeds does it publish the draft.
 
-Preflight refuses non-`main` branches, uncommitted changes in `Package.swift` or the Showcase project, pre-existing local or remote tags, and unauthenticated `gh`. If a pre-commit rewrite fails, the script restores `Package.swift` and the Showcase project before exiting. If the tag push succeeds but a later step fails, `origin/main` is still untouched; finish the GitHub Release (or delete the tag) before retrying.
+Candidate preparation and publishing refuse non-`main` branches, any dirty
+working tree, a local `main` that differs from `origin/main`, pre-existing tags,
+and unauthenticated `gh`. If publication fails after asset upload, the release
+remains a non-public draft until it is fixed or removed.
 
 After publication, verify that Swift Package Index has finished building the
 tagged API reference and that the unversioned documentation link above resolves

--- a/scripts/artifact-tree-digest.py
+++ b/scripts/artifact-tree-digest.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Compute a path-independent digest over an entire artifact directory."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import stat
+from pathlib import Path
+
+
+def update_field(digest: "hashlib._Hash", value: bytes) -> None:
+    digest.update(len(value).to_bytes(8, "big"))
+    digest.update(value)
+
+
+def tree_digest(root: Path) -> str:
+    if not root.is_dir():
+        raise SystemExit(f"Error: artifact directory not found: {root}")
+
+    digest = hashlib.sha256(b"SwiftVLC artifact tree digest v1\0")
+    entries = sorted(root.rglob("*"), key=lambda path: path.relative_to(root).as_posix())
+    if not entries:
+        raise SystemExit(f"Error: artifact directory is empty: {root}")
+
+    for path in entries:
+        relative = path.relative_to(root).as_posix().encode()
+        metadata = path.lstat()
+        mode = stat.S_IMODE(metadata.st_mode).to_bytes(4, "big")
+
+        if stat.S_ISDIR(metadata.st_mode):
+            kind = b"directory"
+            payload = b""
+        elif stat.S_ISREG(metadata.st_mode):
+            kind = b"file"
+            content = hashlib.sha256()
+            with path.open("rb") as source:
+                while chunk := source.read(1024 * 1024):
+                    content.update(chunk)
+            payload = content.digest()
+        elif stat.S_ISLNK(metadata.st_mode):
+            kind = b"symlink"
+            payload = os.readlink(path).encode()
+        else:
+            raise SystemExit(f"Error: unsupported artifact entry type: {path}")
+
+        update_field(digest, kind)
+        update_field(digest, relative)
+        update_field(digest, mode)
+        update_field(digest, payload)
+
+    return digest.hexdigest()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("artifact", type=Path)
+    arguments = parser.parse_args()
+    print(tree_digest(arguments.artifact))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-engine-coverage.sh
+++ b/scripts/check-engine-coverage.sh
@@ -3,9 +3,8 @@
 # check-engine-coverage.sh — report which engine patches CI is not testing.
 #
 # CI does not build libVLC. `ci-use-released-xcframework.sh` rewrites
-# Package.swift to the latest release's url + checksum, so every test job links
-# the engine that was built when that release was cut. That is deliberate: it
-# is what downstream SPM consumers resolve.
+# Package.swift to the exact release declared by the checkout (or by
+# SWIFTVLC_RELEASE_TAG), so every test job links a known engine candidate.
 #
 # The consequence is easy to miss. A patch added to scripts/patches/ after that
 # release is present in the source tree and absent from the binary under test,
@@ -41,14 +40,13 @@ annotate() {
   fi
 }
 
-tag=$(gh release view --json tagName -q .tagName 2>/dev/null || true)
-if [ -z "$tag" ]; then
-  echo "Could not resolve the latest release tag via gh; skipping coverage check." >&2
+artifact_info=$("$SCRIPT_DIR/resolve-release-artifact.sh" 2>/dev/null || true)
+if [ -z "$artifact_info" ]; then
+  echo "Could not resolve the checkout's engine release; skipping coverage check." >&2
   exit 0
 fi
-
-# Shallow CI checkouts do not fetch tags.
-git fetch origin "refs/tags/$tag:refs/tags/$tag" >/dev/null 2>&1 || true
+tag=$(printf '%s' "$artifact_info" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag"])')
 
 if ! git rev-parse -q --verify "$tag^{commit}" >/dev/null; then
   echo "Tag $tag is not available locally; skipping coverage check." >&2

--- a/scripts/check-qualification.sh
+++ b/scripts/check-qualification.sh
@@ -13,9 +13,9 @@
 # that the results exist, that every required row was executed and passed, and
 # that they describe *this* artifact rather than an earlier one.
 #
-# The artifact is identified by a digest over its static libraries, computed
-# here rather than trusted from the record. A record can claim any digest; only
-# a recomputed one can contradict it.
+# The artifact is identified by a digest over the complete XCFramework tree,
+# including libraries, headers, metadata, paths, and modes. Header/ABI drift is
+# release-significant even when the static archive bytes are unchanged.
 #
 # Usage:
 #   ./scripts/check-qualification.sh <version> [xcframework-path]
@@ -28,8 +28,8 @@ cd "$ROOT_DIR"
 
 VERSION="${1:-}"
 XCFW="${2:-Vendor/libvlc.xcframework}"
-MATRIX="$SCRIPT_DIR/qualification/matrix.json"
-RECORD="$SCRIPT_DIR/qualification/${VERSION}.json"
+MATRIX="${SWIFTVLC_QUALIFICATION_MATRIX:-$SCRIPT_DIR/qualification/matrix.json}"
+RECORD="${SWIFTVLC_QUALIFICATION_RECORD:-$SCRIPT_DIR/qualification/${VERSION}.json}"
 
 if [[ -z "$VERSION" ]]; then
   echo "Usage: $0 <version> [xcframework-path]" >&2
@@ -46,15 +46,8 @@ if [[ ! -f "$MATRIX" ]]; then
   exit 1
 fi
 
-# Digest over every slice's static library, in a stable order. Headers and
-# Info.plist are excluded: they carry no executable behaviour, and a header-only
-# change cannot invalidate a device run.
 artifact_digest() {
-  find "$XCFW" -name '*.a' -type f -print0 \
-    | sort -z \
-    | xargs -0 shasum -a 256 \
-    | shasum -a 256 \
-    | cut -d' ' -f1
+  python3 "$SCRIPT_DIR/artifact-tree-digest.py" "$XCFW"
 }
 
 # An xcframework with no static libraries would still produce a stable digest —
@@ -83,6 +76,7 @@ fi
 python3 - "$MATRIX" "$RECORD" "$DIGEST" "$VERSION" <<'PY'
 import json
 import sys
+from pathlib import Path
 
 matrix_path, record_path, digest, version = sys.argv[1:5]
 
@@ -107,6 +101,12 @@ if recorded != digest:
 if record.get("version") != version:
     problems.append(
         f"the record is for version {record.get('version')!r}, not {version!r}"
+    )
+
+if record.get("artifactDigestAlgorithm") != "swiftvlc-tree-v1":
+    problems.append(
+        "the record does not declare artifactDigestAlgorithm "
+        "'swiftvlc-tree-v1'"
     )
 
 required = {
@@ -156,13 +156,59 @@ if failed:
 
 # Fields the criteria call for on every row. A row missing them is not a record
 # of anything reproducible.
+hardware_by_id = {hardware["id"]: hardware for hardware in matrix["hardware"]}
 for key in sorted(executed):
     if key not in required:
         continue
     row = executed[key]
-    for field in ("device", "os", "fixture", "duration", "result"):
+    for field in (
+        "device",
+        "deviceFamily",
+        "productType",
+        "osVersion",
+        "osBuild",
+        "osReleaseType",
+        "fixture",
+        "duration",
+        "evidence",
+        "result",
+    ):
         if not row.get(field):
             problems.append(f"row {key[0]} on {key[1]} is missing {field!r}")
+
+    hardware = hardware_by_id[key[1]]
+    if row.get("deviceFamily") != hardware["deviceFamily"]:
+        problems.append(
+            f"row {key[0]} on {key[1]} records deviceFamily "
+            f"{row.get('deviceFamily')!r}, expected {hardware['deviceFamily']!r}"
+        )
+    try:
+        os_major = int(str(row.get("osVersion", "")).split(".", 1)[0])
+    except ValueError:
+        os_major = None
+    if os_major != hardware["osMajor"]:
+        problems.append(
+            f"row {key[0]} on {key[1]} records OS {row.get('osVersion')!r}, "
+            f"expected major version {hardware['osMajor']}"
+        )
+    if row.get("osReleaseType") != "stable":
+        problems.append(
+            f"row {key[0]} on {key[1]} uses {row.get('osReleaseType')!r} OS "
+            "software; release qualification requires a stable OS build"
+        )
+    evidence = row.get("evidence")
+    if evidence:
+        evidence_path = Path(evidence)
+        if evidence_path.is_absolute() or ".." in evidence_path.parts:
+            problems.append(
+                f"row {key[0]} on {key[1]} evidence must be a safe path "
+                "relative to the qualification record"
+            )
+        elif not (Path(record_path).parent / evidence_path).is_file():
+            problems.append(
+                f"row {key[0]} on {key[1]} evidence file does not exist: "
+                f"{evidence}"
+            )
 
 if problems:
     print(f"Error: {version} is not qualified for release.", file=sys.stderr)

--- a/scripts/ci-use-released-xcframework.sh
+++ b/scripts/ci-use-released-xcframework.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
 # ci-use-released-xcframework.sh — Rewrite Package.swift's libvlc
-# binaryTarget to the url+checksum form from the latest release, so CI can
-# resolve the xcframework via SPM just like a downstream consumer pinning
-# that tag would.
+# binaryTarget to the url+checksum form from the exact release declared by the
+# checkout (or SWIFTVLC_RELEASE_TAG), so CI cannot silently test a different
+# engine because GitHub's "latest" pointer excludes pre-releases.
 #
 # Only the binaryTarget is rewritten; other Package.swift changes on the
 # branch (swiftSettings, new targets, platform bumps) are preserved.
@@ -19,26 +19,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT_DIR"
 
-tag=$(gh release view --json tagName -q .tagName)
-if [ -z "$tag" ]; then
-  echo "Error: could not resolve latest release tag via gh." >&2
-  exit 1
-fi
-
-# Make sure the tag blob is locally available (shallow CI checkouts don't
-# fetch tags by default).
-git fetch origin "refs/tags/$tag:refs/tags/$tag" >/dev/null 2>&1 || true
-
-tag_manifest=$(git show "$tag:Package.swift")
-
-url=$(printf '%s\n' "$tag_manifest" | grep -oE 'https://[^"]*libvlc\.xcframework\.zip' | head -1)
-checksum=$(printf '%s\n' "$tag_manifest" | grep -oE '[a-f0-9]{64}' | head -1)
-
-if [ -z "$url" ] || [ -z "$checksum" ]; then
-  echo "Error: could not extract url/checksum from $tag's Package.swift." >&2
-  echo "  Did release.sh successfully pin the manifest for $tag?" >&2
-  exit 1
-fi
+artifact_info=$("$SCRIPT_DIR/resolve-release-artifact.sh")
+tag=$(printf '%s' "$artifact_info" | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag"])')
+url=$(printf '%s' "$artifact_info" | python3 -c 'import json,sys; print(json.load(sys.stdin)["url"])')
+checksum=$(printf '%s' "$artifact_info" | python3 -c 'import json,sys; print(json.load(sys.stdin)["checksum"])')
 
 # Atomic rewrite of only the binaryTarget line.
 URL="$url" CHECKSUM="$checksum" python3 - <<'PYEOF'

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -18,15 +18,21 @@ Record the results as `scripts/qualification/<version>.json`:
 ```json
 {
   "version": "1.1.0",
+  "artifactDigestAlgorithm": "swiftvlc-tree-v1",
   "artifactDigest": "…",
   "rows": [
     {
       "scenario": "vod-controls",
       "hardware": "iphone-current",
       "device": "iPhone 15 Pro",
-      "os": "iOS 27.0",
+      "deviceFamily": "iPhone",
+      "productType": "iPhone16,1",
+      "osVersion": "26.6",
+      "osBuild": "23G80",
+      "osReleaseType": "stable",
       "fixture": "demo.mkv",
       "duration": "2m14s",
+      "evidence": "evidence/v1.1.0/iphone-current-vod-controls.json",
       "result": "pass",
       "notes": "optional; put log excerpts or anomalies here"
     }
@@ -34,16 +40,17 @@ Record the results as `scripts/qualification/<version>.json`:
 }
 ```
 
-`artifactDigest` is a SHA-256 over every slice's static library, in sorted
-order. Get it for the artifact you are about to qualify with:
+`artifactDigest` is a path-independent SHA-256 over the complete XCFramework
+tree: libraries, headers, `Info.plist`, relative paths, symlinks, and modes.
+Get it for the exact, already-stripped artifact you are about to qualify with:
 
 ```bash
-find Vendor/libvlc.xcframework -name '*.a' -type f -print0 \
-  | sort -z | xargs -0 shasum -a 256 | shasum -a 256 | cut -d' ' -f1
+./scripts/artifact-tree-digest.py Vendor/libvlc.xcframework
 ```
 
-Headers and `Info.plist` are excluded deliberately: they carry no executable
-behaviour, so a header-only change cannot invalidate a device run.
+Do not strip, rewrite headers, or otherwise mutate the XCFramework after this
+digest is recorded. A header-only ABI mismatch can be just as unsafe as a
+library change.
 
 ## Checking before release
 
@@ -53,7 +60,10 @@ behaviour, so a header-only change cannot invalidate a device run.
 
 It fails when the record is absent, describes a different artifact, is for
 another version, omits a required row, contains a row that did not pass, or has
-a row missing any of `device`, `os`, `fixture`, `duration` or `result`.
+a row missing device identity, stable OS build, fixture, duration, evidence, or
+result. Evidence paths are relative to the record and must exist. It also
+rejects an iPhone recorded for an iPad row, the wrong OS major, and beta OS
+software.
 
 The digest is recomputed from the artifact on disk rather than trusted from the
 record — a record can claim any digest, and only a recomputed one can contradict

--- a/scripts/qualification/matrix.json
+++ b/scripts/qualification/matrix.json
@@ -12,9 +12,9 @@
     { "id": "long-stall",          "summary": "Sustained network stall and recovery while in PiP" }
   ],
   "hardware": [
-    { "id": "iphone-minimum", "summary": "iPhone on the minimum supported OS" },
-    { "id": "iphone-current", "summary": "iPhone on the current supported OS" },
-    { "id": "ipad-minimum",   "summary": "iPad on the minimum supported OS" },
-    { "id": "ipad-current",   "summary": "iPad on the current supported OS" }
+    { "id": "iphone-minimum", "deviceFamily": "iPhone", "osMajor": 18, "summary": "iPhone on the minimum supported OS" },
+    { "id": "iphone-current", "deviceFamily": "iPhone", "osMajor": 26, "summary": "iPhone on the current stable OS" },
+    { "id": "ipad-minimum",   "deviceFamily": "iPad",   "osMajor": 18, "summary": "iPad on the minimum supported OS" },
+    { "id": "ipad-current",   "deviceFamily": "iPad",   "osMajor": 26, "summary": "iPad on the current stable OS" }
   ]
 }

--- a/scripts/release-artifact-info.py
+++ b/scripts/release-artifact-info.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Read and validate SwiftVLC's libvlc binary-target release identity."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Dict, NoReturn, Optional
+
+
+TARGET_PATTERN = re.compile(
+    r'\.binaryTarget\(\s*name:\s*"libvlc"(?P<body>.*?)\n\s*\)',
+    re.DOTALL,
+)
+URL_PATTERN = re.compile(r'\burl:\s*"(?P<url>[^"]+)"')
+CHECKSUM_PATTERN = re.compile(r'\bchecksum:\s*"(?P<checksum>[a-f0-9]{64})"')
+TAG_PATTERN = re.compile(
+    r"^https://github\.com/harflabs/SwiftVLC/releases/download/"
+    r"(?P<tag>v[^/]+)/libvlc\.xcframework\.zip$"
+)
+
+
+def fail(message: str) -> NoReturn:
+    raise SystemExit(f"Error: {message}")
+
+
+def parse_manifest(text: str, expected_tag: Optional[str]) -> Dict[str, str]:
+    matches = list(TARGET_PATTERN.finditer(text))
+    if len(matches) != 1:
+        fail(f"expected exactly one libvlc binary target, found {len(matches)}")
+
+    body = matches[0].group("body")
+    url_match = URL_PATTERN.search(body)
+    checksum_match = CHECKSUM_PATTERN.search(body)
+    if url_match is None or checksum_match is None:
+        fail("libvlc binary target must use a release URL and a 64-character checksum")
+
+    url = url_match.group("url")
+    checksum = checksum_match.group("checksum")
+    tag_match = TAG_PATTERN.match(url)
+    if tag_match is None:
+        fail(f"libvlc URL is not a SwiftVLC GitHub release asset: {url}")
+
+    tag = tag_match.group("tag")
+    if expected_tag is not None and tag != expected_tag:
+        fail(f"manifest resolves {tag}, expected {expected_tag}")
+
+    return {"tag": tag, "url": url, "checksum": checksum}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("manifest", type=Path, help="Package.swift to inspect")
+    parser.add_argument("--expect-tag")
+    parser.add_argument("--field", choices=("tag", "url", "checksum"))
+    arguments = parser.parse_args()
+
+    try:
+        text = arguments.manifest.read_text()
+    except OSError as error:
+        fail(f"cannot read {arguments.manifest}: {error}")
+
+    result = parse_manifest(text, arguments.expect_tag)
+    if arguments.field is not None:
+        print(result[arguments.field])
+    else:
+        print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,10 +5,12 @@
 # Prerequisites:
 #   - ./scripts/build-libvlc.sh --all  (produces Vendor/libvlc.xcframework)
 #   - gh authed (gh auth login)
-#   - Clean Package.swift + Showcase project on main
+#   - A completely clean, up-to-date main checkout
 #
 # Usage:
 #   ./scripts/release.sh 0.1.0
+#   ./scripts/release.sh 0.1.0 --prepare /path/to/candidate
+#   ./scripts/release.sh 0.1.0 --candidate /path/to/candidate
 #   ./scripts/release.sh 0.1.0 --dry-run            # strip/zip/checksum only, no push
 #
 set -euo pipefail
@@ -37,11 +39,26 @@ EXPECTED_SLICES=(
 VERSION=""
 DRY_RUN=false
 UNQUALIFIED=false
+PREPARE_DIR=""
+CANDIDATE_DIR=""
 
-for arg in "$@"; do
-  case "$arg" in
-    --dry-run)            DRY_RUN=true ;;
-    --unqualified)        UNQUALIFIED=true ;;
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift ;;
+    --unqualified)
+      UNQUALIFIED=true
+      shift ;;
+    --prepare)
+      [[ $# -ge 2 ]] || { echo "Error: --prepare requires a directory." >&2; exit 2; }
+      PREPARE_DIR="$2"
+      DRY_RUN=true
+      shift 2 ;;
+    --candidate)
+      [[ $# -ge 2 ]] || { echo "Error: --candidate requires a directory." >&2; exit 2; }
+      CANDIDATE_DIR="$2"
+      shift 2 ;;
     --allow-dirty-branch)
       echo "Error: --allow-dirty-branch is no longer supported." >&2
       echo "  Releases advance origin/main and must be run from main." >&2
@@ -50,14 +67,15 @@ for arg in "$@"; do
       sed -n 's/^# \{0,1\}//p' "$0" | sed -n '/^Usage:/,/^$/p'
       exit 0 ;;
     -*)
-      echo "Error: unknown flag '$arg'" >&2
+      echo "Error: unknown flag '$1'" >&2
       exit 1 ;;
     *)
       if [[ -n "$VERSION" ]]; then
-        echo "Error: version already specified ('$VERSION'), got extra arg '$arg'" >&2
+        echo "Error: version already specified ('$VERSION'), got extra arg '$1'" >&2
         exit 1
       fi
-      VERSION="$arg" ;;
+      VERSION="$1"
+      shift ;;
   esac
 done
 
@@ -72,6 +90,24 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 RELEASE_URL="https://github.com/$REPO/releases/download/$TAG/$ZIP_NAME"
 cd "$ROOT_DIR"
+
+if [[ -n "$PREPARE_DIR" && -n "$CANDIDATE_DIR" ]]; then
+  echo "Error: --prepare and --candidate are mutually exclusive." >&2
+  exit 2
+fi
+if [[ "$DRY_RUN" == false && "$UNQUALIFIED" == false && -z "$CANDIDATE_DIR" ]]; then
+  echo "Error: a qualified release must consume a prepared candidate directory." >&2
+  echo "  First: $0 $VERSION --prepare /path/to/candidate" >&2
+  echo "  Then qualify that directory and release with --candidate." >&2
+  exit 1
+fi
+if [[ -n "$CANDIDATE_DIR" ]]; then
+  CANDIDATE_DIR="$(cd "$CANDIDATE_DIR" 2>/dev/null && pwd)" || {
+    echo "Error: candidate directory not found." >&2
+    exit 1
+  }
+  XCFW_PATH="$CANDIDATE_DIR/libvlc.xcframework"
+fi
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -328,15 +364,16 @@ if ! command -v gh &>/dev/null; then
   exit 1
 fi
 
-if [[ "$DRY_RUN" == false ]]; then
+if [[ "$DRY_RUN" == false || -n "$PREPARE_DIR" ]]; then
   if ! gh auth status &>/dev/null; then
     echo "Error: Not authenticated with gh. Run: gh auth login" >&2
     exit 1
   fi
 
-  if [[ -n "$(git status --porcelain -- Package.swift "$SHOWCASE_PROJECT")" ]]; then
-    echo "Error: Package.swift or $SHOWCASE_PROJECT has uncommitted changes." >&2
-    echo "  Commit or stash them first." >&2
+  if [[ -n "$(git status --porcelain)" ]]; then
+    echo "Error: the working tree is not clean." >&2
+    echo "  Every release input and script must come from a committed checkout." >&2
+    git status --short >&2
     exit 1
   fi
 
@@ -361,6 +398,17 @@ if [[ "$DRY_RUN" == false ]]; then
   if [[ "$CURRENT_BRANCH" != "main" ]]; then
     echo "Error: refusing to release from branch '$CURRENT_BRANCH'." >&2
     echo "  Release commits advance origin/main, so rerun from main." >&2
+    exit 1
+  fi
+
+  git fetch --quiet origin main --tags
+  LOCAL_HEAD=$(git rev-parse HEAD)
+  REMOTE_MAIN=$(git rev-parse origin/main)
+  if [[ "$LOCAL_HEAD" != "$REMOTE_MAIN" ]]; then
+    echo "Error: local main is not exactly origin/main." >&2
+    echo "  local:       $LOCAL_HEAD" >&2
+    echo "  origin/main: $REMOTE_MAIN" >&2
+    echo "  Fetch and fast-forward before preparing a release." >&2
     exit 1
   fi
 
@@ -459,52 +507,112 @@ if ! verify_artifact_provenance; then
   exit 1
 fi
 
-# Device qualification. CI cannot execute system PiP on hardware, so the matrix
-# in scripts/qualification is the acceptance gate. Refusing here is the point of
-# issue 88: nothing previously stopped an unqualified artifact being published.
-# Issue 88's criterion is "no release is *marked qualified* while a required
-# device row is unexecuted" — it forbids claiming qualification, not releasing.
-# `--unqualified` publishes as a GitHub pre-release and says so in the notes,
-# so the distinction is visible to anyone who finds the tag rather than only to
-# whoever ran this.
-if [[ "$UNQUALIFIED" == true ]]; then
-  echo "WARNING: releasing WITHOUT device qualification."
-  echo "  Publishing as a pre-release. It must not be described as qualified,"
-  echo "  and the device matrix in scripts/qualification still owes a run."
-else
-  if ! "$SCRIPT_DIR/check-qualification.sh" "$VERSION" "$XCFW_PATH"; then
-    echo "" >&2
-    echo "  To publish anyway as an explicitly unqualified pre-release:" >&2
-    echo "    $0 $VERSION --unqualified" >&2
+# ── Prepare or load immutable candidate ───────────────────────────────────────
+
+if [[ -n "$CANDIDATE_DIR" ]]; then
+  CANDIDATE_MANIFEST="$CANDIDATE_DIR/release-candidate.json"
+  ZIP_PATH="$CANDIDATE_DIR/$ZIP_NAME"
+  WORK_XCFW="$XCFW_PATH"
+
+  for candidate_file in "$CANDIDATE_MANIFEST" "$ZIP_PATH" \
+    "$CANDIDATE_DIR/libvlc-provenance.json"; do
+    if [[ ! -f "$candidate_file" ]]; then
+      echo "Error: prepared candidate is missing $candidate_file." >&2
+      exit 1
+    fi
+  done
+
+  echo "Verifying immutable release candidate..."
+  CANDIDATE_VALUES=$(python3 - "$CANDIDATE_MANIFEST" "$VERSION" <<'PY'
+import json
+import sys
+
+path, version = sys.argv[1:3]
+try:
+    candidate = json.load(open(path))
+except (OSError, ValueError) as error:
+    sys.exit(f"Error: cannot read candidate manifest: {error}")
+
+required = {
+    "version",
+    "artifactDigestAlgorithm",
+    "artifactDigest",
+    "zipChecksum",
+    "provenanceChecksum",
+}
+missing = sorted(required - candidate.keys())
+if missing:
+    sys.exit(f"Error: candidate manifest is missing: {', '.join(missing)}")
+if candidate["version"] != version:
+    sys.exit(
+        f"Error: candidate is for {candidate['version']!r}, not {version!r}"
+    )
+if candidate["artifactDigestAlgorithm"] != "swiftvlc-tree-v1":
+    sys.exit("Error: candidate uses an unsupported artifact digest algorithm")
+print(candidate["artifactDigest"])
+print(candidate["zipChecksum"])
+print(candidate["provenanceChecksum"])
+PY
+)
+  CANDIDATE_TREE_DIGEST=$(printf '%s\n' "$CANDIDATE_VALUES" | sed -n '1p')
+  EXPECTED_ZIP_CHECKSUM=$(printf '%s\n' "$CANDIDATE_VALUES" | sed -n '2p')
+  EXPECTED_PROVENANCE_CHECKSUM=$(printf '%s\n' "$CANDIDATE_VALUES" | sed -n '3p')
+
+  ACTUAL_TREE_DIGEST=$("$SCRIPT_DIR/artifact-tree-digest.py" "$WORK_XCFW")
+  CHECKSUM=$(swift package compute-checksum "$ZIP_PATH")
+  ACTUAL_PROVENANCE_CHECKSUM=$(shasum -a 256 \
+    "$CANDIDATE_DIR/libvlc-provenance.json" | cut -d' ' -f1)
+  if [[ "$ACTUAL_TREE_DIGEST" != "$CANDIDATE_TREE_DIGEST" ]]; then
+    echo "Error: prepared XCFramework changed after candidate creation." >&2
     exit 1
   fi
+  if [[ "$CHECKSUM" != "$EXPECTED_ZIP_CHECKSUM" ]]; then
+    echo "Error: prepared zip changed after candidate creation." >&2
+    exit 1
+  fi
+  if [[ "$ACTUAL_PROVENANCE_CHECKSUM" != "$EXPECTED_PROVENANCE_CHECKSUM" ]]; then
+    echo "Error: prepared provenance changed after candidate creation." >&2
+    exit 1
+  fi
+
+  # Prove the zip expands to the qualified tree; matching independent digests
+  # is stronger than trusting that the side-by-side directory was the source.
+  WORK_DIR=$(make_temp_dir)
+  ditto -x -k "$ZIP_PATH" "$WORK_DIR/unpacked"
+  PACKED_TREE_DIGEST=$("$SCRIPT_DIR/artifact-tree-digest.py" \
+    "$WORK_DIR/unpacked/libvlc.xcframework")
+  if [[ "$PACKED_TREE_DIGEST" != "$CANDIDATE_TREE_DIGEST" ]]; then
+    echo "Error: prepared zip does not contain the qualified XCFramework." >&2
+    exit 1
+  fi
+else
+  WORK_DIR=$(make_temp_dir)
+  WORK_XCFW="$WORK_DIR/libvlc.xcframework"
+
+  echo "Copying xcframework to temp dir..."
+  cp -R "$XCFW_PATH" "$WORK_XCFW"
+
+  echo "Stripping debug symbols from .a files..."
+  BEFORE_SIZE=$(du -sh "$WORK_XCFW" | cut -f1)
+  find "$WORK_XCFW" -name '*.a' -exec strip -S {} \;
+  AFTER_SIZE=$(du -sh "$WORK_XCFW" | cut -f1)
+  echo "  Before: $BEFORE_SIZE → After: $AFTER_SIZE"
+
+  echo "Verifying duplicate symbols in stripped libraries..."
+  "$SCRIPT_DIR/fix-duplicate-symbols.sh" --verify "$WORK_XCFW"
+
+  echo "Creating zip..."
+  ZIP_PATH="$WORK_DIR/$ZIP_NAME"
+  (cd "$WORK_DIR" && ditto -c -k --keepParent libvlc.xcframework "$ZIP_NAME")
+
+  echo "Computing checksum..."
+  CHECKSUM=$(swift package compute-checksum "$ZIP_PATH")
 fi
-
-# ── Strip ─────────────────────────────────────────────────────────────────────
-
-WORK_DIR=$(make_temp_dir)
-
-echo "Copying xcframework to temp dir..."
-cp -R "$XCFW_PATH" "$WORK_DIR/libvlc.xcframework"
-
-echo "Stripping debug symbols from .a files..."
-BEFORE_SIZE=$(du -sh "$WORK_DIR/libvlc.xcframework" | cut -f1)
-find "$WORK_DIR/libvlc.xcframework" -name '*.a' -exec strip -S {} \;
-AFTER_SIZE=$(du -sh "$WORK_DIR/libvlc.xcframework" | cut -f1)
-echo "  Before: $BEFORE_SIZE → After: $AFTER_SIZE"
-
-echo "Verifying duplicate symbols in stripped libraries..."
-"$SCRIPT_DIR/fix-duplicate-symbols.sh" --verify "$WORK_DIR/libvlc.xcframework"
-
-# ── Zip ───────────────────────────────────────────────────────────────────────
-
-echo "Creating zip..."
-ZIP_PATH="$WORK_DIR/$ZIP_NAME"
-(cd "$WORK_DIR" && ditto -c -k --keepParent libvlc.xcframework "$ZIP_NAME")
 
 ZIP_SIZE=$(stat -f%z "$ZIP_PATH")
 ZIP_SIZE_MB=$((ZIP_SIZE / 1024 / 1024))
 echo "  Zip size: ${ZIP_SIZE_MB} MB"
+echo "  SHA256: $CHECKSUM"
 
 if [[ "$ZIP_SIZE" -ge "$MAX_SIZE" ]]; then
   echo "Error: Zip is ${ZIP_SIZE_MB} MB — exceeds GitHub's 2 GB limit." >&2
@@ -512,11 +620,60 @@ if [[ "$ZIP_SIZE" -ge "$MAX_SIZE" ]]; then
   exit 1
 fi
 
-# ── Checksum ──────────────────────────────────────────────────────────────────
+if [[ -n "$PREPARE_DIR" ]]; then
+  if [[ -e "$PREPARE_DIR" ]]; then
+    echo "Error: prepare destination already exists: $PREPARE_DIR" >&2
+    exit 1
+  fi
+  mkdir -p "$(dirname "$PREPARE_DIR")"
+  mkdir "$PREPARE_DIR"
+  cp -R "$WORK_XCFW" "$PREPARE_DIR/libvlc.xcframework"
+  cp "$ZIP_PATH" "$PREPARE_DIR/$ZIP_NAME"
+  cp "$(dirname "$XCFW_PATH")/libvlc-provenance.json" \
+    "$PREPARE_DIR/libvlc-provenance.json"
 
-echo "Computing checksum..."
-CHECKSUM=$(swift package compute-checksum "$ZIP_PATH")
-echo "  SHA256: $CHECKSUM"
+  CANDIDATE_TREE_DIGEST=$("$SCRIPT_DIR/artifact-tree-digest.py" "$WORK_XCFW")
+  PROVENANCE_CHECKSUM=$(shasum -a 256 \
+    "$PREPARE_DIR/libvlc-provenance.json" | cut -d' ' -f1)
+  VERSION="$VERSION" \
+    CANDIDATE_TREE_DIGEST="$CANDIDATE_TREE_DIGEST" \
+    CHECKSUM="$CHECKSUM" \
+    PROVENANCE_CHECKSUM="$PROVENANCE_CHECKSUM" \
+    python3 - "$PREPARE_DIR/release-candidate.json" <<'PY'
+import json
+import os
+import sys
+
+candidate = {
+    "version": os.environ["VERSION"],
+    "artifactDigestAlgorithm": "swiftvlc-tree-v1",
+    "artifactDigest": os.environ["CANDIDATE_TREE_DIGEST"],
+    "zipChecksum": os.environ["CHECKSUM"],
+    "provenanceChecksum": os.environ["PROVENANCE_CHECKSUM"],
+}
+with open(sys.argv[1], "w") as output:
+    json.dump(candidate, output, indent=2, sort_keys=True)
+    output.write("\n")
+PY
+  echo "Prepared immutable candidate at $PREPARE_DIR"
+fi
+
+# Device qualification must describe the exact post-strip tree that the zip
+# contains. Preparation intentionally precedes qualification; stable publishing
+# later requires --candidate and refuses to rebuild or mutate those bytes.
+if [[ -n "$PREPARE_DIR" ]]; then
+  echo "Candidate prepared but not yet device-qualified."
+elif [[ "$UNQUALIFIED" == true ]]; then
+  echo "WARNING: releasing WITHOUT device qualification."
+  echo "  Publishing as a pre-release. It must not be described as qualified,"
+  echo "  and the device matrix in scripts/qualification still owes a run."
+else
+  if ! "$SCRIPT_DIR/check-qualification.sh" "$VERSION" "$WORK_XCFW"; then
+    echo "" >&2
+    echo "  Qualify the prepared candidate before publishing stable." >&2
+    exit 1
+  fi
+fi
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 
@@ -552,14 +709,13 @@ fi
 #
 # Mechanics:
 #   1. Rewrite Package.swift and the Showcase app, commit, and tag.
-#   2. Push the tag first so GitHub can attach the release asset to the exact
-#      commit without advancing origin/main yet.
-#   3. Create the GitHub Release and upload the zip.
-#   4. Fast-forward origin/main to the same commit, so main always points at
-#      the latest published binary and Showcase package version.
+#   2. Push the tag and create a draft GitHub Release containing the asset.
+#   3. Fast-forward origin/main to the same commit.
+#   4. Publish the already-uploaded draft. A failed main push therefore never
+#      leaves a public stable release detached from main.
 #
-# If the tag push succeeds but later steps fail, origin/main is still untouched.
-# Finish the GitHub Release (or delete the tag) and then retry the main push.
+# If the tag or draft upload succeeds but the main push fails, nothing public
+# has been published. Repair or remove the draft/tag before retrying.
 
 echo ""
 echo "Creating release commit on $CURRENT_BRANCH..."
@@ -597,16 +753,21 @@ git push origin "$TAG"
 
 # ── GitHub Release ────────────────────────────────────────────────────────────
 
-echo "Creating GitHub Release..."
-RELEASE_FLAGS=()
+echo "Creating draft GitHub Release..."
+RELEASE_FLAGS=(--draft)
+RELEASE_ASSETS=("$ZIP_PATH" "$(dirname "$XCFW_PATH")/libvlc-provenance.json")
+if [[ -n "$CANDIDATE_DIR" ]]; then
+  RELEASE_ASSETS+=("$CANDIDATE_DIR/release-candidate.json")
+fi
 QUALIFICATION_NOTE=""
 if [[ "$UNQUALIFIED" == true ]]; then
   RELEASE_FLAGS+=(--prerelease)
   QUALIFICATION_NOTE=$'\n> **Not device-qualified.** The physical-device matrix in `scripts/qualification` has not been executed against this artifact. Published as a pre-release for that reason.\n'
 fi
 
-gh release create "$TAG" "$ZIP_PATH" \
+gh release create "$TAG" "${RELEASE_ASSETS[@]}" \
   --repo "$REPO" \
+  --verify-tag \
   ${RELEASE_FLAGS[@]+"${RELEASE_FLAGS[@]}"} \
   --title "SwiftVLC $TAG" \
   --notes "$(cat <<EOF
@@ -626,6 +787,9 @@ echo "Pushing $CURRENT_BRANCH to origin/main..."
 git push origin HEAD:main
 
 echo "  origin/main → $TAG_COMMIT"
+
+echo "Publishing GitHub Release..."
+gh release edit "$TAG" --repo "$REPO" --draft=false
 
 echo ""
 echo "Release $TAG published: https://github.com/$REPO/releases/tag/$TAG"

--- a/scripts/resolve-release-artifact.sh
+++ b/scripts/resolve-release-artifact.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Resolve and verify the exact released libvlc artifact this checkout declares.
+set -euo pipefail
+
+REPO="harflabs/SwiftVLC"
+ASSET_NAME="libvlc.xcframework.zip"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TAG="${SWIFTVLC_RELEASE_TAG:-}"
+
+usage() {
+  echo "Usage: $0 [--tag vX.Y.Z]" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      TAG="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Error: unknown argument '$1'." >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+cd "$ROOT_DIR"
+
+if [[ -z "$TAG" ]]; then
+  if ! TAG=$(python3 "$SCRIPT_DIR/release-artifact-info.py" Package.swift --field tag); then
+    echo "  Supply --tag or SWIFTVLC_RELEASE_TAG when Package.swift uses a local artifact." >&2
+    exit 1
+  fi
+fi
+
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+  echo "Error: invalid release tag '$TAG'." >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Error: GitHub CLI (gh) is required to verify release metadata." >&2
+  exit 1
+fi
+
+temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/swiftvlc-artifact.XXXXXX")
+trap 'rm -rf "$temp_dir"' EXIT
+
+# Shallow Actions checkouts do not have release tags. Refuse a fetch failure:
+# silently falling back to another release is the bug this resolver prevents.
+git fetch --quiet origin "refs/tags/$TAG:refs/tags/$TAG"
+git show "$TAG:Package.swift" > "$temp_dir/Package.swift"
+python3 "$SCRIPT_DIR/release-artifact-info.py" \
+  "$temp_dir/Package.swift" --expect-tag "$TAG" > "$temp_dir/manifest.json"
+
+gh release view "$TAG" --repo "$REPO" \
+  --json tagName,isDraft,isPrerelease,assets > "$temp_dir/release.json"
+
+python3 - "$temp_dir/manifest.json" "$temp_dir/release.json" "$ASSET_NAME" <<'PY'
+import json
+import sys
+
+manifest_path, release_path, asset_name = sys.argv[1:4]
+manifest = json.load(open(manifest_path))
+release = json.load(open(release_path))
+
+if release.get("tagName") != manifest["tag"]:
+    sys.exit(
+        f"Error: GitHub returned release {release.get('tagName')!r}, "
+        f"expected {manifest['tag']!r}."
+    )
+if release.get("isDraft"):
+    sys.exit(f"Error: {manifest['tag']} is still a draft release.")
+
+matches = [asset for asset in release.get("assets", []) if asset.get("name") == asset_name]
+if len(matches) != 1:
+    sys.exit(
+        f"Error: {manifest['tag']} must contain exactly one {asset_name}; "
+        f"found {len(matches)}."
+    )
+
+asset = matches[0]
+expected_digest = f"sha256:{manifest['checksum']}"
+if asset.get("digest") != expected_digest:
+    sys.exit(
+        "Error: release asset digest does not match the tagged Package.swift.\n"
+        f"  manifest: {expected_digest}\n"
+        f"  asset:    {asset.get('digest')}"
+    )
+if asset.get("url") != manifest["url"]:
+    sys.exit(
+        "Error: release asset URL does not match the tagged Package.swift.\n"
+        f"  manifest: {manifest['url']}\n"
+        f"  asset:    {asset.get('url')}"
+    )
+
+manifest["isPrerelease"] = bool(release.get("isPrerelease"))
+manifest["size"] = asset.get("size")
+print(json.dumps(manifest, sort_keys=True))
+PY

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -178,11 +178,11 @@ if [[ "$SKIP_DOWNLOAD" == true ]]; then
   fi
   echo "Keeping existing xcframework at $XCFW_DIR (--skip-download)."
 else
-  resolve_args=()
   if [[ -n "$VERSION" ]]; then
-    resolve_args+=(--tag "$VERSION")
+    artifact_info=$("$SCRIPT_DIR/resolve-release-artifact.sh" --tag "$VERSION")
+  else
+    artifact_info=$("$SCRIPT_DIR/resolve-release-artifact.sh")
   fi
-  artifact_info=$("$SCRIPT_DIR/resolve-release-artifact.sh" "${resolve_args[@]}")
   RESOLVED_TAG=$(printf '%s' "$artifact_info" \
     | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag"])')
   RESOLVED_URL=$(printf '%s' "$artifact_info" \

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -5,7 +5,7 @@
 # / `swift test` and local Showcase development work on a fresh clone.
 #
 # Usage:
-#   ./scripts/setup-dev.sh                  # install latest release (or keep existing)
+#   ./scripts/setup-dev.sh                  # install release declared by Package.swift
 #   ./scripts/setup-dev.sh v0.3.0           # pin to a specific release tag
 #   ./scripts/setup-dev.sh --force          # always re-download, even if Vendor/ exists
 #   ./scripts/setup-dev.sh --skip-download  # only flip local references
@@ -15,6 +15,7 @@ set -euo pipefail
 
 REPO="harflabs/SwiftVLC"
 XCFW_DIR="Vendor/libvlc.xcframework"
+INSTALL_RECORD="Vendor/.swiftvlc-release.json"
 SHOWCASE_PROJECT="Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj"
 ZIP_NAME="libvlc.xcframework.zip"
 
@@ -177,37 +178,105 @@ if [[ "$SKIP_DOWNLOAD" == true ]]; then
   fi
   echo "Keeping existing xcframework at $XCFW_DIR (--skip-download)."
 else
+  resolve_args=()
+  if [[ -n "$VERSION" ]]; then
+    resolve_args+=(--tag "$VERSION")
+  fi
+  artifact_info=$("$SCRIPT_DIR/resolve-release-artifact.sh" "${resolve_args[@]}")
+  RESOLVED_TAG=$(printf '%s' "$artifact_info" \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag"])')
+  RESOLVED_URL=$(printf '%s' "$artifact_info" \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["url"])')
+  RESOLVED_CHECKSUM=$(printf '%s' "$artifact_info" \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["checksum"])')
+
   NEED_DOWNLOAD=false
   if [[ ! -d "$XCFW_DIR" ]]; then
     NEED_DOWNLOAD=true
   elif [[ "$FORCE" == true ]]; then
     echo "Removing existing $XCFW_DIR (--force)..."
     rm -rf "$XCFW_DIR"
+    rm -f "$INSTALL_RECORD"
     NEED_DOWNLOAD=true
   else
-    echo "Keeping existing xcframework at $XCFW_DIR (pass --force to re-download)."
+    installed_values=$(python3 - "$INSTALL_RECORD" <<'PYEOF' || true
+import json
+import sys
+
+try:
+    record = json.load(open(sys.argv[1]))
+    print(record["tag"])
+    print(record["checksum"])
+    print(record["treeDigest"])
+except (OSError, ValueError, KeyError):
+    pass
+PYEOF
+)
+    installed_tag=$(printf '%s\n' "$installed_values" | sed -n '1p')
+    installed_checksum=$(printf '%s\n' "$installed_values" | sed -n '2p')
+    installed_tree_digest=$(printf '%s\n' "$installed_values" | sed -n '3p')
+    actual_tree_digest=$("$SCRIPT_DIR/artifact-tree-digest.py" \
+      "$XCFW_DIR" 2>/dev/null || true)
+    if [[ "$installed_tag" == "$RESOLVED_TAG" \
+      && "$installed_checksum" == "$RESOLVED_CHECKSUM" \
+      && "$installed_tree_digest" == "$actual_tree_digest" ]]; then
+      echo "Keeping verified $RESOLVED_TAG xcframework at $XCFW_DIR."
+    else
+      echo "Replacing unverified or stale xcframework at $XCFW_DIR..."
+      rm -rf "$XCFW_DIR"
+      rm -f "$INSTALL_RECORD"
+      NEED_DOWNLOAD=true
+    fi
   fi
 
   if [[ "$NEED_DOWNLOAD" == true ]]; then
     require_gh
     mkdir -p Vendor
 
-    echo "Downloading $ZIP_NAME..."
-    if [[ -n "$VERSION" ]]; then
-      gh release download "$VERSION" --repo "$REPO" --pattern "$ZIP_NAME" --dir Vendor/
-    else
-      gh release download --repo "$REPO" --pattern "$ZIP_NAME" --dir Vendor/
+    echo "Downloading $ZIP_NAME from $RESOLVED_TAG..."
+    rm -f "Vendor/$ZIP_NAME"
+    gh release download "$RESOLVED_TAG" \
+      --repo "$REPO" --pattern "$ZIP_NAME" --dir Vendor/
+
+    downloaded_checksum=$(swift package compute-checksum "Vendor/$ZIP_NAME")
+    if [[ "$downloaded_checksum" != "$RESOLVED_CHECKSUM" ]]; then
+      rm -f "Vendor/$ZIP_NAME"
+      echo "Error: downloaded asset checksum does not match $RESOLVED_TAG." >&2
+      echo "  expected: $RESOLVED_CHECKSUM" >&2
+      echo "  actual:   $downloaded_checksum" >&2
+      exit 1
     fi
 
     echo "Extracting..."
     (cd Vendor && ditto -x -k "$ZIP_NAME" . && rm "$ZIP_NAME")
     echo "  Installed to $XCFW_DIR"
 
-    # Fix duplicate symbols (json_parse_error/json_read) in the static library.
-    # Two VLC plugins (ytdl, chromecast) each compile their own copy; the
-    # Apple linker in Xcode 16+ treats duplicates as errors on Mac Catalyst.
-    echo "Fixing duplicate symbols in static libraries..."
-    "$SCRIPT_DIR/fix-duplicate-symbols.sh" "$XCFW_DIR"
+    # A release asset is immutable input. It was fixed before packaging; doing
+    # another mutation here would make CI test bytes consumers never receive.
+    echo "Verifying duplicate symbols in released libraries..."
+    "$SCRIPT_DIR/fix-duplicate-symbols.sh" --verify "$XCFW_DIR"
+
+    RESOLVED_TREE_DIGEST=$("$SCRIPT_DIR/artifact-tree-digest.py" "$XCFW_DIR")
+
+    RESOLVED_TAG="$RESOLVED_TAG" \
+      RESOLVED_URL="$RESOLVED_URL" \
+      RESOLVED_CHECKSUM="$RESOLVED_CHECKSUM" \
+      RESOLVED_TREE_DIGEST="$RESOLVED_TREE_DIGEST" \
+      INSTALL_RECORD="$INSTALL_RECORD" \
+      python3 - <<'PYEOF'
+import json
+import os
+
+record = {
+    "tag": os.environ["RESOLVED_TAG"],
+    "url": os.environ["RESOLVED_URL"],
+    "checksum": os.environ["RESOLVED_CHECKSUM"],
+    "treeDigest": os.environ["RESOLVED_TREE_DIGEST"],
+}
+with open(os.environ["INSTALL_RECORD"], "w") as output:
+    json.dump(record, output, indent=2, sort_keys=True)
+    output.write("\n")
+PYEOF
   fi
 fi
 

--- a/scripts/tests/release-integrity.sh
+++ b/scripts/tests/release-integrity.sh
@@ -128,6 +128,12 @@ bash -n \
   scripts/resolve-release-artifact.sh \
   scripts/setup-dev.sh
 
+# GitHub's macOS runners still execute these scripts with Bash 3.2. An empty
+# array expansion under nounset fails there even though newer Bash accepts it.
+if grep -En '\$\{[A-Za-z_][A-Za-z0-9_]*\[@\]\}' scripts/setup-dev.sh >/dev/null; then
+  fail "setup-dev.sh contains an array expansion that is unsafe under Bash 3.2 nounset"
+fi
+
 artifact_info=$(./scripts/resolve-release-artifact.sh)
 actual_tag=$(printf '%s' "$artifact_info" \
   | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag"])')

--- a/scripts/tests/release-integrity.sh
+++ b/scripts/tests/release-integrity.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/swiftvlc-release-tests.XXXXXX")
+trap 'rm -rf "$temp_dir"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+checksum="03a57454a6159c455406889c7867e0b284db028d2734a10bdf85a6a7285c862f"
+cat > "$temp_dir/Package.swift" <<EOF
+let package = Package(targets: [
+  .binaryTarget(
+    name: "libvlc",
+    url: "https://github.com/harflabs/SwiftVLC/releases/download/v1.1.0-beta.1/libvlc.xcframework.zip",
+    checksum: "$checksum"
+  )
+])
+EOF
+
+resolved_tag=$(python3 "$SCRIPT_DIR/release-artifact-info.py" \
+  "$temp_dir/Package.swift" --field tag)
+[[ "$resolved_tag" == "v1.1.0-beta.1" ]] || fail "pre-release tag was not parsed"
+
+python3 "$SCRIPT_DIR/release-artifact-info.py" \
+  "$temp_dir/Package.swift" --expect-tag v1.1.0-beta.1 >/dev/null
+if python3 "$SCRIPT_DIR/release-artifact-info.py" \
+  "$temp_dir/Package.swift" --expect-tag v1.1.0 >/dev/null 2>&1; then
+  fail "mismatched expected tag was accepted"
+fi
+
+sed 's#url: "https://[^\"]*"#path: "Vendor/libvlc.xcframework"#' \
+  "$temp_dir/Package.swift" > "$temp_dir/LocalPackage.swift"
+if python3 "$SCRIPT_DIR/release-artifact-info.py" \
+  "$temp_dir/LocalPackage.swift" >/dev/null 2>&1; then
+  fail "local binary target was treated as a released artifact"
+fi
+
+mkdir -p "$temp_dir/tree-a/Headers" "$temp_dir/tree-b/Headers"
+printf 'binary' > "$temp_dir/tree-a/libvlc.a"
+printf 'header' > "$temp_dir/tree-a/Headers/libvlc.h"
+cp -R "$temp_dir/tree-a/." "$temp_dir/tree-b/"
+
+digest_a=$("$SCRIPT_DIR/artifact-tree-digest.py" "$temp_dir/tree-a")
+digest_b=$("$SCRIPT_DIR/artifact-tree-digest.py" "$temp_dir/tree-b")
+[[ "$digest_a" == "$digest_b" ]] || fail "digest depends on the artifact root path"
+
+touch -t 202001010000 "$temp_dir/tree-b/Headers/libvlc.h"
+digest_b=$("$SCRIPT_DIR/artifact-tree-digest.py" "$temp_dir/tree-b")
+[[ "$digest_a" == "$digest_b" ]] || fail "digest depends on file timestamps"
+
+printf 'changed header' > "$temp_dir/tree-b/Headers/libvlc.h"
+digest_b=$("$SCRIPT_DIR/artifact-tree-digest.py" "$temp_dir/tree-b")
+[[ "$digest_a" != "$digest_b" ]] || fail "header changes do not affect the digest"
+
+python3 - "$temp_dir/matrix.json" "$temp_dir/record.json" "$digest_a" <<'PY'
+import json
+import sys
+
+matrix_path, record_path, digest = sys.argv[1:4]
+open(str(record_path).rsplit("/", 1)[0] + "/evidence.json", "w").write("{}\n")
+matrix = {
+    "scenarios": [{"id": "vod"}],
+    "hardware": [
+        {"id": "iphone-current", "deviceFamily": "iPhone", "osMajor": 26}
+    ],
+}
+record = {
+    "version": "1.1.0",
+    "artifactDigestAlgorithm": "swiftvlc-tree-v1",
+    "artifactDigest": digest,
+    "rows": [
+        {
+            "scenario": "vod",
+            "hardware": "iphone-current",
+            "device": "Test phone",
+            "deviceFamily": "iPhone",
+            "productType": "iPhone16,1",
+            "osVersion": "26.6",
+            "osBuild": "23G80",
+            "osReleaseType": "stable",
+            "fixture": "fixture.mp4",
+            "duration": "2m",
+            "evidence": "evidence.json",
+            "result": "pass",
+        }
+    ],
+}
+json.dump(matrix, open(matrix_path, "w"))
+json.dump(record, open(record_path, "w"))
+PY
+
+SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
+  SWIFTVLC_QUALIFICATION_RECORD="$temp_dir/record.json" \
+  "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null
+
+if SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
+  SWIFTVLC_QUALIFICATION_RECORD="$temp_dir/record.json" \
+  "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-b" >/dev/null 2>&1; then
+  fail "qualification survived a header change"
+fi
+
+python3 - "$temp_dir/record.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+record = json.load(open(path))
+record["rows"][0]["osReleaseType"] = "beta"
+json.dump(record, open(path, "w"))
+PY
+if SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
+  SWIFTVLC_QUALIFICATION_RECORD="$temp_dir/record.json" \
+  "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null 2>&1; then
+  fail "qualification accepted a beta OS row"
+fi
+
+cd "$ROOT_DIR"
+bash -n \
+  scripts/check-engine-coverage.sh \
+  scripts/check-qualification.sh \
+  scripts/ci-use-released-xcframework.sh \
+  scripts/release.sh \
+  scripts/resolve-release-artifact.sh \
+  scripts/setup-dev.sh
+
+artifact_info=$(./scripts/resolve-release-artifact.sh)
+actual_tag=$(printf '%s' "$artifact_info" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag"])')
+[[ "$actual_tag" == "v1.1.0-beta.1" ]] \
+  || fail "checkout resolved $actual_tag instead of v1.1.0-beta.1"
+
+stable_info=$(SWIFTVLC_RELEASE_TAG=v1.0.0 ./scripts/resolve-release-artifact.sh)
+stable_tag=$(printf '%s' "$stable_info" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag"])')
+[[ "$stable_tag" == "v1.0.0" ]] \
+  || fail "explicit release override resolved $stable_tag instead of v1.0.0"
+
+if ./scripts/release.sh 1.1.0 >/dev/null 2>&1; then
+  fail "stable release was accepted without a prepared candidate"
+fi
+
+echo "Release-integrity tests passed."


### PR DESCRIPTION
## Summary

- resolve the exact libvlc release declared by Package.swift or an explicit override instead of GitHub latest
- verify the tagged manifest, release asset URL, and GitHub SHA-256 digest before CI or setup uses the binary
- detect and replace stale Vendor caches without mutating released libraries
- qualify the complete post-strip XCFramework tree, including headers and metadata
- require stable releases to consume an immutable prepared candidate and publish through a draft release
- validate device family, stable OS major/build, and committed qualification evidence

## Root cause

GitHub latest excludes pre-releases, while multiple jobs selected releases independently. That let green checks test v1.0.0 even though main and the v1.1.0 work expected beta.1. Qualification also hashed unstripped static archives before release.sh stripped them and excluded headers, so the recorded device run did not identify the shipped artifact.

This supersedes the narrower approach in #154 and advances the unfinished release-gate and provenance criteria in #88 and #97. It intentionally does not close either milestone issue; physical qualification and reproducible engine builds still remain.

## Validation

- scripts/tests/release-integrity.sh
- bash syntax checks for release scripts
- all GitHub workflow YAML parsed successfully
- swift build
- CI=true swift test --no-parallel
- SwiftFormat and SwiftLint strict checks
- patch manifest and all eight libvlc archive-member manifests
- live verification of v1.1.0-beta.1 tag, URL, checksum, and GitHub asset digest