### PR TITLE
Expose native generation on public player events

### DIFF
--- a/Sources/SwiftVLC/Player/EventBridge.swift
+++ b/Sources/SwiftVLC/Player/EventBridge.swift
@@ -109,6 +109,10 @@ final class EventBridge: Sendable {
     nativeHandleGeneration.withLock { $0 }
   }
 
+  var currentNativePlayerGeneration: NativePlayerGeneration {
+    NativePlayerGeneration(currentNativeHandleGeneration)
+  }
+
   /// Creates a new independent `AsyncStream` for consuming player events.
   /// Each stream is offered events broadcast after creation that pass its
   /// filter. Delivery under consumer lag follows `policy`.
@@ -121,6 +125,13 @@ final class EventBridge: Sendable {
 
   func makeSourcedStream(policy: EventBufferingPolicy) -> AsyncStream<SourcedPlayerEvent> {
     context.makeSourcedStream(policy: policy)
+  }
+
+  func makeEnvelopeStream(
+    policy: EventBufferingPolicy?,
+    filter: (@Sendable (PlayerEventEnvelope) -> Bool)?
+  ) -> AsyncStream<PlayerEventEnvelope> {
+    context.makeEnvelopeStream(policy: policy, filter: filter)
   }
 
   /// Marks a new authoritative timeline. Clock samples emitted before this
@@ -245,6 +256,7 @@ private final class EventBridgeCallbackAttachment: Sendable {
 
 private final class EventBridgeCallbackContext: Sendable {
   private let events = Broadcaster<PlayerEvent>(defaultBufferSize: 64)
+  private let eventEnvelopes = Broadcaster<PlayerEventEnvelope>(defaultBufferSize: 64)
   private let sourcedEvents = Broadcaster<SourcedPlayerEvent>(defaultBufferSize: 64)
   /// Stamped onto every sourced event so the consumer can tell clock samples
   /// that predate an accepted seek from ones that follow it. Lives here
@@ -267,6 +279,13 @@ private final class EventBridgeCallbackContext: Sendable {
     sourcedEvents.subscribe(policy: policy)
   }
 
+  func makeEnvelopeStream(
+    policy: EventBufferingPolicy?,
+    filter: (@Sendable (PlayerEventEnvelope) -> Bool)?
+  ) -> AsyncStream<PlayerEventEnvelope> {
+    eventEnvelopes.subscribe(policy: policy, filter: filter)
+  }
+
   func broadcast(_ event: PlayerEvent, nativeHandleGeneration: UInt64) {
     // Each broadcaster is gated on its own emptiness so a libVLC event
     // with no consumers costs neither the lock-and-snapshot nor the
@@ -283,6 +302,14 @@ private final class EventBridgeCallbackContext: Sendable {
         )
       )
     }
+    if !eventEnvelopes.isEmpty {
+      eventEnvelopes.broadcast(
+        PlayerEventEnvelope(
+          event: event,
+          nativeGeneration: NativePlayerGeneration(nativeHandleGeneration)
+        )
+      )
+    }
     if !events.isEmpty {
       events.broadcast(event)
     }
@@ -295,16 +322,12 @@ private final class EventBridgeCallbackContext: Sendable {
     }
   }
 
-  func finishAll() {
-    events.finishAll()
-    sourcedEvents.finishAll()
-  }
-
   /// Permanently closes both broadcasters, so streams handed out after this
   /// point are already finished rather than waiting on a source that will
   /// never emit again.
   func terminate() {
     events.terminate()
+    eventEnvelopes.terminate()
     sourcedEvents.terminate()
   }
 }

