### PR TITLE
Attribute PiP lifecycle events to playback generations

### DIFF
--- a/Sources/SwiftVLC/PiP/PiPCallbackSnapshot.swift
+++ b/Sources/SwiftVLC/PiP/PiPCallbackSnapshot.swift
@@ -34,6 +34,10 @@ struct PiPCallbackSnapshot: @unchecked Sendable {
   /// The generation is what makes that guarantee checkable rather than
   /// incidental.
   var generation: UInt64 = 0
+  /// Media session paired with the cached handle at publication time.
+  /// Native activity signals capture this before hopping to the main actor,
+  /// so a media replacement during that hop cannot relabel the lifecycle.
+  var playbackGeneration: PlaybackGeneration?
 
   /// `true` once a handle has been published, so a query can distinguish
   /// "not attached yet" from "attached to a player that reports nothing".
@@ -60,6 +64,7 @@ extension PiPController: NativeHandleSnapshotObserver {
     let pointer: OpaquePointer? = player.pointer
     let timebase = controlTimebase
     let active = pipPlaybackActive
+    let playbackGeneration = player.generation
 
     callbackSnapshot.withLock { snapshot in
       if snapshot.playerPointer != pointer {
@@ -68,6 +73,7 @@ extension PiPController: NativeHandleSnapshotObserver {
       snapshot.playerPointer = pointer
       snapshot.controlTimebase = timebase
       snapshot.isPlaybackActive = active
+      snapshot.playbackGeneration = playbackGeneration
     }
   }
 
@@ -78,6 +84,7 @@ extension PiPController: NativeHandleSnapshotObserver {
       snapshot.playerPointer = nil
       snapshot.controlTimebase = nil
       snapshot.isPlaybackActive = false
+      snapshot.playbackGeneration = nil
       snapshot.generation &+= 1
     }
   }

--- a/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
@@ -22,7 +22,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
       // a controller replaced in the meantime can still deliver, and its
       // lifecycle describes a session that is over.
       guard let self, isCurrentAVController(identity) else { return }
-      pendingStopReason = nil
+      clearUnownedStopReasonBeforeStart()
       // Auto-PiP starts arrive from AVKit without start() or an intent
       // transition — last chance to issue the deferred session
       // activation before the PiP window owns playback.
@@ -46,7 +46,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
       // a controller replaced in the meantime can still deliver, and its
       // lifecycle describes a session that is over.
       guard let self, isCurrentAVController(identity) else { return }
-      pendingStopReason = nil
+      clearUnownedStopReasonBeforeStart()
       syncPlaybackStateForPictureInPicture()
       invalidatePictureInPicturePlaybackState()
       updatePiPActive(true)
@@ -91,7 +91,6 @@ extension PiPController: AVPictureInPictureControllerDelegate {
       // lifecycle describes a session that is over.
       guard let self, isCurrentAVController(identity) else { return }
       let reason = resolveStopReason()
-      pendingStopReason = nil
       updatePiPActive(false)
       publishPiPEvent(.didStop(reason: reason), mediaGeneration: mediaGeneration)
     }

--- a/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
@@ -16,6 +16,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
     _ avController: AVPictureInPictureController
   ) {
     let identity = ObjectIdentifier(avController)
+    let mediaGeneration = callbackSnapshot.withLock { $0.playbackGeneration }
     pipMainActorAsync { [weak self] in
       // Rejected unless it comes from the installed controller: the hop means
       // a controller replaced in the meantime can still deliver, and its
@@ -28,7 +29,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
       activateAudioSessionIfNeeded()
       syncPlaybackStateForPictureInPicture()
       invalidatePictureInPicturePlaybackState()
-      publishPiPEvent(.willStart)
+      publishPiPEvent(.willStart, mediaGeneration: mediaGeneration)
     }
   }
 
@@ -39,6 +40,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
     _ avController: AVPictureInPictureController
   ) {
     let identity = ObjectIdentifier(avController)
+    let mediaGeneration = callbackSnapshot.withLock { $0.playbackGeneration }
     pipMainActorAsync { [weak self] in
       // Rejected unless it comes from the installed controller: the hop means
       // a controller replaced in the meantime can still deliver, and its
@@ -48,7 +50,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
       syncPlaybackStateForPictureInPicture()
       invalidatePictureInPicturePlaybackState()
       updatePiPActive(true)
-      publishPiPEvent(.didStart)
+      publishPiPEvent(.didStart, mediaGeneration: mediaGeneration)
     }
   }
 
@@ -61,12 +63,16 @@ extension PiPController: AVPictureInPictureControllerDelegate {
     _ avController: AVPictureInPictureController
   ) {
     let identity = ObjectIdentifier(avController)
+    let mediaGeneration = callbackSnapshot.withLock { $0.playbackGeneration }
     pipMainActorAsync { [weak self] in
       // Rejected unless it comes from the installed controller: the hop means
       // a controller replaced in the meantime can still deliver, and its
       // lifecycle describes a session that is over.
       guard let self, isCurrentAVController(identity) else { return }
-      publishPiPEvent(.willStop(reason: resolveStopReason()))
+      publishPiPEvent(
+        .willStop(reason: resolveStopReason()),
+        mediaGeneration: mediaGeneration
+      )
     }
   }
 
@@ -78,6 +84,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
     _ avController: AVPictureInPictureController
   ) {
     let identity = ObjectIdentifier(avController)
+    let mediaGeneration = callbackSnapshot.withLock { $0.playbackGeneration }
     pipMainActorAsync { [weak self] in
       // Rejected unless it comes from the installed controller: the hop means
       // a controller replaced in the meantime can still deliver, and its
@@ -86,7 +93,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
       let reason = resolveStopReason()
       pendingStopReason = nil
       updatePiPActive(false)
-      publishPiPEvent(.didStop(reason: reason))
+      publishPiPEvent(.didStop(reason: reason), mediaGeneration: mediaGeneration)
     }
   }
 
@@ -186,6 +193,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
     failedToStartPictureInPictureWithError error: Error
   ) {
     let identity = ObjectIdentifier(avController)
+    let mediaGeneration = callbackSnapshot.withLock { $0.playbackGeneration }
     pipMainActorAsync { [weak self] in
       // Rejected unless it comes from the installed controller: the hop means
       // a controller replaced in the meantime can still deliver, and its
@@ -193,7 +201,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
       guard let self, isCurrentAVController(identity) else { return }
       notePendingStopReason(.failure)
       updatePiPActive(false)
-      publishPiPEvent(.failedToStart(error))
+      publishPiPEvent(.failedToStart(error), mediaGeneration: mediaGeneration)
     }
   }
 }

--- a/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
@@ -70,7 +70,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
       // lifecycle describes a session that is over.
       guard let self, isCurrentAVController(identity) else { return }
       publishPiPEvent(
-        .willStop(reason: resolveStopReason()),
+        .willStop(reason: resolveWillStopReason()),
         mediaGeneration: mediaGeneration
       )
     }

--- a/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
@@ -28,7 +28,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
       activateAudioSessionIfNeeded()
       syncPlaybackStateForPictureInPicture()
       invalidatePictureInPicturePlaybackState()
-      pipEventBroadcaster.broadcast(.willStart)
+      publishPiPEvent(.willStart)
     }
   }
 
@@ -48,7 +48,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
       syncPlaybackStateForPictureInPicture()
       invalidatePictureInPicturePlaybackState()
       updatePiPActive(true)
-      pipEventBroadcaster.broadcast(.didStart)
+      publishPiPEvent(.didStart)
     }
   }
 
@@ -66,7 +66,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
       // a controller replaced in the meantime can still deliver, and its
       // lifecycle describes a session that is over.
       guard let self, isCurrentAVController(identity) else { return }
-      pipEventBroadcaster.broadcast(.willStop(reason: resolveStopReason()))
+      publishPiPEvent(.willStop(reason: resolveStopReason()))
     }
   }
 
@@ -86,7 +86,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
       let reason = resolveStopReason()
       pendingStopReason = nil
       updatePiPActive(false)
-      pipEventBroadcaster.broadcast(.didStop(reason: reason))
+      publishPiPEvent(.didStop(reason: reason))
     }
   }
 
@@ -193,7 +193,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
       guard let self, isCurrentAVController(identity) else { return }
       notePendingStopReason(.failure)
       updatePiPActive(false)
-      pipEventBroadcaster.broadcast(.failedToStart(error))
+      publishPiPEvent(.failedToStart(error))
     }
   }
 }

--- a/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
@@ -198,7 +198,6 @@ extension PiPController: AVPictureInPictureControllerDelegate {
       // a controller replaced in the meantime can still deliver, and its
       // lifecycle describes a session that is over.
       guard let self, isCurrentAVController(identity) else { return }
-      notePendingStopReason(.failure)
       updatePiPActive(false)
       publishPiPEvent(.failedToStart(error), mediaGeneration: mediaGeneration)
     }

