### PR TITLE
Emit generation-scoped terminal outcomes

### DIFF
--- a/Sources/SwiftVLC/Player/EventBridge.swift
+++ b/Sources/SwiftVLC/Player/EventBridge.swift
@@ -85,6 +85,7 @@ final class EventBridge: Sendable {
     // terminal classification before the successor is attached, so neither an
     // old late callback nor an early successor callback can cross the reset.
     context.endCoordinator.clearForHandleReplacement()
+    context.clearPendingStopForNativeHandleReplacement()
 
     let generation = nativeHandleGeneration.withLock { generation in
       precondition(generation < UInt64.max, "Native handle generation exhausted")
@@ -134,6 +135,68 @@ final class EventBridge: Sendable {
     context.makeEnvelopeStream(policy: policy, filter: filter)
   }
 
+  func makeTerminalOutcomeStream() -> AsyncStream<PlaybackTerminalOutcome> {
+    context.makeTerminalOutcomeStream()
+  }
+
+  /// Aligns the event bridge with a wrapper-initiated media generation.
+  /// The outgoing generation is frozen as a replacement before the new
+  /// timeline becomes current.
+  @discardableResult
+  func synchronizePlaybackGeneration(
+    _ generation: UInt64,
+    media: OpaquePointer?,
+    outgoingNativeHandleGeneration: UInt64? = nil
+  ) -> UInt64 {
+    context.synchronizePlaybackGeneration(
+      generation,
+      media: media,
+      nativeHandleGeneration: outgoingNativeHandleGeneration
+        ?? currentNativeHandleGeneration,
+      retiringNativeHandle: outgoingNativeHandleGeneration != nil
+    )
+  }
+
+  /// Records that the current generation is expected to stop because the
+  /// wrapper issued an explicit stop request.
+  func markRequestedStop(playbackGeneration: UInt64) {
+    context.markRequestedStop(playbackGeneration: playbackGeneration)
+  }
+
+  /// Records timeline facts learned synchronously by the wrapper rather than
+  /// through a native player event.
+  func updateKnownDuration(_ duration: Duration?, playbackGeneration: UInt64) {
+    context.updateKnownDuration(duration, playbackGeneration: playbackGeneration)
+  }
+
+  /// Records an accepted seek or frame step immediately, including while the
+  /// native event thread is quiescent because playback is paused.
+  func updateAuthoritativeTimeline(
+    time: Duration,
+    position: Double?,
+    playbackGeneration: UInt64
+  ) {
+    context.updateAuthoritativeTimeline(
+      time: time,
+      position: position,
+      playbackGeneration: playbackGeneration
+    )
+  }
+
+  /// Ends the current generation without waiting for another native event.
+  /// Used when shutdown or native-handle retirement makes future callbacks
+  /// unobservable by construction.
+  func finishCurrentPlaybackGeneration(
+    cause: PlaybackTerminalCause,
+    playbackGeneration: UInt64
+  ) {
+    context.finishPlaybackGeneration(
+      playbackGeneration,
+      cause: cause,
+      nativeHandleGeneration: currentNativeHandleGeneration
+    )
+  }
+
   /// Marks a new authoritative timeline. Clock samples emitted before this
   /// point carry a lower revision and are discarded by the consumer.
   @discardableResult
@@ -144,8 +207,16 @@ final class EventBridge: Sendable {
   /// Pushes an event through the same fan-out path the C callback uses,
   /// including subscription buffering — unlike
   /// `Player._handleEventForTesting`, which bypasses the bridge entirely.
-  func _broadcastForTesting(_ event: PlayerEvent, nativeHandleGeneration: UInt64) {
-    context.broadcast(event, nativeHandleGeneration: nativeHandleGeneration)
+  func _broadcastForTesting(
+    _ event: PlayerEvent,
+    nativeHandleGeneration: UInt64,
+    playbackGeneration: UInt64? = nil
+  ) {
+    context.broadcast(
+      event,
+      nativeHandleGeneration: nativeHandleGeneration,
+      playbackGeneration: playbackGeneration
+    )
   }
 
   /// Exercises the complete native callback ordering with a synthetic event.
@@ -219,6 +290,7 @@ final class EventBridge: Sendable {
 
 struct SourcedPlayerEvent {
   let nativeHandleGeneration: UInt64
+  let playbackGeneration: UInt64
   let event: PlayerEvent
   /// The timeline revision current when libVLC emitted this event.
   ///
@@ -231,10 +303,12 @@ struct SourcedPlayerEvent {
 
   init(
     nativeHandleGeneration: UInt64,
+    playbackGeneration: UInt64,
     event: PlayerEvent,
     timelineRevision: UInt64 = 0
   ) {
     self.nativeHandleGeneration = nativeHandleGeneration
+    self.playbackGeneration = playbackGeneration
     self.event = event
     self.timelineRevision = timelineRevision
   }
@@ -258,10 +332,47 @@ private final class EventBridgeCallbackContext: Sendable {
   private let events = Broadcaster<PlayerEvent>(defaultBufferSize: 64)
   private let eventEnvelopes = Broadcaster<PlayerEventEnvelope>(defaultBufferSize: 64)
   private let sourcedEvents = Broadcaster<SourcedPlayerEvent>(defaultBufferSize: 64)
+  private let terminalOutcomes = Broadcaster<PlaybackTerminalOutcome>(defaultBufferSize: 16)
   /// Stamped onto every sourced event so the consumer can tell clock samples
   /// that predate an accepted seek from ones that follow it. Lives here
   /// because the stamp has to be taken on libVLC's thread, at emission.
   private let timelineRevision = Mutex<UInt64>(0)
+  private struct TimelineSnapshot: Sendable {
+    var time: Duration = .zero
+    var duration: Duration?
+    var position: Double = 0
+    var bufferFill: Float = 0
+    var activeVideoOutputs = 0
+
+    var publicValue: PlaybackFinalTimeline {
+      PlaybackFinalTimeline(
+        time: time,
+        duration: duration,
+        position: position,
+        bufferFill: bufferFill,
+        activeVideoOutputs: activeVideoOutputs
+      )
+    }
+  }
+
+  private struct PlaybackLifecycleState: Sendable {
+    var currentGeneration: UInt64 = 0
+    var currentMediaIdentity: UInt?
+    var mediaGenerations: [UInt: UInt64] = [:]
+    /// Wrapper-initiated `set_media` calls echo through `MediaChanged`. This
+    /// token distinguishes that echo from an external change which happens to
+    /// reuse the same media pointer.
+    var pendingWrapperMediaChangedGeneration: UInt64?
+    /// Retired generations awaiting their ordered `MediaStopping` callback
+    /// when the successor reuses the exact same retained media pointer.
+    var retiredMediaGenerations: [UInt: [UInt64]] = [:]
+    var snapshots: [UInt64: TimelineSnapshot] = [:]
+    var terminalIntents: [UInt64: PlaybackTerminalCause] = [:]
+    var lastEmittedGeneration: UInt64 = 0
+    var pendingStoppedGeneration: UInt64?
+  }
+
+  private let playbackLifecycle = Mutex(PlaybackLifecycleState())
   let endCoordinator: PlaybackEndCoordinator
 
   init(endCoordinator: PlaybackEndCoordinator) {
@@ -286,7 +397,123 @@ private final class EventBridgeCallbackContext: Sendable {
     eventEnvelopes.subscribe(policy: policy, filter: filter)
   }
 
-  func broadcast(_ event: PlayerEvent, nativeHandleGeneration: UInt64) {
+  func makeTerminalOutcomeStream() -> AsyncStream<PlaybackTerminalOutcome> {
+    terminalOutcomes.subscribe(policy: .unbounded)
+  }
+
+  func synchronizePlaybackGeneration(
+    _ generation: UInt64,
+    media: OpaquePointer?,
+    nativeHandleGeneration: UInt64,
+    retiringNativeHandle: Bool
+  ) -> UInt64 {
+    let result = playbackLifecycle.withLock { state -> (UInt64, PlaybackTerminalOutcome?) in
+      let outgoing = state.currentGeneration
+      let outgoingIdentity = state.currentMediaIdentity
+      let outcome = makeOutcome(
+        in: &state,
+        generation: outgoing,
+        cause: state.terminalIntents[outgoing] ?? .replacement,
+        nativeHandleGeneration: nativeHandleGeneration
+      )
+      precondition(state.currentGeneration < UInt64.max, "Playback generation exhausted")
+      let adoptedGeneration = max(generation, state.currentGeneration + 1)
+      state.currentGeneration = adoptedGeneration
+      state.currentMediaIdentity = Self.identity(of: media)
+      state.pendingWrapperMediaChangedGeneration = adoptedGeneration
+      if let identity = state.currentMediaIdentity {
+        if
+          !retiringNativeHandle,
+          outcome != nil,
+          outgoing > 0,
+          identity == outgoingIdentity {
+          state.retiredMediaGenerations[identity, default: []].append(outgoing)
+        }
+        state.mediaGenerations[identity] = adoptedGeneration
+      }
+      state.snapshots[adoptedGeneration] = TimelineSnapshot()
+      return (adoptedGeneration, outcome)
+    }
+    if let outcome = result.1 {
+      terminalOutcomes.broadcast(outcome)
+    }
+    return result.0
+  }
+
+  func markRequestedStop(playbackGeneration: UInt64) {
+    playbackLifecycle.withLock { state in
+      guard playbackGeneration > state.lastEmittedGeneration else { return }
+      state.terminalIntents[playbackGeneration] = .requestedStop
+      state.pendingStoppedGeneration = playbackGeneration
+      // An explicit stop applies to the session the caller can currently see.
+      // Prefer it over an unresolved same-pointer replacement callback; a late
+      // retiring callback is harmless because this generation is now ending
+      // too, while attributing the requested stop to the retired generation
+      // would leave the current one without an outcome.
+      if
+        playbackGeneration == state.currentGeneration,
+        let identity = state.currentMediaIdentity {
+        state.retiredMediaGenerations[identity] = nil
+      }
+    }
+  }
+
+  func updateKnownDuration(_ duration: Duration?, playbackGeneration: UInt64) {
+    playbackLifecycle.withLock { state in
+      guard
+        playbackGeneration == state.currentGeneration,
+        playbackGeneration > state.lastEmittedGeneration
+      else { return }
+      var snapshot = state.snapshots[playbackGeneration] ?? TimelineSnapshot()
+      snapshot.duration = duration
+      state.snapshots[playbackGeneration] = snapshot
+    }
+  }
+
+  func updateAuthoritativeTimeline(
+    time: Duration,
+    position: Double?,
+    playbackGeneration: UInt64
+  ) {
+    playbackLifecycle.withLock { state in
+      guard
+        playbackGeneration == state.currentGeneration,
+        playbackGeneration > state.lastEmittedGeneration
+      else { return }
+      var snapshot = state.snapshots[playbackGeneration] ?? TimelineSnapshot()
+      snapshot.time = time
+      if let position {
+        snapshot.position = position
+      }
+      state.snapshots[playbackGeneration] = snapshot
+    }
+  }
+
+  func finishPlaybackGeneration(
+    _ generation: UInt64,
+    cause: PlaybackTerminalCause,
+    nativeHandleGeneration: UInt64
+  ) {
+    let outcome = playbackLifecycle.withLock { state in
+      makeOutcome(
+        in: &state,
+        generation: generation,
+        cause: state.terminalIntents[generation] ?? cause,
+        nativeHandleGeneration: nativeHandleGeneration
+      )
+    }
+    if let outcome {
+      terminalOutcomes.broadcast(outcome)
+    }
+  }
+
+  func broadcast(
+    _ event: PlayerEvent,
+    nativeHandleGeneration: UInt64,
+    playbackGeneration: UInt64? = nil
+  ) {
+    let playbackGeneration = playbackGeneration ?? currentPlaybackGeneration
+    recordTimeline(event, generation: playbackGeneration)
     // Each broadcaster is gated on its own emptiness so a libVLC event
     // with no consumers costs neither the lock-and-snapshot nor the
     // sourced-wrapper construction. The sourced broadcast (the player's
@@ -297,6 +524,7 @@ private final class EventBridgeCallbackContext: Sendable {
       sourcedEvents.broadcast(
         SourcedPlayerEvent(
           nativeHandleGeneration: nativeHandleGeneration,
+          playbackGeneration: playbackGeneration,
           event: event,
           timelineRevision: timelineRevision.withLock { $0 }
         )
@@ -306,7 +534,8 @@ private final class EventBridgeCallbackContext: Sendable {
       eventEnvelopes.broadcast(
         PlayerEventEnvelope(
           event: event,
-          nativeGeneration: NativePlayerGeneration(nativeHandleGeneration)
+          nativeGeneration: NativePlayerGeneration(nativeHandleGeneration),
+          playbackGeneration: PlaybackGeneration(playbackGeneration)
         )
       )
     }
@@ -329,6 +558,194 @@ private final class EventBridgeCallbackContext: Sendable {
     events.terminate()
     eventEnvelopes.terminate()
     sourcedEvents.terminate()
+    terminalOutcomes.terminate()
+  }
+
+  var currentPlaybackGeneration: UInt64 {
+    playbackLifecycle.withLock { $0.currentGeneration }
+  }
+
+  func noteExternalMediaChanged(
+    _ media: OpaquePointer?,
+    nativeHandleGeneration: UInt64
+  ) -> UInt64 {
+    let result = playbackLifecycle.withLock { state -> (UInt64, PlaybackTerminalOutcome?) in
+      let identity = Self.identity(of: media)
+      if
+        state.pendingWrapperMediaChangedGeneration == state.currentGeneration,
+        identity == state.currentMediaIdentity {
+        state.pendingWrapperMediaChangedGeneration = nil
+        return (state.currentGeneration, nil)
+      }
+      state.pendingWrapperMediaChangedGeneration = nil
+      let outgoing = state.currentGeneration
+      let outgoingIdentity = state.currentMediaIdentity
+      let outcome = makeOutcome(
+        in: &state,
+        generation: outgoing,
+        cause: state.terminalIntents[outgoing] ?? .replacement,
+        nativeHandleGeneration: nativeHandleGeneration
+      )
+      precondition(state.currentGeneration < UInt64.max, "Playback generation exhausted")
+      state.currentGeneration += 1
+      state.currentMediaIdentity = identity
+      if let identity {
+        if outcome != nil, outgoing > 0, identity == outgoingIdentity {
+          state.retiredMediaGenerations[identity, default: []].append(outgoing)
+        }
+        state.mediaGenerations[identity] = state.currentGeneration
+      }
+      state.snapshots[state.currentGeneration] = TimelineSnapshot()
+      return (state.currentGeneration, outcome)
+    }
+    if let outcome = result.1 {
+      terminalOutcomes.broadcast(outcome)
+    }
+    return result.0
+  }
+
+  func noteMediaStopping(
+    media: OpaquePointer?,
+    reason: libvlc_stopping_reason_t,
+    nativeHandleGeneration: UInt64
+  ) -> UInt64 {
+    let result = playbackLifecycle.withLock { state -> (UInt64, PlaybackTerminalOutcome?) in
+      let identity = Self.identity(of: media)
+      let generation: UInt64
+      if
+        let identity,
+        var retired = state.retiredMediaGenerations[identity],
+        !retired.isEmpty {
+        generation = retired.removeFirst()
+        state.retiredMediaGenerations[identity] = retired.isEmpty ? nil : retired
+      } else {
+        generation = identity.flatMap { state.mediaGenerations[$0] }
+          ?? state.currentGeneration
+      }
+      state.pendingStoppedGeneration = generation
+      let engineCause: PlaybackTerminalCause = switch reason {
+      case libvlc_stopping_reason_eos: .naturalEnd
+      case libvlc_stopping_reason_user: .requestedStop
+      case libvlc_stopping_reason_error: .failure(.unknown)
+      default: .unknownNativeStop
+      }
+      let outcome = makeOutcome(
+        in: &state,
+        generation: generation,
+        cause: state.terminalIntents[generation] ?? engineCause,
+        nativeHandleGeneration: nativeHandleGeneration
+      )
+      return (generation, outcome)
+    }
+    if let outcome = result.1 {
+      terminalOutcomes.broadcast(outcome)
+    }
+    return result.0
+  }
+
+  func noteEncounteredError(nativeHandleGeneration: UInt64) -> UInt64 {
+    let result = playbackLifecycle.withLock { state -> (UInt64, PlaybackTerminalOutcome?) in
+      let generation = state.currentGeneration
+      state.terminalIntents[generation] = .failure(.unknown)
+      let outcome = makeOutcome(
+        in: &state,
+        generation: generation,
+        cause: .failure(.unknown),
+        nativeHandleGeneration: nativeHandleGeneration
+      )
+      return (generation, outcome)
+    }
+    if let outcome = result.1 {
+      terminalOutcomes.broadcast(outcome)
+    }
+    return result.0
+  }
+
+  func consumeStoppedGeneration(nativeHandleGeneration: UInt64) -> UInt64 {
+    let result = playbackLifecycle.withLock { state -> (UInt64, PlaybackTerminalOutcome?) in
+      let generation = state.pendingStoppedGeneration ?? state.currentGeneration
+      state.pendingStoppedGeneration = nil
+      let outcome = makeOutcome(
+        in: &state,
+        generation: generation,
+        cause: state.terminalIntents[generation] ?? .unknownNativeStop,
+        nativeHandleGeneration: nativeHandleGeneration
+      )
+      return (generation, outcome)
+    }
+    if let outcome = result.1 {
+      terminalOutcomes.broadcast(outcome)
+    }
+    return result.0
+  }
+
+  func noteCurrentGenerationProgress(_ generation: UInt64) {
+    playbackLifecycle.withLock { state in
+      if generation == state.currentGeneration, let identity = state.currentMediaIdentity {
+        // Native callbacks are serialized. Once the successor opens or plays,
+        // every stopping callback ordered before that progress has arrived, so
+        // an unresolved same-pointer retirement can no longer be consumed by a
+        // future stop belonging to the successor.
+        state.retiredMediaGenerations[identity] = nil
+      }
+      if generation == state.currentGeneration {
+        state.pendingWrapperMediaChangedGeneration = nil
+      }
+      if
+        let pending = state.pendingStoppedGeneration,
+        pending < generation,
+        pending <= state.lastEmittedGeneration {
+        state.pendingStoppedGeneration = nil
+      }
+    }
+  }
+
+  func clearPendingStopForNativeHandleReplacement() {
+    playbackLifecycle.withLock { state in
+      state.pendingStoppedGeneration = nil
+      state.pendingWrapperMediaChangedGeneration = nil
+      state.retiredMediaGenerations.removeAll()
+    }
+  }
+
+  private func recordTimeline(_ event: PlayerEvent, generation: UInt64) {
+    guard generation > 0 else { return }
+    playbackLifecycle.withLock { state in
+      var snapshot = state.snapshots[generation] ?? TimelineSnapshot()
+      switch event {
+      case .timeChanged(let time): snapshot.time = time
+      case .lengthChanged(let duration): snapshot.duration = duration
+      case .positionChanged(let position): snapshot.position = position
+      case .bufferingProgress(let fill): snapshot.bufferFill = fill
+      case .voutChanged(let count): snapshot.activeVideoOutputs = count
+      default: break
+      }
+      state.snapshots[generation] = snapshot
+    }
+  }
+
+  private func makeOutcome(
+    in state: inout PlaybackLifecycleState,
+    generation: UInt64,
+    cause: PlaybackTerminalCause,
+    nativeHandleGeneration: UInt64
+  ) -> PlaybackTerminalOutcome? {
+    guard generation > state.lastEmittedGeneration else { return nil }
+    state.lastEmittedGeneration = generation
+    let snapshot = state.snapshots[generation] ?? TimelineSnapshot()
+    state.terminalIntents[generation] = nil
+    state.snapshots = state.snapshots.filter { $0.key >= generation }
+    state.mediaGenerations = state.mediaGenerations.filter { $0.value >= generation }
+    return PlaybackTerminalOutcome(
+      generation: PlaybackGeneration(generation),
+      nativeGeneration: NativePlayerGeneration(nativeHandleGeneration),
+      cause: cause,
+      finalTimeline: snapshot.publicValue
+    )
+  }
+
+  private static func identity(of media: OpaquePointer?) -> UInt? {
+    media.map { UInt(bitPattern: $0) }
   }
 }
 
@@ -355,28 +772,61 @@ private func playerEventCallback(
   // run synchronously on this thread and may issue player commands, so doing
   // this after broadcast lets reentrant work classify the stop without the
   // engine's authoritative cause.
-  if event.pointee.type == Int32(libvlc_MediaPlayerMediaStopping.rawValue) {
-    coordinator.noteStoppingReason(event.pointee.u.media_player_media_stopping.reason)
-  }
+  let playbackGeneration: UInt64
   let shouldSynthesizeEnd: Bool
   switch mapped {
-  case .encounteredError:
-    coordinator.markError()
+  case .mediaChanged:
+    playbackGeneration = context.noteExternalMediaChanged(
+      event.pointee.u.media_player_media_changed.new_media,
+      nativeHandleGeneration: attachment.nativeHandleGeneration
+    )
     shouldSynthesizeEnd = false
+
+  case .mediaStopping:
+    let stopping = event.pointee.u.media_player_media_stopping
+    coordinator.noteStoppingReason(stopping.reason)
+    playbackGeneration = context.noteMediaStopping(
+      media: stopping.media,
+      reason: stopping.reason,
+      nativeHandleGeneration: attachment.nativeHandleGeneration
+    )
+    shouldSynthesizeEnd = false
+
+  case .encounteredError:
+    playbackGeneration = context.noteEncounteredError(
+      nativeHandleGeneration: attachment.nativeHandleGeneration
+    )
+    shouldSynthesizeEnd = false
+
   case .stateChanged(.stopped):
+    playbackGeneration = context.consumeStoppedGeneration(
+      nativeHandleGeneration: attachment.nativeHandleGeneration
+    )
     shouldSynthesizeEnd = coordinator.consumeStoppedShouldSynthesizeEnd()
+
+  case .stateChanged(.opening), .stateChanged(.playing):
+    playbackGeneration = context.currentPlaybackGeneration
+    context.noteCurrentGenerationProgress(playbackGeneration)
+    shouldSynthesizeEnd = false
+
   default:
+    playbackGeneration = context.currentPlaybackGeneration
     shouldSynthesizeEnd = false
   }
 
   // Both emissions are made from the same immutable attachment token. Every
   // subscriber therefore observes `.stopped` then `.endReached` with one
   // generation, independent of consumer lag or native pointer reuse.
-  context.broadcast(mapped, nativeHandleGeneration: attachment.nativeHandleGeneration)
+  context.broadcast(
+    mapped,
+    nativeHandleGeneration: attachment.nativeHandleGeneration,
+    playbackGeneration: playbackGeneration
+  )
   if shouldSynthesizeEnd {
     context.broadcast(
       .endReached,
-      nativeHandleGeneration: attachment.nativeHandleGeneration
+      nativeHandleGeneration: attachment.nativeHandleGeneration,
+      playbackGeneration: playbackGeneration
     )
   }
 }

--- a/Sources/SwiftVLC/Player/PlaybackEndCoordinator.swift
+++ b/Sources/SwiftVLC/Player/PlaybackEndCoordinator.swift
@@ -4,27 +4,16 @@ import Synchronization
 /// Decides, on libVLC's event thread, whether a `stopped` transition is a
 /// natural end-of-media.
 ///
-/// libVLC 4 collapses natural end and requested stop into the same
-/// `Stopped` event. Every cause that should suppress synthesis —
-/// a library-issued `stop()`, a decoding error, an attached
-/// ``MediaListPlayer`` driving the handle — is recorded here, and the
-/// event callback synthesizes ``PlayerEvent/endReached`` only when a
-/// `stopped` arrives with none of them pending.
+/// libVLC 4 collapses natural end and requested stop into the same `Stopped`
+/// event. The patched engine reports an authoritative reason just before that
+/// transition; the event callback synthesizes ``PlayerEvent/endReached`` only
+/// for an explicit end-of-stream reason. A stop with no reason remains unknown.
 ///
-/// Causes are recorded by `@MainActor` callers (`Player`'s library
-/// stop, `MediaListPlayer`'s suppression) and by the event callback
-/// itself (errors); the callback consumes them on `stopped`. Every
-/// access goes through one `Mutex`, and main-actor causes are recorded
-/// *before* the native call that will eventually produce the `Stopped`.
+/// The engine reason is recorded on its event thread; list-player suppression
+/// is changed by `@MainActor` attachment code. Every access goes through one
+/// `Mutex`.
 final class PlaybackEndCoordinator: Sendable {
   private struct EndState {
-    /// A library-issued stop is in flight; the next `stopped` is not a
-    /// natural end. Consumed (cleared) by that `stopped`.
-    var libraryStopPending = false
-    /// A decode/input error was reported for the current session; the
-    /// `stopped` that follows it must not read as a natural end.
-    /// Consumed by that `stopped`.
-    var sawErrorSinceLastPlay = false
     /// A `MediaListPlayer` drives this handle through list-player C
     /// calls that never pass through `Player.stop()` — every
     /// list-initiated advancement would synthesize a spurious end.
@@ -36,20 +25,6 @@ final class PlaybackEndCoordinator: Sendable {
 
   private let state = Mutex(EndState())
 
-  /// Records a library-issued stop. Call *before*
-  /// `libvlc_media_player_stop_async`, and skip the call entirely when
-  /// the native player is already terminal — a stop on a stopped player
-  /// emits no new `Stopped`, so the flag would go stale and silently
-  /// swallow the next genuine natural end.
-  func markLibraryStop() {
-    state.withLock { $0.libraryStopPending = true }
-  }
-
-  /// Records an error event for the current playback session.
-  func markError() {
-    state.withLock { $0.sawErrorSinceLastPlay = true }
-  }
-
   /// Clears every pending cause. Only for the native-handle replacement
   /// path, where the old handle's `Stopped` can never be observed (the
   /// bridge is reattached first): a flag left set there would suppress
@@ -60,8 +35,6 @@ final class PlaybackEndCoordinator: Sendable {
   /// played.
   func clearForHandleReplacement() {
     state.withLock {
-      $0.libraryStopPending = false
-      $0.sawErrorSinceLastPlay = false
       // A reason recorded on the outgoing handle describes a stop that will
       // never arrive here. Left behind, it would classify the *successor's*
       // first stop — `MediaPlayerMediaStopping` can precede a replacement that
@@ -93,17 +66,12 @@ final class PlaybackEndCoordinator: Sendable {
   /// When the engine supplied a reason, it decides: only `eos` is a natural
   /// end, and `user` and `error` are not.
   ///
-  /// When it supplied none, the inference below applies unchanged — an engine
-  /// that does not report a reason must keep working, not lose end-of-media
-  /// entirely. That fallback is the weaker answer, and knowing why matters: it
-  /// concludes "natural end" from the *absence* of a known cause, so anything
-  /// it has not been told about reads as end of media. Supplying a reason is
-  /// what removes the guesswork, not the fallback itself.
+  /// When it supplied none, the stop remains unattributed. Absence of a known
+  /// cause is not evidence of EOF, so it must never be promoted to a confirmed
+  /// natural end.
   func consumeStoppedShouldSynthesizeEnd() -> Bool {
     state.withLock { state in
       defer {
-        state.libraryStopPending = false
-        state.sawErrorSinceLastPlay = false
         state.stoppingReason = nil
       }
 
@@ -113,9 +81,7 @@ final class PlaybackEndCoordinator: Sendable {
         return reason == libvlc_stopping_reason_eos && !state.suppressSynthesis
       }
 
-      return !state.libraryStopPending
-        && !state.sawErrorSinceLastPlay
-        && !state.suppressSynthesis
+      return false
     }
   }
 }

--- a/Sources/SwiftVLC/Player/PlaybackStatus.swift
+++ b/Sources/SwiftVLC/Player/PlaybackStatus.swift
@@ -20,9 +20,9 @@ public struct PlaybackGeneration: Hashable, Sendable, Comparable, CustomStringCo
 
   /// Orders two generations by when their sessions began.
   ///
-  /// The counter wraps on overflow, so ordering is only meaningful between
-  /// generations from the same player observed within one run. Reaching that
-  /// boundary needs 2^64 media changes.
+  /// Ordering is only meaningful between generations from the same player
+  /// observed within one run. SwiftVLC traps rather than aliasing an earlier
+  /// identity if the 64-bit counter is ever exhausted.
   public static func < (lhs: Self, rhs: Self) -> Bool {
     lhs.value < rhs.value
   }

--- a/Sources/SwiftVLC/Player/PlaybackTerminalOutcome.swift
+++ b/Sources/SwiftVLC/Player/PlaybackTerminalOutcome.swift
@@ -1,0 +1,76 @@
+/// Why a playback generation ended.
+public enum PlaybackTerminalCause: Hashable, Sendable {
+  /// The input reached a clean end of stream.
+  case naturalEnd
+  /// The application explicitly asked the player to stop.
+  case requestedStop
+  /// A different media or native playback session replaced this generation.
+  case replacement
+  /// Player shutdown cancelled the generation before another terminal cause won.
+  case cancellation
+  /// Playback failed.
+  case failure(PlaybackFailureKind)
+  /// libVLC stopped without supplying an authoritative reason.
+  case unknownNativeStop
+}
+
+/// The playback subsystem that failed, when SwiftVLC can identify it.
+///
+/// The bundled engine currently distinguishes a general playback error from
+/// clean EOF and user stop, but does not attribute every error to a subsystem.
+/// Such failures are reported as ``unknown`` instead of guessing from timing
+/// or log text.
+public enum PlaybackFailureKind: Hashable, Sendable {
+  /// Media source or transport failed.
+  case source
+  /// Container or stream demultiplexing failed.
+  case demux
+  /// Audio, video, or subtitle decoding failed.
+  case decoder
+  /// Video rendering failed.
+  case renderer
+  /// Audio or video output failed.
+  case output
+  /// The engine reported failure without a reliable subsystem attribution.
+  case unknown
+}
+
+/// Timeline and render state frozen before a terminal transition resets the
+/// player's observable properties.
+public struct PlaybackFinalTimeline: Hashable, Sendable {
+  /// Last playback time reported for the generation.
+  public let time: Duration
+  /// Last known media duration.
+  public let duration: Duration?
+  /// Last fractional playback position.
+  public let position: Double
+  /// Last buffering fill level, normalized to `0.0 ... 1.0`.
+  public let bufferFill: Float
+  /// Last number of active native video outputs.
+  public let activeVideoOutputs: Int
+}
+
+/// The immutable terminal result for one media generation.
+public struct PlaybackTerminalOutcome: Hashable, Sendable {
+  /// Media session this result belongs to.
+  public let generation: PlaybackGeneration
+  /// Native libVLC player that produced or was retired by the result.
+  public let nativeGeneration: NativePlayerGeneration
+  /// Authoritative cause when the engine or wrapper supplied one.
+  public let cause: PlaybackTerminalCause
+  /// State captured before terminal reset, identical for every subscriber.
+  public let finalTimeline: PlaybackFinalTimeline
+}
+
+extension Player {
+  /// Lossless terminal outcomes for active subscribers.
+  ///
+  /// Each playback generation is emitted at most once. The payload is frozen
+  /// in the native event bridge before `.stopped` can clear ``currentTime``,
+  /// ``position``, or ``bufferFill``. Unlike ``events``, this stream carries
+  /// no high-frequency timing events and therefore uses an unbounded buffer so
+  /// a stalled consumer cannot lose a one-shot result.
+  public nonisolated var terminalOutcomes: AsyncStream<PlaybackTerminalOutcome> {
+    eventBridge.makeTerminalOutcomeStream()
+  }
+}

--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -6,6 +6,13 @@ import Synchronization
 /// `@Observable` properties, plus the deferred-pause / playback-intent
 /// reconciliation state machine.
 extension Player {
+  /// Publishes every mirror fed by a duration mutation, including values
+  /// learned from the fallback native poll rather than an event callback.
+  func didUpdateDuration() {
+    publishCapabilitySnapshot()
+    eventBridge.updateKnownDuration(duration, playbackGeneration: sessionGeneration)
+  }
+
   // MARK: - Native state probes
 
   /// libVLC's view of the player state — read directly from the
@@ -65,6 +72,15 @@ extension Player {
     guard
       sourcedEvent.nativeHandleGeneration == eventBridge.currentNativeHandleGeneration
     else { return }
+    if case .mediaChanged = sourcedEvent.event {
+      guard sourcedEvent.playbackGeneration >= sessionGeneration else { return }
+      handleEvent(
+        sourcedEvent.event,
+        sourcePlaybackGeneration: sourcedEvent.playbackGeneration
+      )
+      return
+    }
+    guard sourcedEvent.playbackGeneration == sessionGeneration else { return }
     guard isTimelineSampleCurrent(sourcedEvent) else { return }
     handleEvent(sourcedEvent.event)
   }
@@ -91,7 +107,10 @@ extension Player {
   /// Maps a single `PlayerEvent` to the observable-property updates and
   /// state-machine transitions it implies. Called from
   /// `startEventConsumer`'s loop on every event the bridge yields.
-  func handleEvent(_ event: PlayerEvent) {
+  func handleEvent(
+    _ event: PlayerEvent,
+    sourcePlaybackGeneration: UInt64? = nil
+  ) {
     let interval = Signposts.signposter.beginInterval("Player.handleEvent")
     defer { Signposts.signposter.endInterval("Player.handleEvent", interval) }
     switch event {
@@ -157,12 +176,23 @@ extension Player {
       // whatever was restoring the previous session: a `MediaListPlayer`
       // advancing the list calls `libvlc_media_list_player_next` directly, so
       // `load(_:)` never runs and nothing else advances the generation.
-      // Compared by native identity rather than bumped unconditionally,
-      // because libVLC echoes the wrapper's own load back through here and a
-      // second advance would supersede a `recast(to:)` for a change it had
-      // already accounted for.
-      if currentMedia?.pointer != sessionGenerationMedia {
-        sessionGeneration &+= 1
+      // EventBridge distinguishes the wrapper's expected echo from an
+      // externally initiated change and stamps the authoritative generation.
+      // That remains correct even when a playlist intentionally reuses the
+      // exact same retained media pointer for consecutive sessions.
+      if
+        let sourcePlaybackGeneration,
+        sourcePlaybackGeneration > sessionGeneration {
+        sessionGeneration = sourcePlaybackGeneration
+        sessionGenerationMedia = currentMedia?.pointer
+        publishPlaybackStatus()
+      } else if currentMedia?.pointer != sessionGenerationMedia {
+        if sourcePlaybackGeneration == nil {
+          sessionGeneration = eventBridge.synchronizePlaybackGeneration(
+            sessionGeneration &+ 1,
+            media: currentMedia?.pointer
+          )
+        }
         sessionGenerationMedia = currentMedia?.pointer
         // The state has not changed, so `publishPlaybackState` will not run:
         // without this the status would keep reporting the old session.
@@ -475,6 +505,7 @@ extension Player {
     handleSourcedEvent(
       SourcedPlayerEvent(
         nativeHandleGeneration: nativeHandleGeneration,
+        playbackGeneration: sessionGeneration,
         event: event
       )
     )

--- a/Sources/SwiftVLC/Player/Player+Programs.swift
+++ b/Sources/SwiftVLC/Player/Player+Programs.swift
@@ -117,6 +117,7 @@ extension Player {
     let wasPlaying = isPlaybackRequestedActive
     let priorRenderer = selectedRenderer
     let priorPointer = pointer
+    let priorNativeHandleGeneration = eventBridge.currentNativeHandleGeneration
     let priorNeedsReplacement = nativePlayerNeedsReplacementBeforePlayback
     let priorNeedsRebind = needsDrawableRebindForPlayback
     let priorSubtitle = selectedSubtitleTrack
@@ -146,7 +147,11 @@ extension Player {
     // gone, so every remaining step is restoration. Each suspension is a
     // point where the caller can be cancelled or another operation can take
     // over, and past that point this recast must stop mutating the session.
-    sessionGeneration &+= 1
+    sessionGeneration = eventBridge.synchronizePlaybackGeneration(
+      sessionGeneration &+ 1,
+      media: currentMedia?.pointer,
+      outgoingNativeHandleGeneration: priorNativeHandleGeneration
+    )
     publishPlaybackStatus()
     let generation = sessionGeneration
 

--- a/Sources/SwiftVLC/Player/Player+Seek.swift
+++ b/Sources/SwiftVLC/Player/Player+Seek.swift
@@ -114,7 +114,8 @@ extension Player {
   func commitSeekTarget(milliseconds: Int64, revision: UInt64) {
     acceptedTimelineRevision = revision
     currentTime = .milliseconds(milliseconds)
-    publishPosition(forTargetMilliseconds: milliseconds)
+    let position = publishPosition(forTargetMilliseconds: milliseconds)
+    recordAuthoritativeTimeline(position: position)
   }
 
   // MARK: - Lenient Seeking
@@ -156,6 +157,7 @@ extension Player {
       let durationMs = try? duration.checkedNonnegativeMilliseconds(parameter: "duration") {
       currentTime = .milliseconds(checkedMilliseconds(for: position, durationMs: durationMs))
     }
+    recordAuthoritativeTimeline(position: position.rawValue)
     return true
   }
 
@@ -209,7 +211,8 @@ extension Player {
           targetMs = Swift.min(targetMs, durationMs)
         }
         currentTime = .milliseconds(targetMs)
-        publishPosition(forTargetMilliseconds: targetMs)
+        let position = publishPosition(forTargetMilliseconds: targetMs)
+        recordAuthoritativeTimeline(position: position)
       }
     }
     return true
@@ -253,6 +256,7 @@ extension Player {
     let ms = libvlc_media_player_get_time(pointer)
     if ms >= 0 {
       currentTime = .milliseconds(ms)
+      recordAuthoritativeTimeline(position: nil)
     }
   }
 
@@ -286,15 +290,27 @@ extension Player {
   /// Publishes the fractional position derived from a just-issued seek
   /// target. libVLC emits no `positionChanged` while paused, so without
   /// this the ``position`` shadow would stay stale until playback resumes.
-  private func publishPosition(forTargetMilliseconds targetMs: Int64) {
+  @discardableResult
+  private func publishPosition(forTargetMilliseconds targetMs: Int64) -> Double? {
     guard
       let duration,
       let durationMs = try? duration.checkedNonnegativeMilliseconds(parameter: "duration"),
       durationMs > 0
-    else { return }
+    else { return nil }
     let fraction = Swift.min(1.0, Swift.max(0.0, Double(targetMs) / Double(durationMs)))
     withMutation(keyPath: \.position) {
       _position = fraction
     }
+    return fraction
+  }
+
+  /// Keeps terminal outcomes aligned with synchronous timeline mutations for
+  /// which libVLC does not guarantee a corresponding event.
+  private func recordAuthoritativeTimeline(position: Double?) {
+    eventBridge.updateAuthoritativeTimeline(
+      time: currentTime,
+      position: position,
+      playbackGeneration: sessionGeneration
+    )
   }
 }

--- a/Sources/SwiftVLC/Player/Player+Teardown.swift
+++ b/Sources/SwiftVLC/Player/Player+Teardown.swift
@@ -221,6 +221,10 @@ extension Player {
     publishPlaybackIntent(false)
     pauseTransition = nil
     deferredPauseCommand = nil
+    eventBridge.finishCurrentPlaybackGeneration(
+      cause: .cancellation,
+      playbackGeneration: sessionGeneration
+    )
     eventTask?.cancel()
     eventTask = nil
     _marqueeRestoreTask?.cancel()

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -37,7 +37,7 @@ public final class Player {
 
   /// Total media duration (nil until known).
   public internal(set) var duration: Duration? {
-    didSet { publishCapabilitySnapshot() }
+    didSet { didUpdateDuration() }
   }
 
   /// Whether the current media is seekable.
@@ -567,6 +567,10 @@ public final class Player {
   }
 
   isolated deinit {
+    eventBridge.finishCurrentPlaybackGeneration(
+      cause: .cancellation,
+      playbackGeneration: sessionGeneration
+    )
     eventTask?.cancel()
     _marqueeRestoreTask?.cancel()
     // The player is going away for good, so future subscribers must receive
@@ -639,26 +643,15 @@ public final class Player {
     // player can never play.
     guard !isShutdown else { return }
     // Any recast still restoring the outgoing session no longer owns it.
-    sessionGeneration &+= 1
+    sessionGeneration = eventBridge.synchronizePlaybackGeneration(
+      sessionGeneration &+ 1,
+      media: media.pointer
+    )
     currentMedia = media
-    // Recorded so libVLC echoing this same change back as `.mediaChanged`
-    // does not advance the generation a second time.
     sessionGenerationMedia = media.pointer
     publishPlaybackStatus()
     resetMediaDerivedState()
-    // No `markLibraryStop()` here: setting media on a *started* handle
-    // replaces the input seamlessly — libVLC 4 emits `MediaStopping` for
-    // the interrupted input but the player never leaves the started
-    // state, so no `Stopped` ever arrives to consume the flag. A mark
-    // here goes stale and silently swallows the new media's genuine
-    // natural end. (An explicit `stop()` before `load()` records its own
-    // flag, and its in-flight `Stopped` consumes it — see
-    // ``PlaybackEndCoordinator/clearForHandleReplacement()``.)
     libvlc_media_player_set_media(pointer, media.pointer)
-    // No eager `refreshTracks()` here. The track list isn't populated
-    // until libVLC emits `ESAdded` events after the demuxer opens, so
-    // the `.tracksChanged` / `.mediaChanged` handlers refresh from a
-    // single source of truth.
     notifyMediaDependentObservables()
   }
 
@@ -676,6 +669,7 @@ public final class Player {
       throw .invalidState("play(_:) called on a player that has been shut down")
     }
     if shouldReplaceNativePlayerBeforePlaybackLoad {
+      let outgoingNativeHandleGeneration = eventBridge.currentNativeHandleGeneration
       let resumeBeforeRelease = shouldResumeNativePlayerBeforeStop
       // Nothing is published until the native swap succeeds. Committing
       // `currentMedia` first meant a rejected renderer left every public
@@ -688,7 +682,11 @@ public final class Player {
       )
       // Same supersession bump as `load(_:)`: this branch replaces the media
       // without going through it.
-      sessionGeneration &+= 1
+      sessionGeneration = eventBridge.synchronizePlaybackGeneration(
+        sessionGeneration &+ 1,
+        media: media.pointer,
+        outgoingNativeHandleGeneration: outgoingNativeHandleGeneration
+      )
       currentMedia = media
       sessionGenerationMedia = media.pointer
       publishPlaybackStatus()
@@ -912,7 +910,7 @@ public final class Player {
     case .idle, .stopped, .error:
       break
     default:
-      endCoordinator.markLibraryStop()
+      eventBridge.markRequestedStop(playbackGeneration: sessionGeneration)
     }
     libvlc_media_player_stop_async(pointer)
   }

--- a/Sources/SwiftVLC/Player/PlayerEvent.swift
+++ b/Sources/SwiftVLC/Player/PlayerEvent.swift
@@ -46,10 +46,10 @@ public enum PlayerEvent: Sendable, CustomStringConvertible {
   ///
   /// libVLC 4 reports natural end-of-media and a requested stop as the
   /// same `.stateChanged(.stopped)` transition; SwiftVLC synthesizes this
-  /// event when a `stopped` arrives that no library-issued stop, error,
-  /// or attached ``MediaListPlayer`` accounts for. Always delivered
-  /// immediately after the `.stateChanged(.stopped)` it belongs to, from
-  /// the same native handle. Not emitted while a ``MediaListPlayer``
+  /// event only when the engine's preceding stopping reason identifies a
+  /// clean end of stream. An unattributed stop is never treated as EOF.
+  /// Always delivered immediately after the `.stateChanged(.stopped)` it
+  /// belongs to, from the same native handle. Not emitted while a ``MediaListPlayer``
   /// drives this player — list advancement stops the handle between
   /// items.
   case endReached

--- a/Sources/SwiftVLC/Player/PlayerEventEnvelope.swift
+++ b/Sources/SwiftVLC/Player/PlayerEventEnvelope.swift
@@ -28,31 +28,35 @@ public struct NativePlayerGeneration: Hashable, Sendable, Comparable, CustomStri
   }
 }
 
-/// A raw player event paired with the native handle that emitted it.
+/// A raw player event paired with the native handle and playback session that
+/// emitted it.
 ///
 /// The legacy ``Player/events`` stream remains available for source
-/// compatibility. Consumers that retain, queue, or merge events across native
-/// handle replacement should use this envelope and compare
-/// ``nativeGeneration`` with ``Player/nativeEventGeneration`` before applying
-/// the event.
+/// compatibility. Consumers that retain, queue, or merge events should use
+/// this envelope and compare ``nativeGeneration`` with
+/// ``Player/nativeEventGeneration`` and ``playbackGeneration`` with
+/// ``Player/generation`` before applying the event.
 public struct PlayerEventEnvelope: Sendable {
   /// The raw event mapped from libVLC.
   public let event: PlayerEvent
   /// The native libVLC handle that emitted ``event``.
   public let nativeGeneration: NativePlayerGeneration
+  /// The media session that emitted ``event``.
+  public let playbackGeneration: PlaybackGeneration
 }
 
 extension Player {
   /// The native libVLC handle currently installed behind this player.
   ///
-  /// Compare this value with ``PlayerEventEnvelope/nativeGeneration`` before
-  /// applying an event that may have waited in a queue across renderer recast
-  /// or native-handle replacement.
+  /// Compare this value with ``PlayerEventEnvelope/nativeGeneration`` and the
+  /// current ``generation`` with the envelope's playback generation before
+  /// applying an event that may have waited in a queue across renderer recast,
+  /// native-handle replacement, or media change.
   public nonisolated var nativeEventGeneration: NativePlayerGeneration {
     eventBridge.currentNativePlayerGeneration
   }
 
-  /// Raw events paired with the native handle that emitted them.
+  /// Raw events paired with the native handle and media session that emitted them.
   ///
   /// The default newest-64 policy has the same bounded, lossy behavior as
   /// ``Player/events``. Use ``eventEnvelopes(policy:filter:)`` or the

--- a/Sources/SwiftVLC/Player/PlayerEventLane.swift
+++ b/Sources/SwiftVLC/Player/PlayerEventLane.swift
@@ -89,11 +89,13 @@ extension Player {
     eventBridge.makeStream(policy: .unbounded, filter: { $0.lane == .control })
   }
 
-  /// Lossless control events paired with their native-handle generation.
+  /// Lossless control events paired with their native-handle and playback
+  /// generations.
   ///
   /// No timing volume can evict a value because timing events never enter
-  /// this stream. Compare each envelope with ``nativeEventGeneration`` before
-  /// applying work that may outlive a native-handle replacement.
+  /// this stream. Compare each envelope with ``nativeEventGeneration`` and
+  /// ``generation`` before applying work that may outlive a handle replacement
+  /// or media change.
   public nonisolated var controlEventEnvelopes: AsyncStream<PlayerEventEnvelope> {
     eventBridge.makeEnvelopeStream(policy: .unbounded) { envelope in
       envelope.event.lane == .control
@@ -128,7 +130,8 @@ extension Player {
     )
   }
 
-  /// Coalesced timing events paired with their native-handle generation.
+  /// Coalesced timing events paired with their native-handle and playback
+  /// generations.
   public nonisolated var timingEventEnvelopes: AsyncStream<PlayerEventEnvelope> {
     eventBridge.makeEnvelopeStream(policy: .newest(Self.timingLaneBufferSize)) { envelope in
       envelope.event.lane == .timing

--- a/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
+++ b/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
@@ -110,13 +110,11 @@ public final class MediaListPlayer {
     }
   }
 
-  /// Detach-time end-synthesis bookkeeping for a previously attached
-  /// player. A nil detach or final list-player teardown stops the still-bound
-  /// handle later, so it records that stop as library-initiated before lifting
-  /// suppression. Replacing or transferring an attachment does not stop the
-  /// old player and must not leave a stale stop mark that can swallow its next
-  /// genuine end. Suppression is lifted unless another list player has since
-  /// taken over the attachment.
+  /// Detach-time terminal bookkeeping for a previously attached player. A nil
+  /// detach or final list-player teardown stops the still-bound handle later,
+  /// so it records that stop as requested before lifting raw-end suppression.
+  /// Replacing or transferring an attachment does not stop the old player.
+  /// Suppression is lifted unless another list player has since taken over.
   private func detachForEndSynthesis(
     _ previous: Player,
     nativeStopWillFollow: Bool = true
@@ -126,7 +124,9 @@ public final class MediaListPlayer {
       case .idle, .stopped, .error:
         break
       default:
-        previous.endCoordinator.markLibraryStop()
+        previous.eventBridge.markRequestedStop(
+          playbackGeneration: previous.sessionGeneration
+        )
       }
     }
     let owner = previous.attachedMediaListPlayer

--- a/Tests/SwiftVLCTests/Player/AuthoritativeStopReasonTests.swift
+++ b/Tests/SwiftVLCTests/Player/AuthoritativeStopReasonTests.swift
@@ -68,17 +68,15 @@ struct AuthoritativeStopReasonTests {
 
     // No reason supplied for this one, and no other cause recorded.
     #expect(
-      coordinator.consumeStoppedShouldSynthesizeEnd(),
-      "the fallback inference should apply once the reason is consumed"
+      !coordinator.consumeStoppedShouldSynthesizeEnd(),
+      "an unattributed successor stop was promoted to a confirmed end"
     )
   }
 
-  /// Without a reason the inference still applies, so an engine that does not
-  /// report one behaves as before rather than losing end-of-media entirely.
+  /// Without a reason, a stop is not evidence of a clean end of stream.
   @Test
   func `A library-issued stop without a reason is still not a natural end`() {
     let coordinator = PlaybackEndCoordinator()
-    coordinator.markLibraryStop()
 
     #expect(!coordinator.consumeStoppedShouldSynthesizeEnd())
   }
@@ -95,7 +93,6 @@ struct AuthoritativeStopReasonTests {
     coordinator.noteStoppingReason(libvlc_stopping_reason_eos)
 
     coordinator.clearForHandleReplacement()
-    coordinator.markLibraryStop()
 
     #expect(
       !coordinator.consumeStoppedShouldSynthesizeEnd(),

--- a/Tests/SwiftVLCTests/Player/PlaybackEndCoordinatorTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlaybackEndCoordinatorTests.swift
@@ -1,138 +1,42 @@
 @testable import SwiftVLC
+import CLibVLC
 import Testing
 
-/// Decision table of ``PlaybackEndCoordinator``: a `stopped` synthesizes
-/// `.endReached` only when no cause is pending; a library stop and an
-/// error are one-shots consumed by the `stopped` that accounts for them,
-/// while list-player suppression is a level that only `setSuppressed`
-/// changes. Pure state-machine tests — no libVLC instance, no playback.
+/// Decision table of ``PlaybackEndCoordinator``: only the engine's explicit
+/// EOS reason synthesizes `.endReached`; an unattributed stop stays unknown.
 extension Logic {
   struct PlaybackEndCoordinatorTests {
     @Test
-    func `Stopped with no recorded cause synthesizes an end`() {
+    func `Stopped with no reason remains unattributed`() {
       let coordinator = PlaybackEndCoordinator()
-      #expect(coordinator.consumeStoppedShouldSynthesizeEnd())
-    }
-
-    @Test
-    func `Library stop suppresses one stopped and is consumed by it`() {
-      let coordinator = PlaybackEndCoordinator()
-      coordinator.markLibraryStop()
       #expect(!coordinator.consumeStoppedShouldSynthesizeEnd())
-      #expect(coordinator.consumeStoppedShouldSynthesizeEnd())
     }
 
     @Test
-    func `Error suppresses one stopped and is consumed by it`() {
+    func `End-of-stream reason synthesizes exactly once`() {
       let coordinator = PlaybackEndCoordinator()
-      coordinator.markError()
-      #expect(!coordinator.consumeStoppedShouldSynthesizeEnd())
+      coordinator.noteStoppingReason(libvlc_stopping_reason_eos)
       #expect(coordinator.consumeStoppedShouldSynthesizeEnd())
+      #expect(!coordinator.consumeStoppedShouldSynthesizeEnd())
     }
 
     @Test
-    func `Library stop and error together are both consumed by one stopped`() {
-      let coordinator = PlaybackEndCoordinator()
-      coordinator.markLibraryStop()
-      coordinator.markError()
-      #expect(!coordinator.consumeStoppedShouldSynthesizeEnd())
-      #expect(coordinator.consumeStoppedShouldSynthesizeEnd())
-    }
-
-    @Test
-    func `Repeated marks of the same cause still cost a single stopped`() {
-      let coordinator = PlaybackEndCoordinator()
-      coordinator.markLibraryStop()
-      coordinator.markLibraryStop()
-      coordinator.markError()
-      coordinator.markError()
-      #expect(!coordinator.consumeStoppedShouldSynthesizeEnd())
-      #expect(coordinator.consumeStoppedShouldSynthesizeEnd())
-    }
-
-    @Test
-    func `Suppression is a level, not a one-shot`() {
+    func `List-player suppression outranks end of stream`() {
       let coordinator = PlaybackEndCoordinator()
       coordinator.setSuppressed(true)
-      for _ in 0..<3 {
-        #expect(
-          !coordinator.consumeStoppedShouldSynthesizeEnd(),
-          "stopped synthesized while a list player is attached"
-        )
-      }
-      coordinator.setSuppressed(false)
-      #expect(coordinator.consumeStoppedShouldSynthesizeEnd())
-    }
-
-    @Test
-    func `Suppressed stopped still consumes the one-shot causes`() {
-      let coordinator = PlaybackEndCoordinator()
-      coordinator.setSuppressed(true)
-      coordinator.markLibraryStop()
-      coordinator.markError()
+      coordinator.noteStoppingReason(libvlc_stopping_reason_eos)
       #expect(!coordinator.consumeStoppedShouldSynthesizeEnd())
+
       coordinator.setSuppressed(false)
-      #expect(
-        coordinator.consumeStoppedShouldSynthesizeEnd(),
-        "one-shots survived a suppressed stopped and swallowed a later natural end"
-      )
+      #expect(!coordinator.consumeStoppedShouldSynthesizeEnd())
     }
 
     @Test
-    func `Handle-replacement clear drops the one-shots`() {
+    func `Handle replacement clears the outgoing reason`() {
       let coordinator = PlaybackEndCoordinator()
-      coordinator.markLibraryStop()
-      coordinator.markError()
+      coordinator.noteStoppingReason(libvlc_stopping_reason_eos)
       coordinator.clearForHandleReplacement()
-      #expect(
-        coordinator.consumeStoppedShouldSynthesizeEnd(),
-        "a cleared one-shot still suppressed the next natural end"
-      )
-    }
-
-    @Test
-    func `Handle-replacement clear leaves suppression in place`() {
-      let coordinator = PlaybackEndCoordinator()
-      coordinator.setSuppressed(true)
-      coordinator.markLibraryStop()
-      coordinator.clearForHandleReplacement()
-      #expect(
-        !coordinator.consumeStoppedShouldSynthesizeEnd(),
-        "handle replacement lifted list-player suppression"
-      )
-      coordinator.setSuppressed(false)
-      #expect(coordinator.consumeStoppedShouldSynthesizeEnd())
-    }
-
-    /// Every combination of the three causes: synthesis only with none
-    /// pending, the one-shots always consumed, suppression always kept.
-    @Test(
-      arguments: [
-        (false, false, false),
-        (true, false, false),
-        (false, true, false),
-        (false, false, true),
-        (true, true, false),
-        (true, false, true),
-        (false, true, true),
-        (true, true, true)
-      ] as [(Bool, Bool, Bool)]
-    )
-    func `Full decision table`(libraryStop: Bool, error: Bool, suppressed: Bool) {
-      let coordinator = PlaybackEndCoordinator()
-      if libraryStop {
-        coordinator.markLibraryStop()
-      }
-      if error {
-        coordinator.markError()
-      }
-      coordinator.setSuppressed(suppressed)
-
-      let expected = !libraryStop && !error && !suppressed
-      #expect(coordinator.consumeStoppedShouldSynthesizeEnd() == expected)
-
-      // Second stopped: one-shots are gone; only suppression can remain.
-      #expect(coordinator.consumeStoppedShouldSynthesizeEnd() == !suppressed)
+      #expect(!coordinator.consumeStoppedShouldSynthesizeEnd())
     }
   }
 }

--- a/Tests/SwiftVLCTests/Player/PlaybackTerminalOutcomeTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlaybackTerminalOutcomeTests.swift
@@ -1,0 +1,197 @@
+@testable import SwiftVLC
+import CLibVLC
+import Testing
+
+extension Integration {
+  @Suite(.tags(.mainActor, .async), .serialized)
+  @MainActor struct PlaybackTerminalOutcomeTests {
+    @Test
+    func `Replacement freezes the outgoing generation and final timeline`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let first = try Media(url: TestMedia.twosecURL)
+      player.load(first)
+      let generation = player.generation
+      let nativeGeneration = player.nativeEventGeneration
+      let outcome = firstOutcome(from: player.terminalOutcomes)
+
+      let native = player.eventBridge.currentNativeHandleGeneration
+      // Duration can be learned by the wrapper's native poll without a
+      // LengthChanged callback, and paused seeks may not emit clock events.
+      // Both synchronous facts still belong in the frozen outcome.
+      player._setStateForTesting(duration: .seconds(60))
+      player.commitSeekTarget(
+        milliseconds: 15000,
+        revision: player.eventBridge.advanceTimelineRevision()
+      )
+      player.eventBridge._broadcastForTesting(.bufferingProgress(0.75), nativeHandleGeneration: native)
+      player.eventBridge._broadcastForTesting(.voutChanged(2), nativeHandleGeneration: native)
+
+      try player.load(Media(url: TestMedia.silenceURL))
+
+      let value = try #require(await outcome.value)
+      #expect(value.generation == generation)
+      #expect(value.nativeGeneration == nativeGeneration)
+      #expect(value.cause == .replacement)
+      #expect(value.finalTimeline.time == .seconds(15))
+      #expect(value.finalTimeline.duration == .seconds(60))
+      #expect(value.finalTimeline.position == 0.25)
+      #expect(value.finalTimeline.bufferFill == 0.75)
+      #expect(value.finalTimeline.activeVideoOutputs == 2)
+    }
+
+    @Test
+    func `An explicit stop intent outranks a following media replacement`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let outgoing = player.sessionGeneration
+      let outcome = firstOutcome(from: player.terminalOutcomes)
+
+      player.eventBridge.markRequestedStop(playbackGeneration: outgoing)
+      try player.load(Media(url: TestMedia.silenceURL))
+
+      let value = try #require(await outcome.value)
+      #expect(value.generation == PlaybackGeneration(outgoing))
+      #expect(value.cause == .requestedStop)
+    }
+
+    @Test
+    func `Authoritative EOF emits once before the stopped reset`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let media = try Media(url: TestMedia.twosecURL)
+      player.load(media)
+      let expectedGeneration = player.generation
+      let stream = player.terminalOutcomes
+      let outcomes = collect(stream, for: .milliseconds(100))
+
+      let native = player.eventBridge.currentNativeHandleGeneration
+      player.eventBridge._broadcastForTesting(.timeChanged(.seconds(2)), nativeHandleGeneration: native)
+      var stopping = libvlc_event_t()
+      stopping.type = Int32(libvlc_MediaPlayerMediaStopping.rawValue)
+      stopping.u.media_player_media_stopping.media = media.pointer
+      stopping.u.media_player_media_stopping.reason = libvlc_stopping_reason_eos
+      player.eventBridge._emitNativeEventForTesting(stopping)
+
+      var stopped = libvlc_event_t()
+      stopped.type = Int32(libvlc_MediaPlayerStopped.rawValue)
+      player.eventBridge._emitNativeEventForTesting(stopped)
+
+      let values = await outcomes.value
+      #expect(values.count == 1)
+      let value = try #require(values.first)
+      #expect(value.generation == expectedGeneration)
+      #expect(value.cause == .naturalEnd)
+      #expect(value.finalTimeline.time == .seconds(2))
+    }
+
+    @Test
+    func `Unattributed stop reports unknown and never claims natural end`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let outcome = firstOutcome(from: player.terminalOutcomes)
+
+      var stopped = libvlc_event_t()
+      stopped.type = Int32(libvlc_MediaPlayerStopped.rawValue)
+      player.eventBridge._emitNativeEventForTesting(stopped)
+
+      let value = try #require(await outcome.value)
+      #expect(value.cause == .unknownNativeStop)
+      await Task.yield()
+      #expect(!player.didReachEnd)
+    }
+
+    @Test
+    func `A stale terminal transition cannot reset its successor`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let outgoing = player.sessionGeneration
+      try player.load(Media(url: TestMedia.silenceURL))
+      player._setStateForTesting(
+        state: .playing,
+        currentTime: .seconds(9),
+        duration: .seconds(30),
+        position: 0.3
+      )
+
+      player.handleSourcedEvent(
+        SourcedPlayerEvent(
+          nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
+          playbackGeneration: outgoing,
+          event: .stateChanged(.stopped)
+        )
+      )
+
+      #expect(player.state == .playing)
+      #expect(player.currentTime == .seconds(9))
+      #expect(player.position == 0.3)
+    }
+
+    @Test
+    func `Reloading the same media cannot attribute the retired stop to its successor`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let media = try Media(url: TestMedia.twosecURL)
+      player.load(media)
+      let firstGeneration = player.generation
+      let sharedPointer = try #require(player.currentMedia?.pointer)
+      let outcomes = collect(player.terminalOutcomes, for: .milliseconds(100))
+
+      player.load(Media(retaining: sharedPointer))
+      let secondGeneration = player.generation
+
+      var retiredStopping = libvlc_event_t()
+      retiredStopping.type = Int32(libvlc_MediaPlayerMediaStopping.rawValue)
+      retiredStopping.u.media_player_media_stopping.media = sharedPointer
+      retiredStopping.u.media_player_media_stopping.reason = libvlc_stopping_reason_user
+      player.eventBridge._emitNativeEventForTesting(retiredStopping)
+
+      player.eventBridge._broadcastForTesting(
+        .stateChanged(.opening),
+        nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration
+      )
+
+      var currentStopping = libvlc_event_t()
+      currentStopping.type = Int32(libvlc_MediaPlayerMediaStopping.rawValue)
+      currentStopping.u.media_player_media_stopping.media = sharedPointer
+      currentStopping.u.media_player_media_stopping.reason = libvlc_stopping_reason_eos
+      player.eventBridge._emitNativeEventForTesting(currentStopping)
+
+      let values = await outcomes.value
+      #expect(values.map(\.generation) == [firstGeneration, secondGeneration])
+      #expect(values.map(\.cause) == [.replacement, .naturalEnd])
+    }
+
+    private func firstOutcome(
+      from stream: AsyncStream<PlaybackTerminalOutcome>
+    ) -> Task<PlaybackTerminalOutcome?, Never> {
+      Task.detached {
+        await withTaskGroup(of: PlaybackTerminalOutcome?.self) { group in
+          group.addTask { await stream.first(where: { _ in true }) }
+          group.addTask {
+            try? await Task.sleep(for: .seconds(1))
+            return nil
+          }
+          let value = await group.next() ?? nil
+          group.cancelAll()
+          return value
+        }
+      }
+    }
+
+    private func collect(
+      _ stream: AsyncStream<PlaybackTerminalOutcome>,
+      for duration: Duration
+    ) -> Task<[PlaybackTerminalOutcome], Never> {
+      Task.detached {
+        let collector = Task { () -> [PlaybackTerminalOutcome] in
+          var values: [PlaybackTerminalOutcome] = []
+          for await value in stream {
+            values.append(value)
+          }
+          return values
+        }
+        try? await Task.sleep(for: duration)
+        collector.cancel()
+        return await collector.value
+      }
+    }
+  }
+}

--- a/Tests/SwiftVLCTests/Player/PlayerEventLaneTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerEventLaneTests.swift
@@ -1,4 +1,5 @@
 @testable import SwiftVLC
+import CLibVLC
 import Foundation
 import Testing
 
@@ -165,6 +166,76 @@ extension Integration {
       let stale = try #require(predecessorEnvelope)
       #expect(stale.nativeGeneration == predecessor)
       #expect(stale.nativeGeneration != player.nativeEventGeneration)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `A queued predecessor event remains attributable after same-handle media replacement`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let predecessor = player.generation
+      let nativeGeneration = player.nativeEventGeneration
+      let stream = player.controlEventEnvelopes
+
+      try player.load(Media(url: TestMedia.silenceURL))
+      let successor = player.generation
+      #expect(successor > predecessor)
+      #expect(player.nativeEventGeneration == nativeGeneration)
+
+      player.eventBridge._broadcastForTesting(
+        .stateChanged(.stopped),
+        nativeHandleGeneration: nativeGeneration.value,
+        playbackGeneration: predecessor.value
+      )
+      player.eventBridge._broadcastForTesting(
+        .mediaChanged,
+        nativeHandleGeneration: nativeGeneration.value,
+        playbackGeneration: successor.value
+      )
+
+      var predecessorEnvelope: PlayerEventEnvelope?
+      drain: for await envelope in stream {
+        switch envelope.event {
+        case .stateChanged(.stopped):
+          predecessorEnvelope = envelope
+        case .mediaChanged:
+          break drain
+        default:
+          break
+        }
+      }
+
+      let stale = try #require(predecessorEnvelope)
+      #expect(stale.nativeGeneration == player.nativeEventGeneration)
+      #expect(stale.playbackGeneration == predecessor)
+      #expect(stale.playbackGeneration != player.generation)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `An external replay of the same media pointer starts a new generation`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let media = try Media(url: TestMedia.twosecURL)
+      let first = PlaybackGeneration(
+        player.eventBridge.synchronizePlaybackGeneration(1, media: media.pointer)
+      )
+      let stream = player.controlEventEnvelopes
+
+      var changed = libvlc_event_t()
+      changed.type = Int32(libvlc_MediaPlayerMediaChanged.rawValue)
+      changed.u.media_player_media_changed.new_media = media.pointer
+      player.eventBridge._emitNativeEventForTesting(changed)
+      player.eventBridge._emitNativeEventForTesting(changed)
+
+      var generations: [PlaybackGeneration] = []
+      for await envelope in stream {
+        guard case .mediaChanged = envelope.event else { continue }
+        generations.append(envelope.playbackGeneration)
+        if generations.count == 2 {
+          break
+        }
+      }
+
+      #expect(generations.first == first)
+      #expect(generations.last.map { $0 > first } == true)
     }
 
     @Test(.timeLimit(.minutes(1)))

--- a/Tests/SwiftVLCTests/Player/PlayerSeekAuthorityTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerSeekAuthorityTests.swift
@@ -26,6 +26,7 @@ extension Integration {
       // A sample libVLC produced before the seek, still queued.
       let stale = SourcedPlayerEvent(
         nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
+        playbackGeneration: player.sessionGeneration,
         event: .timeChanged(.seconds(3)),
         timelineRevision: player.acceptedTimelineRevision
       )
@@ -50,6 +51,7 @@ extension Integration {
 
       let stale = SourcedPlayerEvent(
         nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
+        playbackGeneration: player.sessionGeneration,
         event: .positionChanged(0.03),
         timelineRevision: player.acceptedTimelineRevision
       )
@@ -74,6 +76,7 @@ extension Integration {
 
       let fresh = SourcedPlayerEvent(
         nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
+        playbackGeneration: player.sessionGeneration,
         event: .timeChanged(.seconds(43)),
         timelineRevision: player.acceptedTimelineRevision
       )
@@ -96,6 +99,7 @@ extension Integration {
 
       let supersededSample = SourcedPlayerEvent(
         nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
+        playbackGeneration: player.sessionGeneration,
         event: .timeChanged(.seconds(10)),
         timelineRevision: firstRevision
       )
@@ -116,6 +120,7 @@ extension Integration {
 
       let staleTransition = SourcedPlayerEvent(
         nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
+        playbackGeneration: player.sessionGeneration,
         event: .stateChanged(.playing),
         timelineRevision: 0
       )
@@ -146,6 +151,7 @@ extension Integration {
 
       let landed = SourcedPlayerEvent(
         nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
+        playbackGeneration: player.sessionGeneration,
         event: .timeChanged(.seconds(40)),
         timelineRevision: concurrentRevision
       )
@@ -184,6 +190,7 @@ extension Integration {
 
       let previousGenerationSample = SourcedPlayerEvent(
         nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
+        playbackGeneration: player.sessionGeneration,
         event: .timeChanged(.seconds(7)),
         timelineRevision: player.acceptedTimelineRevision
       )
@@ -219,6 +226,7 @@ extension Integration {
       // Produced by libVLC before the jump, still queued behind it.
       let stale = SourcedPlayerEvent(
         nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
+        playbackGeneration: player.sessionGeneration,
         event: .timeChanged(.seconds(10)),
         timelineRevision: player.acceptedTimelineRevision
       )

--- a/Tests/SwiftVLCTests/Player/PlayerStopOutcomeTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerStopOutcomeTests.swift
@@ -144,7 +144,11 @@ extension Integration {
     @Test
     func `A stopped event for the awaited generation reports stopped`() async {
       let stream = Self.eventStream([
-        SourcedPlayerEvent(nativeHandleGeneration: 7, event: .stateChanged(.stopped))
+        SourcedPlayerEvent(
+          nativeHandleGeneration: 7,
+          playbackGeneration: 0,
+          event: .stateChanged(.stopped)
+        )
       ])
 
       let outcome = await Player.awaitOutputSafeStop(
@@ -162,7 +166,11 @@ extension Integration {
     @Test
     func `An error event alone never reports output-safe`() async {
       let stream = Self.eventStream([
-        SourcedPlayerEvent(nativeHandleGeneration: 7, event: .stateChanged(.error))
+        SourcedPlayerEvent(
+          nativeHandleGeneration: 7,
+          playbackGeneration: 0,
+          event: .stateChanged(.error)
+        )
       ])
 
       let outcome = await Player.awaitOutputSafeStop(
@@ -180,8 +188,16 @@ extension Integration {
     @Test
     func `An error followed by a stop reports stopped`() async {
       let stream = Self.eventStream([
-        SourcedPlayerEvent(nativeHandleGeneration: 7, event: .stateChanged(.error)),
-        SourcedPlayerEvent(nativeHandleGeneration: 7, event: .stateChanged(.stopped))
+        SourcedPlayerEvent(
+          nativeHandleGeneration: 7,
+          playbackGeneration: 0,
+          event: .stateChanged(.error)
+        ),
+        SourcedPlayerEvent(
+          nativeHandleGeneration: 7,
+          playbackGeneration: 0,
+          event: .stateChanged(.stopped)
+        )
       ])
 
       let outcome = await Player.awaitOutputSafeStop(
@@ -198,7 +214,11 @@ extension Integration {
     @Test
     func `A stop from another generation is ignored`() async {
       let stream = Self.eventStream([
-        SourcedPlayerEvent(nativeHandleGeneration: 99, event: .stateChanged(.stopped))
+        SourcedPlayerEvent(
+          nativeHandleGeneration: 99,
+          playbackGeneration: 0,
+          event: .stateChanged(.stopped)
+        )
       ])
 
       let outcome = await Player.awaitOutputSafeStop(
@@ -214,8 +234,16 @@ extension Integration {
     @Test
     func `Unrelated events do not end the wait`() async {
       let stream = Self.eventStream([
-        SourcedPlayerEvent(nativeHandleGeneration: 7, event: .timeChanged(.seconds(1))),
-        SourcedPlayerEvent(nativeHandleGeneration: 7, event: .stateChanged(.playing))
+        SourcedPlayerEvent(
+          nativeHandleGeneration: 7,
+          playbackGeneration: 0,
+          event: .timeChanged(.seconds(1))
+        ),
+        SourcedPlayerEvent(
+          nativeHandleGeneration: 7,
+          playbackGeneration: 0,
+          event: .stateChanged(.playing)
+        )
       ])
 
       let outcome = await Player.awaitOutputSafeStop(


### PR DESCRIPTION
## Summary

- add a lossless terminal-outcome stream with exactly-once playback/native generation attribution and frozen pre-reset timeline state
- classify authoritative engine EOS, requested stops, replacements, cancellation, unknown failures, and unattributed native stops without guessing EOF
- carry playback generation on public event envelopes, including same-handle and identical-media-pointer replacements
- reject stale playback-generation events internally and preserve synchronous duration, seek, jump, and frame-step timeline updates
- simplify legacy endReached synthesis to authoritative EOS only

## Validation

- CI=true swift test --no-parallel --enable-code-coverage (1,822 tests, 164 suites)
- swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
- swiftlint lint --strict --quiet Sources Tests Showcase
- swiftformat Sources Tests Showcase --lint
- scripts/doc-coverage.sh (774/774, 100%)
- git diff --check

Advances #78 and #85.

This intentionally does not close #85: detailed source/demux/decoder/renderer/output attribution and the physical failure matrix remain to be completed.