--- a/Sources/SwiftVLC/Player/PlayerEventEnvelope.swift
+++ b/Sources/SwiftVLC/Player/PlayerEventEnvelope.swift
@@ -1,0 +1,75 @@
+/// Opaque identity of the native libVLC player that emitted an event.
+///
+/// A ``Player`` can replace its underlying libVLC player while the Swift
+/// object and its event streams stay alive. Native pointer addresses are not
+/// identities: an allocator may reuse a retired address for a later handle.
+/// This monotonic value makes an event from the retired handle rejectable even
+/// in that case.
+///
+/// This is deliberately distinct from ``PlaybackGeneration``. A playback
+/// generation identifies a media session, while a native-player generation
+/// identifies the concrete libVLC handle carrying it. One can change without
+/// the other.
+public struct NativePlayerGeneration: Hashable, Sendable, Comparable, CustomStringConvertible {
+  let value: UInt64
+
+  init(_ value: UInt64) {
+    self.value = value
+  }
+
+  /// Orders two generations by when their native handles were installed.
+  public static func < (lhs: Self, rhs: Self) -> Bool {
+    lhs.value < rhs.value
+  }
+
+  /// A short description suitable for diagnostics.
+  public var description: String {
+    "native generation \(value)"
+  }
+}
+
+/// A raw player event paired with the native handle that emitted it.
+///
+/// The legacy ``Player/events`` stream remains available for source
+/// compatibility. Consumers that retain, queue, or merge events across native
+/// handle replacement should use this envelope and compare
+/// ``nativeGeneration`` with ``Player/nativeEventGeneration`` before applying
+/// the event.
+public struct PlayerEventEnvelope: Sendable {
+  /// The raw event mapped from libVLC.
+  public let event: PlayerEvent
+  /// The native libVLC handle that emitted ``event``.
+  public let nativeGeneration: NativePlayerGeneration
+}
+
+extension Player {
+  /// The native libVLC handle currently installed behind this player.
+  ///
+  /// Compare this value with ``PlayerEventEnvelope/nativeGeneration`` before
+  /// applying an event that may have waited in a queue across renderer recast
+  /// or native-handle replacement.
+  public nonisolated var nativeEventGeneration: NativePlayerGeneration {
+    eventBridge.currentNativePlayerGeneration
+  }
+
+  /// Raw events paired with the native handle that emitted them.
+  ///
+  /// The default newest-64 policy has the same bounded, lossy behavior as
+  /// ``Player/events``. Use ``eventEnvelopes(policy:filter:)`` or the
+  /// lane-specific envelope streams when one-shot control delivery must be
+  /// lossless.
+  public nonisolated var eventEnvelopes: AsyncStream<PlayerEventEnvelope> {
+    eventBridge.makeEnvelopeStream(policy: .newest(64), filter: nil)
+  }
+
+  /// Raw event envelopes with an explicit buffering policy and filter.
+  ///
+  /// The filter runs synchronously on libVLC's event thread under the same
+  /// constraints documented by ``Player/events(policy:filter:)``.
+  public nonisolated func eventEnvelopes(
+    policy: EventBufferingPolicy = .newest(64),
+    filter: (@Sendable (PlayerEventEnvelope) -> Bool)? = nil
+  ) -> AsyncStream<PlayerEventEnvelope> {
+    eventBridge.makeEnvelopeStream(policy: policy, filter: filter)
+  }
+}

--- a/Sources/SwiftVLC/Player/PlayerEventLane.swift
+++ b/Sources/SwiftVLC/Player/PlayerEventLane.swift
@@ -89,6 +89,17 @@ extension Player {
     eventBridge.makeStream(policy: .unbounded, filter: { $0.lane == .control })
   }
 
+  /// Lossless control events paired with their native-handle generation.
+  ///
+  /// No timing volume can evict a value because timing events never enter
+  /// this stream. Compare each envelope with ``nativeEventGeneration`` before
+  /// applying work that may outlive a native-handle replacement.
+  public nonisolated var controlEventEnvelopes: AsyncStream<PlayerEventEnvelope> {
+    eventBridge.makeEnvelopeStream(policy: .unbounded) { envelope in
+      envelope.event.lane == .control
+    }
+  }
+
   /// Coalesced stream of continuous events — the playback clock, buffer fill,
   /// and render counters.
   ///
@@ -115,6 +126,13 @@ extension Player {
       policy: .newest(Self.timingLaneBufferSize),
       filter: { $0.lane == .timing }
     )
