### PR TITLE
Scope native events to monotonic handle generations

### DIFF
--- a/Sources/SwiftVLC/Player/EventBridge.swift
+++ b/Sources/SwiftVLC/Player/EventBridge.swift
@@ -12,8 +12,9 @@ import Synchronization
 final class EventBridge: Sendable {
   private nonisolated(unsafe) var eventManager: OpaquePointer
   private let context: EventBridgeCallbackContext
-  private nonisolated(unsafe) let contextOpaque: UnsafeMutableRawPointer
+  private nonisolated(unsafe) var attachmentOpaque: UnsafeMutableRawPointer?
   private nonisolated(unsafe) var attachedEventTypes: [Int32]
+  private let nativeHandleGeneration = Mutex<UInt64>(1)
   private let invalidated = Mutex(false)
 
   init(eventManager: OpaquePointer, endCoordinator: PlaybackEndCoordinator) {
@@ -21,15 +22,18 @@ final class EventBridge: Sendable {
 
     let context = EventBridgeCallbackContext(endCoordinator: endCoordinator)
     self.context = context
-    let opaque = Unmanaged.passRetained(context).toOpaque()
-    contextOpaque = opaque
+    let attachment = EventBridgeCallbackAttachment(
+      context: context,
+      nativeHandleGeneration: 1
+    )
+    let opaque = Unmanaged.passRetained(attachment).toOpaque()
+    attachmentOpaque = opaque
 
     attachedEventTypes = Self.attachEvents(to: eventManager, opaque: opaque)
   }
 
   deinit {
     invalidate()
-    Unmanaged<EventBridgeCallbackContext>.fromOpaque(contextOpaque).release()
   }
 
   /// Detaches all event listeners and finishes all streams.
@@ -43,8 +47,14 @@ final class EventBridge: Sendable {
     }
     guard shouldCleanUp else { return }
 
-    Self.detachEvents(attachedEventTypes, from: eventManager, opaque: contextOpaque)
+    guard let attachmentOpaque else { return }
+    Self.detachEvents(attachedEventTypes, from: eventManager, opaque: attachmentOpaque)
     attachedEventTypes = []
+    self.attachmentOpaque = nil
+    // `libvlc_event_detach` takes the same event-manager lock that surrounds
+    // callback execution. Once every detach returns, no callback can still be
+    // borrowing this attachment token, so releasing it here is safe.
+    Unmanaged<EventBridgeCallbackAttachment>.fromOpaque(attachmentOpaque).release()
     // `terminate()`, not `finishAll()`: invalidation is permanent. The
     // mid-life native handle swap goes through `reattach(to:)` and never
     // lands here, so the only callers are shutdown and deinit — after which
@@ -61,13 +71,42 @@ final class EventBridge: Sendable {
   /// still points at the previous UIView. The Swift `Player.events` stream must
   /// survive that native-handle swap, so this detaches callbacks from the previous
   /// event manager and attaches the same broadcaster to the new one.
-  func reattach(to newEventManager: OpaquePointer) {
+  @discardableResult
+  func reattach(to newEventManager: OpaquePointer) -> UInt64 {
     let isInvalidated = invalidated.withLock { $0 }
-    guard !isInvalidated else { return }
+    guard !isInvalidated, let oldAttachmentOpaque = attachmentOpaque else {
+      return nativeHandleGeneration.withLock { $0 }
+    }
 
-    Self.detachEvents(attachedEventTypes, from: eventManager, opaque: contextOpaque)
+    Self.detachEvents(attachedEventTypes, from: eventManager, opaque: oldAttachmentOpaque)
+    Unmanaged<EventBridgeCallbackAttachment>.fromOpaque(oldAttachmentOpaque).release()
+
+    // The retiring handle cannot emit after detach returns. Clear its pending
+    // terminal classification before the successor is attached, so neither an
+    // old late callback nor an early successor callback can cross the reset.
+    context.endCoordinator.clearForHandleReplacement()
+
+    let generation = nativeHandleGeneration.withLock { generation in
+      precondition(generation < UInt64.max, "Native handle generation exhausted")
+      generation += 1
+      return generation
+    }
+    let attachment = EventBridgeCallbackAttachment(
+      context: context,
+      nativeHandleGeneration: generation
+    )
+    let newAttachmentOpaque = Unmanaged.passRetained(attachment).toOpaque()
     eventManager = newEventManager
-    attachedEventTypes = Self.attachEvents(to: newEventManager, opaque: contextOpaque)
+    attachmentOpaque = newAttachmentOpaque
+    attachedEventTypes = Self.attachEvents(to: newEventManager, opaque: newAttachmentOpaque)
+    return generation
+  }
+
+  /// Monotonic identity of the native player currently feeding this bridge.
+  /// Unlike a pointer address, it cannot alias a retired A handle after an
+  /// allocator reuses that address for a later C handle.
+  var currentNativeHandleGeneration: UInt64 {
+    nativeHandleGeneration.withLock { $0 }
   }
 
   /// Creates a new independent `AsyncStream` for consuming player events.
@@ -94,8 +133,16 @@ final class EventBridge: Sendable {
   /// Pushes an event through the same fan-out path the C callback uses,
   /// including subscription buffering — unlike
   /// `Player._handleEventForTesting`, which bypasses the bridge entirely.
-  func _broadcastForTesting(_ event: PlayerEvent, source: UInt) {
-    context.broadcast(event, source: source)
+  func _broadcastForTesting(_ event: PlayerEvent, nativeHandleGeneration: UInt64) {
+    context.broadcast(event, nativeHandleGeneration: nativeHandleGeneration)
+  }
+
+  /// Exercises the complete native callback ordering with a synthetic event.
+  func _emitNativeEventForTesting(_ event: libvlc_event_t) {
+    guard let attachmentOpaque else { return }
+    withUnsafePointer(to: event) { event in
+      playerEventCallback(event: event, opaque: attachmentOpaque)
+    }
   }
 
   static let playerEventTypes: [Int32] = [
@@ -160,7 +207,7 @@ final class EventBridge: Sendable {
 }
 
 struct SourcedPlayerEvent {
-  let source: UInt
+  let nativeHandleGeneration: UInt64
   let event: PlayerEvent
   /// The timeline revision current when libVLC emitted this event.
   ///
@@ -171,10 +218,28 @@ struct SourcedPlayerEvent {
   /// pre-seek rather than silently authoritative.
   let timelineRevision: UInt64
 
-  init(source: UInt, event: PlayerEvent, timelineRevision: UInt64 = 0) {
-    self.source = source
+  init(
+    nativeHandleGeneration: UInt64,
+    event: PlayerEvent,
+    timelineRevision: UInt64 = 0
+  ) {
+    self.nativeHandleGeneration = nativeHandleGeneration
     self.event = event
     self.timelineRevision = timelineRevision
+  }
+}
+
+/// Immutable identity and shared fan-out context for one native attachment.
+/// A fresh retained token is passed to libVLC on every handle replacement;
+/// callbacks can therefore never acquire a successor's generation by reading
+/// mutable shared state after they were emitted by a predecessor.
+private final class EventBridgeCallbackAttachment: Sendable {
+  let context: EventBridgeCallbackContext
+  let nativeHandleGeneration: UInt64
+
+  init(context: EventBridgeCallbackContext, nativeHandleGeneration: UInt64) {
+    self.context = context
+    self.nativeHandleGeneration = nativeHandleGeneration
   }
 }
 
@@ -202,7 +267,7 @@ private final class EventBridgeCallbackContext: Sendable {
     sourcedEvents.subscribe(policy: policy)
   }
 
-  func broadcast(_ event: PlayerEvent, source: UInt) {
+  func broadcast(_ event: PlayerEvent, nativeHandleGeneration: UInt64) {
     // Each broadcaster is gated on its own emptiness so a libVLC event
     // with no consumers costs neither the lock-and-snapshot nor the
     // sourced-wrapper construction. The sourced broadcast (the player's
@@ -212,7 +277,7 @@ private final class EventBridgeCallbackContext: Sendable {
     if !sourcedEvents.isEmpty {
       sourcedEvents.broadcast(
         SourcedPlayerEvent(
-          source: source,
+          nativeHandleGeneration: nativeHandleGeneration,
           event: event,
           timelineRevision: timelineRevision.withLock { $0 }
         )
@@ -257,34 +322,40 @@ private func playerEventCallback(
   let interval = Signposts.signposter.beginInterval("EventBridge.callback")
   defer { Signposts.signposter.endInterval("EventBridge.callback", interval) }
 
-  let context = Unmanaged<EventBridgeCallbackContext>.fromOpaque(opaque).takeUnretainedValue()
+  let attachment = Unmanaged<EventBridgeCallbackAttachment>.fromOpaque(opaque)
+    .takeUnretainedValue()
+  let context = attachment.context
 
   guard let mapped = mapEvent(event.pointee) else { return }
-  let source = sourceIdentifier(for: event.pointee)
-  context.broadcast(mapped, source: source)
-
-  // End-of-media synthesis happens here, on the event thread, immediately
-  // after the `stopped` broadcast: every subscriber observes `.stopped`
-  // then `.endReached` from the same source, with no consumer-lag race
-  // and internal source filtering working unchanged.
   let coordinator = context.endCoordinator
-  // Recorded before the `stopped` that follows it, so the decision below has
-  // the engine's own answer rather than only SwiftVLC's inference.
+  // Record every terminal fact before exposing its raw event. Public filters
+  // run synchronously on this thread and may issue player commands, so doing
+  // this after broadcast lets reentrant work classify the stop without the
+  // engine's authoritative cause.
   if event.pointee.type == Int32(libvlc_MediaPlayerMediaStopping.rawValue) {
     coordinator.noteStoppingReason(event.pointee.u.media_player_media_stopping.reason)
   }
+  let shouldSynthesizeEnd: Bool
   switch mapped {
   case .encounteredError:
     coordinator.markError()
-  case .stateChanged(.stopped) where coordinator.consumeStoppedShouldSynthesizeEnd():
-    context.broadcast(.endReached, source: source)
+    shouldSynthesizeEnd = false
+  case .stateChanged(.stopped):
+    shouldSynthesizeEnd = coordinator.consumeStoppedShouldSynthesizeEnd()
   default:
-    break
+    shouldSynthesizeEnd = false
   }
-}
 
-func sourceIdentifier(for event: libvlc_event_t) -> UInt {
-  event.p_obj.map { UInt(bitPattern: $0) } ?? 0
+  // Both emissions are made from the same immutable attachment token. Every
+  // subscriber therefore observes `.stopped` then `.endReached` with one
+  // generation, independent of consumer lag or native pointer reuse.
+  context.broadcast(mapped, nativeHandleGeneration: attachment.nativeHandleGeneration)
+  if shouldSynthesizeEnd {
+    context.broadcast(
+      .endReached,
+      nativeHandleGeneration: attachment.nativeHandleGeneration
+    )
+  }
 }
 
 /// Maps a single libVLC `libvlc_event_t` to a typed `PlayerEvent`.

--- a/Sources/SwiftVLC/Player/Player+Drawable.swift
+++ b/Sources/SwiftVLC/Player/Player+Drawable.swift
@@ -298,14 +298,15 @@ extension Player {
 
     carryOverPerPlayerState(from: oldPointer, to: newPointer)
 
+    // Reattachment detaches the retiring generation, clears its pending
+    // terminal cause, then installs the successor generation as one operation.
     eventBridge.reattach(to: newEventManager)
     // The old handle's terminal events are unobservable from here on; a
     // pending stop/error cause would otherwise outlive its `Stopped` and
     // suppress the next genuine natural end. The same applies to its
-    // closing `voutChanged(0)` — the source filter drops it after the
+    // closing `voutChanged(0)` — the generation filter drops it after the
     // reattach — so reset the mirrored output count here instead of
     // leaving it pinned to the dead handle's outputs.
-    endCoordinator.clearForHandleReplacement()
     activeVideoOutputs = 0
     #if os(iOS) || os(macOS)
     moveDirectPiPVideoCallbacks(to: newLifetime)

--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -62,7 +62,9 @@ extension Player {
   // MARK: - handleEvent dispatch
 
   func handleSourcedEvent(_ sourcedEvent: SourcedPlayerEvent) {
-    guard sourcedEvent.source == Self.sourceIdentifier(for: pointer) else { return }
+    guard
+      sourcedEvent.nativeHandleGeneration == eventBridge.currentNativeHandleGeneration
+    else { return }
     guard isTimelineSampleCurrent(sourcedEvent) else { return }
     handleEvent(sourcedEvent.event)
   }
@@ -460,23 +462,22 @@ extension Player {
     currentMedia = Media(retaining: media)
   }
 
-  static func sourceIdentifier(for pointer: OpaquePointer) -> UInt {
-    UInt(bitPattern: UnsafeRawPointer(pointer))
-  }
-
   func _handleEventForTesting(_ event: PlayerEvent) {
     handleEvent(event)
   }
 
-  /// Injects an event attributed to a specific native handle, so tests can
-  /// exercise the source scoping in ``handleSourcedEvent(_:)`` — an event
-  /// arriving from a handle the player has already replaced must not be
-  /// applied to the current session.
+  /// Injects an event attributed to a native-handle generation, so tests can
+  /// exercise the scoping in ``handleSourcedEvent(_:)``.
   ///
   /// Staging the attribution is the point: a retiring handle emitting after
   /// its replacement is a race, not something a test can schedule.
-  func _handleEventForTesting(_ event: PlayerEvent, source: OpaquePointer) {
-    handleSourcedEvent(SourcedPlayerEvent(source: Self.sourceIdentifier(for: source), event: event))
+  func _handleEventForTesting(_ event: PlayerEvent, nativeHandleGeneration: UInt64) {
+    handleSourcedEvent(
+      SourcedPlayerEvent(
+        nativeHandleGeneration: nativeHandleGeneration,
+        event: event
+      )
+    )
   }
 
   func _hasDeferredPauseForTesting() -> Bool {

--- a/Sources/SwiftVLC/Player/Player+Teardown.swift
+++ b/Sources/SwiftVLC/Player/Player+Teardown.swift
@@ -66,7 +66,7 @@ extension Player {
     default:
       break
     }
-    let source = Self.sourceIdentifier(for: pointer)
+    let nativeHandleGeneration = eventBridge.currentNativeHandleGeneration
     let stream = eventBridge.makeSourcedStream(policy: .unbounded)
     // A terminal event that fired between the check above and the
     // subscription is invisible to the stream — re-check before waiting
@@ -80,7 +80,10 @@ extension Player {
       break
     }
     stop()
-    let outcome = await Self.awaitOutputSafeStop(on: stream, source: source)
+    let outcome = await Self.awaitOutputSafeStop(
+      on: stream,
+      nativeHandleGeneration: nativeHandleGeneration
+    )
     // The internal consumer mirrors the same terminal event onto
     // `state` on its own main-actor schedule and may still be draining
     // its backlog when the dedicated wait resumes. Reconcile here so
@@ -126,7 +129,7 @@ extension Player {
   ///   (see `TestCondition.canPlayMedia`).
   nonisolated static func awaitOutputSafeStop(
     on stream: AsyncStream<SourcedPlayerEvent>,
-    source: UInt,
+    nativeHandleGeneration: UInt64,
     timeout: Duration = .seconds(10)
   )
     async -> PlayerStopOutcome {
@@ -134,7 +137,7 @@ extension Player {
       group.addTask {
         for await sourced in stream {
           guard
-            sourced.source == source,
+            sourced.nativeHandleGeneration == nativeHandleGeneration,
             case .stateChanged(let state) = sourced.event
           else { continue }
           // Only `.stopped` ends the wait. An `.error` is ignored here: the

--- a/Tests/SwiftVLCTests/PiP/PiPStateObserverLaneTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPStateObserverLaneTests.swift
@@ -118,19 +118,19 @@ extension Integration {
       let player = Player(instance: TestInstance.makeAudioOnly())
       let controller = PiPController(player: player)
       let bridge = player.eventBridge
-      let source = Player.sourceIdentifier(for: player.pointer)
+      let nativeHandleGeneration = bridge.currentNativeHandleGeneration
 
       // Broadcast first, so it sits on the oldest side of the backlog — where
       // a newest-wins buffer evicts.
-      bridge._broadcastForTesting(.seekableChanged(true), source: source)
+      bridge._broadcastForTesting(.seekableChanged(true), nativeHandleGeneration: nativeHandleGeneration)
       // Both observer tasks are @MainActor and so is this test, so none of
       // this is delivered until the first suspension below: the whole burst
       // queues against a stalled consumer, which is the real-world condition.
       for index in 0..<500 {
-        bridge._broadcastForTesting(.timeChanged(.milliseconds(index)), source: source)
-        bridge._broadcastForTesting(.positionChanged(Double(index) / 500), source: source)
+        bridge._broadcastForTesting(.timeChanged(.milliseconds(index)), nativeHandleGeneration: nativeHandleGeneration)
+        bridge._broadcastForTesting(.positionChanged(Double(index) / 500), nativeHandleGeneration: nativeHandleGeneration)
       }
-      bridge._broadcastForTesting(.lengthChanged(.seconds(7)), source: source)
+      bridge._broadcastForTesting(.lengthChanged(.seconds(7)), nativeHandleGeneration: nativeHandleGeneration)
 
       #expect(
         await drainObserver(of: controller, untilDurationIs: 7000),
@@ -152,9 +152,9 @@ extension Integration {
       let player = Player(instance: TestInstance.makeAudioOnly())
       let controller = PiPController(player: player)
       let bridge = player.eventBridge
-      let source = Player.sourceIdentifier(for: player.pointer)
+      let nativeHandleGeneration = bridge.currentNativeHandleGeneration
 
-      bridge._broadcastForTesting(.lengthChanged(.seconds(3)), source: source)
+      bridge._broadcastForTesting(.lengthChanged(.seconds(3)), nativeHandleGeneration: nativeHandleGeneration)
       #expect(await drainObserver(of: controller, untilDurationIs: 3000))
 
       // A tick alone, with no control event following it, has to reach the
@@ -162,7 +162,7 @@ extension Integration {
       // downstream effect keeps this independent of capability polling.
       var sawTick = false
       let timing = player.timingEvents
-      bridge._broadcastForTesting(.timeChanged(.milliseconds(42)), source: source)
+      bridge._broadcastForTesting(.timeChanged(.milliseconds(42)), nativeHandleGeneration: nativeHandleGeneration)
       for await event in timing {
         if case .timeChanged = event {
           sawTick = true

--- a/Tests/SwiftVLCTests/Player/AuthoritativeStopReasonTests.swift
+++ b/Tests/SwiftVLCTests/Player/AuthoritativeStopReasonTests.swift
@@ -1,5 +1,6 @@
 @testable import SwiftVLC
 import CLibVLC
+import Synchronization
 import Testing
 
 /// Issue 85 criterion 4: an unattributed stop is never reported as a confirmed
@@ -100,5 +101,34 @@ struct AuthoritativeStopReasonTests {
       !coordinator.consumeStoppedShouldSynthesizeEnd(),
       "an end-of-stream reason from a replaced handle confirmed the successor's stop as a natural end"
     )
+  }
+
+  /// Public filters execute inline on libVLC's callback thread. Recording the
+  /// reason after fan-out lets reentrant work inspect or consume a stop before
+  /// its authoritative cause exists.
+  @Test
+  @MainActor
+  func `The stopping reason is recorded before the raw event is exposed`() {
+    let player = Player(instance: TestInstance.makeAudioOnly())
+    let coordinator = player.endCoordinator
+    let classificationObservedByFilter = Mutex<Bool?>(nil)
+    let stream = player.events(policy: .unbounded) { event in
+      guard case .mediaStopping = event else { return false }
+      classificationObservedByFilter.withLock {
+        $0 = coordinator.consumeStoppedShouldSynthesizeEnd()
+      }
+      return true
+    }
+
+    var event = libvlc_event_t()
+    event.type = Int32(libvlc_MediaPlayerMediaStopping.rawValue)
+    event.u.media_player_media_stopping.reason = libvlc_stopping_reason_error
+    player.eventBridge._emitNativeEventForTesting(event)
+
+    #expect(
+      classificationObservedByFilter.withLock { $0 } == false,
+      "the filter classified an engine-reported error as natural end"
+    )
+    withExtendedLifetime(stream) {}
   }
 }

--- a/Tests/SwiftVLCTests/Player/PlaybackFreeTeardownRaceTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlaybackFreeTeardownRaceTests.swift
@@ -88,6 +88,7 @@ extension Integration {
           finished.withLock { $0 = true }
         }
 
+        var previousGeneration = player.eventBridge.currentNativeHandleGeneration
         for _ in 0..<10 {
           let oldPointer = player.pointer
           player.setDrawable(NSObject())
@@ -97,6 +98,12 @@ extension Integration {
             player.pointer != oldPointer,
             "swap did not replace the native player handle"
           )
+          let generation = player.eventBridge.currentNativeHandleGeneration
+          #expect(
+            generation > previousGeneration,
+            "native attachment generation did not advance across a handle swap"
+          )
+          previousGeneration = generation
         }
         #expect(
           !finished.withLock { $0 },

--- a/Tests/SwiftVLCTests/Player/PlayerEndReachedTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerEndReachedTests.swift
@@ -36,9 +36,9 @@ extension Integration {
   @MainActor struct PlayerEndReachedTests {
     /// Natural end of the 1s fixture: exactly one `.endReached`, ordered
     /// after `.stateChanged(.stopped)` in the raw sequence, and a
-    /// parallel sourced subscription sees both carrying the same source.
+    /// parallel sourced subscription sees both carrying the same generation.
     @Test(.timeLimit(.minutes(1)))
-    func `Natural end emits exactly one endReached after stopped with the same source`() async throws {
+    func `Natural end emits exactly one endReached after stopped with the same generation`() async throws {
       let player = Player(instance: TestInstance.makePlayback())
       let stream = player.events(policy: .unbounded, filter: nil)
       let sourcedStream = player.eventBridge.makeSourcedStream(policy: .unbounded)
@@ -49,15 +49,15 @@ extension Integration {
           collected.withLock { $0.append(event) }
         }
       }
-      let stoppedSource = Mutex<UInt?>(nil)
-      let endSource = Mutex<UInt?>(nil)
+      let stoppedGeneration = Mutex<UInt64?>(nil)
+      let endGeneration = Mutex<UInt64?>(nil)
       let sourcedCollector = Task.detached { @Sendable in
         for await sourced in sourcedStream {
           switch sourced.event {
           case .stateChanged(.stopped):
-            stoppedSource.withLock { $0 = sourced.source }
+            stoppedGeneration.withLock { $0 = sourced.nativeHandleGeneration }
           case .endReached:
-            endSource.withLock { $0 = sourced.source }
+            endGeneration.withLock { $0 = sourced.nativeHandleGeneration }
           default:
             continue
           }
@@ -84,9 +84,9 @@ extension Integration {
       )
       #expect(stoppedIndex < endIndex, "endReached did not follow stopped: \(snapshot)")
 
-      let stopped = try #require(stoppedSource.withLock { $0 }, "sourced stream never saw stopped")
-      let end = try #require(endSource.withLock { $0 }, "sourced stream never saw endReached")
-      #expect(stopped == end, "stopped and endReached carried different sources")
+      let stopped = try #require(stoppedGeneration.withLock { $0 }, "sourced stream never saw stopped")
+      let end = try #require(endGeneration.withLock { $0 }, "sourced stream never saw endReached")
+      #expect(stopped == end, "stopped and endReached carried different generations")
     }
 
     @Test(.timeLimit(.minutes(1)))

--- a/Tests/SwiftVLCTests/Player/PlayerEventLaneTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerEventLaneTests.swift
@@ -42,17 +42,17 @@ extension Integration {
     func `A timing burst cannot evict a control event`() async {
       let player = Player(instance: TestInstance.shared)
       let bridge = player.eventBridge
-      let source = Player.sourceIdentifier(for: player.pointer)
+      let nativeHandleGeneration = bridge.currentNativeHandleGeneration
       let stream = player.controlEvents
 
-      bridge._broadcastForTesting(.lengthChanged(.seconds(2)), source: source)
+      bridge._broadcastForTesting(.lengthChanged(.seconds(2)), nativeHandleGeneration: nativeHandleGeneration)
       for index in 0..<500 {
-        bridge._broadcastForTesting(.timeChanged(.milliseconds(index)), source: source)
-        bridge._broadcastForTesting(.positionChanged(Double(index) / 500), source: source)
+        bridge._broadcastForTesting(.timeChanged(.milliseconds(index)), nativeHandleGeneration: nativeHandleGeneration)
+        bridge._broadcastForTesting(.positionChanged(Double(index) / 500), nativeHandleGeneration: nativeHandleGeneration)
       }
       // Bounds the drain: once this arrives, everything before it has been
       // delivered or dropped, so the assertions below are not racing.
-      bridge._broadcastForTesting(.mediaChanged, source: source)
+      bridge._broadcastForTesting(.mediaChanged, nativeHandleGeneration: nativeHandleGeneration)
 
       var sawBuriedControlEvent = false
       var timingEventCount = 0
@@ -79,15 +79,15 @@ extension Integration {
     func `The timing lane stays bounded and carries no control events`() async {
       let player = Player(instance: TestInstance.shared)
       let bridge = player.eventBridge
-      let source = Player.sourceIdentifier(for: player.pointer)
+      let nativeHandleGeneration = bridge.currentNativeHandleGeneration
       let stream = player.timingEvents
 
       for index in 0..<500 {
-        bridge._broadcastForTesting(.timeChanged(.milliseconds(index)), source: source)
+        bridge._broadcastForTesting(.timeChanged(.milliseconds(index)), nativeHandleGeneration: nativeHandleGeneration)
       }
       // A control event cannot bound this drain — it is filtered out — so the
       // final timing sample is the sentinel instead.
-      bridge._broadcastForTesting(.voutChanged(7), source: source)
+      bridge._broadcastForTesting(.voutChanged(7), nativeHandleGeneration: nativeHandleGeneration)
 
       var delivered: [PlayerEvent] = []
       drain: for await event in stream {

--- a/Tests/SwiftVLCTests/Player/PlayerEventStreamPolicyTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerEventStreamPolicyTests.swift
@@ -82,11 +82,11 @@ extension Integration {
     func `Internal consumer mirrors a buried one-shot event after a main-actor stall`() async throws {
       let player = Player(instance: TestInstance.shared)
       let bridge = player.eventBridge
-      let source = Player.sourceIdentifier(for: player.pointer)
+      let nativeHandleGeneration = bridge.currentNativeHandleGeneration
 
-      bridge._broadcastForTesting(.lengthChanged(.seconds(2)), source: source)
+      bridge._broadcastForTesting(.lengthChanged(.seconds(2)), nativeHandleGeneration: nativeHandleGeneration)
       for _ in 0..<128 {
-        bridge._broadcastForTesting(.timeChanged(.zero), source: source)
+        bridge._broadcastForTesting(.timeChanged(.zero), nativeHandleGeneration: nativeHandleGeneration)
       }
 
       try #require(
@@ -104,7 +104,7 @@ extension Integration {
     func `Unbounded policy and filter combine on the public events stream`() async {
       let player = Player(instance: TestInstance.shared)
       let bridge = player.eventBridge
-      let source = Player.sourceIdentifier(for: player.pointer)
+      let nativeHandleGeneration = bridge.currentNativeHandleGeneration
       let stream = player.events(policy: .unbounded, filter: { event in
         if case .timeChanged = event {
           return false
@@ -112,12 +112,12 @@ extension Integration {
         return true
       })
 
-      bridge._broadcastForTesting(.stateChanged(.opening), source: source)
+      bridge._broadcastForTesting(.stateChanged(.opening), nativeHandleGeneration: nativeHandleGeneration)
       for _ in 0..<150 {
-        bridge._broadcastForTesting(.timeChanged(.zero), source: source)
+        bridge._broadcastForTesting(.timeChanged(.zero), nativeHandleGeneration: nativeHandleGeneration)
       }
-      bridge._broadcastForTesting(.stateChanged(.playing), source: source)
-      bridge._broadcastForTesting(.mediaChanged, source: source)
+      bridge._broadcastForTesting(.stateChanged(.playing), nativeHandleGeneration: nativeHandleGeneration)
+      bridge._broadcastForTesting(.mediaChanged, nativeHandleGeneration: nativeHandleGeneration)
 
       var states: [PlayerState] = []
       var timeChangedCount = 0
@@ -145,7 +145,7 @@ extension Integration {
     func `stateTransitions is lossless and firehose-free without playback`() async throws {
       let player = Player(instance: TestInstance.shared)
       let bridge = player.eventBridge
-      let source = Player.sourceIdentifier(for: player.pointer)
+      let nativeHandleGeneration = bridge.currentNativeHandleGeneration
       let transitions = player.stateTransitions
 
       let collected = Mutex<[PlayerState]>([])
@@ -155,13 +155,13 @@ extension Integration {
         }
       }
 
-      bridge._broadcastForTesting(.stateChanged(.opening), source: source)
-      bridge._broadcastForTesting(.stateChanged(.playing), source: source)
+      bridge._broadcastForTesting(.stateChanged(.opening), nativeHandleGeneration: nativeHandleGeneration)
+      bridge._broadcastForTesting(.stateChanged(.playing), nativeHandleGeneration: nativeHandleGeneration)
       for _ in 0..<100 {
-        bridge._broadcastForTesting(.timeChanged(.zero), source: source)
+        bridge._broadcastForTesting(.timeChanged(.zero), nativeHandleGeneration: nativeHandleGeneration)
       }
-      bridge._broadcastForTesting(.stateChanged(.stopping), source: source)
-      bridge._broadcastForTesting(.stateChanged(.stopped), source: source)
+      bridge._broadcastForTesting(.stateChanged(.stopping), nativeHandleGeneration: nativeHandleGeneration)
+      bridge._broadcastForTesting(.stateChanged(.stopped), nativeHandleGeneration: nativeHandleGeneration)
 
       try #require(
         await poll(until: { collected.withLock { $0.count >= 4 } }),

--- a/Tests/SwiftVLCTests/Player/PlayerSeekAuthorityTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerSeekAuthorityTests.swift
@@ -25,7 +25,7 @@ extension Integration {
 
       // A sample libVLC produced before the seek, still queued.
       let stale = SourcedPlayerEvent(
-        source: Player.sourceIdentifier(for: player.pointer),
+        nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
         event: .timeChanged(.seconds(3)),
         timelineRevision: player.acceptedTimelineRevision
       )
@@ -49,7 +49,7 @@ extension Integration {
       player._setStateForTesting(state: .paused, duration: .seconds(100), isSeekable: true)
 
       let stale = SourcedPlayerEvent(
-        source: Player.sourceIdentifier(for: player.pointer),
+        nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
         event: .positionChanged(0.03),
         timelineRevision: player.acceptedTimelineRevision
       )
@@ -73,7 +73,7 @@ extension Integration {
       try player.seek(to: .seconds(42))
 
       let fresh = SourcedPlayerEvent(
-        source: Player.sourceIdentifier(for: player.pointer),
+        nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
         event: .timeChanged(.seconds(43)),
         timelineRevision: player.acceptedTimelineRevision
       )
@@ -95,7 +95,7 @@ extension Integration {
       try player.seek(to: .seconds(80))
 
       let supersededSample = SourcedPlayerEvent(
-        source: Player.sourceIdentifier(for: player.pointer),
+        nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
         event: .timeChanged(.seconds(10)),
         timelineRevision: firstRevision
       )
@@ -115,7 +115,7 @@ extension Integration {
       try player.seek(to: .seconds(42))
 
       let staleTransition = SourcedPlayerEvent(
-        source: Player.sourceIdentifier(for: player.pointer),
+        nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
         event: .stateChanged(.playing),
         timelineRevision: 0
       )
@@ -145,7 +145,7 @@ extension Integration {
       try player.seek(to: .seconds(42), fast: true)
 
       let landed = SourcedPlayerEvent(
-        source: Player.sourceIdentifier(for: player.pointer),
+        nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
         event: .timeChanged(.seconds(40)),
         timelineRevision: concurrentRevision
       )
@@ -183,7 +183,7 @@ extension Integration {
       player._setStateForTesting(state: .paused, duration: .seconds(100), isSeekable: true)
 
       let previousGenerationSample = SourcedPlayerEvent(
-        source: Player.sourceIdentifier(for: player.pointer),
+        nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
         event: .timeChanged(.seconds(7)),
         timelineRevision: player.acceptedTimelineRevision
       )
@@ -218,7 +218,7 @@ extension Integration {
 
       // Produced by libVLC before the jump, still queued behind it.
       let stale = SourcedPlayerEvent(
-        source: Player.sourceIdentifier(for: player.pointer),
+        nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
         event: .timeChanged(.seconds(10)),
         timelineRevision: player.acceptedTimelineRevision
       )

--- a/Tests/SwiftVLCTests/Player/PlayerStateTransitionCompletenessTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerStateTransitionCompletenessTests.swift
@@ -21,7 +21,7 @@ extension Integration {
     func `A native error reaches the transition stream`() async throws {
       let player = Player(instance: TestInstance.shared)
       let bridge = player.eventBridge
-      let source = Player.sourceIdentifier(for: player.pointer)
+      let nativeHandleGeneration = bridge.currentNativeHandleGeneration
       let transitions = player.stateTransitions
       let collected = Mutex<[PlayerState]>([])
       let collector = Task.detached { @Sendable in
@@ -30,7 +30,7 @@ extension Integration {
         }
       }
 
-      bridge._broadcastForTesting(.encounteredError, source: source)
+      bridge._broadcastForTesting(.encounteredError, nativeHandleGeneration: nativeHandleGeneration)
 
       try #require(
         await poll(until: { collected.withLock { $0.contains(.error) } }),
@@ -43,7 +43,7 @@ extension Integration {
     func `Entering buffering reaches the transition stream`() async throws {
       let player = Player(instance: TestInstance.shared)
       let bridge = player.eventBridge
-      let source = Player.sourceIdentifier(for: player.pointer)
+      let nativeHandleGeneration = bridge.currentNativeHandleGeneration
       let transitions = player.stateTransitions
       let collected = Mutex<[PlayerState]>([])
       let collector = Task.detached { @Sendable in
@@ -52,7 +52,7 @@ extension Integration {
         }
       }
 
-      bridge._broadcastForTesting(.bufferingProgress(0.25), source: source)
+      bridge._broadcastForTesting(.bufferingProgress(0.25), nativeHandleGeneration: nativeHandleGeneration)
 
       try #require(
         await poll(until: { collected.withLock { $0.contains(.buffering) } }),
@@ -68,7 +68,7 @@ extension Integration {
     func `Buffering progress does not re-announce the state`() async throws {
       let player = Player(instance: TestInstance.shared)
       let bridge = player.eventBridge
-      let source = Player.sourceIdentifier(for: player.pointer)
+      let nativeHandleGeneration = bridge.currentNativeHandleGeneration
       let transitions = player.stateTransitions
       let collected = Mutex<[PlayerState]>([])
       let collector = Task.detached { @Sendable in
@@ -78,11 +78,11 @@ extension Integration {
       }
 
       for index in 0..<200 {
-        bridge._broadcastForTesting(.bufferingProgress(Float(index) / 200), source: source)
+        bridge._broadcastForTesting(.bufferingProgress(Float(index) / 200), nativeHandleGeneration: nativeHandleGeneration)
       }
       // Bounds the drain: once this lands, every buffering report before it
       // has been processed.
-      bridge._broadcastForTesting(.stateChanged(.playing), source: source)
+      bridge._broadcastForTesting(.stateChanged(.playing), nativeHandleGeneration: nativeHandleGeneration)
 
       try #require(
         await poll(until: { collected.withLock { $0.contains(.playing) } }),
@@ -133,7 +133,7 @@ extension Integration {
     func `The recast wait observes failure instead of timing out`() async {
       let player = Player(instance: TestInstance.shared)
       let bridge = player.eventBridge
-      let source = Player.sourceIdentifier(for: player.pointer)
+      let nativeHandleGeneration = bridge.currentNativeHandleGeneration
       // The wait is generation-scoped now, so it consumes `playbackStatus`
       // and is anchored to the player's current generation.
       let statuses = player.playbackStatus
@@ -144,7 +144,7 @@ extension Integration {
       }
       // Give the wait a turn to subscribe before the error is broadcast.
       await Task.yield()
-      bridge._broadcastForTesting(.encounteredError, source: source)
+      bridge._broadcastForTesting(.encounteredError, nativeHandleGeneration: nativeHandleGeneration)
 
       #expect(
         await result.value == .failed,

--- a/Tests/SwiftVLCTests/Player/PlayerStopOutcomeTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerStopOutcomeTests.swift
@@ -142,14 +142,14 @@ extension Integration {
 
     /// A stop for the awaited handle ends the wait as output-safe.
     @Test
-    func `A stopped event for the awaited source reports stopped`() async {
+    func `A stopped event for the awaited generation reports stopped`() async {
       let stream = Self.eventStream([
-        SourcedPlayerEvent(source: 7, event: .stateChanged(.stopped))
+        SourcedPlayerEvent(nativeHandleGeneration: 7, event: .stateChanged(.stopped))
       ])
 
       let outcome = await Player.awaitOutputSafeStop(
         on: stream,
-        source: 7,
+        nativeHandleGeneration: 7,
         timeout: .seconds(5)
       )
 
@@ -162,12 +162,12 @@ extension Integration {
     @Test
     func `An error event alone never reports output-safe`() async {
       let stream = Self.eventStream([
-        SourcedPlayerEvent(source: 7, event: .stateChanged(.error))
+        SourcedPlayerEvent(nativeHandleGeneration: 7, event: .stateChanged(.error))
       ])
 
       let outcome = await Player.awaitOutputSafeStop(
         on: stream,
-        source: 7,
+        nativeHandleGeneration: 7,
         timeout: .milliseconds(50)
       )
 
@@ -180,13 +180,13 @@ extension Integration {
     @Test
     func `An error followed by a stop reports stopped`() async {
       let stream = Self.eventStream([
-        SourcedPlayerEvent(source: 7, event: .stateChanged(.error)),
-        SourcedPlayerEvent(source: 7, event: .stateChanged(.stopped))
+        SourcedPlayerEvent(nativeHandleGeneration: 7, event: .stateChanged(.error)),
+        SourcedPlayerEvent(nativeHandleGeneration: 7, event: .stateChanged(.stopped))
       ])
 
       let outcome = await Player.awaitOutputSafeStop(
         on: stream,
-        source: 7,
+        nativeHandleGeneration: 7,
         timeout: .seconds(5)
       )
 
@@ -196,14 +196,14 @@ extension Integration {
     /// A stop belonging to a different native handle must be ignored: it says
     /// nothing about the handle this caller is waiting on.
     @Test
-    func `A stop from another source is ignored`() async {
+    func `A stop from another generation is ignored`() async {
       let stream = Self.eventStream([
-        SourcedPlayerEvent(source: 99, event: .stateChanged(.stopped))
+        SourcedPlayerEvent(nativeHandleGeneration: 99, event: .stateChanged(.stopped))
       ])
 
       let outcome = await Player.awaitOutputSafeStop(
         on: stream,
-        source: 7,
+        nativeHandleGeneration: 7,
         timeout: .milliseconds(50)
       )
 
@@ -214,13 +214,13 @@ extension Integration {
     @Test
     func `Unrelated events do not end the wait`() async {
       let stream = Self.eventStream([
-        SourcedPlayerEvent(source: 7, event: .timeChanged(.seconds(1))),
-        SourcedPlayerEvent(source: 7, event: .stateChanged(.playing))
+        SourcedPlayerEvent(nativeHandleGeneration: 7, event: .timeChanged(.seconds(1))),
+        SourcedPlayerEvent(nativeHandleGeneration: 7, event: .stateChanged(.playing))
       ])
 
       let outcome = await Player.awaitOutputSafeStop(
         on: stream,
-        source: 7,
+        nativeHandleGeneration: 7,
         timeout: .milliseconds(50)
       )
 
@@ -234,7 +234,7 @@ extension Integration {
 
       let outcome = await Player.awaitOutputSafeStop(
         on: stream,
-        source: 7,
+        nativeHandleGeneration: 7,
         timeout: .milliseconds(50)
       )
 

--- a/Tests/SwiftVLCTests/Player/PlayerTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerTests.swift
@@ -86,24 +86,43 @@ extension Integration {
     }
 
     @Test
-    func `Stale terminal event from replaced native player does not clear playback intent`() throws {
+    func `A terminal event from generation A cannot mutate generation C`() throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
       let first = try Media(url: TestMedia.testMP4URL)
       let second = try Media(url: TestMedia.twosecURL)
+      let third = try Media(url: TestMedia.silenceURL)
 
       player.load(first)
       player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
-      let oldPointer = player.pointer
+      let firstGeneration = player.eventBridge.currentNativeHandleGeneration
 
       do {
         try player.play(second)
       } catch {
         _ = error
       }
+      let secondGeneration = player.eventBridge.currentNativeHandleGeneration
+      #expect(secondGeneration > firstGeneration)
+
+      // Force another native replacement. A pointer-address filter can accept
+      // A here if the allocator reuses A's address for C; the monotonic token
+      // must reject it regardless of the concrete addresses chosen this run.
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      do {
+        try player.play(third)
+      } catch {
+        _ = error
+      }
+      let thirdGeneration = player.eventBridge.currentNativeHandleGeneration
 
       #expect(player.isPlaybackRequestedActive)
-      player._handleEventForTesting(.stateChanged(.stopped), source: oldPointer)
+      #expect(thirdGeneration > secondGeneration)
+      player._handleEventForTesting(
+        .stateChanged(.stopped),
+        nativeHandleGeneration: firstGeneration
+      )
       #expect(player.isPlaybackRequestedActive)
+      #expect(player.currentMedia === third)
       player.stop()
     }
 


### PR DESCRIPTION
Advances issue 85 and the remaining generation criterion from issue 78.

## Problem

Internal event attribution uses the raw libVLC player pointer. Native handle A can be retired, B installed, and the allocator can later reuse the same address for C. A queued event from A then compares equal to C and can mutate the successor session.

Terminal cause recording also happens after public fan-out. Public filters execute synchronously on the libVLC callback thread, so reentrant work can observe or consume a stop before the engine reason is recorded. Clearing the retiring cause after attaching the successor creates the inverse race: an early successor callback can be erased.

## Change

- Pass a fresh retained callback attachment token to libVLC for every native handle.
- Stamp internal events with an immutable monotonic UInt64 generation instead of a pointer address.
- Release an old token only after every libvlc_event_detach returns; libVLC serializes callback execution and detach with the same event-manager lock.
- Clear the retiring stop cause in the detach/attach gap.
- Record stopping reason and error state before raw event fan-out, while preserving stopped then endReached delivery order.
- Scope stopAndWait to the immutable handle generation.

## Regression evidence

- A terminal event from generation A is rejected after real A to B to C replacements.
- Ten repeated real handle swaps strictly advance the generation.
- A synchronous public filter sees an engine-reported error classification before the raw mediaStopping event.
- 1,815 CI-mode tests pass against v1.1.0-beta.1.
- Strict-concurrency build, SwiftFormat, SwiftLint, patch manifest, and release-integrity tests pass.

## Remaining milestone work

This establishes trustworthy internal native-handle identity and callback ordering. Public generation-bearing event envelopes, exactly-once structured terminal outcomes with a pre-reset timeline, richer failure attribution, and playback-health/PiP criteria remain follow-up work.