--- a/Sources/SwiftVLC/PiP/PiPController+Events.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Events.swift
@@ -168,7 +168,6 @@ extension PiPController {
       // Defensive counterpart to `willStart`: the native path synthesizes
       // didStart directly, and a backend callback should still promote the
       // accepted successor if no willStart was observable.
-      failedPiPLifecycle = nil
       if
         pipLifecycleAttribution == nil
         || pipLifecycleAttribution?.controllerGeneration != pipControllerGeneration {
@@ -176,15 +175,24 @@ extension PiPController {
       }
       pipLifecycleAttributionPhase = .started
       attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
-    case .willStop(let reason):
-      if reason == .failure, let failedPiPLifecycle {
+      // A successful newer start is a terminal progress boundary for an
+      // older failed attempt whose optional stop never arrived. Do not retire
+      // a newer queued failure when AVKit repeats didStart for the older
+      // lifecycle that is still stopping.
+      if
+        let failedPiPLifecycle,
+        failedPiPLifecycle.attribution.sequence < attribution.sequence {
+        self.failedPiPLifecycle = nil
+      }
+    case .willStop:
+      if failedLifecycleOwnsNextStop, let failedPiPLifecycle {
         attribution = failedPiPLifecycle.attribution
       } else {
         pipLifecycleAttributionPhase = .stopping
         attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
       }
-    case .didStop(let reason):
-      if reason == .failure, let failedPiPLifecycle {
+    case .didStop:
+      if failedLifecycleOwnsNextStop, let failedPiPLifecycle {
         attribution = failedPiPLifecycle.attribution
         self.failedPiPLifecycle = nil
         consumedFailedLifecycle = true
@@ -192,21 +200,32 @@ extension PiPController {
         attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
       }
     case .failedToStart:
-      attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
-      if pendingStopReason == .failure {
-        // A later failed-to-start callback is a terminal progress boundary for
-        // any earlier failed attempt whose optional didStop never arrived.
-        // Keep only the latest failure so its own terminal stop cannot consume
-        // a stale predecessor's identity.
+      if
+        pipLifecycleAttributionPhase == .started
+        || pipLifecycleAttributionPhase == .stopping,
+        let queuedPiPStartAttribution {
+        // An already-started lifecycle cannot own a later start-failure
+        // callback. The failure belongs to the accepted retry, while the
+        // older lifecycle remains current until its own didStop arrives.
+        attribution = queuedPiPStartAttribution
+        self.queuedPiPStartAttribution = nil
         failedPiPLifecycle = FailedPiPLifecycle(
           attribution: attribution,
           stopReason: .failure
         )
-        // The failure reason now belongs to the saved failed lifecycle. The
-        // current slot must be free for a retry accepted before the optional
-        // trailing stop arrives.
+      } else {
+        attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
+        // A failed start is terminal even when an earlier discriminating
+        // signal already won the stop reason. Preserve that winning reason
+        // alongside the retired lifecycle instead of leaving a dead awaiting
+        // start in the current slot forever.
+        failedPiPLifecycle = FailedPiPLifecycle(
+          attribution: attribution,
+          stopReason: pendingStopReason ?? .failure
+        )
         pendingStopReason = nil
         clearCurrentPiPLifecycleAttribution()
+        promoteQueuedPiPStartAttributionIfNeeded()
       }
     }
 
@@ -317,9 +336,11 @@ extension PiPController {
   private func makePiPLifecycleAttribution(
     mediaGeneration: PlaybackGeneration? = nil
   ) -> PiPLifecycleAttribution {
-    PiPLifecycleAttribution(
+    pipLifecycleSequence &+= 1
+    return PiPLifecycleAttribution(
       mediaGeneration: mediaGeneration ?? player.generation,
-      controllerGeneration: pipControllerGeneration
+      controllerGeneration: pipControllerGeneration,
+      sequence: pipLifecycleSequence
     )
   }
 
@@ -411,7 +432,7 @@ extension PiPController {
   /// independently current lifecycle's reason; otherwise use that current
   /// reason, natural end of media, or the user's close affordance.
   func resolveStopReason() -> PiPStopReason {
-    if let failedPiPLifecycle {
+    if failedLifecycleOwnsNextStop, let failedPiPLifecycle {
       return failedPiPLifecycle.stopReason
     }
     if let pendingStopReason {
@@ -421,6 +442,16 @@ extension PiPController {
       return .mediaEnded
     }
     return .userClosed
+  }
+
+  /// Whether the oldest lifecycle still awaiting a terminal stop is the
+  /// failed slot rather than the current slot. AVKit does not attach identity
+  /// to didStop, so accepted-start sequence is the only reliable discriminator
+  /// when a retry fails while an older session is still stopping.
+  private var failedLifecycleOwnsNextStop: Bool {
+    guard let failedPiPLifecycle else { return false }
+    guard let pipLifecycleAttribution else { return true }
+    return failedPiPLifecycle.attribution.sequence < pipLifecycleAttribution.sequence
   }
 }
 

--- a/Sources/SwiftVLC/PiP/PiPController+Events.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Events.swift
@@ -150,7 +150,7 @@ extension PiPController {
     switch event {
     case .willStart:
       // A failed attempt's trailing stop can arrive after its retry reaches
-      // willStart. Keep failed identities until that stop is consumed or the
+      // willStart. Keep the failed identity until that stop is consumed or the
       // retry reaches didStart, which is the boundary that retires a failure
       // with no trailing terminal callback.
       // Preserve an accepted request's identity even if the player adopted
@@ -167,7 +167,7 @@ extension PiPController {
       // Defensive counterpart to `willStart`: the native path synthesizes
       // didStart directly, and a backend callback should still promote the
       // accepted successor if no willStart was observable.
-      failedPiPLifecycleAttributions.removeAll(keepingCapacity: true)
+      failedPiPLifecycleAttribution = nil
       if
         pipLifecycleAttribution == nil
         || pipLifecycleAttribution?.controllerGeneration != pipControllerGeneration {
@@ -176,22 +176,27 @@ extension PiPController {
       pipLifecycleAttributionPhase = .started
       attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
     case .willStop(let reason):
-      if reason == .failure, let failedAttribution = failedPiPLifecycleAttributions.first {
+      if reason == .failure, let failedAttribution = failedPiPLifecycleAttribution {
         attribution = failedAttribution
       } else {
         pipLifecycleAttributionPhase = .stopping
         attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
       }
     case .didStop(let reason):
-      if reason == .failure, !failedPiPLifecycleAttributions.isEmpty {
-        attribution = failedPiPLifecycleAttributions.removeFirst()
+      if reason == .failure, let failedAttribution = failedPiPLifecycleAttribution {
+        attribution = failedAttribution
+        failedPiPLifecycleAttribution = nil
       } else {
         attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
       }
     case .failedToStart:
       attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
       if pendingStopReason == .failure {
-        failedPiPLifecycleAttributions.append(attribution)
+        // A later failed-to-start callback is a terminal progress boundary for
+        // any earlier failed attempt whose optional didStop never arrived.
+        // Keep only the latest failure so its own terminal stop cannot consume
+        // a stale predecessor's identity.
+        failedPiPLifecycleAttribution = attribution
         clearCurrentPiPLifecycleAttribution()
       }
     }
@@ -238,11 +243,11 @@ extension PiPController {
     if
       pipLifecycleAttributionPhase == .idle,
       pipLifecycleAttribution == nil,
-      failedPiPLifecycleAttributions.isEmpty {
+      failedPiPLifecycleAttribution == nil {
       pendingStopReason = nil
     }
     let currentLifecycleIsStopping = pipLifecycleAttributionPhase == .stopping
-      || (pendingStopReason != nil && failedPiPLifecycleAttributions.isEmpty)
+      || (pendingStopReason != nil && failedPiPLifecycleAttribution == nil)
     if pipLifecycleAttribution != nil, currentLifecycleIsStopping {
       if queuedPiPStartAttribution == nil {
         queuedPiPStartAttribution = makePiPLifecycleAttribution()
@@ -326,7 +331,7 @@ extension PiPController {
 
   func clearPiPLifecycleAttribution() {
     clearCurrentPiPLifecycleAttribution()
-    failedPiPLifecycleAttributions.removeAll(keepingCapacity: false)
+    failedPiPLifecycleAttribution = nil
     queuedPiPStartAttribution = nil
   }
 
@@ -364,7 +369,7 @@ extension PiPController {
     if let pendingStopReason {
       return pendingStopReason
     }
-    if !failedPiPLifecycleAttributions.isEmpty {
+    if failedPiPLifecycleAttribution != nil {
       return .failure
     }
     if player.didReachEnd {

--- a/Sources/SwiftVLC/PiP/PiPController+Events.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Events.swift
@@ -55,6 +55,27 @@ public enum PiPEvent: Sendable {
   case failedToStart(any Error)
 }
 
+/// A Picture-in-Picture lifecycle transition paired with the controller and
+/// media generations that own it.
+///
+/// AVKit callbacks are asynchronous. A start failure or stop can arrive after
+/// the player has adopted another media or the direct backend has replaced its
+/// AVKit controller. These identities let queued consumers reject a transition
+/// that no longer belongs to their current session.
+///
+/// Controller-generation ordering is meaningful only within the owning
+/// ``PiPController``. Its streams finish when that owner deinits, so a view
+/// reconstruction must replace the subscription along with the controller.
+public struct PiPEventEnvelope: Sendable {
+  /// The lifecycle transition reported by AVKit or the native backend.
+  public let event: PiPEvent
+  /// Media session active when the PiP lifecycle began.
+  public let mediaGeneration: PlaybackGeneration
+  /// AVKit controller or native-backend generation that emitted the event.
+  /// Ordering is meaningful only within the owning ``PiPController``.
+  public let controllerGeneration: UInt64
+}
+
 // MARK: - Lifecycle event stream
 
 extension PiPController {
@@ -106,6 +127,71 @@ extension PiPController {
   /// reason as authoritative.
   public var pipEvents: AsyncStream<PiPEvent> {
     pipEventBroadcaster.subscribe(policy: .unbounded)
+  }
+
+  /// Lossless PiP lifecycle events carrying controller and media identity.
+  ///
+  /// Prefer this stream when work can remain queued across a player media
+  /// change or an AVKit backend-controller replacement. Each access returns an
+  /// independent unbounded stream, and streams finish when this controller
+  /// deinits, matching ``pipEvents``.
+  public var pipEventEnvelopes: AsyncStream<PiPEventEnvelope> {
+    pipEventEnvelopeBroadcaster.subscribe(policy: .unbounded)
+  }
+
+  /// Broadcasts one transition onto the compatibility and attributed streams.
+  /// The lifecycle's media generation is captured by an accepted explicit
+  /// start, or by the first callback for a system-initiated start.
+  func publishPiPEvent(_ event: PiPEvent) {
+    switch event {
+    case .willStart:
+      // Preserve an accepted request's identity even if the player adopted
+      // successor media before AVKit replied. An auto-start has no accepted
+      // request, so it begins a fresh lifecycle here.
+      if !pipAcceptedStartPending {
+        capturePiPLifecycleAttribution()
+      }
+    case .didStart, .willStop, .didStop, .failedToStart:
+      if
+        pipLifecycleMediaGeneration == nil
+        || pipLifecycleControllerGeneration != pipControllerGeneration {
+        capturePiPLifecycleAttribution()
+      }
+    }
+    pipAcceptedStartPending = false
+
+    let envelope = PiPEventEnvelope(
+      event: event,
+      mediaGeneration: pipLifecycleMediaGeneration ?? player.generation,
+      controllerGeneration: pipLifecycleControllerGeneration ?? pipControllerGeneration
+    )
+    pipEventBroadcaster.broadcast(event)
+    pipEventEnvelopeBroadcaster.broadcast(envelope)
+
+    if case .didStop = event {
+      clearPiPLifecycleAttribution()
+    }
+  }
+
+  /// Captures attribution only when the backend confirms that it actually
+  /// issued the request. Refused starts cannot later own a lifecycle callback.
+  func noteAcceptedPiPStartRequest(_ result: PiPStartResult) -> PiPStartResult {
+    if result == .accepted {
+      capturePiPLifecycleAttribution()
+      pipAcceptedStartPending = true
+    }
+    return result
+  }
+
+  private func capturePiPLifecycleAttribution() {
+    pipLifecycleMediaGeneration = player.generation
+    pipLifecycleControllerGeneration = pipControllerGeneration
+  }
+
+  func clearPiPLifecycleAttribution() {
+    pipLifecycleMediaGeneration = nil
+    pipLifecycleControllerGeneration = nil
+    pipAcceptedStartPending = false
   }
 
   /// The current Picture in Picture state, followed by every subsequent

--- a/Sources/SwiftVLC/PiP/PiPController+Events.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Events.swift
@@ -230,6 +230,17 @@ extension PiPController {
   /// issued the request. Refused starts cannot later own a lifecycle callback.
   func noteAcceptedPiPStartRequest(_ result: PiPStartResult) -> PiPStartResult {
     guard result == .accepted else { return result }
+    // `stop()` records a reason even while idle so it cannot miss a start
+    // animation that AVKit has not reported yet. If there is demonstrably no
+    // lifecycle (including no failed attribution awaiting its trailing stop),
+    // that reason belongs to nothing and must not make this new request look
+    // like an overlapping retry.
+    if
+      pipLifecycleAttributionPhase == .idle,
+      pipLifecycleAttribution == nil,
+      failedPiPLifecycleAttributions.isEmpty {
+      pendingStopReason = nil
+    }
     let currentLifecycleIsStopping = pipLifecycleAttributionPhase == .stopping
       || (pendingStopReason != nil && failedPiPLifecycleAttributions.isEmpty)
     if pipLifecycleAttribution != nil, currentLifecycleIsStopping {

--- a/Sources/SwiftVLC/PiP/PiPController+Events.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Events.swift
@@ -142,49 +142,79 @@ extension PiPController {
   /// Broadcasts one transition onto the compatibility and attributed streams.
   /// The lifecycle's media generation is captured by an accepted explicit
   /// start, or by the first callback for a system-initiated start.
-  func publishPiPEvent(_ event: PiPEvent) {
+  func publishPiPEvent(
+    _ event: PiPEvent,
+    mediaGeneration mediaGenerationOverride: PlaybackGeneration? = nil
+  ) {
+    let attribution: PiPLifecycleAttribution
     switch event {
     case .willStart:
+      // Reaching a successor start callback means AVKit did not emit a
+      // trailing stop for any older failed attempt. The delegate clears the
+      // older stop reason at the same boundary, so discard its saved identity
+      // as well.
+      failedPiPLifecycleAttributions.removeAll(keepingCapacity: true)
       // Preserve an accepted request's identity even if the player adopted
       // successor media before AVKit replied. An auto-start has no accepted
       // request, so it begins a fresh lifecycle here.
       if pipLifecycleAttributionPhase != .awaitingStart {
-        capturePiPLifecycleAttribution()
+        capturePiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
       }
       pipLifecycleAttributionPhase = .awaitingStart
+      attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
     case .didStart:
       if
-        pipLifecycleMediaGeneration == nil
-        || pipLifecycleControllerGeneration != pipControllerGeneration {
-        capturePiPLifecycleAttribution()
+        pipLifecycleAttribution == nil
+        || pipLifecycleAttribution?.controllerGeneration != pipControllerGeneration {
+        capturePiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
       }
       pipLifecycleAttributionPhase = .started
-    case .willStop, .didStop:
-      if
-        pipLifecycleMediaGeneration == nil
-        || pipLifecycleControllerGeneration != pipControllerGeneration {
-        capturePiPLifecycleAttribution()
+      attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
+    case .willStop(let reason):
+      if reason == .failure, let failedAttribution = failedPiPLifecycleAttributions.first {
+        attribution = failedAttribution
+      } else {
+        attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
+      }
+    case .didStop(let reason):
+      if reason == .failure, !failedPiPLifecycleAttributions.isEmpty {
+        attribution = failedPiPLifecycleAttributions.removeFirst()
+      } else {
+        attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
       }
     case .failedToStart:
-      if
-        pipLifecycleMediaGeneration == nil
-        || pipLifecycleControllerGeneration != pipControllerGeneration {
-        capturePiPLifecycleAttribution()
-      }
-      pipLifecycleAttributionPhase = .failed
+      attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
+      failedPiPLifecycleAttributions.append(attribution)
+      clearCurrentPiPLifecycleAttribution()
     }
 
     let envelope = PiPEventEnvelope(
       event: event,
-      mediaGeneration: pipLifecycleMediaGeneration ?? player.generation,
-      controllerGeneration: pipLifecycleControllerGeneration ?? pipControllerGeneration
+      mediaGeneration: attribution.mediaGeneration,
+      controllerGeneration: attribution.controllerGeneration
     )
     pipEventBroadcaster.broadcast(event)
     pipEventEnvelopeBroadcaster.broadcast(envelope)
 
-    if case .didStop = event {
-      clearPiPLifecycleAttribution()
+    if case .didStop(let reason) = event, reason != .failure {
+      clearCurrentPiPLifecycleAttribution()
     }
+  }
+
+  private func currentPiPLifecycleAttribution(
+    mediaGeneration: PlaybackGeneration?
+  ) -> PiPLifecycleAttribution {
+    if
+      let pipLifecycleAttribution,
+      pipLifecycleAttribution.controllerGeneration == pipControllerGeneration {
+      return pipLifecycleAttribution
+    }
+    return capturePiPLifecycleAttribution(mediaGeneration: mediaGeneration)
+  }
+
+  private func clearCurrentPiPLifecycleAttribution() {
+    pipLifecycleAttribution = nil
+    pipLifecycleAttributionPhase = .idle
   }
 
   /// Captures attribution only when the backend confirms that it actually
@@ -192,7 +222,7 @@ extension PiPController {
   func noteAcceptedPiPStartRequest(_ result: PiPStartResult) -> PiPStartResult {
     guard result == .accepted else { return result }
     switch pipLifecycleAttributionPhase {
-    case .idle, .failed:
+    case .idle:
       capturePiPLifecycleAttribution()
       pipLifecycleAttributionPhase = .awaitingStart
     case .awaitingStart, .started:
@@ -203,20 +233,28 @@ extension PiPController {
     return result
   }
 
-  func capturePiPLifecycleAttribution() {
-    pipLifecycleMediaGeneration = player.generation
-    pipLifecycleControllerGeneration = pipControllerGeneration
+  @discardableResult
+  func capturePiPLifecycleAttribution(
+    mediaGeneration: PlaybackGeneration? = nil
+  ) -> PiPLifecycleAttribution {
+    let attribution = PiPLifecycleAttribution(
+      mediaGeneration: mediaGeneration ?? player.generation,
+      controllerGeneration: pipControllerGeneration
+    )
+    pipLifecycleAttribution = attribution
+    return attribution
   }
 
-  func adoptActivePiPLifecycleAttribution() {
-    capturePiPLifecycleAttribution()
+  func adoptActivePiPLifecycleAttribution(
+    mediaGeneration: PlaybackGeneration?
+  ) {
+    capturePiPLifecycleAttribution(mediaGeneration: mediaGeneration)
     pipLifecycleAttributionPhase = .started
   }
 
   func clearPiPLifecycleAttribution() {
-    pipLifecycleMediaGeneration = nil
-    pipLifecycleControllerGeneration = nil
-    pipLifecycleAttributionPhase = .idle
+    clearCurrentPiPLifecycleAttribution()
+    failedPiPLifecycleAttributions.removeAll(keepingCapacity: false)
   }
 
   /// The current Picture in Picture state, followed by every subsequent

--- a/Sources/SwiftVLC/PiP/PiPController+Events.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Events.swift
@@ -181,12 +181,17 @@ extension PiPController {
       // lifecycle that is still stopping.
       if
         let failedPiPLifecycle,
-        failedPiPLifecycle.attribution.sequence < attribution.sequence {
+        failedPiPLifecycle.attribution.sequence < attribution.sequence,
+        !failedPiPLifecycle.willStopObserved {
         self.failedPiPLifecycle = nil
       }
     case .willStop:
       if failedLifecycleOwnsNextStop, let failedPiPLifecycle {
         attribution = failedPiPLifecycle.attribution
+        // Once AVKit has promised a terminal callback for this failed
+        // lifecycle, a newer didStart must not retire it as an omitted stop.
+        // Keep it until the matching didStop consumes the slot.
+        self.failedPiPLifecycle?.willStopObserved = true
       } else {
         pipLifecycleAttributionPhase = .stopping
         attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
@@ -289,8 +294,7 @@ extension PiPController {
     // like an overlapping retry.
     if
       pipLifecycleAttributionPhase == .idle,
-      pipLifecycleAttribution == nil,
-      failedPiPLifecycle == nil {
+      pipLifecycleAttribution == nil {
       pendingStopReason = nil
     }
     let currentLifecycleIsStopping = pipLifecycleAttributionPhase == .stopping

--- a/Sources/SwiftVLC/PiP/PiPController+Events.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Events.swift
@@ -154,6 +154,7 @@ extension PiPController {
       // older stop reason at the same boundary, so discard its saved identity
       // as well.
       failedPiPLifecycleAttributions.removeAll(keepingCapacity: true)
+      promoteQueuedPiPStartAttributionIfNeeded()
       // Preserve an accepted request's identity even if the player adopted
       // successor media before AVKit replied. An auto-start has no accepted
       // request, so it begins a fresh lifecycle here.
@@ -163,6 +164,11 @@ extension PiPController {
       pipLifecycleAttributionPhase = .awaitingStart
       attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
     case .didStart:
+      // Defensive counterpart to `willStart`: the native path synthesizes
+      // didStart directly, and a backend callback should still promote the
+      // accepted successor if no willStart was observable.
+      failedPiPLifecycleAttributions.removeAll(keepingCapacity: true)
+      promoteQueuedPiPStartAttributionIfNeeded()
       if
         pipLifecycleAttribution == nil
         || pipLifecycleAttribution?.controllerGeneration != pipControllerGeneration {
@@ -184,8 +190,10 @@ extension PiPController {
       }
     case .failedToStart:
       attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
-      failedPiPLifecycleAttributions.append(attribution)
-      clearCurrentPiPLifecycleAttribution()
+      if pendingStopReason == .failure {
+        failedPiPLifecycleAttributions.append(attribution)
+        clearCurrentPiPLifecycleAttribution()
+      }
     }
 
     let envelope = PiPEventEnvelope(
@@ -198,6 +206,7 @@ extension PiPController {
 
     if case .didStop(let reason) = event, reason != .failure {
       clearCurrentPiPLifecycleAttribution()
+      promoteQueuedPiPStartAttributionIfNeeded()
     }
   }
 
@@ -221,13 +230,24 @@ extension PiPController {
   /// issued the request. Refused starts cannot later own a lifecycle callback.
   func noteAcceptedPiPStartRequest(_ result: PiPStartResult) -> PiPStartResult {
     guard result == .accepted else { return result }
+    if pipLifecycleAttribution != nil, pendingStopReason != nil {
+      queuedPiPStartAttribution = makePiPLifecycleAttribution()
+      return result
+    }
     switch pipLifecycleAttributionPhase {
     case .idle:
       capturePiPLifecycleAttribution()
       pipLifecycleAttributionPhase = .awaitingStart
-    case .awaitingStart, .started:
-      // Repeating start while AVKit is already starting/active still issues
-      // the backend method, but it does not begin a new PiP lifecycle.
+    case .awaitingStart:
+      if nativeBackend != nil, !isActive {
+        // The native backend cannot observe AVKit's failed-to-start callback.
+        // A later accepted request while still inactive therefore supersedes
+        // the unobservable attempt instead of preserving it forever.
+        capturePiPLifecycleAttribution()
+      }
+    case .started:
+      // Repeating start while AVKit is active still issues the backend method,
+      // but it does not begin a new PiP lifecycle.
       break
     }
     return result
@@ -237,12 +257,25 @@ extension PiPController {
   func capturePiPLifecycleAttribution(
     mediaGeneration: PlaybackGeneration? = nil
   ) -> PiPLifecycleAttribution {
-    let attribution = PiPLifecycleAttribution(
+    let attribution = makePiPLifecycleAttribution(mediaGeneration: mediaGeneration)
+    pipLifecycleAttribution = attribution
+    return attribution
+  }
+
+  private func makePiPLifecycleAttribution(
+    mediaGeneration: PlaybackGeneration? = nil
+  ) -> PiPLifecycleAttribution {
+    PiPLifecycleAttribution(
       mediaGeneration: mediaGeneration ?? player.generation,
       controllerGeneration: pipControllerGeneration
     )
-    pipLifecycleAttribution = attribution
-    return attribution
+  }
+
+  private func promoteQueuedPiPStartAttributionIfNeeded() {
+    guard let queuedPiPStartAttribution else { return }
+    pipLifecycleAttribution = queuedPiPStartAttribution
+    self.queuedPiPStartAttribution = nil
+    pipLifecycleAttributionPhase = .awaitingStart
   }
 
   func adoptActivePiPLifecycleAttribution(
@@ -255,6 +288,7 @@ extension PiPController {
   func clearPiPLifecycleAttribution() {
     clearCurrentPiPLifecycleAttribution()
     failedPiPLifecycleAttributions.removeAll(keepingCapacity: false)
+    queuedPiPStartAttribution = nil
   }
 
   /// The current Picture in Picture state, followed by every subsequent

--- a/Sources/SwiftVLC/PiP/PiPController+Events.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Events.swift
@@ -209,8 +209,15 @@ extension PiPController {
     pipEventBroadcaster.broadcast(event)
     pipEventEnvelopeBroadcaster.broadcast(envelope)
 
-    if case .didStop(let reason) = event, reason != .failure {
-      clearCurrentPiPLifecycleAttribution()
+    if case .didStop(let reason) = event {
+      if reason != .failure {
+        clearCurrentPiPLifecycleAttribution()
+      }
+      // A failed-to-start callback clears the failed lifecycle before its
+      // optional trailing stop arrives. That stop still releases a retry
+      // accepted while the old lifecycle was stopping. Conversely, when an
+      // independently accepted retry is already current, promotion must not
+      // overwrite it.
       promoteQueuedPiPStartAttributionIfNeeded()
     }
   }
@@ -296,7 +303,10 @@ extension PiPController {
   }
 
   private func promoteQueuedPiPStartAttributionIfNeeded() {
-    guard let queuedPiPStartAttribution else { return }
+    guard
+      pipLifecycleAttribution == nil,
+      let queuedPiPStartAttribution
+    else { return }
     pipLifecycleAttribution = queuedPiPStartAttribution
     self.queuedPiPStartAttribution = nil
     pipLifecycleAttributionPhase = .awaitingStart
@@ -319,6 +329,19 @@ extension PiPController {
     }
     return currentPiPLifecycleAttribution(
       mediaGeneration: signaledMediaGeneration
+    ).mediaGeneration
+  }
+
+  /// Resolves an iOS native active signal against the exact accepted request
+  /// snapshotted when that signal arrived. The request generation is passed by
+  /// value so another accepted start during the callback's main-actor hop
+  /// cannot replace its provenance.
+  func attributedNativePiPStartMediaGeneration(
+    signaledMediaGeneration: PlaybackGeneration?,
+    acceptedRequestMediaGeneration: PlaybackGeneration?
+  ) -> PlaybackGeneration {
+    capturePiPLifecycleAttribution(
+      mediaGeneration: acceptedRequestMediaGeneration ?? signaledMediaGeneration
     ).mediaGeneration
   }
 

--- a/Sources/SwiftVLC/PiP/PiPController+Events.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Events.swift
@@ -288,11 +288,20 @@ extension PiPController {
 
   /// Resolves the media identity a native backend must persist while active.
   /// An accepted explicit request owns the lifecycle even when the native
-  /// active signal arrives after the player has adopted successor media.
+  /// active signal arrives after the player has adopted successor media. An
+  /// activation from a replacement native window controller cannot have been
+  /// caused by a request issued to the previous controller, so it begins a
+  /// system-initiated lifecycle at signal time instead.
   func attributedNativePiPStartMediaGeneration(
-    signaledMediaGeneration: PlaybackGeneration?
+    signaledMediaGeneration: PlaybackGeneration?,
+    preservesAcceptedRequest: Bool
   ) -> PlaybackGeneration {
-    currentPiPLifecycleAttribution(
+    if !preservesAcceptedRequest {
+      return capturePiPLifecycleAttribution(
+        mediaGeneration: signaledMediaGeneration
+      ).mediaGeneration
+    }
+    return currentPiPLifecycleAttribution(
       mediaGeneration: signaledMediaGeneration
     ).mediaGeneration
   }

--- a/Sources/SwiftVLC/PiP/PiPController+Events.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Events.swift
@@ -183,12 +183,13 @@ extension PiPController {
         $0.attribution.sequence < attribution.sequence && !$0.willStopObserved
       }
     case .willStop:
-      if failedLifecycleOwnsNextStop, let failedPiPLifecycle = failedPiPLifecycles.first {
+      if let failedIndex = failedLifecycleIndexOwningNextWillStop {
+        let failedPiPLifecycle = failedPiPLifecycles[failedIndex]
         attribution = failedPiPLifecycle.attribution
         // Once AVKit has promised a terminal callback for this failed
         // lifecycle, a newer didStart must not retire it as an omitted stop.
         // Keep it until the matching didStop consumes the slot.
-        failedPiPLifecycles[0].willStopObserved = true
+        failedPiPLifecycles[failedIndex].willStopObserved = true
       } else {
         pipLifecycleAttributionPhase = .stopping
         attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
@@ -489,6 +490,42 @@ extension PiPController {
       return .mediaEnded
     }
     return .userClosed
+  }
+
+  /// Resolves a `willStop` against the oldest lifecycle that has not already
+  /// observed that callback. A failed lifecycle remains first for `didStop`
+  /// after its own `willStop`, but must not steal a distinct `willStop` from
+  /// an active retry during that delay.
+  func resolveWillStopReason() -> PiPStopReason {
+    if let failedIndex = failedLifecycleIndexOwningNextWillStop {
+      return failedPiPLifecycles[failedIndex].stopReason
+    }
+    if let pendingStopReason {
+      return pendingStopReason
+    }
+    if player.didReachEnd {
+      return .mediaEnded
+    }
+    return .userClosed
+  }
+
+  /// The failed lifecycle that owns the next `willStop`, if any. Unlike
+  /// `didStop`, this skips failed entries for which `willStop` was already
+  /// observed and compares the next unobserved entry with the current
+  /// lifecycle's accepted-start sequence.
+  private var failedLifecycleIndexOwningNextWillStop: Int? {
+    guard
+      let failedIndex = failedPiPLifecycles.firstIndex(where: {
+        !$0.willStopObserved
+      }) else { return nil }
+    guard let pipLifecycleAttribution else { return failedIndex }
+    if pipLifecycleAttributionPhase == .stopping {
+      return failedIndex
+    }
+    return failedPiPLifecycles[failedIndex].attribution.sequence
+      < pipLifecycleAttribution.sequence
+      ? failedIndex
+      : nil
   }
 
   /// Whether the oldest lifecycle still awaiting a terminal stop is the

--- a/Sources/SwiftVLC/PiP/PiPController+Events.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Events.swift
@@ -147,6 +147,7 @@ extension PiPController {
     mediaGeneration mediaGenerationOverride: PlaybackGeneration? = nil
   ) {
     let attribution: PiPLifecycleAttribution
+    var consumedFailedLifecycle = false
     switch event {
     case .willStart:
       // A failed attempt's trailing stop can arrive after its retry reaches
@@ -167,7 +168,7 @@ extension PiPController {
       // Defensive counterpart to `willStart`: the native path synthesizes
       // didStart directly, and a backend callback should still promote the
       // accepted successor if no willStart was observable.
-      failedPiPLifecycleAttribution = nil
+      failedPiPLifecycle = nil
       if
         pipLifecycleAttribution == nil
         || pipLifecycleAttribution?.controllerGeneration != pipControllerGeneration {
@@ -176,16 +177,17 @@ extension PiPController {
       pipLifecycleAttributionPhase = .started
       attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
     case .willStop(let reason):
-      if reason == .failure, let failedAttribution = failedPiPLifecycleAttribution {
-        attribution = failedAttribution
+      if reason == .failure, let failedPiPLifecycle {
+        attribution = failedPiPLifecycle.attribution
       } else {
         pipLifecycleAttributionPhase = .stopping
         attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
       }
     case .didStop(let reason):
-      if reason == .failure, let failedAttribution = failedPiPLifecycleAttribution {
-        attribution = failedAttribution
-        failedPiPLifecycleAttribution = nil
+      if reason == .failure, let failedPiPLifecycle {
+        attribution = failedPiPLifecycle.attribution
+        self.failedPiPLifecycle = nil
+        consumedFailedLifecycle = true
       } else {
         attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
       }
@@ -196,7 +198,14 @@ extension PiPController {
         // any earlier failed attempt whose optional didStop never arrived.
         // Keep only the latest failure so its own terminal stop cannot consume
         // a stale predecessor's identity.
-        failedPiPLifecycleAttribution = attribution
+        failedPiPLifecycle = FailedPiPLifecycle(
+          attribution: attribution,
+          stopReason: .failure
+        )
+        // The failure reason now belongs to the saved failed lifecycle. The
+        // current slot must be free for a retry accepted before the optional
+        // trailing stop arrives.
+        pendingStopReason = nil
         clearCurrentPiPLifecycleAttribution()
       }
     }
@@ -209,8 +218,9 @@ extension PiPController {
     pipEventBroadcaster.broadcast(event)
     pipEventEnvelopeBroadcaster.broadcast(envelope)
 
-    if case .didStop(let reason) = event {
-      if reason != .failure {
+    if case .didStop = event {
+      if !consumedFailedLifecycle {
+        pendingStopReason = nil
         clearCurrentPiPLifecycleAttribution()
       }
       // A failed-to-start callback clears the failed lifecycle before its
@@ -238,6 +248,17 @@ extension PiPController {
     pipLifecycleAttributionPhase = .idle
   }
 
+  /// Clears a stop reason recorded while no lifecycle existed. A reason tied
+  /// to an accepted or already-signalled lifecycle must survive `willStart`:
+  /// an application may stop an accepted retry before AVKit reports its start.
+  func clearUnownedStopReasonBeforeStart() {
+    guard
+      pipLifecycleAttributionPhase == .idle,
+      pipLifecycleAttribution == nil
+    else { return }
+    pendingStopReason = nil
+  }
+
   /// Captures attribution only when the backend confirms that it actually
   /// issued the request. Refused starts cannot later own a lifecycle callback.
   func noteAcceptedPiPStartRequest(_ result: PiPStartResult) -> PiPStartResult {
@@ -250,11 +271,11 @@ extension PiPController {
     if
       pipLifecycleAttributionPhase == .idle,
       pipLifecycleAttribution == nil,
-      failedPiPLifecycleAttribution == nil {
+      failedPiPLifecycle == nil {
       pendingStopReason = nil
     }
     let currentLifecycleIsStopping = pipLifecycleAttributionPhase == .stopping
-      || (pendingStopReason != nil && failedPiPLifecycleAttribution == nil)
+      || (pendingStopReason != nil && failedPiPLifecycle == nil)
     if pipLifecycleAttribution != nil, currentLifecycleIsStopping {
       if queuedPiPStartAttribution == nil {
         queuedPiPStartAttribution = makePiPLifecycleAttribution()
@@ -354,7 +375,7 @@ extension PiPController {
 
   func clearPiPLifecycleAttribution() {
     clearCurrentPiPLifecycleAttribution()
-    failedPiPLifecycleAttribution = nil
+    failedPiPLifecycle = nil
     queuedPiPStartAttribution = nil
   }
 
@@ -385,15 +406,16 @@ extension PiPController {
     pendingStopReason = reason
   }
 
-  /// Resolves the stop reason for the in-flight stop without clearing
-  /// it: pending discriminating signal, else natural end of media,
-  /// else the user's close affordance.
+  /// Resolves the stop reason for the in-flight stop without clearing it. A
+  /// failed attempt awaiting its optional trailing stop wins before the
+  /// independently current lifecycle's reason; otherwise use that current
+  /// reason, natural end of media, or the user's close affordance.
   func resolveStopReason() -> PiPStopReason {
+    if let failedPiPLifecycle {
+      return failedPiPLifecycle.stopReason
+    }
     if let pendingStopReason {
       return pendingStopReason
-    }
-    if failedPiPLifecycleAttribution != nil {
-      return .failure
     }
     if player.didReachEnd {
       return .mediaEnded

--- a/Sources/SwiftVLC/PiP/PiPController+Events.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Events.swift
@@ -149,11 +149,10 @@ extension PiPController {
     let attribution: PiPLifecycleAttribution
     switch event {
     case .willStart:
-      // Reaching a successor start callback means AVKit did not emit a
-      // trailing stop for any older failed attempt. The delegate clears the
-      // older stop reason at the same boundary, so discard its saved identity
-      // as well.
-      failedPiPLifecycleAttributions.removeAll(keepingCapacity: true)
+      // A failed attempt's trailing stop can arrive after its retry reaches
+      // willStart. Keep failed identities until that stop is consumed or the
+      // retry reaches didStart, which is the boundary that retires a failure
+      // with no trailing terminal callback.
       promoteQueuedPiPStartAttributionIfNeeded()
       // Preserve an accepted request's identity even if the player adopted
       // successor media before AVKit replied. An auto-start has no accepted
@@ -180,6 +179,7 @@ extension PiPController {
       if reason == .failure, let failedAttribution = failedPiPLifecycleAttributions.first {
         attribution = failedAttribution
       } else {
+        pipLifecycleAttributionPhase = .stopping
         attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
       }
     case .didStop(let reason):
@@ -230,17 +230,16 @@ extension PiPController {
   /// issued the request. Refused starts cannot later own a lifecycle callback.
   func noteAcceptedPiPStartRequest(_ result: PiPStartResult) -> PiPStartResult {
     guard result == .accepted else { return result }
-    if
-      pipLifecycleAttribution != nil,
-      pendingStopReason != nil,
-      failedPiPLifecycleAttributions.isEmpty {
+    let currentLifecycleIsStopping = pipLifecycleAttributionPhase == .stopping
+      || (pendingStopReason != nil && failedPiPLifecycleAttributions.isEmpty)
+    if pipLifecycleAttribution != nil, currentLifecycleIsStopping {
       if queuedPiPStartAttribution == nil {
         queuedPiPStartAttribution = makePiPLifecycleAttribution()
       }
       return result
     }
     switch pipLifecycleAttributionPhase {
-    case .idle:
+    case .idle, .stopping:
       capturePiPLifecycleAttribution()
       pipLifecycleAttributionPhase = .awaitingStart
     case .awaitingStart:
@@ -329,6 +328,9 @@ extension PiPController {
   func resolveStopReason() -> PiPStopReason {
     if let pendingStopReason {
       return pendingStopReason
+    }
+    if !failedPiPLifecycleAttributions.isEmpty {
+      return .failure
     }
     if player.didReachEnd {
       return .mediaEnded

--- a/Sources/SwiftVLC/PiP/PiPController+Events.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Events.swift
@@ -179,27 +179,24 @@ extension PiPController {
       // older failed attempt whose optional stop never arrived. Do not retire
       // a newer queued failure when AVKit repeats didStart for the older
       // lifecycle that is still stopping.
-      if
-        let failedPiPLifecycle,
-        failedPiPLifecycle.attribution.sequence < attribution.sequence,
-        !failedPiPLifecycle.willStopObserved {
-        self.failedPiPLifecycle = nil
+      failedPiPLifecycles.removeAll {
+        $0.attribution.sequence < attribution.sequence && !$0.willStopObserved
       }
     case .willStop:
-      if failedLifecycleOwnsNextStop, let failedPiPLifecycle {
+      if failedLifecycleOwnsNextStop, let failedPiPLifecycle = failedPiPLifecycles.first {
         attribution = failedPiPLifecycle.attribution
         // Once AVKit has promised a terminal callback for this failed
         // lifecycle, a newer didStart must not retire it as an omitted stop.
         // Keep it until the matching didStop consumes the slot.
-        self.failedPiPLifecycle?.willStopObserved = true
+        failedPiPLifecycles[0].willStopObserved = true
       } else {
         pipLifecycleAttributionPhase = .stopping
         attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
       }
     case .didStop:
-      if failedLifecycleOwnsNextStop, let failedPiPLifecycle {
+      if failedLifecycleOwnsNextStop, let failedPiPLifecycle = failedPiPLifecycles.first {
         attribution = failedPiPLifecycle.attribution
-        self.failedPiPLifecycle = nil
+        failedPiPLifecycles.removeFirst()
         consumedFailedLifecycle = true
       } else {
         attribution = currentPiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
@@ -214,7 +211,7 @@ extension PiPController {
         // older lifecycle remains current until its own didStop arrives.
         attribution = queuedPiPStartAttribution
         self.queuedPiPStartAttribution = nil
-        failedPiPLifecycle = FailedPiPLifecycle(
+        recordFailedPiPLifecycle(
           attribution: attribution,
           stopReason: .failure
         )
@@ -224,7 +221,7 @@ extension PiPController {
         // signal already won the stop reason. Preserve that winning reason
         // alongside the retired lifecycle instead of leaving a dead awaiting
         // start in the current slot forever.
-        failedPiPLifecycle = FailedPiPLifecycle(
+        recordFailedPiPLifecycle(
           attribution: attribution,
           stopReason: pendingStopReason ?? .failure
         )
@@ -254,6 +251,24 @@ extension PiPController {
       // overwrite it.
       promoteQueuedPiPStartAttributionIfNeeded()
     }
+  }
+
+  /// Publishes a native transition that crossed a controller handoff without
+  /// consuming lifecycle state the successor may already have created. The
+  /// backend supplies the media identity captured at signal time; only the
+  /// public envelope/compatibility streams need to inherit the new owner's
+  /// controller generation.
+  func publishTransferredNativePiPEvent(
+    _ event: PiPEvent,
+    mediaGeneration: PlaybackGeneration?
+  ) {
+    let attribution = makePiPLifecycleAttribution(mediaGeneration: mediaGeneration)
+    pipEventBroadcaster.broadcast(event)
+    pipEventEnvelopeBroadcaster.broadcast(PiPEventEnvelope(
+      event: event,
+      mediaGeneration: attribution.mediaGeneration,
+      controllerGeneration: attribution.controllerGeneration
+    ))
   }
 
   private func currentPiPLifecycleAttribution(
@@ -298,7 +313,7 @@ extension PiPController {
       pendingStopReason = nil
     }
     let currentLifecycleIsStopping = pipLifecycleAttributionPhase == .stopping
-      || (pendingStopReason != nil && failedPiPLifecycle == nil)
+      || (pendingStopReason != nil && failedPiPLifecycles.isEmpty)
     if pipLifecycleAttribution != nil, currentLifecycleIsStopping {
       if queuedPiPStartAttribution == nil {
         queuedPiPStartAttribution = makePiPLifecycleAttribution()
@@ -358,6 +373,34 @@ extension PiPController {
     pipLifecycleAttributionPhase = .awaitingStart
   }
 
+  /// Saves a failed start in accepted-request order. Reaching a newer failed
+  /// start proves that any older failure without `willStop` omitted its
+  /// optional terminal callback. A failure for which AVKit already emitted
+  /// `willStop` remains queued until its matching `didStop` arrives.
+  private func recordFailedPiPLifecycle(
+    attribution: PiPLifecycleAttribution,
+    stopReason: PiPStopReason
+  ) {
+    failedPiPLifecycles.removeAll {
+      $0.attribution.sequence < attribution.sequence && !$0.willStopObserved
+    }
+    if
+      let existingIndex = failedPiPLifecycles.firstIndex(where: {
+        $0.attribution.sequence == attribution.sequence
+      }) {
+      guard !failedPiPLifecycles[existingIndex].willStopObserved else { return }
+      failedPiPLifecycles[existingIndex] = FailedPiPLifecycle(
+        attribution: attribution,
+        stopReason: stopReason
+      )
+      return
+    }
+    failedPiPLifecycles.append(FailedPiPLifecycle(
+      attribution: attribution,
+      stopReason: stopReason
+    ))
+  }
+
   /// Resolves the media identity a native backend must persist while active.
   /// An accepted explicit request owns the lifecycle even when the native
   /// active signal arrives after the player has adopted successor media. An
@@ -400,7 +443,7 @@ extension PiPController {
 
   func clearPiPLifecycleAttribution() {
     clearCurrentPiPLifecycleAttribution()
-    failedPiPLifecycle = nil
+    failedPiPLifecycles.removeAll(keepingCapacity: true)
     queuedPiPStartAttribution = nil
   }
 
@@ -436,7 +479,7 @@ extension PiPController {
   /// independently current lifecycle's reason; otherwise use that current
   /// reason, natural end of media, or the user's close affordance.
   func resolveStopReason() -> PiPStopReason {
-    if failedLifecycleOwnsNextStop, let failedPiPLifecycle {
+    if failedLifecycleOwnsNextStop, let failedPiPLifecycle = failedPiPLifecycles.first {
       return failedPiPLifecycle.stopReason
     }
     if let pendingStopReason {
@@ -453,7 +496,7 @@ extension PiPController {
   /// to didStop, so accepted-start sequence is the only reliable discriminator
   /// when a retry fails while an older session is still stopping.
   private var failedLifecycleOwnsNextStop: Bool {
-    guard let failedPiPLifecycle else { return false }
+    guard let failedPiPLifecycle = failedPiPLifecycles.first else { return false }
     guard let pipLifecycleAttribution else { return true }
     return failedPiPLifecycle.attribution.sequence < pipLifecycleAttribution.sequence
   }

--- a/Sources/SwiftVLC/PiP/PiPController+Events.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Events.swift
@@ -153,11 +153,12 @@ extension PiPController {
       // willStart. Keep failed identities until that stop is consumed or the
       // retry reaches didStart, which is the boundary that retires a failure
       // with no trailing terminal callback.
-      promoteQueuedPiPStartAttributionIfNeeded()
       // Preserve an accepted request's identity even if the player adopted
       // successor media before AVKit replied. An auto-start has no accepted
       // request, so it begins a fresh lifecycle here.
-      if pipLifecycleAttributionPhase != .awaitingStart {
+      if
+        pipLifecycleAttribution == nil
+        || pipLifecycleAttribution?.controllerGeneration != pipControllerGeneration {
         capturePiPLifecycleAttribution(mediaGeneration: mediaGenerationOverride)
       }
       pipLifecycleAttributionPhase = .awaitingStart
@@ -167,7 +168,6 @@ extension PiPController {
       // didStart directly, and a backend callback should still promote the
       // accepted successor if no willStart was observable.
       failedPiPLifecycleAttributions.removeAll(keepingCapacity: true)
-      promoteQueuedPiPStartAttributionIfNeeded()
       if
         pipLifecycleAttribution == nil
         || pipLifecycleAttribution?.controllerGeneration != pipControllerGeneration {
@@ -243,12 +243,16 @@ extension PiPController {
       capturePiPLifecycleAttribution()
       pipLifecycleAttributionPhase = .awaitingStart
     case .awaitingStart:
-      if nativeBackend != nil, !isActive {
+      #if os(iOS)
+      if let nativeBackend, !nativeBackend.isActive, !isActive {
         // The native backend cannot observe AVKit's failed-to-start callback.
         // A later accepted request while still inactive therefore supersedes
         // the unobservable attempt instead of preserving it forever.
         capturePiPLifecycleAttribution()
       }
+      #else
+      return result
+      #endif
     case .started:
       // Repeating start while AVKit is active still issues the backend method,
       // but it does not begin a new PiP lifecycle.
@@ -280,6 +284,17 @@ extension PiPController {
     pipLifecycleAttribution = queuedPiPStartAttribution
     self.queuedPiPStartAttribution = nil
     pipLifecycleAttributionPhase = .awaitingStart
+  }
+
+  /// Resolves the media identity a native backend must persist while active.
+  /// An accepted explicit request owns the lifecycle even when the native
+  /// active signal arrives after the player has adopted successor media.
+  func attributedNativePiPStartMediaGeneration(
+    signaledMediaGeneration: PlaybackGeneration?
+  ) -> PlaybackGeneration {
+    currentPiPLifecycleAttribution(
+      mediaGeneration: signaledMediaGeneration
+    ).mediaGeneration
   }
 
   func adoptActivePiPLifecycleAttribution(

--- a/Sources/SwiftVLC/PiP/PiPController+Events.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Events.swift
@@ -148,17 +148,31 @@ extension PiPController {
       // Preserve an accepted request's identity even if the player adopted
       // successor media before AVKit replied. An auto-start has no accepted
       // request, so it begins a fresh lifecycle here.
-      if !pipAcceptedStartPending {
+      if pipLifecycleAttributionPhase != .awaitingStart {
         capturePiPLifecycleAttribution()
       }
-    case .didStart, .willStop, .didStop, .failedToStart:
+      pipLifecycleAttributionPhase = .awaitingStart
+    case .didStart:
       if
         pipLifecycleMediaGeneration == nil
         || pipLifecycleControllerGeneration != pipControllerGeneration {
         capturePiPLifecycleAttribution()
       }
+      pipLifecycleAttributionPhase = .started
+    case .willStop, .didStop:
+      if
+        pipLifecycleMediaGeneration == nil
+        || pipLifecycleControllerGeneration != pipControllerGeneration {
+        capturePiPLifecycleAttribution()
+      }
+    case .failedToStart:
+      if
+        pipLifecycleMediaGeneration == nil
+        || pipLifecycleControllerGeneration != pipControllerGeneration {
+        capturePiPLifecycleAttribution()
+      }
+      pipLifecycleAttributionPhase = .failed
     }
-    pipAcceptedStartPending = false
 
     let envelope = PiPEventEnvelope(
       event: event,
@@ -176,22 +190,33 @@ extension PiPController {
   /// Captures attribution only when the backend confirms that it actually
   /// issued the request. Refused starts cannot later own a lifecycle callback.
   func noteAcceptedPiPStartRequest(_ result: PiPStartResult) -> PiPStartResult {
-    if result == .accepted {
+    guard result == .accepted else { return result }
+    switch pipLifecycleAttributionPhase {
+    case .idle, .failed:
       capturePiPLifecycleAttribution()
-      pipAcceptedStartPending = true
+      pipLifecycleAttributionPhase = .awaitingStart
+    case .awaitingStart, .started:
+      // Repeating start while AVKit is already starting/active still issues
+      // the backend method, but it does not begin a new PiP lifecycle.
+      break
     }
     return result
   }
 
-  private func capturePiPLifecycleAttribution() {
+  func capturePiPLifecycleAttribution() {
     pipLifecycleMediaGeneration = player.generation
     pipLifecycleControllerGeneration = pipControllerGeneration
+  }
+
+  func adoptActivePiPLifecycleAttribution() {
+    capturePiPLifecycleAttribution()
+    pipLifecycleAttributionPhase = .started
   }
 
   func clearPiPLifecycleAttribution() {
     pipLifecycleMediaGeneration = nil
     pipLifecycleControllerGeneration = nil
-    pipAcceptedStartPending = false
+    pipLifecycleAttributionPhase = .idle
   }
 
   /// The current Picture in Picture state, followed by every subsequent

--- a/Sources/SwiftVLC/PiP/PiPController+Events.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Events.swift
@@ -230,8 +230,13 @@ extension PiPController {
   /// issued the request. Refused starts cannot later own a lifecycle callback.
   func noteAcceptedPiPStartRequest(_ result: PiPStartResult) -> PiPStartResult {
     guard result == .accepted else { return result }
-    if pipLifecycleAttribution != nil, pendingStopReason != nil {
-      queuedPiPStartAttribution = makePiPLifecycleAttribution()
+    if
+      pipLifecycleAttribution != nil,
+      pendingStopReason != nil,
+      failedPiPLifecycleAttributions.isEmpty {
+      if queuedPiPStartAttribution == nil {
+        queuedPiPStartAttribution = makePiPLifecycleAttribution()
+      }
       return result
     }
     switch pipLifecycleAttributionPhase {

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -246,6 +246,7 @@ public final class PiPController: NSObject {
   struct FailedPiPLifecycle {
     let attribution: PiPLifecycleAttribution
     let stopReason: PiPStopReason
+    var willStopObserved = false
   }
 
   enum PiPLifecycleAttributionPhase: Equatable {

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -200,6 +200,8 @@ public final class PiPController: NSObject {
   @ObservationIgnored
   let pipEventBroadcaster = Broadcaster<PiPEvent>()
   @ObservationIgnored
+  let pipEventEnvelopeBroadcaster = Broadcaster<PiPEventEnvelope>()
+  @ObservationIgnored
   let pipSnapshotBroadcaster = Broadcaster<PiPSnapshot>()
   @ObservationIgnored
   private var pipSnapshotRevision: UInt64 = 0
@@ -208,6 +210,18 @@ public final class PiPController: NSObject {
   /// from a replaced one can be told apart from a current one.
   @ObservationIgnored
   private(set) var pipControllerGeneration: UInt64 = 0
+  /// The media generation captured when the current PiP lifecycle began.
+  /// Kept until its terminal `didStop`, so a delayed failure/stop remains
+  /// attributable after the player has already adopted another media.
+  @ObservationIgnored
+  var pipLifecycleMediaGeneration: PlaybackGeneration?
+  /// The concrete backend controller that owns the captured PiP lifecycle.
+  @ObservationIgnored
+  var pipLifecycleControllerGeneration: UInt64?
+  /// Whether the captured lifecycle came from an accepted explicit start and
+  /// is still waiting for its first AVKit/native lifecycle callback.
+  @ObservationIgnored
+  var pipAcceptedStartPending = false
 
   /// The best-known reason for an in-flight PiP stop, recorded by the
   /// first discriminating signal (restore callback, start failure,
@@ -403,6 +417,7 @@ public final class PiPController: NSObject {
     self.nativeBackend = nativeBackend
 
     super.init()
+    pipControllerGeneration = 1
     // Seeded here, not on first change: a controller whose flags never move
     // would otherwise leave `pipSnapshots` with nothing to replay.
     publishPiPSnapshot()
@@ -454,6 +469,7 @@ public final class PiPController: NSObject {
     self.nativeBackend = nativeBackend
 
     super.init()
+    pipControllerGeneration = 1
     // Seeded here, not on first change: a controller whose flags never move
     // would otherwise leave `pipSnapshots` with nothing to replay.
     publishPiPSnapshot()
@@ -506,6 +522,7 @@ public final class PiPController: NSObject {
 
   isolated deinit {
     pipEventBroadcaster.terminate()
+    pipEventEnvelopeBroadcaster.terminate()
     pipSnapshotBroadcaster.terminate()
     cancelDeferredPause()
     stateObserverTask?.cancel()
@@ -543,7 +560,8 @@ public final class PiPController: NSObject {
   /// not tell a request that reached AVKit from one that never left the
   /// controller — and therefore could not decide whether to fall back to
   /// full-screen playback. Asynchronous AVKit failure after an accepted start
-  /// stays where it belongs, on ``pipEvents``.
+  /// stays where it belongs, on ``pipEventEnvelopes`` (or the compatibility
+  /// ``pipEvents`` stream when generation attribution is not needed).
   @discardableResult
   public func start() -> PiPStartResult {
     guard player.currentMedia != nil else { return .noMedia }
@@ -558,18 +576,18 @@ public final class PiPController: NSObject {
       if nativeBackend.isPossible {
         activateAudioSessionIfNeeded()
       }
-      return nativeBackend.start()
+      return noteAcceptedPiPStartRequest(nativeBackend.start())
     }
     #endif
     #if os(macOS)
     if let nativeBackend {
-      return nativeBackend.start()
+      return noteAcceptedPiPStartRequest(nativeBackend.start())
     }
     #endif
     guard let pipController else { return .backendUnavailable }
     activateAudioSessionIfNeeded()
     pipController.startPictureInPicture()
-    return .accepted
+    return noteAcceptedPiPStartRequest(.accepted)
   }
 
   /// Stops Picture-in-Picture.
@@ -672,7 +690,9 @@ public final class PiPController: NSObject {
     controller.canStartPictureInPictureAutomaticallyFromInline = startsAutomaticallyFromInline
     #endif
     pipControllerGeneration &+= 1
+    clearPiPLifecycleAttribution()
     pipController = controller
+    publishPiPSnapshot()
     updatePiPPossible(controller.isPictureInPicturePossible)
     updatePiPActive(controller.isPictureInPictureActive)
     observePiPState(of: controller)
@@ -1114,9 +1134,9 @@ public final class PiPController: NSObject {
     updatePiPActive(isActive)
     guard changed else { return }
     if isActive {
-      pipEventBroadcaster.broadcast(.didStart)
+      publishPiPEvent(.didStart)
     } else {
-      pipEventBroadcaster.broadcast(.didStop(reason: .unknown))
+      publishPiPEvent(.didStop(reason: .unknown))
       pendingStopReason = nil
     }
   }

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -215,11 +215,13 @@ public final class PiPController: NSObject {
   /// player has already adopted another media.
   @ObservationIgnored
   var pipLifecycleAttribution: PiPLifecycleAttribution?
-  /// Failed starts can be followed by a trailing stop after another start has
-  /// already been accepted. Keep their identity outside the new lifecycle so
-  /// consuming the old stop cannot relabel or clear the retry.
+  /// A failed start can be followed by a trailing stop after another start has
+  /// already been accepted. Keep its identity outside the new lifecycle so
+  /// consuming the old stop cannot relabel or clear the retry. A later failure
+  /// replaces this slot: reaching the next terminal start outcome proves the
+  /// earlier failure omitted its optional stop callback.
   @ObservationIgnored
-  var failedPiPLifecycleAttributions: [PiPLifecycleAttribution] = []
+  var failedPiPLifecycleAttribution: PiPLifecycleAttribution?
   /// A start accepted while an older lifecycle is still waiting for its stop.
   /// Promoted only after that stop is consumed.
   @ObservationIgnored

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -210,6 +210,11 @@ public final class PiPController: NSObject {
   /// from a replaced one can be told apart from a current one.
   @ObservationIgnored
   private(set) var pipControllerGeneration: UInt64 = 0
+  /// Monotonic identity for start attempts within this controller. Controller
+  /// generation alone cannot order two overlapping requests issued to the
+  /// same AVKit controller.
+  @ObservationIgnored
+  var pipLifecycleSequence: UInt64 = 0
   /// Identity captured when the current PiP lifecycle began. Kept until its
   /// terminal `didStop`, so a delayed callback remains attributable after the
   /// player has already adopted another media.
@@ -235,6 +240,7 @@ public final class PiPController: NSObject {
   struct PiPLifecycleAttribution {
     let mediaGeneration: PlaybackGeneration
     let controllerGeneration: UInt64
+    let sequence: UInt64
   }
 
   struct FailedPiPLifecycle {

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -216,12 +216,12 @@ public final class PiPController: NSObject {
   @ObservationIgnored
   var pipLifecycleAttribution: PiPLifecycleAttribution?
   /// A failed start can be followed by a trailing stop after another start has
-  /// already been accepted. Keep its identity outside the new lifecycle so
-  /// consuming the old stop cannot relabel or clear the retry. A later failure
-  /// replaces this slot: reaching the next terminal start outcome proves the
-  /// earlier failure omitted its optional stop callback.
+  /// already been accepted. Keep its identity and stop reason outside the new
+  /// lifecycle so consuming the old stop cannot relabel or clear the retry. A
+  /// later failure replaces this slot: reaching the next terminal start
+  /// outcome proves the earlier failure omitted its optional stop callback.
   @ObservationIgnored
-  var failedPiPLifecycleAttribution: PiPLifecycleAttribution?
+  var failedPiPLifecycle: FailedPiPLifecycle?
   /// A start accepted while an older lifecycle is still waiting for its stop.
   /// Promoted only after that stop is consumed.
   @ObservationIgnored
@@ -235,6 +235,11 @@ public final class PiPController: NSObject {
   struct PiPLifecycleAttribution {
     let mediaGeneration: PlaybackGeneration
     let controllerGeneration: UInt64
+  }
+
+  struct FailedPiPLifecycle {
+    let attribution: PiPLifecycleAttribution
+    let stopReason: PiPStopReason
   }
 
   enum PiPLifecycleAttributionPhase: Equatable {

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -614,6 +614,7 @@ public final class PiPController: NSObject {
     }
     #endif
     guard let pipController else { return .backendUnavailable }
+    guard isPossible else { return .notPossible }
     activateAudioSessionIfNeeded()
     pipController.startPictureInPicture()
     return noteAcceptedPiPStartRequest(.accepted)
@@ -629,8 +630,8 @@ public final class PiPController: NSObject {
     // Recorded unconditionally: between AVKit beginning the start
     // animation and the didStart callback, `isActive` is still false,
     // and a stop issued in that window would otherwise be reported as
-    // the user's close tap. A stale record is harmless — the next
-    // willStart/didStart clears it.
+    // the user's close tap. If no lifecycle was actually in flight, the next
+    // accepted start (or an automatic willStart/didStart) clears it.
     notePendingStopReason(.unknown)
     #if os(iOS)
     if let nativeBackend {

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -210,25 +210,31 @@ public final class PiPController: NSObject {
   /// from a replaced one can be told apart from a current one.
   @ObservationIgnored
   private(set) var pipControllerGeneration: UInt64 = 0
-  /// The media generation captured when the current PiP lifecycle began.
-  /// Kept until its terminal `didStop`, so a delayed failure/stop remains
-  /// attributable after the player has already adopted another media.
+  /// Identity captured when the current PiP lifecycle began. Kept until its
+  /// terminal `didStop`, so a delayed callback remains attributable after the
+  /// player has already adopted another media.
   @ObservationIgnored
-  var pipLifecycleMediaGeneration: PlaybackGeneration?
-  /// The concrete backend controller that owns the captured PiP lifecycle.
+  var pipLifecycleAttribution: PiPLifecycleAttribution?
+  /// Failed starts can be followed by a trailing stop after another start has
+  /// already been accepted. Keep their identity outside the new lifecycle so
+  /// consuming the old stop cannot relabel or clear the retry.
   @ObservationIgnored
-  var pipLifecycleControllerGeneration: UInt64?
+  var failedPiPLifecycleAttributions: [PiPLifecycleAttribution] = []
   /// Which part of the attributed PiP lifecycle is in flight. This prevents a
   /// redundant accepted start from stealing an active lifecycle while still
   /// allowing a fresh request after a terminal start failure.
   @ObservationIgnored
   var pipLifecycleAttributionPhase: PiPLifecycleAttributionPhase = .idle
 
+  struct PiPLifecycleAttribution {
+    let mediaGeneration: PlaybackGeneration
+    let controllerGeneration: UInt64
+  }
+
   enum PiPLifecycleAttributionPhase {
     case idle
     case awaitingStart
     case started
-    case failed
   }
 
   /// The best-known reason for an in-flight PiP stop, recorded by the
@@ -453,7 +459,9 @@ public final class PiPController: NSObject {
     updatePiPPossible(nativeBackend.isPossible)
     updatePiPActive(nativeBackend.isActive)
     if nativeBackend.isActive {
-      adoptActivePiPLifecycleAttribution()
+      adoptActivePiPLifecycleAttribution(
+        mediaGeneration: nativeBackend.activeMediaGeneration
+      )
     }
     startStateObserver()
     startPlaybackIntentObserver()
@@ -490,7 +498,9 @@ public final class PiPController: NSObject {
     updatePiPPossible(nativeBackend.isPossible)
     updatePiPActive(nativeBackend.isActive)
     if nativeBackend.isActive {
-      adoptActivePiPLifecycleAttribution()
+      adoptActivePiPLifecycleAttribution(
+        mediaGeneration: nativeBackend.activeMediaGeneration
+      )
     }
     startStateObserver()
     startPlaybackIntentObserver()
@@ -1134,7 +1144,10 @@ public final class PiPController: NSObject {
   /// ``PiPStopReason/unknown`` — including for stops caused by a
   /// native-handle replacement (player swap, renderer recast) tearing
   /// PiP down. See ``pipEvents``.
-  func handleNativePictureInPictureActiveChanged(_ isActive: Bool) {
+  func handleNativePictureInPictureActiveChanged(
+    _ isActive: Bool,
+    mediaGeneration: PlaybackGeneration? = nil
+  ) {
     #if os(iOS)
     if isActive {
       // Native auto-start does not deliver SwiftVLC's AVKit delegate
@@ -1148,9 +1161,9 @@ public final class PiPController: NSObject {
     updatePiPActive(isActive)
     guard changed else { return }
     if isActive {
-      publishPiPEvent(.didStart)
+      publishPiPEvent(.didStart, mediaGeneration: mediaGeneration)
     } else {
-      publishPiPEvent(.didStop(reason: .unknown))
+      publishPiPEvent(.didStop(reason: .unknown), mediaGeneration: mediaGeneration)
       pendingStopReason = nil
     }
   }

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -235,10 +235,11 @@ public final class PiPController: NSObject {
     let controllerGeneration: UInt64
   }
 
-  enum PiPLifecycleAttributionPhase {
+  enum PiPLifecycleAttributionPhase: Equatable {
     case idle
     case awaitingStart
     case started
+    case stopping
   }
 
   /// The best-known reason for an in-flight PiP stop, recorded by the

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -220,13 +220,13 @@ public final class PiPController: NSObject {
   /// player has already adopted another media.
   @ObservationIgnored
   var pipLifecycleAttribution: PiPLifecycleAttribution?
-  /// A failed start can be followed by a trailing stop after another start has
-  /// already been accepted. Keep its identity and stop reason outside the new
-  /// lifecycle so consuming the old stop cannot relabel or clear the retry. A
-  /// later failure replaces this slot: reaching the next terminal start
-  /// outcome proves the earlier failure omitted its optional stop callback.
+  /// Failed starts can each be followed by a trailing stop after newer starts
+  /// have already been accepted. Keep their identities and stop reasons in
+  /// accepted-start order outside the current lifecycle, so consuming an old
+  /// stop cannot relabel or clear a retry. A later terminal start outcome
+  /// retires only older failures for which AVKit never promised a stop.
   @ObservationIgnored
-  var failedPiPLifecycle: FailedPiPLifecycle?
+  var failedPiPLifecycles: [FailedPiPLifecycle] = []
   /// A start accepted while an older lifecycle is still waiting for its stop.
   /// Promoted only after that stop is consumed.
   @ObservationIgnored
@@ -1166,7 +1166,9 @@ public final class PiPController: NSObject {
   /// PiP down. See ``pipEvents``.
   func handleNativePictureInPictureActiveChanged(
     _ isActive: Bool,
-    mediaGeneration: PlaybackGeneration? = nil
+    mediaGeneration: PlaybackGeneration? = nil,
+    forceTransitionEvent: Bool = false,
+    preservesCurrentLifecycle: Bool = false
   ) {
     #if os(iOS)
     if isActive {
@@ -1179,7 +1181,14 @@ public final class PiPController: NSObject {
     #endif
     let changed = self.isActive != isActive
     updatePiPActive(isActive)
-    guard changed else { return }
+    guard changed || forceTransitionEvent else { return }
+    if preservesCurrentLifecycle {
+      publishTransferredNativePiPEvent(
+        isActive ? .didStart : .didStop(reason: .unknown),
+        mediaGeneration: mediaGeneration
+      )
+      return
+    }
     if isActive {
       publishPiPEvent(.didStart, mediaGeneration: mediaGeneration)
     } else {

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -151,7 +151,7 @@ public final class PiPController: NSObject {
   #endif
   #if os(macOS)
   @ObservationIgnored
-  private var nativeBackend: MacNativePiPBackend?
+  var nativeBackend: MacNativePiPBackend?
   #endif
 
   /// Whether AVKit may start PiP automatically when the app moves to
@@ -220,6 +220,10 @@ public final class PiPController: NSObject {
   /// consuming the old stop cannot relabel or clear the retry.
   @ObservationIgnored
   var failedPiPLifecycleAttributions: [PiPLifecycleAttribution] = []
+  /// A start accepted while an older lifecycle is still waiting for its stop.
+  /// Promoted only after that stop is consumed.
+  @ObservationIgnored
+  var queuedPiPStartAttribution: PiPLifecycleAttribution?
   /// Which part of the attributed PiP lifecycle is in flight. This prevents a
   /// redundant accepted start from stealing an active lifecycle while still
   /// allowing a fresh request after a terminal start failure.

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -218,10 +218,18 @@ public final class PiPController: NSObject {
   /// The concrete backend controller that owns the captured PiP lifecycle.
   @ObservationIgnored
   var pipLifecycleControllerGeneration: UInt64?
-  /// Whether the captured lifecycle came from an accepted explicit start and
-  /// is still waiting for its first AVKit/native lifecycle callback.
+  /// Which part of the attributed PiP lifecycle is in flight. This prevents a
+  /// redundant accepted start from stealing an active lifecycle while still
+  /// allowing a fresh request after a terminal start failure.
   @ObservationIgnored
-  var pipAcceptedStartPending = false
+  var pipLifecycleAttributionPhase: PiPLifecycleAttributionPhase = .idle
+
+  enum PiPLifecycleAttributionPhase {
+    case idle
+    case awaitingStart
+    case started
+    case failed
+  }
 
   /// The best-known reason for an in-flight PiP stop, recorded by the
   /// first discriminating signal (restore callback, start failure,
@@ -444,6 +452,9 @@ public final class PiPController: NSObject {
     nativeBackend.reconcileRequiresLinearPlayback(ifOwnedBy: self)
     updatePiPPossible(nativeBackend.isPossible)
     updatePiPActive(nativeBackend.isActive)
+    if nativeBackend.isActive {
+      adoptActivePiPLifecycleAttribution()
+    }
     startStateObserver()
     startPlaybackIntentObserver()
     player.registerNativeHandleSnapshotObserver(self)
@@ -478,6 +489,9 @@ public final class PiPController: NSObject {
     nativeBackend.owner = self
     updatePiPPossible(nativeBackend.isPossible)
     updatePiPActive(nativeBackend.isActive)
+    if nativeBackend.isActive {
+      adoptActivePiPLifecycleAttribution()
+    }
     startStateObserver()
     startPlaybackIntentObserver()
     player.registerNativeHandleSnapshotObserver(self)

--- a/Sources/SwiftVLC/PiP/PiPStartResult.swift
+++ b/Sources/SwiftVLC/PiP/PiPStartResult.swift
@@ -6,14 +6,16 @@
 /// Picture went on to appear. AVKit can still fail asynchronously after
 /// accepting a start — a call arriving, the app losing audio focus, the system
 /// declining under memory pressure — and those arrive on
-/// ``PiPController/pipEvents`` as ordered lifecycle events. Keeping the two
-/// separate matters: a caller that wants to fall back to full-screen playback
-/// needs to know immediately that the request never left the building, and
-/// waiting on an event that will never arrive is indistinguishable from waiting
-/// on one that is merely slow.
+/// ``PiPController/pipEventEnvelopes`` as ordered, generation-attributed
+/// lifecycle events. The compatibility ``PiPController/pipEvents`` stream
+/// carries the same transitions without their identities. Keeping the
+/// immediate result and asynchronous lifecycle separate matters: a caller that
+/// wants to fall back to full-screen playback needs to know immediately that
+/// the request never left the building, and waiting on an event that will never
+/// arrive is indistinguishable from waiting on one that is merely slow.
 public enum PiPStartResult: Sendable, Equatable {
-  /// The backend start request was issued. Watch ``PiPController/pipEvents``
-  /// for what happens next.
+  /// The backend start request was issued. Watch
+  /// ``PiPController/pipEventEnvelopes`` for what happens next.
   case accepted
 
   /// No media is loaded, so there is nothing to show. Load media first.

--- a/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
@@ -142,7 +142,8 @@ final class MacNativePiPBackend: NSObject, @unchecked Sendable {
       let signaledMediaGeneration = owner?.player.generation
         ?? mediaController.player?.generation
       activeMediaGeneration = owner?.attributedNativePiPStartMediaGeneration(
-        signaledMediaGeneration: signaledMediaGeneration
+        signaledMediaGeneration: signaledMediaGeneration,
+        preservesAcceptedRequest: true
       ) ?? signaledMediaGeneration
     }
     let lifecycleMediaGeneration = activeMediaGeneration

--- a/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
@@ -15,7 +15,13 @@ import Synchronization
 @MainActor
 final class MacNativePiPBackend: NSObject, @unchecked Sendable {
   let mediaController = MacNativePiPMediaController()
-  weak var owner: PiPController?
+  weak var owner: PiPController? {
+    didSet {
+      ownerGeneration &+= 1
+      scheduleActiveTransitionDeliveryIfNeeded()
+    }
+  }
+
   weak var hostView: MacNativePiPHostView?
   weak var drawableView: MacNativePiPDrawableView?
 
@@ -23,6 +29,16 @@ final class MacNativePiPBackend: NSObject, @unchecked Sendable {
   private(set) var isPossible = false
   private(set) var isActive = false
   private(set) var activeMediaGeneration: PlaybackGeneration?
+  private struct PendingActiveTransition {
+    let isActive: Bool
+    let mediaGeneration: PlaybackGeneration?
+    let playerIdentity: ObjectIdentifier
+    let ownerGeneration: UInt64
+  }
+
+  private var ownerGeneration: UInt64 = 0
+  private var pendingActiveTransitions: [PendingActiveTransition] = []
+  private var hasScheduledActiveTransitionDelivery = false
 
   func adopt(
     hostView: MacNativePiPHostView,
@@ -138,10 +154,11 @@ final class MacNativePiPBackend: NSObject, @unchecked Sendable {
 
   func setActive(_ isActive: Bool) {
     guard self.isActive != isActive else { return }
+    let signaledOwner = owner
     if isActive {
-      let signaledMediaGeneration = owner?.player.generation
+      let signaledMediaGeneration = signaledOwner?.player.generation
         ?? mediaController.player?.generation
-      activeMediaGeneration = owner?.attributedNativePiPStartMediaGeneration(
+      activeMediaGeneration = signaledOwner?.attributedNativePiPStartMediaGeneration(
         signaledMediaGeneration: signaledMediaGeneration,
         preservesAcceptedRequest: true
       ) ?? signaledMediaGeneration
@@ -151,10 +168,44 @@ final class MacNativePiPBackend: NSObject, @unchecked Sendable {
     if !isActive {
       activeMediaGeneration = nil
     }
-    Task { @MainActor [weak owner] in
-      owner?.handleNativePictureInPictureActiveChanged(
-        isActive,
-        mediaGeneration: lifecycleMediaGeneration
+    // A same-player SwiftUI reconstruction can replace `owner` before this
+    // deferred delivery runs. Persist transitions that were signalled to a
+    // live owner and route them to whichever controller currently owns that
+    // player's adopted backend. Initial ownerless state is still adopted from
+    // `isActive` and must not synthesize a historical event.
+    guard let signaledOwner else { return }
+    pendingActiveTransitions.append(PendingActiveTransition(
+      isActive: isActive,
+      mediaGeneration: lifecycleMediaGeneration,
+      playerIdentity: ObjectIdentifier(signaledOwner.player),
+      ownerGeneration: ownerGeneration
+    ))
+    scheduleActiveTransitionDeliveryIfNeeded()
+  }
+
+  private func scheduleActiveTransitionDeliveryIfNeeded() {
+    guard
+      !pendingActiveTransitions.isEmpty,
+      !hasScheduledActiveTransitionDelivery
+    else { return }
+    hasScheduledActiveTransitionDelivery = true
+    Task { @MainActor [weak self] in
+      self?.deliverPendingActiveTransitions()
+    }
+  }
+
+  private func deliverPendingActiveTransitions() {
+    hasScheduledActiveTransitionDelivery = false
+    guard let owner else { return }
+    let ownerIdentity = ObjectIdentifier(owner.player)
+    let transitions = pendingActiveTransitions
+    pendingActiveTransitions.removeAll(keepingCapacity: true)
+    for transition in transitions where transition.playerIdentity == ownerIdentity {
+      owner.handleNativePictureInPictureActiveChanged(
+        transition.isActive,
+        mediaGeneration: transition.mediaGeneration,
+        forceTransitionEvent: true,
+        preservesCurrentLifecycle: transition.ownerGeneration != ownerGeneration
       )
     }
   }

--- a/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
@@ -139,8 +139,11 @@ final class MacNativePiPBackend: NSObject, @unchecked Sendable {
   func setActive(_ isActive: Bool) {
     guard self.isActive != isActive else { return }
     if isActive {
-      activeMediaGeneration = owner?.player.generation
+      let signaledMediaGeneration = owner?.player.generation
         ?? mediaController.player?.generation
+      activeMediaGeneration = owner?.attributedNativePiPStartMediaGeneration(
+        signaledMediaGeneration: signaledMediaGeneration
+      ) ?? signaledMediaGeneration
     }
     let lifecycleMediaGeneration = activeMediaGeneration
     self.isActive = isActive

--- a/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
@@ -135,7 +135,7 @@ final class MacNativePiPBackend: NSObject, @unchecked Sendable {
     }
   }
 
-  private func setActive(_ isActive: Bool) {
+  func setActive(_ isActive: Bool) {
     guard self.isActive != isActive else { return }
     self.isActive = isActive
     Task { @MainActor [weak owner] in

--- a/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
@@ -22,6 +22,7 @@ final class MacNativePiPBackend: NSObject, @unchecked Sendable {
   private let presenter = MacPrivatePiPPresenter()
   private(set) var isPossible = false
   private(set) var isActive = false
+  private(set) var activeMediaGeneration: PlaybackGeneration?
 
   func adopt(
     hostView: MacNativePiPHostView,
@@ -137,9 +138,20 @@ final class MacNativePiPBackend: NSObject, @unchecked Sendable {
 
   func setActive(_ isActive: Bool) {
     guard self.isActive != isActive else { return }
+    if isActive {
+      activeMediaGeneration = owner?.player.generation
+        ?? mediaController.player?.generation
+    }
+    let lifecycleMediaGeneration = activeMediaGeneration
     self.isActive = isActive
+    if !isActive {
+      activeMediaGeneration = nil
+    }
     Task { @MainActor [weak owner] in
-      owner?.handleNativePictureInPictureActiveChanged(isActive)
+      owner?.handleNativePictureInPictureActiveChanged(
+        isActive,
+        mediaGeneration: lifecycleMediaGeneration
+      )
     }
   }
 

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -223,7 +223,11 @@ final class IOSNativePiPDrawableAttachment: UIView, IOSNativePiPDrawable {
   @objc(pictureInPictureReady)
   nonisolated func pictureInPictureReady() -> IOSNativePictureInPictureReadyBlock {
     let attachment = attachment
+    let nativeMediaController = nativeMediaController
     return { [weak nativePiPBackend] windowController in
+      let mediaGeneration = nativeMediaController.callbackSnapshot.withLock {
+        $0.playbackGeneration
+      }
       nonisolated(unsafe) let windowController = windowController
       Task { @MainActor in
         guard
@@ -234,7 +238,8 @@ final class IOSNativePiPDrawableAttachment: UIView, IOSNativePiPDrawable {
         else { return }
         nativePiPBackend.handlePictureInPictureReady(
           windowController,
-          generation: generation
+          generation: generation,
+          mediaGeneration: mediaGeneration
         )
       }
     }
@@ -642,12 +647,20 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
       let attachment = callbackGenerations.currentAttachment(),
       let generation = callbackGenerations.reserveReadyCallback(for: attachment)
     else { return }
-    handlePictureInPictureReady(controller, generation: generation)
+    let mediaGeneration = mediaController.callbackSnapshot.withLock {
+      $0.playbackGeneration
+    }
+    handlePictureInPictureReady(
+      controller,
+      generation: generation,
+      mediaGeneration: mediaGeneration
+    )
   }
 
   func handlePictureInPictureReady(
     _ controller: AnyObject,
-    generation: IOSNativePiPCallbackGenerations.ReadyCallback
+    generation: IOSNativePiPCallbackGenerations.ReadyCallback,
+    mediaGeneration: PlaybackGeneration?
   ) {
     guard let controller = controller as? NSObject else { return }
 
@@ -661,7 +674,11 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
 
       windowController = controller
       installStateChangeHandler(on: controller, generation: generation)
-      observeAVPictureInPictureController(on: controller, generation: generation)
+      observeAVPictureInPictureController(
+        on: controller,
+        generation: generation,
+        initialActiveMediaGeneration: mediaGeneration
+      )
 
       if avPictureInPictureController == nil {
         setPossible(true)
@@ -791,7 +808,8 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
 
   private func observeAVPictureInPictureController(
     on controller: NSObject,
-    generation: IOSNativePiPCallbackGenerations.ReadyCallback
+    generation: IOSNativePiPCallbackGenerations.ReadyCallback,
+    initialActiveMediaGeneration: PlaybackGeneration?
   ) {
     guard controller.responds(to: IOSNativePiPSelector.avPictureInPictureController) else { return }
     guard let avController = controller.value(forKey: "avPipController") as? AVPictureInPictureController else { return }
@@ -801,7 +819,10 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
     avController.canStartPictureInPictureAutomaticallyFromInline =
       startsAutomaticallyFromInline
     setPossible(avController.isPictureInPicturePossible)
-    setActive(avController.isPictureInPictureActive)
+    setActive(
+      avController.isPictureInPictureActive,
+      mediaGeneration: initialActiveMediaGeneration
+    )
 
     possibleObservation = avController.observe(
       \.isPictureInPicturePossible,

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -56,13 +56,22 @@ typealias IOSNativePiPStateChangeEventHandler = @convention(block) (Bool) -> Voi
 /// while the SwiftUI view detaches, reattaches, or receives a replacement
 /// native window controller.
 final class IOSNativePiPCallbackGenerations: Sendable {
-  struct Attachment: Equatable {
+  struct Attachment: Equatable, Sendable {
     fileprivate let rawValue: UInt64
   }
 
-  struct ReadyCallback: Equatable {
+  struct ReadyCallback: Equatable, Sendable {
     fileprivate let attachment: Attachment
     fileprivate let rawValue: UInt64
+  }
+
+  /// Provenance captured when an explicit start reaches one exact native
+  /// window controller. Native active signals snapshot this value before
+  /// hopping to the main actor, so a later media load or accepted start cannot
+  /// relabel the signal that was already delivered.
+  struct AcceptedStart: Equatable, Sendable {
+    fileprivate let callback: ReadyCallback
+    let mediaGeneration: PlaybackGeneration
   }
 
   private struct State {
@@ -70,6 +79,7 @@ final class IOSNativePiPCallbackGenerations: Sendable {
     var currentAttachment: Attachment?
     var nextReadyCallback: UInt64 = 0
     var currentReadyCallback: ReadyCallback?
+    var acceptedStart: AcceptedStart?
   }
 
   private let state = Mutex(State())
@@ -81,6 +91,7 @@ final class IOSNativePiPCallbackGenerations: Sendable {
       let attachment = Attachment(rawValue: state.nextAttachment)
       state.currentAttachment = attachment
       state.currentReadyCallback = nil
+      state.acceptedStart = nil
       return attachment
     }
   }
@@ -90,6 +101,7 @@ final class IOSNativePiPCallbackGenerations: Sendable {
     state.withLock { state in
       state.currentAttachment = nil
       state.currentReadyCallback = nil
+      state.acceptedStart = nil
     }
   }
 
@@ -108,8 +120,51 @@ final class IOSNativePiPCallbackGenerations: Sendable {
         rawValue: state.nextReadyCallback
       )
       state.currentReadyCallback = callback
+      state.acceptedStart = nil
       return callback
     }
+  }
+
+  @MainActor
+  @discardableResult
+  func recordAcceptedStart(mediaGeneration: PlaybackGeneration) -> Bool {
+    state.withLock { state in
+      guard let callback = state.currentReadyCallback else { return false }
+      state.acceptedStart = AcceptedStart(
+        callback: callback,
+        mediaGeneration: mediaGeneration
+      )
+      return true
+    }
+  }
+
+  nonisolated func acceptedStart(
+    at callback: ReadyCallback
+  ) -> AcceptedStart? {
+    state.withLock { state in
+      guard
+        state.currentAttachment == callback.attachment,
+        state.currentReadyCallback == callback,
+        state.acceptedStart?.callback == callback
+      else { return nil }
+      return state.acceptedStart
+    }
+  }
+
+  @MainActor
+  func currentAcceptedStart() -> AcceptedStart? {
+    state.withLock { state in
+      guard
+        let callback = state.currentReadyCallback,
+        state.acceptedStart?.callback == callback
+      else { return nil }
+      return state.acceptedStart
+    }
+  }
+
+  @MainActor
+  func clearAcceptedStart() {
+    state.withLock { $0.acceptedStart = nil }
   }
 
   @MainActor
@@ -601,12 +656,6 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
   private var possibleObservation: NSKeyValueObservation?
   private var activeObservation: NSKeyValueObservation?
   private var stateChangeEventHandler: IOSNativePiPStateChangeEventHandler?
-  /// The native window controller that accepted the most recent explicit
-  /// start. A later ready callback replaces `windowController` and clears
-  /// this identity; an active signal from that replacement is therefore an
-  /// automatic start, not a delayed result of the old request.
-  private weak var acceptedStartWindowController: NSObject?
-
   private(set) var isPossible = false
   private(set) var isActive = false
   private(set) var activeMediaGeneration: PlaybackGeneration?
@@ -700,11 +749,22 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
       warnIfVideoOutputBlocksPictureInPicture()
       return .notPossible
     }
-    let result = performWindowControllerAction(IOSNativePiPSelector.start)
-    if result == .accepted {
-      acceptedStartWindowController = windowController
+    guard
+      let windowController,
+      windowController.responds(to: IOSNativePiPSelector.start)
+    else { return .backendUnavailable }
+
+    // Record before invoking the native selector. Its active callback may be
+    // synchronous, and that callback must be able to snapshot the request it
+    // is acknowledging. A repeated start while already active does not begin
+    // a new lifecycle and must not seed provenance for a future one.
+    if !isActive, let mediaGeneration = mediaController.player?.generation {
+      callbackGenerations.recordAcceptedStart(
+        mediaGeneration: mediaGeneration
+      )
     }
-    return result
+    _ = windowController.perform(IOSNativePiPSelector.start)
+    return .accepted
   }
 
   /// One-time diagnostic for the common misconfiguration where a custom
@@ -790,7 +850,7 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
     activeObservation = nil
     avPictureInPictureController = nil
     stateChangeEventHandler = nil
-    acceptedStartWindowController = nil
+    callbackGenerations.clearAcceptedStart()
     windowController = nil
   }
 
@@ -801,14 +861,22 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
     guard controller.responds(to: IOSNativePiPSelector.setStateChangeEventHandler) else { return }
 
     let mediaController = mediaController
+    let callbackGenerations = callbackGenerations
     let handler: IOSNativePiPStateChangeEventHandler = { [weak self] isStarted in
       let mediaGeneration = isStarted
         ? mediaController.callbackSnapshot.withLock { $0.playbackGeneration }
         : nil
+      let acceptedStart = isStarted
+        ? callbackGenerations.acceptedStart(at: generation)
+        : nil
       Task { @MainActor in
         guard let self else { return }
         self.callbackGenerations.performIfCurrent(generation) {
-          self.setActive(isStarted, mediaGeneration: mediaGeneration)
+          self.setActiveFromNativeSignal(
+            isStarted,
+            mediaGeneration: mediaGeneration,
+            acceptedStart: acceptedStart
+          )
         }
       }
     }
@@ -829,11 +897,13 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
     avController.canStartPictureInPictureAutomaticallyFromInline =
       startsAutomaticallyFromInline
     setPossible(avController.isPictureInPicturePossible)
-    setActive(
+    setActiveFromNativeSignal(
       avController.isPictureInPictureActive,
-      mediaGeneration: initialActiveMediaGeneration
+      mediaGeneration: initialActiveMediaGeneration,
+      acceptedStart: nil
     )
 
+    let callbackGenerations = callbackGenerations
     possibleObservation = avController.observe(
       \.isPictureInPicturePossible,
       options: [.initial, .new]
@@ -856,10 +926,17 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
       let mediaGeneration = isActive
         ? mediaController.callbackSnapshot.withLock { $0.playbackGeneration }
         : nil
+      let acceptedStart = isActive
+        ? callbackGenerations.acceptedStart(at: generation)
+        : nil
       Task { @MainActor [weak self] in
         guard let self else { return }
         callbackGenerations.performIfCurrent(generation) {
-          self.setActive(isActive, mediaGeneration: mediaGeneration)
+          self.setActiveFromNativeSignal(
+            isActive,
+            mediaGeneration: mediaGeneration,
+            acceptedStart: acceptedStart
+          )
         }
       }
     }
@@ -914,17 +991,28 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
     _ isActive: Bool,
     mediaGeneration: PlaybackGeneration? = nil
   ) {
+    setActiveFromNativeSignal(
+      isActive,
+      mediaGeneration: mediaGeneration,
+      acceptedStart: isActive ? callbackGenerations.currentAcceptedStart() : nil
+    )
+  }
+
+  func setActiveFromNativeSignal(
+    _ isActive: Bool,
+    mediaGeneration: PlaybackGeneration?,
+    acceptedStart: IOSNativePiPCallbackGenerations.AcceptedStart?
+  ) {
     guard self.isActive != isActive else { return }
     if isActive {
       let signaledMediaGeneration = mediaGeneration
         ?? owner?.player.generation
         ?? mediaController.player?.generation
-      let preservesAcceptedRequest = acceptedStartWindowController === windowController
       activeMediaGeneration = owner?.attributedNativePiPStartMediaGeneration(
         signaledMediaGeneration: signaledMediaGeneration,
-        preservesAcceptedRequest: preservesAcceptedRequest
+        acceptedRequestMediaGeneration: acceptedStart?.mediaGeneration
       ) ?? signaledMediaGeneration
-      acceptedStartWindowController = nil
+      callbackGenerations.clearAcceptedStart()
     }
     let lifecycleMediaGeneration = activeMediaGeneration
     self.isActive = isActive

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -906,9 +906,12 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
   ) {
     guard self.isActive != isActive else { return }
     if isActive {
-      activeMediaGeneration = mediaGeneration
+      let signaledMediaGeneration = mediaGeneration
         ?? owner?.player.generation
         ?? mediaController.player?.generation
+      activeMediaGeneration = owner?.attributedNativePiPStartMediaGeneration(
+        signaledMediaGeneration: signaledMediaGeneration
+      ) ?? signaledMediaGeneration
     }
     let lifecycleMediaGeneration = activeMediaGeneration
     self.isActive = isActive

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -599,6 +599,7 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
 
   private(set) var isPossible = false
   private(set) var isActive = false
+  private(set) var activeMediaGeneration: PlaybackGeneration?
   private(set) var requiresLinearPlayback = true
   private(set) var startsAutomaticallyFromInline = true
   private(set) var playbackStateInvalidationCount: UInt64 = 0
@@ -872,8 +873,19 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
 
   func setActive(_ isActive: Bool) {
     guard self.isActive != isActive else { return }
+    if isActive {
+      activeMediaGeneration = owner?.player.generation
+        ?? mediaController.player?.generation
+    }
+    let lifecycleMediaGeneration = activeMediaGeneration
     self.isActive = isActive
-    owner?.handleNativePictureInPictureActiveChanged(isActive)
+    owner?.handleNativePictureInPictureActiveChanged(
+      isActive,
+      mediaGeneration: lifecycleMediaGeneration
+    )
+    if !isActive {
+      activeMediaGeneration = nil
+    }
   }
 }
 

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -773,11 +773,15 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
   ) {
     guard controller.responds(to: IOSNativePiPSelector.setStateChangeEventHandler) else { return }
 
+    let mediaController = mediaController
     let handler: IOSNativePiPStateChangeEventHandler = { [weak self] isStarted in
+      let mediaGeneration = isStarted
+        ? mediaController.callbackSnapshot.withLock { $0.playbackGeneration }
+        : nil
       Task { @MainActor in
         guard let self else { return }
         self.callbackGenerations.performIfCurrent(generation) {
-          self.setActive(isStarted)
+          self.setActive(isStarted, mediaGeneration: mediaGeneration)
         }
       }
     }
@@ -812,15 +816,19 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
       }
     }
 
+    let mediaController = mediaController
     activeObservation = avController.observe(
       \.isPictureInPictureActive,
       options: [.initial, .new]
     ) { [weak self] controller, _ in
       let isActive = controller.isPictureInPictureActive
+      let mediaGeneration = isActive
+        ? mediaController.callbackSnapshot.withLock { $0.playbackGeneration }
+        : nil
       Task { @MainActor [weak self] in
         guard let self else { return }
         callbackGenerations.performIfCurrent(generation) {
-          self.setActive(isActive)
+          self.setActive(isActive, mediaGeneration: mediaGeneration)
         }
       }
     }
@@ -871,10 +879,14 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
     owner?.handleNativePictureInPictureReady()
   }
 
-  func setActive(_ isActive: Bool) {
+  func setActive(
+    _ isActive: Bool,
+    mediaGeneration: PlaybackGeneration? = nil
+  ) {
     guard self.isActive != isActive else { return }
     if isActive {
-      activeMediaGeneration = owner?.player.generation
+      activeMediaGeneration = mediaGeneration
+        ?? owner?.player.generation
         ?? mediaController.player?.generation
     }
     let lifecycleMediaGeneration = activeMediaGeneration
@@ -950,11 +962,13 @@ final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling,
   @MainActor
   func refreshCallbackSnapshot() {
     let pointer = player?.pointer
+    let playbackGeneration = player?.generation
     callbackSnapshot.withLock { snapshot in
       if snapshot.playerPointer != pointer {
         snapshot.generation &+= 1
       }
       snapshot.playerPointer = pointer
+      snapshot.playbackGeneration = playbackGeneration
     }
   }
 
@@ -967,6 +981,7 @@ final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling,
         snapshot.generation &+= 1
       }
       snapshot.playerPointer = nil
+      snapshot.playbackGeneration = nil
     }
   }
 

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -601,6 +601,11 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
   private var possibleObservation: NSKeyValueObservation?
   private var activeObservation: NSKeyValueObservation?
   private var stateChangeEventHandler: IOSNativePiPStateChangeEventHandler?
+  /// The native window controller that accepted the most recent explicit
+  /// start. A later ready callback replaces `windowController` and clears
+  /// this identity; an active signal from that replacement is therefore an
+  /// automatic start, not a delayed result of the old request.
+  private weak var acceptedStartWindowController: NSObject?
 
   private(set) var isPossible = false
   private(set) var isActive = false
@@ -695,7 +700,11 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
       warnIfVideoOutputBlocksPictureInPicture()
       return .notPossible
     }
-    return performWindowControllerAction(IOSNativePiPSelector.start)
+    let result = performWindowControllerAction(IOSNativePiPSelector.start)
+    if result == .accepted {
+      acceptedStartWindowController = windowController
+    }
+    return result
   }
 
   /// One-time diagnostic for the common misconfiguration where a custom
@@ -781,6 +790,7 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
     activeObservation = nil
     avPictureInPictureController = nil
     stateChangeEventHandler = nil
+    acceptedStartWindowController = nil
     windowController = nil
   }
 
@@ -909,9 +919,12 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
       let signaledMediaGeneration = mediaGeneration
         ?? owner?.player.generation
         ?? mediaController.player?.generation
+      let preservesAcceptedRequest = acceptedStartWindowController === windowController
       activeMediaGeneration = owner?.attributedNativePiPStartMediaGeneration(
-        signaledMediaGeneration: signaledMediaGeneration
+        signaledMediaGeneration: signaledMediaGeneration,
+        preservesAcceptedRequest: preservesAcceptedRequest
       ) ?? signaledMediaGeneration
+      acceptedStartWindowController = nil
     }
     let lifecycleMediaGeneration = activeMediaGeneration
     self.isActive = isActive

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -870,7 +870,7 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
     owner?.handleNativePictureInPictureReady()
   }
 
-  private func setActive(_ isActive: Bool) {
+  func setActive(_ isActive: Bool) {
     guard self.isActive != isActive else { return }
     self.isActive = isActive
     owner?.handleNativePictureInPictureActiveChanged(isActive)

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -1011,7 +1011,7 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
       activeMediaGeneration = owner?.attributedNativePiPStartMediaGeneration(
         signaledMediaGeneration: signaledMediaGeneration,
         acceptedRequestMediaGeneration: acceptedStart?.mediaGeneration
-      ) ?? signaledMediaGeneration
+      ) ?? acceptedStart?.mediaGeneration ?? signaledMediaGeneration
       callbackGenerations.clearAcceptedStart()
     }
     let lifecycleMediaGeneration = activeMediaGeneration

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -521,14 +521,16 @@ public final class Player {
   /// media load. Clock samples stamped older than this are stale and are
   /// dropped rather than allowed to overwrite the seek target.
   var acceptedTimelineRevision: UInt64 = 0
-  /// Bumped whenever the session a ``recast(to:)`` is restoring is taken over
-  /// — by another recast or by a media load. An in-flight recast compares this
-  /// after every suspension and stops mutating once it no longer owns the
-  /// session, rather than reapplying stale tracks or transport state to
-  /// someone else's media.
-  var sessionGeneration: UInt64 = 0
+  /// Bumped when ``recast(to:)`` is superseded so suspended work rejects stale restoration.
+  var sessionGeneration: UInt64 = 0 {
+    didSet {
+      #if os(iOS) || os(macOS)
+      refreshNativeHandleSnapshots()
+      #endif
+    }
+  }
+
   /// The native media the generation was last advanced for.
-  ///
   /// libVLC reports a media change back as `.mediaChanged` whether or not the
   /// wrapper initiated it, so the handler cannot tell the two apart by the
   /// event alone. Comparing identity does: a change this player asked for has

--- a/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
@@ -110,8 +110,22 @@ or when your layout needs more control than ``PiPVideoView`` offers:
 ```swift
 let controller = PiPController(player: player)
 container.layer.addSublayer(controller.layer)
-controller.start()
+switch controller.start() {
+case .accepted:
+  // Observe pipEventEnvelopes for the attributed asynchronous outcome.
+  break
+case .noMedia, .notPossible, .backendUnavailable:
+  // Keep or restore the inline presentation.
+  break
+}
 ```
+
+A ``PiPStartResult/accepted`` result means only that SwiftVLC issued the
+backend request. AVKit may still reject it asynchronously. Consume
+``PiPController/pipEventEnvelopes`` when callbacks can outlive a media change
+or controller reconstruction; each envelope carries the media and controller
+generation that owns the lifecycle. ``PiPController/pipEvents`` remains the
+unattributed compatibility stream.
 
 ``PiPController/layer`` uses `videoGravity = .resizeAspect`. Size the
 parent view to the aspect ratio you want. On macOS, the direct public
@@ -205,6 +219,8 @@ compile the PiP wrapper on visionOS. ``PiPController`` and
 - ``PiPController/isPossible``
 - ``PiPController/isActive``
 - ``PiPController/layer``
+- ``PiPController/pipEventEnvelopes``
+- ``PiPController/pipSnapshots``
 
 ### Control
 - ``PiPController/start()``

--- a/Tests/SwiftVLCTests/PiP/PiPEventOverlapTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventOverlapTests.swift
@@ -145,6 +145,53 @@ extension Integration {
     }
 
     @Test
+    func `An active retry owns its willStop while a failed stop is delayed`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let avController = makeDummyAVController(for: controller)
+      let stream = controller.pipEventEnvelopes
+      let failedMediaGeneration = player.generation
+      let failure = NSError(domain: "swiftvlc.test.pip.delayed-failed-stop", code: 1)
+
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureController(
+        avController,
+        failedToStartPictureInPictureWithError: failure
+      )
+      controller.pictureInPictureControllerWillStopPictureInPicture(avController)
+
+      try player.load(Media(url: TestMedia.silenceURL))
+      let retryMediaGeneration = player.generation
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStartPictureInPicture(avController)
+      controller.stop()
+      controller.pictureInPictureControllerWillStopPictureInPicture(avController)
+
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+
+      let envelopes = await collect(7, from: stream)
+      #expect(envelopes[1].mediaGeneration == failedMediaGeneration)
+      #expect(envelopes[4].mediaGeneration == retryMediaGeneration)
+      #expect(envelopes[5].mediaGeneration == failedMediaGeneration)
+      #expect(envelopes[6].mediaGeneration == retryMediaGeneration)
+      guard case .willStop(reason: .unknown) = envelopes[4].event else {
+        Issue.record("Expected the active retry's programmatic willStop")
+        return
+      }
+      guard case .didStop(reason: .failure) = envelopes[5].event else {
+        Issue.record("Expected the delayed failed stop first")
+        return
+      }
+      guard case .didStop(reason: .unknown) = envelopes[6].event else {
+        Issue.record("Expected the active retry's stop second")
+        return
+      }
+    }
+
+    @Test
     func `Promised failed stop remains ordered ahead of a failed retry`() async throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
       try player.load(Media(url: TestMedia.twosecURL))

--- a/Tests/SwiftVLCTests/PiP/PiPEventOverlapTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventOverlapTests.swift
@@ -108,6 +108,108 @@ extension Integration {
         $0.mediaGeneration == retryMediaGeneration
       })
     }
+
+    @Test
+    func `A failed willStop survives a newer didStart until didStop`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let avController = makeDummyAVController(for: controller)
+      let stream = controller.pipEventEnvelopes
+      let failedMediaGeneration = player.generation
+      let failure = NSError(domain: "swiftvlc.test.pip.failed-will-stop", code: 1)
+
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureController(
+        avController,
+        failedToStartPictureInPictureWithError: failure
+      )
+      controller.pictureInPictureControllerWillStopPictureInPicture(avController)
+
+      try player.load(Media(url: TestMedia.silenceURL))
+      let retryMediaGeneration = player.generation
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+
+      let envelopes = await collect(6, from: stream)
+      #expect(envelopes[1].mediaGeneration == failedMediaGeneration)
+      #expect(envelopes[4].mediaGeneration == failedMediaGeneration)
+      #expect(envelopes[5].mediaGeneration == retryMediaGeneration)
+      guard case .didStop(reason: .failure) = envelopes[4].event else {
+        Issue.record("Expected the promised failed-lifecycle stop")
+        return
+      }
+    }
+
+    @Test
+    func `A cleanup stop after failure cannot poison a successful retry`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let avController = makeDummyAVController(for: controller)
+      let stream = controller.pipEventEnvelopes
+      let failure = NSError(domain: "swiftvlc.test.pip.failed-cleanup-stop", code: 1)
+
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureController(
+        avController,
+        failedToStartPictureInPictureWithError: failure
+      )
+      controller.stop()
+      #expect(controller.pendingStopReason == .unknown)
+
+      try player.load(Media(url: TestMedia.silenceURL))
+      let retryMediaGeneration = player.generation
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      #expect(controller.pendingStopReason == nil)
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+
+      let envelopes = await collect(4, from: stream)
+      #expect(envelopes.dropFirst().allSatisfy {
+        $0.mediaGeneration == retryMediaGeneration
+      })
+      guard case .didStop(reason: .userClosed) = envelopes[3].event else {
+        Issue.record("Expected the retry's independent user-close reason")
+        return
+      }
+    }
+
+    #if os(iOS)
+    @Test
+    func `An ownerless native active signal retains its accepted media`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let backend = IOSNativePiPBackend()
+      let attachment = backend.attach(to: player)
+      _ = try #require(backend.callbackGenerations.reserveReadyCallback(for: attachment))
+      var original: PiPController? = PiPController(player: player, nativeBackend: backend)
+      weak var releasedOriginal = original
+      let acceptedMediaGeneration = player.generation
+      #expect(backend.callbackGenerations.recordAcceptedStart(
+        mediaGeneration: acceptedMediaGeneration
+      ))
+
+      original = nil
+      await Task.yield()
+      #expect(releasedOriginal == nil)
+      #expect(backend.owner == nil)
+
+      try player.load(Media(url: TestMedia.silenceURL))
+      backend.setActive(true, mediaGeneration: player.generation)
+      let successor = PiPController(player: player, nativeBackend: backend)
+      let stream = successor.pipEventEnvelopes
+      backend.setActive(false)
+
+      let envelope = try #require(await collect(1, from: stream).first)
+      #expect(envelope.mediaGeneration == acceptedMediaGeneration)
+      withExtendedLifetime(successor) {}
+    }
+    #endif
   }
 }
 #endif

--- a/Tests/SwiftVLCTests/PiP/PiPEventOverlapTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventOverlapTests.swift
@@ -145,6 +145,50 @@ extension Integration {
     }
 
     @Test
+    func `Promised failed stop remains ordered ahead of a failed retry`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let avController = makeDummyAVController(for: controller)
+      let stream = controller.pipEventEnvelopes
+      let originalMediaGeneration = player.generation
+      let originalFailure = NSError(domain: "swiftvlc.test.pip.promised-failure", code: 1)
+      let retryFailure = NSError(domain: "swiftvlc.test.pip.retry-failure", code: 2)
+
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureController(
+        avController,
+        failedToStartPictureInPictureWithError: originalFailure
+      )
+      controller.pictureInPictureControllerWillStopPictureInPicture(avController)
+
+      try player.load(Media(url: TestMedia.silenceURL))
+      let retryMediaGeneration = player.generation
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureController(
+        avController,
+        failedToStartPictureInPictureWithError: retryFailure
+      )
+
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+
+      let envelopes = await collect(5, from: stream)
+      #expect(envelopes[1].mediaGeneration == originalMediaGeneration)
+      #expect(envelopes[2].mediaGeneration == retryMediaGeneration)
+      #expect(envelopes[3].mediaGeneration == originalMediaGeneration)
+      #expect(envelopes[4].mediaGeneration == retryMediaGeneration)
+      guard case .didStop(reason: .failure) = envelopes[3].event else {
+        Issue.record("Expected the promised original failure stop first")
+        return
+      }
+      guard case .didStop(reason: .failure) = envelopes[4].event else {
+        Issue.record("Expected the failed retry stop second")
+        return
+      }
+    }
+
+    @Test
     func `A cleanup stop after failure cannot poison a successful retry`() async throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
       try player.load(Media(url: TestMedia.twosecURL))

--- a/Tests/SwiftVLCTests/PiP/PiPEventOverlapTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventOverlapTests.swift
@@ -1,0 +1,113 @@
+#if os(iOS) || os(macOS)
+@testable import SwiftVLC
+import AVKit
+import Foundation
+import Testing
+
+extension Integration {
+  @Suite(.tags(.mainActor))
+  @MainActor struct PiPEventOverlapTests {
+    private func makeDummyAVController(for controller: PiPController) -> AVPictureInPictureController {
+      if let installed = controller.pipController {
+        return installed
+      }
+      let contentSource = AVPictureInPictureController.ContentSource(
+        sampleBufferDisplayLayer: controller.layer,
+        playbackDelegate: controller._playbackDelegateForTesting
+      )
+      return AVPictureInPictureController(contentSource: contentSource)
+    }
+
+    private func collect(
+      _ count: Int,
+      from stream: AsyncStream<PiPEventEnvelope>
+    )
+      async -> [PiPEventEnvelope] {
+      var collected: [PiPEventEnvelope] = []
+      for await event in stream {
+        collected.append(event)
+        if collected.count == count {
+          break
+        }
+      }
+      return collected
+    }
+
+    @Test
+    func `A queued retry failure does not steal the older lifecycle's stop`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let avController = makeDummyAVController(for: controller)
+      let stream = controller.pipEventEnvelopes
+      let originalMediaGeneration = player.generation
+      let failure = NSError(domain: "swiftvlc.test.pip.queued-retry-failure", code: 1)
+
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStartPictureInPicture(avController)
+      controller.pictureInPictureControllerWillStopPictureInPicture(avController)
+
+      try player.load(Media(url: TestMedia.silenceURL))
+      let retryMediaGeneration = player.generation
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureController(
+        avController,
+        failedToStartPictureInPictureWithError: failure
+      )
+
+      // The older, already-started lifecycle still owns the first terminal
+      // stop. A later optional stop belongs to the failed retry.
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+
+      let envelopes = await collect(6, from: stream)
+      #expect(envelopes[3].mediaGeneration == retryMediaGeneration)
+      #expect(envelopes[4].mediaGeneration == originalMediaGeneration)
+      #expect(envelopes[5].mediaGeneration == retryMediaGeneration)
+      guard case .didStop(reason: .userClosed) = envelopes[4].event else {
+        Issue.record("Expected the older lifecycle's undiscriminated stop")
+        return
+      }
+      guard case .didStop(reason: .failure) = envelopes[5].event else {
+        Issue.record("Expected the queued retry's failure stop")
+        return
+      }
+    }
+
+    @Test
+    func `A stopped accepted start retires when its failure arrives`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let avController = makeDummyAVController(for: controller)
+      let stream = controller.pipEventEnvelopes
+      let failedMediaGeneration = player.generation
+      let failure = NSError(domain: "swiftvlc.test.pip.stopped-start-failure", code: 1)
+
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.stop()
+      controller.pictureInPictureController(
+        avController,
+        failedToStartPictureInPictureWithError: failure
+      )
+      #expect(controller.resolveStopReason() == .unknown)
+
+      // AVKit may omit didStop after a start failure. A new successful start
+      // must therefore replace the retired attempt instead of queuing forever
+      // behind its old awaiting-start slot.
+      try player.load(Media(url: TestMedia.silenceURL))
+      let retryMediaGeneration = player.generation
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStartPictureInPicture(avController)
+
+      let envelopes = await collect(3, from: stream)
+      #expect(envelopes[0].mediaGeneration == failedMediaGeneration)
+      #expect(envelopes.dropFirst().allSatisfy {
+        $0.mediaGeneration == retryMediaGeneration
+      })
+    }
+  }
+}
+#endif

--- a/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
@@ -664,7 +664,13 @@ extension Integration {
       backend.attach(to: player)
       let original = PiPController(player: player, nativeBackend: backend)
       let acceptedGeneration = player.generation
+      #if os(iOS)
+      let windowController = NativePiPWindowControllerProbe()
+      backend.handlePictureInPictureReady(windowController)
+      #expect(original.noteAcceptedPiPStartRequest(backend.start()) == .accepted)
+      #else
       #expect(original.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      #endif
 
       try player.load(Media(url: TestMedia.silenceURL))
       #if os(iOS)
@@ -680,6 +686,32 @@ extension Integration {
       let envelope = try #require(await collect(1, from: stream).first)
       #expect(envelope.mediaGeneration == acceptedGeneration)
       withExtendedLifetime(original) {}
+    }
+
+    @Test
+    func `An automatic native start retires an accepted request from a replaced controller`() async throws {
+      #if os(iOS)
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let backend = IOSNativePiPBackend()
+      backend.attach(to: player)
+      let controller = PiPController(player: player, nativeBackend: backend)
+      let stream = controller.pipEventEnvelopes
+
+      backend.handlePictureInPictureReady(NativePiPWindowControllerProbe())
+      #expect(controller.noteAcceptedPiPStartRequest(backend.start()) == .accepted)
+
+      try player.load(Media(url: TestMedia.silenceURL))
+      let automaticMediaGeneration = player.generation
+      // libVLC rebuilt its native window controller for the successor media.
+      // An active signal from this controller cannot be the result of the
+      // explicit request sent to the retired controller.
+      backend.handlePictureInPictureReady(NativePiPWindowControllerProbe())
+      backend.setActive(true, mediaGeneration: automaticMediaGeneration)
+
+      let envelope = try #require(await collect(1, from: stream).first)
+      #expect(envelope.mediaGeneration == automaticMediaGeneration)
+      #endif
     }
 
     @Test
@@ -749,4 +781,10 @@ extension Integration {
     }
   }
 }
+
+#if os(iOS)
+private final class NativePiPWindowControllerProbe: NSObject {
+  @objc func startPictureInPicture() {}
+}
+#endif
 #endif

--- a/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
@@ -209,9 +209,17 @@ extension Integration {
       let retryMediaGeneration = player.generation
       #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
       controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
 
-      let envelopes = await collect(2, from: stream)
-      #expect(envelopes[1].mediaGeneration == retryMediaGeneration)
+      let envelopes = await collect(4, from: stream)
+      #expect(envelopes.dropFirst().allSatisfy {
+        $0.mediaGeneration == retryMediaGeneration
+      })
+      guard case .didStop(reason: .userClosed) = envelopes[3].event else {
+        Issue.record("Expected the successful retry's independent stop")
+        return
+      }
     }
 
     @Test
@@ -236,23 +244,48 @@ extension Integration {
       #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
 
       // AVKit may finish the failed lifecycle after the application has
-      // already issued its retry. That old stop must consume only the saved
-      // failed identity, leaving the accepted retry intact.
-      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+      // already issued its retry and delivered willStart. That old stop must
+      // consume only the saved failed identity, leaving the retry intact.
       controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
       controller.pictureInPictureControllerDidStartPictureInPicture(avController)
       controller.pictureInPictureControllerDidStopPictureInPicture(avController)
 
       let envelopes = await collect(5, from: stream)
       #expect(envelopes[0].mediaGeneration == failedMediaGeneration)
-      #expect(envelopes[1].mediaGeneration == failedMediaGeneration)
-      #expect(envelopes.dropFirst(2).allSatisfy {
+      #expect(envelopes[2].mediaGeneration == failedMediaGeneration)
+      #expect([envelopes[1], envelopes[3], envelopes[4]].allSatisfy {
         $0.mediaGeneration == retryMediaGeneration
       })
-      guard case .didStop(reason: .failure) = envelopes[1].event else {
+      guard case .didStop(reason: .failure) = envelopes[2].event else {
         Issue.record("Expected the failed attempt's trailing stop")
         return
       }
+    }
+
+    @Test
+    func `A retry accepted during an undiscriminated stop keeps its media`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let avController = makeDummyAVController(for: controller)
+      let stream = controller.pipEventEnvelopes
+
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStartPictureInPicture(avController)
+      controller.pictureInPictureControllerWillStopPictureInPicture(avController)
+
+      try player.load(Media(url: TestMedia.silenceURL))
+      let retryMediaGeneration = player.generation
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      try player.load(Media(url: TestMedia.twosecURL))
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+
+      let envelopes = await collect(5, from: stream)
+      #expect(envelopes[4].mediaGeneration == retryMediaGeneration)
     }
 
     @Test

--- a/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
@@ -171,6 +171,50 @@ extension Integration {
     }
 
     @Test
+    func `A redundant accepted start does not steal an active lifecycle`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let avController = makeDummyAVController(for: controller)
+      let stream = controller.pipEventEnvelopes
+      let lifecycleMediaGeneration = player.generation
+
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStartPictureInPicture(avController)
+      try player.load(Media(url: TestMedia.silenceURL))
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+
+      let envelopes = await collect(3, from: stream)
+      #expect(envelopes.allSatisfy {
+        $0.mediaGeneration == lifecycleMediaGeneration
+      })
+    }
+
+    @Test
+    func `A fresh accepted start after failure captures the new media`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let avController = makeDummyAVController(for: controller)
+      let stream = controller.pipEventEnvelopes
+      let failure = NSError(domain: "swiftvlc.test.pip.retry", code: 1)
+
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureController(
+        avController,
+        failedToStartPictureInPictureWithError: failure
+      )
+      try player.load(Media(url: TestMedia.silenceURL))
+      let retryMediaGeneration = player.generation
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+
+      let envelopes = await collect(2, from: stream)
+      #expect(envelopes[1].mediaGeneration == retryMediaGeneration)
+    }
+
+    @Test
     func `restore then stop reports restoreRequested, plain stop reports userClosed`() async {
       let player = Player(instance: TestInstance.shared)
       let controller = PiPController(player: player)
@@ -376,6 +420,32 @@ extension Integration {
       let events = await collect(2, from: stream)
       #expect(events.map(\.controllerGeneration) == [1, 1])
       #expect(events.allSatisfy { $0.mediaGeneration == player.generation })
+    }
+
+    @Test
+    func `Adopting active native PiP seeds its media generation`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      #if os(iOS)
+      let backend = IOSNativePiPBackend()
+      #else
+      let backend = MacNativePiPBackend()
+      #endif
+      backend.setActive(true)
+      let lifecycleMediaGeneration = player.generation
+      let controller = PiPController(player: player, nativeBackend: backend)
+      let stream = controller.pipEventEnvelopes
+
+      #expect(controller.isActive)
+      try player.load(Media(url: TestMedia.silenceURL))
+      controller.handleNativePictureInPictureActiveChanged(false)
+
+      let envelope = try #require(await collect(1, from: stream).first)
+      #expect(envelope.mediaGeneration == lifecycleMediaGeneration)
+      guard case .didStop = envelope.event else {
+        Issue.record("Expected .didStop, got \(envelope.event)")
+        return
+      }
     }
 
     @Test

--- a/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
@@ -758,6 +758,45 @@ extension Integration {
       let envelope = try #require(await collect(1, from: stream).first)
       #expect(envelope.mediaGeneration == acceptedGeneration)
     }
+
+    @Test
+    func `A queued macOS transition follows a same-player owner handoff`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let backend = MacNativePiPBackend()
+      backend.attach(to: player)
+      let original = PiPController(player: player, nativeBackend: backend)
+      let originalStream = original.pipEventEnvelopes
+
+      backend.setActive(true)
+      _ = try #require(await collect(1, from: originalStream).first)
+      let lifecycleMediaGeneration = try #require(backend.activeMediaGeneration)
+
+      // `setActive(false)` defers observer delivery. Reconstruct the
+      // controller synchronously before that task runs; the transition must
+      // follow the adopted same-player backend instead of the captured owner.
+      backend.setActive(false)
+      let successor = PiPController(player: player, nativeBackend: backend)
+      let successorStream = successor.pipEventEnvelopes
+      try player.load(Media(url: TestMedia.silenceURL))
+      let retryMediaGeneration = player.generation
+      #expect(successor.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      backend.setActive(true)
+
+      let envelopes = await collect(2, from: successorStream)
+      #expect(backend.owner === successor)
+      #expect(envelopes[0].mediaGeneration == lifecycleMediaGeneration)
+      #expect(envelopes[1].mediaGeneration == retryMediaGeneration)
+      guard case .didStop(reason: .unknown) = envelopes[0].event else {
+        Issue.record("Expected the queued stop on the successor owner")
+        return
+      }
+      guard case .didStart = envelopes[1].event else {
+        Issue.record("Expected the successor's accepted retry to remain current")
+        return
+      }
+      withExtendedLifetime(original) {}
+    }
     #endif
 
     @Test

--- a/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
@@ -215,6 +215,45 @@ extension Integration {
     }
 
     @Test
+    func `A failed attempt's trailing stop does not consume its accepted retry`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let avController = makeDummyAVController(for: controller)
+      let stream = controller.pipEventEnvelopes
+      let failedMediaGeneration = player.generation
+      let failure = NSError(domain: "swiftvlc.test.pip.overlapping-retry", code: 1)
+
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureController(
+        avController,
+        failedToStartPictureInPictureWithError: failure
+      )
+      try player.load(Media(url: TestMedia.silenceURL))
+      let retryMediaGeneration = player.generation
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+
+      // AVKit may finish the failed lifecycle after the application has
+      // already issued its retry. That old stop must consume only the saved
+      // failed identity, leaving the accepted retry intact.
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+
+      let envelopes = await collect(5, from: stream)
+      #expect(envelopes[0].mediaGeneration == failedMediaGeneration)
+      #expect(envelopes[1].mediaGeneration == failedMediaGeneration)
+      #expect(envelopes.dropFirst(2).allSatisfy {
+        $0.mediaGeneration == retryMediaGeneration
+      })
+      guard case .didStop(reason: .failure) = envelopes[1].event else {
+        Issue.record("Expected the failed attempt's trailing stop")
+        return
+      }
+    }
+
+    @Test
     func `restore then stop reports restoreRequested, plain stop reports userClosed`() async {
       let player = Player(instance: TestInstance.shared)
       let controller = PiPController(player: player)
@@ -423,7 +462,7 @@ extension Integration {
     }
 
     @Test
-    func `Adopting active native PiP seeds its media generation`() async throws {
+    func `Adopting active native PiP retains its original media generation`() async throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
       try player.load(Media(url: TestMedia.twosecURL))
       #if os(iOS)
@@ -431,14 +470,15 @@ extension Integration {
       #else
       let backend = MacNativePiPBackend()
       #endif
+      backend.attach(to: player)
       backend.setActive(true)
       let lifecycleMediaGeneration = player.generation
+      try player.load(Media(url: TestMedia.silenceURL))
       let controller = PiPController(player: player, nativeBackend: backend)
       let stream = controller.pipEventEnvelopes
 
       #expect(controller.isActive)
-      try player.load(Media(url: TestMedia.silenceURL))
-      controller.handleNativePictureInPictureActiveChanged(false)
+      backend.setActive(false)
 
       let envelope = try #require(await collect(1, from: stream).first)
       #expect(envelope.mediaGeneration == lifecycleMediaGeneration)

--- a/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
@@ -384,6 +384,43 @@ extension Integration {
     }
 
     @Test
+    func `A failure stop promotes the retry queued by an undiscriminated stop`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let avController = makeDummyAVController(for: controller)
+      let stream = controller.pipEventEnvelopes
+      let failure = NSError(domain: "swiftvlc.test.pip.queued-failure", code: 1)
+
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStartPictureInPicture(avController)
+      controller.pictureInPictureControllerWillStopPictureInPicture(avController)
+
+      try player.load(Media(url: TestMedia.silenceURL))
+      let retryMediaGeneration = player.generation
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+
+      // The media can move again before AVKit finishes the old failed
+      // lifecycle. The queued retry, not this signal-time generation, owns the
+      // next start.
+      try player.load(Media(url: TestMedia.twosecURL))
+      controller.pictureInPictureController(
+        avController,
+        failedToStartPictureInPictureWithError: failure
+      )
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+
+      let envelopes = await collect(6, from: stream)
+      #expect(envelopes[5].mediaGeneration == retryMediaGeneration)
+      guard case .didStop(reason: .failure) = envelopes[4].event else {
+        Issue.record("Expected the failed lifecycle's trailing stop")
+        return
+      }
+    }
+
+    @Test
     func `A failure that loses stop precedence preserves the old lifecycle and queues its retry`() async throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
       try player.load(Media(url: TestMedia.twosecURL))

--- a/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
@@ -192,6 +192,33 @@ extension Integration {
     }
 
     @Test
+    func `A late willStart remains with the attempt stopped before it began`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let avController = makeDummyAVController(for: controller)
+      let stream = controller.pipEventEnvelopes
+      let stoppedMediaGeneration = player.generation
+
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.stop()
+      try player.load(Media(url: TestMedia.silenceURL))
+      let retryMediaGeneration = player.generation
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+
+      let envelopes = await collect(4, from: stream)
+      #expect(envelopes.prefix(3).allSatisfy {
+        $0.mediaGeneration == stoppedMediaGeneration
+      })
+      #expect(envelopes[3].mediaGeneration == retryMediaGeneration)
+    }
+
+    @Test
     func `A fresh accepted start after failure captures the new media`() async throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
       try player.load(Media(url: TestMedia.twosecURL))
@@ -538,14 +565,11 @@ extension Integration {
     }
 
     @Test
-    func `A later inactive native start supersedes an unobservable failed attempt`() async throws {
+    func `A later inactive iOS native start supersedes an unobservable failed attempt`() async throws {
+      #if os(iOS)
       let player = Player(instance: TestInstance.makeAudioOnly())
       try player.load(Media(url: TestMedia.twosecURL))
-      #if os(iOS)
       let backend = IOSNativePiPBackend()
-      #else
-      let backend = MacNativePiPBackend()
-      #endif
       backend.attach(to: player)
       let controller = PiPController(player: player, nativeBackend: backend)
       let stream = controller.pipEventEnvelopes
@@ -558,7 +582,29 @@ extension Integration {
 
       let envelope = try #require(await collect(1, from: stream).first)
       #expect(envelope.mediaGeneration == retryMediaGeneration)
+      #endif
     }
+
+    #if os(macOS)
+    @Test
+    func `A macOS active update queued to its owner preserves the accepted media`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let backend = MacNativePiPBackend()
+      backend.attach(to: player)
+      let controller = PiPController(player: player, nativeBackend: backend)
+      let stream = controller.pipEventEnvelopes
+      let acceptedGeneration = player.generation
+
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      backend.setActive(true)
+      try player.load(Media(url: TestMedia.silenceURL))
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+
+      let envelope = try #require(await collect(1, from: stream).first)
+      #expect(envelope.mediaGeneration == acceptedGeneration)
+    }
+    #endif
 
     @Test
     func `Callback snapshot publishes media generation before a callback hop`() throws {
@@ -604,6 +650,36 @@ extension Integration {
         Issue.record("Expected .didStop, got \(envelope.event)")
         return
       }
+    }
+
+    @Test
+    func `An active native backend persists accepted media across owner reconstruction`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      #if os(iOS)
+      let backend = IOSNativePiPBackend()
+      #else
+      let backend = MacNativePiPBackend()
+      #endif
+      backend.attach(to: player)
+      let original = PiPController(player: player, nativeBackend: backend)
+      let acceptedGeneration = player.generation
+      #expect(original.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+
+      try player.load(Media(url: TestMedia.silenceURL))
+      #if os(iOS)
+      backend.setActive(true, mediaGeneration: player.generation)
+      #else
+      backend.setActive(true)
+      #endif
+
+      let successor = PiPController(player: player, nativeBackend: backend)
+      let stream = successor.pipEventEnvelopes
+      backend.setActive(false)
+
+      let envelope = try #require(await collect(1, from: stream).first)
+      #expect(envelope.mediaGeneration == acceptedGeneration)
+      withExtendedLifetime(original) {}
     }
 
     @Test

--- a/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
@@ -324,6 +324,49 @@ extension Integration {
     }
 
     @Test
+    func `A failed stop cannot consume the programmatic stop reason of its retry`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let avController = makeDummyAVController(for: controller)
+      let stream = controller.pipEventEnvelopes
+      let failedMediaGeneration = player.generation
+      let failure = NSError(domain: "swiftvlc.test.pip.retry-stop", code: 1)
+
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureController(
+        avController,
+        failedToStartPictureInPictureWithError: failure
+      )
+
+      try player.load(Media(url: TestMedia.silenceURL))
+      let retryMediaGeneration = player.generation
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.stop()
+
+      // The first stop still belongs to the failed attempt. Its reason and
+      // attribution must move together, leaving the retry's programmatic stop
+      // intact across the later will-start callback.
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+
+      let envelopes = await collect(4, from: stream)
+      #expect(envelopes[0].mediaGeneration == failedMediaGeneration)
+      #expect(envelopes[1].mediaGeneration == failedMediaGeneration)
+      #expect(envelopes[2].mediaGeneration == retryMediaGeneration)
+      #expect(envelopes[3].mediaGeneration == retryMediaGeneration)
+      guard case .didStop(reason: .failure) = envelopes[1].event else {
+        Issue.record("Expected the failed attempt's trailing stop")
+        return
+      }
+      guard case .didStop(reason: .unknown) = envelopes[3].event else {
+        Issue.record("Expected the retry's programmatic stop reason")
+        return
+      }
+    }
+
+    @Test
     func `A second failed attempt retires an earlier failure without a trailing stop`() async throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
       try player.load(Media(url: TestMedia.twosecURL))

--- a/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
@@ -427,12 +427,13 @@ extension Integration {
     }
 
     @Test
-    func `A failure stop promotes the retry queued by an undiscriminated stop`() async throws {
+    func `A failed queued retry is not promoted after the older stop`() async throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
       try player.load(Media(url: TestMedia.twosecURL))
       let controller = PiPController(player: player)
       let avController = makeDummyAVController(for: controller)
       let stream = controller.pipEventEnvelopes
+      let originalMediaGeneration = player.generation
       let failure = NSError(domain: "swiftvlc.test.pip.queued-failure", code: 1)
 
       #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
@@ -444,10 +445,13 @@ extension Integration {
       let retryMediaGeneration = player.generation
       #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
 
-      // The media can move again before AVKit finishes the old failed
-      // lifecycle. The queued retry, not this signal-time generation, owns the
-      // next start.
+      // The media can move again before AVKit reports that the queued retry
+      // failed. That failure still belongs to the accepted retry. Once the
+      // older lifecycle stops, the failed retry must not be promoted as a
+      // phantom awaiting start; a later willStart is an automatic start for
+      // the signal-time media.
       try player.load(Media(url: TestMedia.twosecURL))
+      let automaticMediaGeneration = player.generation
       controller.pictureInPictureController(
         avController,
         failedToStartPictureInPictureWithError: failure
@@ -456,9 +460,11 @@ extension Integration {
       controller.pictureInPictureControllerWillStartPictureInPicture(avController)
 
       let envelopes = await collect(6, from: stream)
-      #expect(envelopes[5].mediaGeneration == retryMediaGeneration)
-      guard case .didStop(reason: .failure) = envelopes[4].event else {
-        Issue.record("Expected the failed lifecycle's trailing stop")
+      #expect(envelopes[3].mediaGeneration == retryMediaGeneration)
+      #expect(envelopes[4].mediaGeneration == originalMediaGeneration)
+      #expect(envelopes[5].mediaGeneration == automaticMediaGeneration)
+      guard case .didStop(reason: .userClosed) = envelopes[4].event else {
+        Issue.record("Expected the older lifecycle's undiscriminated stop")
         return
       }
     }

--- a/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
@@ -324,6 +324,41 @@ extension Integration {
     }
 
     @Test
+    func `A second failed attempt retires an earlier failure without a trailing stop`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let avController = makeDummyAVController(for: controller)
+      let stream = controller.pipEventEnvelopes
+      let firstMediaGeneration = player.generation
+      let failure = NSError(domain: "swiftvlc.test.pip.consecutive-failures", code: 1)
+
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureController(
+        avController,
+        failedToStartPictureInPictureWithError: failure
+      )
+
+      try player.load(Media(url: TestMedia.silenceURL))
+      let secondMediaGeneration = player.generation
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureController(
+        avController,
+        failedToStartPictureInPictureWithError: failure
+      )
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+
+      let envelopes = await collect(3, from: stream)
+      #expect(envelopes[0].mediaGeneration == firstMediaGeneration)
+      #expect(envelopes[1].mediaGeneration == secondMediaGeneration)
+      #expect(envelopes[2].mediaGeneration == secondMediaGeneration)
+      guard case .didStop(reason: .failure) = envelopes[2].event else {
+        Issue.record("Expected the second failed attempt's trailing stop")
+        return
+      }
+    }
+
+    @Test
     func `A retry accepted during an undiscriminated stop keeps its media`() async throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
       try player.load(Media(url: TestMedia.twosecURL))

--- a/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
@@ -254,6 +254,45 @@ extension Integration {
     }
 
     @Test
+    func `A failure that loses stop precedence preserves the old lifecycle and queues its retry`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let avController = makeDummyAVController(for: controller)
+      let stream = controller.pipEventEnvelopes
+      let originalMediaGeneration = player.generation
+      let failure = NSError(domain: "swiftvlc.test.pip.restore-precedence", code: 1)
+
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStartPictureInPicture(avController)
+      controller.pictureInPictureController(
+        avController,
+        restoreUserInterfaceForPictureInPictureStopWithCompletionHandler: { _ in }
+      )
+      controller.pictureInPictureController(
+        avController,
+        failedToStartPictureInPictureWithError: failure
+      )
+
+      try player.load(Media(url: TestMedia.silenceURL))
+      let retryMediaGeneration = player.generation
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+
+      let envelopes = await collect(5, from: stream)
+      #expect(envelopes.prefix(4).allSatisfy {
+        $0.mediaGeneration == originalMediaGeneration
+      })
+      #expect(envelopes[4].mediaGeneration == retryMediaGeneration)
+      guard case .didStop(reason: .restoreRequested) = envelopes[3].event else {
+        Issue.record("Expected restore to retain stop precedence")
+        return
+      }
+    }
+
+    @Test
     func `restore then stop reports restoreRequested, plain stop reports userClosed`() async {
       let player = Player(instance: TestInstance.shared)
       let controller = PiPController(player: player)
@@ -459,6 +498,48 @@ extension Integration {
       let events = await collect(2, from: stream)
       #expect(events.map(\.controllerGeneration) == [1, 1])
       #expect(events.allSatisfy { $0.mediaGeneration == player.generation })
+    }
+
+    @Test
+    func `A later inactive native start supersedes an unobservable failed attempt`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      #if os(iOS)
+      let backend = IOSNativePiPBackend()
+      #else
+      let backend = MacNativePiPBackend()
+      #endif
+      backend.attach(to: player)
+      let controller = PiPController(player: player, nativeBackend: backend)
+      let stream = controller.pipEventEnvelopes
+
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      try player.load(Media(url: TestMedia.silenceURL))
+      let retryMediaGeneration = player.generation
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.handleNativePictureInPictureActiveChanged(true)
+
+      let envelope = try #require(await collect(1, from: stream).first)
+      #expect(envelope.mediaGeneration == retryMediaGeneration)
+    }
+
+    @Test
+    func `Callback snapshot publishes media generation before a callback hop`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let signalGeneration = controller.callbackSnapshot.withLock {
+        $0.playbackGeneration
+      }
+
+      try player.load(Media(url: TestMedia.silenceURL))
+      let successorGeneration = controller.callbackSnapshot.withLock {
+        $0.playbackGeneration
+      }
+
+      #expect(signalGeneration != nil)
+      #expect(signalGeneration != successorGeneration)
+      #expect(successorGeneration == player.generation)
     }
 
     @Test

--- a/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
@@ -250,6 +250,39 @@ extension Integration {
     }
 
     @Test
+    func `An idle stop reason does not poison the next failed start retry`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let avController = makeDummyAVController(for: controller)
+      let stream = controller.pipEventEnvelopes
+      let failure = NSError(domain: "swiftvlc.test.pip.idle-stop", code: 1)
+
+      controller.stop()
+      #expect(controller.pendingStopReason == .unknown)
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureController(
+        avController,
+        failedToStartPictureInPictureWithError: failure
+      )
+
+      try player.load(Media(url: TestMedia.silenceURL))
+      let retryMediaGeneration = player.generation
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStartPictureInPicture(avController)
+
+      let envelopes = await collect(3, from: stream)
+      #expect(envelopes.dropFirst().allSatisfy {
+        $0.mediaGeneration == retryMediaGeneration
+      })
+      guard case .failedToStart = envelopes[0].event else {
+        Issue.record("Expected the first attempt to fail")
+        return
+      }
+    }
+
+    @Test
     func `A failed attempt's trailing stop does not consume its accepted retry`() async throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
       try player.load(Media(url: TestMedia.twosecURL))

--- a/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
@@ -49,6 +49,21 @@ extension Integration {
       return collected
     }
 
+    private func collect(
+      _ count: Int,
+      from stream: AsyncStream<PiPEventEnvelope>
+    )
+      async -> [PiPEventEnvelope] {
+      var collected: [PiPEventEnvelope] = []
+      for await event in stream {
+        collected.append(event)
+        if collected.count == count {
+          break
+        }
+      }
+      return collected
+    }
+
     @Test
     func `willStart and didStart delegate callbacks emit events`() async {
       let player = Player(instance: TestInstance.shared)
@@ -99,6 +114,60 @@ extension Integration {
       #expect(nsError.code == 42)
       // failedToStart must also resync isActive to false.
       #expect(controller.isActive == false)
+    }
+
+    @Test
+    func `An accepted start failure retains its controller and media generation`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let avController = makeDummyAVController(for: controller)
+      let stream = controller.pipEventEnvelopes
+      let acceptedMediaGeneration = player.generation
+      let acceptedControllerGeneration = controller.pipControllerGeneration
+
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      try player.load(Media(url: TestMedia.silenceURL))
+      #expect(player.generation > acceptedMediaGeneration)
+
+      let failure = NSError(domain: "swiftvlc.test.pip.generation", code: 17)
+      controller.pictureInPictureController(
+        avController,
+        failedToStartPictureInPictureWithError: failure
+      )
+
+      let envelope = try #require(await collect(1, from: stream).first)
+      #expect(envelope.mediaGeneration == acceptedMediaGeneration)
+      #expect(envelope.controllerGeneration == acceptedControllerGeneration)
+      guard case .failedToStart(let error) = envelope.event else {
+        Issue.record("Expected .failedToStart, got \(envelope.event)")
+        return
+      }
+      #expect((error as NSError).code == 17)
+    }
+
+    @Test
+    func `willStart does not steal an accepted request for successor media`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let avController = makeDummyAVController(for: controller)
+      let stream = controller.pipEventEnvelopes
+      let acceptedMediaGeneration = player.generation
+
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      try player.load(Media(url: TestMedia.silenceURL))
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStartPictureInPicture(avController)
+
+      let envelopes = await collect(2, from: stream)
+      #expect(envelopes.map(\.mediaGeneration) == [
+        acceptedMediaGeneration,
+        acceptedMediaGeneration
+      ])
+      #expect(envelopes.allSatisfy {
+        $0.controllerGeneration == controller.pipControllerGeneration
+      })
     }
 
     @Test
@@ -291,6 +360,25 @@ extension Integration {
     }
 
     @Test
+    func `Native backend events carry one nonzero controller generation`() async {
+      let player = Player(instance: TestInstance.shared)
+      #if os(iOS)
+      let backend = IOSNativePiPBackend()
+      #else
+      let backend = MacNativePiPBackend()
+      #endif
+      let controller = PiPController(player: player, nativeBackend: backend)
+      let stream = controller.pipEventEnvelopes
+
+      controller.handleNativePictureInPictureActiveChanged(true)
+      controller.handleNativePictureInPictureActiveChanged(false)
+
+      let events = await collect(2, from: stream)
+      #expect(events.map(\.controllerGeneration) == [1, 1])
+      #expect(events.allSatisfy { $0.mediaGeneration == player.generation })
+    }
+
+    @Test
     func `pipEvents stream finishes when the controller deinits`() async throws {
       let player = Player(instance: TestInstance.shared)
       var controller: PiPController? = PiPController(player: player)
@@ -302,6 +390,19 @@ extension Integration {
       // rather than suspend forever.
       for await event in stream {
         Issue.record("Expected no events, got \(event)")
+      }
+    }
+
+    @Test
+    func `pipEventEnvelopes stream finishes when the controller deinits`() async throws {
+      let player = Player(instance: TestInstance.shared)
+      var controller: PiPController? = PiPController(player: player)
+      let stream = try #require(controller?.pipEventEnvelopes)
+
+      controller = nil
+
+      for await event in stream {
+        Issue.record("Expected no envelopes, got \(event)")
       }
     }
 
@@ -324,6 +425,23 @@ extension Integration {
         Issue.record("Both subscribers should see .willStart first")
         return
       }
+    }
+
+    @Test
+    func `multiple envelope subscribers receive identical attribution`() async {
+      let player = Player(instance: TestInstance.shared)
+      let controller = PiPController(player: player)
+      let avController = makeDummyAVController(for: controller)
+      let first = controller.pipEventEnvelopes
+      let second = controller.pipEventEnvelopes
+
+      controller.pictureInPictureControllerWillStartPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStartPictureInPicture(avController)
+
+      let a = await collect(2, from: first)
+      let b = await collect(2, from: second)
+      #expect(a.map(\.mediaGeneration) == b.map(\.mediaGeneration))
+      #expect(a.map(\.controllerGeneration) == b.map(\.controllerGeneration))
     }
   }
 }

--- a/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
@@ -232,6 +232,8 @@ extension Integration {
       try player.load(Media(url: TestMedia.silenceURL))
       let retryMediaGeneration = player.generation
       #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      try player.load(Media(url: TestMedia.twosecURL))
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
 
       // AVKit may finish the failed lifecycle after the application has
       // already issued its retry. That old stop must consume only the saved
@@ -277,6 +279,8 @@ extension Integration {
 
       try player.load(Media(url: TestMedia.silenceURL))
       let retryMediaGeneration = player.generation
+      #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
+      try player.load(Media(url: TestMedia.twosecURL))
       #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
       controller.pictureInPictureControllerDidStopPictureInPicture(avController)
       controller.pictureInPictureControllerWillStartPictureInPicture(avController)

--- a/Tests/SwiftVLCTests/PiP/PiPNativeSignalProvenanceTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPNativeSignalProvenanceTests.swift
@@ -1,0 +1,50 @@
+#if os(iOS)
+@testable import SwiftVLC
+import Testing
+
+extension Integration {
+  @Suite(.tags(.mainActor))
+  @MainActor struct PiPNativeSignalProvenanceTests {
+    @Test
+    func `active signal preserves accepted provenance across its actor hop`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let backend = IOSNativePiPBackend()
+      let attachment = backend.attach(to: player)
+      let controller = PiPController(player: player, nativeBackend: backend)
+      let stream = controller.pipEventEnvelopes
+      let ready = try #require(
+        backend.callbackGenerations.reserveReadyCallback(for: attachment)
+      )
+      let signaledMediaGeneration = player.generation
+
+      #expect(
+        backend.callbackGenerations.recordAcceptedStart(
+          mediaGeneration: signaledMediaGeneration
+        )
+      )
+      let acceptedAtSignal = try #require(
+        backend.callbackGenerations.acceptedStart(at: ready)
+      )
+
+      // A successor request is accepted before the signal's queued main-actor
+      // work runs. The already-delivered signal must retain the first request.
+      try player.load(Media(url: TestMedia.silenceURL))
+      #expect(
+        backend.callbackGenerations.recordAcceptedStart(
+          mediaGeneration: player.generation
+        )
+      )
+      backend.setActiveFromNativeSignal(
+        true,
+        mediaGeneration: signaledMediaGeneration,
+        acceptedStart: acceptedAtSignal
+      )
+
+      var iterator = stream.makeAsyncIterator()
+      let envelope = try #require(await iterator.next())
+      #expect(envelope.mediaGeneration == signaledMediaGeneration)
+    }
+  }
+}
+#endif

--- a/Tests/SwiftVLCTests/PiP/PiPStartResultTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPStartResultTests.swift
@@ -1,5 +1,6 @@
 #if os(iOS) || os(macOS)
 @_spi(PrivateMacOSPiP) @testable import SwiftVLC
+import AVKit
 import Testing
 
 /// `start()` used to return `Void` from four indistinguishable early exits, so
@@ -51,6 +52,25 @@ extension Integration {
       if !controller.isPossible {
         #expect(result != .accepted, "start claimed acceptance while PiP was impossible")
       }
+    }
+
+    @Test
+    func `A direct impossible start records no lifecycle attribution`() throws {
+      let player = Player(instance: TestInstance.shared)
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      if controller.pipController == nil {
+        let contentSource = AVPictureInPictureController.ContentSource(
+          sampleBufferDisplayLayer: controller.layer,
+          playbackDelegate: controller._playbackDelegateForTesting
+        )
+        controller.pipController = AVPictureInPictureController(contentSource: contentSource)
+      }
+      controller._setStateForTesting(isPossible: false)
+
+      #expect(controller.start() == .notPossible)
+      #expect(controller.pipLifecycleAttribution == nil)
+      #expect(controller.pipLifecycleAttributionPhase == .idle)
     }
 
     /// `toggle()` has to propagate the start result when it takes the start


### PR DESCRIPTION
## Summary

- add a lossless `pipEventEnvelopes` stream pairing each PiP lifecycle event with its playback and controller generations
- retain the accepted request identity through delayed AVKit callbacks, including media replacement before `willStart` or `failedToStart`
- give native iOS/macOS backends a nonzero controller generation and reset attribution when the direct AVKit controller is replaced
- preserve the existing bare `pipEvents` compatibility stream and document immediate-versus-asynchronous start semantics

## Validation

- `CI=true ./scripts/ci-run-with-timeouts.py 600 180 swift test --no-parallel --enable-code-coverage` — 1,827 tests / 164 suites passed
- `swift test --filter PiP --no-parallel` — 230 tests / 20 suites passed
- iOS Simulator `xcodebuild build-for-testing` — succeeded for arm64 and x86_64
- `swift build -Xswiftc -warnings-as-errors`
- strict SwiftLint and SwiftFormat — clean
- DocC coverage — 779/779 public symbols (100%)
- patch manifest and release-integrity checks — passed

Advances #104. The issue should remain open until accepted-path behavior and delayed failure attribution are recorded on physical iOS hardware.