+  }
+
+  /// Coalesced timing events paired with their native-handle generation.
+  public nonisolated var timingEventEnvelopes: AsyncStream<PlayerEventEnvelope> {
+    eventBridge.makeEnvelopeStream(policy: .newest(Self.timingLaneBufferSize)) { envelope in
+      envelope.event.lane == .timing
+    }
   }
 
   /// Newest-N across the whole timing lane. Sized to hold at least one of each

--- a/Tests/SwiftVLCTests/Player/PlayerEventLaneTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerEventLaneTests.swift
@@ -1,4 +1,5 @@
 @testable import SwiftVLC
+import Foundation
 import Testing
 
 @Suite(.tags(.logic))
@@ -25,6 +26,14 @@ struct PlayerEventLaneClassificationTests {
     #expect(PlayerEvent.pausableChanged(true).lane == .control)
     #expect(PlayerEvent.tracksChanged.lane == .control)
     #expect(PlayerEvent.programSelected(unselectedId: 1, selectedId: 2).lane == .control)
+  }
+
+  @Test
+  func `Native generations are ordered opaque diagnostic values`() {
+    let first = NativePlayerGeneration(1)
+    let second = NativePlayerGeneration(2)
+    #expect(first < second)
+    #expect(first.description == "native generation 1")
   }
 }
 
@@ -111,6 +120,157 @@ extension Integration {
         return
       }
       #expect(count == 7)
+    }
+
+    /// A public consumer can keep a lossless control subscription alive across
+    /// a native replacement and reject an event that was already queued from
+    /// the predecessor. Pointer equality cannot prove this because an
+    /// allocator may reuse the old address; the monotonic token can.
+    @Test(.timeLimit(.minutes(1)))
+    func `A queued predecessor event remains attributable after native replacement`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let bridge = player.eventBridge
+      let stream = player.controlEventEnvelopes
+      let predecessor = player.nativeEventGeneration
+
+      player.setDrawable(NSObject())
+      player.stop()
+      try player.prepareDrawableForPlayback()
+      let successor = player.nativeEventGeneration
+      #expect(successor > predecessor)
+
+      // Simulate a value already queued from A becoming visible only after B
+      // was installed. The following sentinel bounds the drain.
+      bridge._broadcastForTesting(
+        .stateChanged(.stopped),
+        nativeHandleGeneration: predecessor.value
+      )
+      bridge._broadcastForTesting(
+        .mediaChanged,
+        nativeHandleGeneration: successor.value
+      )
+
+      var predecessorEnvelope: PlayerEventEnvelope?
+      drain: for await envelope in stream {
+        switch envelope.event {
+        case .stateChanged(.stopped):
+          predecessorEnvelope = envelope
+        case .mediaChanged:
+          break drain
+        default:
+          break
+        }
+      }
+
+      let stale = try #require(predecessorEnvelope)
+      #expect(stale.nativeGeneration == predecessor)
+      #expect(stale.nativeGeneration != player.nativeEventGeneration)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `Envelope control lane excludes the timing firehose`() async {
+      let player = Player(instance: TestInstance.shared)
+      let bridge = player.eventBridge
+      let generation = player.nativeEventGeneration
+      let stream = player.controlEventEnvelopes
+
+      bridge._broadcastForTesting(
+        .lengthChanged(.seconds(2)),
+        nativeHandleGeneration: generation.value
+      )
+      for index in 0..<500 {
+        bridge._broadcastForTesting(
+          .timeChanged(.milliseconds(index)),
+          nativeHandleGeneration: generation.value
+        )
+      }
+      bridge._broadcastForTesting(.mediaChanged, nativeHandleGeneration: generation.value)
+
+      var events: [PlayerEvent] = []
+      drain: for await envelope in stream {
+        events.append(envelope.event)
+        if case .mediaChanged = envelope.event {
+          break drain
+        }
+        #expect(envelope.nativeGeneration == generation)
+      }
+
+      #expect(events.contains { event in
+        if case .lengthChanged = event {
+          true
+        } else {
+          false
+        }
+      })
+      #expect(events.allSatisfy { $0.lane == .control })
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `Default and filtered envelope streams preserve attribution`() async throws {
+      let player = Player(instance: TestInstance.shared)
+      let bridge = player.eventBridge
+      let generation = player.nativeEventGeneration
+      let defaultStream = player.eventEnvelopes
+      let filteredStream = player.eventEnvelopes(policy: .unbounded) { envelope in
+        envelope.event.lane == .control
+      }
+
+      bridge._broadcastForTesting(
+        .timeChanged(.seconds(1)),
+        nativeHandleGeneration: generation.value
+      )
+      bridge._broadcastForTesting(.mediaChanged, nativeHandleGeneration: generation.value)
+
+      var defaultSawTiming = false
+      defaultDrain: for await envelope in defaultStream {
+        #expect(envelope.nativeGeneration == generation)
+        switch envelope.event {
+        case .timeChanged:
+          defaultSawTiming = true
+        case .mediaChanged:
+          break defaultDrain
+        default:
+          break
+        }
+      }
+
+      var firstFiltered: PlayerEventEnvelope?
+      for await envelope in filteredStream {
+        firstFiltered = envelope
+        break
+      }
+      let filteredEnvelope = try #require(firstFiltered)
+      #expect(filteredEnvelope.nativeGeneration == generation)
+      #expect(filteredEnvelope.event.lane == .control)
+      #expect(defaultSawTiming)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `Envelope timing lane remains bounded`() async {
+      let player = Player(instance: TestInstance.shared)
+      let bridge = player.eventBridge
+      let generation = player.nativeEventGeneration
+      let stream = player.timingEventEnvelopes
+
+      for index in 0..<500 {
+        bridge._broadcastForTesting(
+          .timeChanged(.milliseconds(index)),
+          nativeHandleGeneration: generation.value
+        )
+      }
+      bridge._broadcastForTesting(.voutChanged(7), nativeHandleGeneration: generation.value)
+
+      var delivered: [PlayerEventEnvelope] = []
+      drain: for await envelope in stream {
+        delivered.append(envelope)
+        if case .voutChanged = envelope.event {
+          break drain
+        }
+      }
+
+      #expect(delivered.count <= Player.timingLaneBufferSize)
+      #expect(delivered.allSatisfy { $0.event.lane == .timing })
+      #expect(delivered.allSatisfy { $0.nativeGeneration == generation })
     }
   }
 }


### PR DESCRIPTION
Advances issue #78.

## Problem

PR #160 made native callback attribution internally trustworthy, but public subscribers still received a bare `PlayerEvent`. An event queued before a native-handle replacement could therefore arrive after the successor was installed with no identity a consumer could compare. Pointer addresses are insufficient because allocators reuse them.

## Change

- Adds opaque, monotonic `NativePlayerGeneration`.
- Adds `PlayerEventEnvelope`, pairing every raw event with the immutable attachment generation that emitted it.
- Exposes `Player.nativeEventGeneration`, default and policy-aware envelope streams, and lossless control/coalesced timing envelope lanes.
- Keeps `PlaybackGeneration` separate: it identifies a media session, while this type identifies the concrete libVLC handle. Neither is presented as the other.
- Permanently terminates the new broadcaster with the existing raw and internal streams.

## Regression proof

A test keeps the public control-envelope stream alive across a real native-player replacement, queues an event attributed to the predecessor, and proves it remains distinguishable from the current generation. Additional tests cover the lossless control lane under a 500-sample timing burst, policy/filter propagation, default delivery, timing-lane boundedness, ordering and diagnostic formatting.

## Validation

- `CI=true swift test --no-parallel --enable-code-coverage`: 1820 tests, 163 suites pass.
- Doc coverage: 747/747 public symbols, 100%.
- Strict-concurrency build: clean.
- SwiftFormat, strict SwiftLint and diff check: clean.

## Scope

This completes the old-native-handle attribution part of issue 78. It does not claim that native-handle generation is media generation, and it does not complete the authoritative terminal snapshot work tracked by issue 85.