### PR TITLE
Preserve playlist pause requests across media adoption

### DIFF
--- a/Sources/SwiftVLC/Player/EventBridge.swift
+++ b/Sources/SwiftVLC/Player/EventBridge.swift
@@ -114,6 +114,24 @@ final class EventBridge: Sendable {
     NativePlayerGeneration(currentNativeHandleGeneration)
   }
 
+  /// Playback generation already accepted by the callback lane, which can be
+  /// ahead of the main actor while a native media-change event is queued.
+  var currentPlaybackGeneration: UInt64 {
+    context.currentPlaybackGeneration
+  }
+
+  /// Runs a main-actor mutation only if the callback lane is still on the
+  /// expected playback generation. The comparison and mutation share the
+  /// callback lane's lifecycle lock, giving callers a real linearization point
+  /// against a concurrent native media-change callback.
+  @MainActor
+  func performIfCurrentPlaybackGeneration(
+    _ expectedGeneration: UInt64,
+    _ mutation: () -> Void
+  ) -> Bool {
+    context.performIfCurrentPlaybackGeneration(expectedGeneration, mutation)
+  }
+
   /// Creates a new independent `AsyncStream` for consuming player events.
   /// Each stream is offered events broadcast after creation that pass its
   /// filter. Delivery under consumer lag follows `policy`.
@@ -563,6 +581,18 @@ private final class EventBridgeCallbackContext: Sendable {
 
   var currentPlaybackGeneration: UInt64 {
     playbackLifecycle.withLock { $0.currentGeneration }
+  }
+
+  @MainActor
+  func performIfCurrentPlaybackGeneration(
+    _ expectedGeneration: UInt64,
+    _ mutation: () -> Void
+  ) -> Bool {
+    playbackLifecycle.withLock { state in
+      guard state.currentGeneration == expectedGeneration else { return false }
+      mutation()
+      return true
+    }
   }
 
   func noteExternalMediaChanged(

--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -18,7 +18,12 @@ extension Player {
   /// libVLC's view of the player state — read directly from the
   /// underlying handle, not the cached `state` property.
   var nativePlaybackState: PlayerState {
-    PlayerState(from: libvlc_media_player_get_state(pointer))
+    #if DEBUG
+    if let _nativePlaybackStateOverrideForTesting {
+      return _nativePlaybackStateOverrideForTesting
+    }
+    #endif
+    return PlayerState(from: libvlc_media_player_get_state(pointer))
   }
 
   /// Whether issuing `set_pause(1)` right now is safe with respect to
@@ -171,6 +176,8 @@ extension Player {
       withMutation(keyPath: \.hasVideoOutput) {}
 
     case .mediaChanged:
+      let previousSessionGeneration = sessionGeneration
+      let playbackControlIntent = playbackControlIntent
       syncCurrentMediaFromNative()
       // A media change the wrapper did not initiate still has to supersede
       // whatever was restoring the previous session: a `MediaListPlayer`
@@ -198,14 +205,21 @@ extension Player {
         // without this the status would keep reporting the old session.
         publishPlaybackStatus()
       }
-      resetMediaDerivedState()
+      let adoptedExternalGeneration = sessionGeneration > previousSessionGeneration
+      let carriesPlaybackControl = adoptedExternalGeneration && playbackControlIntent != nil
+      resetMediaDerivedState(preservingPlaybackIntent: carriesPlaybackControl)
+      if adoptedExternalGeneration, let playbackControlIntent {
+        reconcilePauseControlAfterExternalMediaAdoption(
+          playbackGeneration: sessionGeneration,
+          command: playbackControlIntent
+        )
+      }
       refreshTracks()
       notifyMediaDependentObservables()
 
     case .encounteredError:
       publishPlaybackState(.error)
-      pauseTransition = nil
-      deferredPauseCommand = nil
+      clearPauseControlState(for: sessionGeneration)
       reconcilePlaybackIntent(for: .error)
 
     case .bufferingProgress(let pct):
@@ -316,6 +330,11 @@ extension Player {
     publishPlaybackIntent(active)
   }
 
+  func setPlaybackControlIntent(_ command: DeferredPauseCommand) {
+    playbackControlIntent = command
+    publishPlaybackIntent(command == .resume)
+  }
+
   /// Reconciles the published playback intent with libVLC's reported
   /// state, *unless* a user-initiated transition is in flight. While
   /// pausing or resuming, the intent published by `pause()`/`resume()`
@@ -331,6 +350,7 @@ extension Player {
       publishPlaybackIntent(false)
 
     case .idle, .stopped, .stopping, .error:
+      guard !hasPauseControl(after: sessionGeneration) else { return }
       publishPlaybackIntent(false)
     }
   }
@@ -342,28 +362,58 @@ extension Player {
   func updatePauseTransition(for newState: PlayerState) {
     switch (pauseTransition, newState) {
     case (.pausing, .paused), (.resuming, .playing):
+      guard pauseTransitionPlaybackGeneration == sessionGeneration else { return }
       pauseTransition = nil
       performDeferredPauseCommandIfNeeded()
     case (_, .idle), (_, .stopped), (_, .stopping), (_, .error):
-      pauseTransition = nil
-      deferredPauseCommand = nil
+      clearPauseControlState(for: sessionGeneration)
     default:
       break
     }
   }
 
+  /// Clears only pause work owned by `playbackGeneration`. A queued event for
+  /// an outgoing playlist item must not erase work already accepted for its
+  /// successor on the callback lane.
+  func clearPauseControlState(for playbackGeneration: UInt64) {
+    if pauseTransitionPlaybackGeneration == playbackGeneration {
+      pauseTransition = nil
+    }
+    if deferredPauseCommandPlaybackGeneration == playbackGeneration {
+      deferredPauseCommand = nil
+    }
+  }
+
+  /// Whether the callback lane has already accepted pause/resume work for a
+  /// media generation that the main actor has not adopted yet.
+  func hasPauseControl(after playbackGeneration: UInt64) -> Bool {
+    (pauseTransitionPlaybackGeneration ?? 0) > playbackGeneration
+      || (deferredPauseCommandPlaybackGeneration ?? 0) > playbackGeneration
+  }
+
   /// If a pause/resume command was deferred (because the player wasn't
   /// in a stable state at the time), retry it now.
   func performDeferredPauseCommandIfNeeded() {
-    guard pauseTransition == nil, let command = deferredPauseCommand else {
+    guard
+      pauseTransition == nil,
+      let command = deferredPauseCommand,
+      let playbackGeneration = deferredPauseCommandPlaybackGeneration,
+      playbackGeneration == sessionGeneration
+    else {
+      return
+    }
+    guard playbackGeneration == eventBridge.currentPlaybackGeneration else {
+      // The callback lane has already adopted a successor. Retrying this
+      // outgoing command would act on the shared native handle's new media.
+      deferredPauseCommand = nil
       return
     }
     deferredPauseCommand = nil
     switch command {
     case .pause:
-      pause()
+      _ = issuePause(playbackGeneration: playbackGeneration)
     case .resume:
-      resume()
+      _ = issueResume(playbackGeneration: playbackGeneration)
     }
   }
 
@@ -372,7 +422,7 @@ extension Player {
   /// Resets the observable state that depends on the current media —
   /// times, duration, seek/pause flags, buffer fill. Called when media
   /// is loaded or replaced.
-  func resetMediaDerivedState() {
+  func resetMediaDerivedState(preservingPlaybackIntent: Bool = false) {
     // New media, new timeline: clock samples still queued from the previous
     // one describe a media that is no longer loaded and must not be applied.
     acceptedTimelineRevision = eventBridge.advanceTimelineRevision()
@@ -381,9 +431,32 @@ extension Player {
     // "duration cleared, seekability still the previous media's". Suppress
     // those partial publishes and emit one atomic snapshot below.
     isSuppressingCapabilityPublish = true
-    pauseTransition = nil
-    deferredPauseCommand = nil
-    publishPlaybackIntent(false)
+    if
+      let pauseTransitionPlaybackGeneration,
+      pauseTransitionPlaybackGeneration < sessionGeneration {
+      pauseTransition = nil
+    }
+    // A native MediaListPlayer can advance the event bridge and accept a
+    // pause for a later item before queued media-change events reach the main
+    // actor. Preserve current and future commands through each adoption;
+    // commands from an older media generation are still retired.
+    if
+      let deferredPauseCommandPlaybackGeneration,
+      deferredPauseCommandPlaybackGeneration < sessionGeneration {
+      deferredPauseCommand = nil
+    }
+    // A deferred command was requested after the in-flight transition, so it
+    // is the latest user intent and wins when both survive adoption.
+    let intendsActivePlayback = if preservingPlaybackIntent {
+      isPlaybackRequestedActive
+    } else {
+      switch deferredPauseCommand {
+      case .pause: false
+      case .resume: true
+      case nil: pauseTransition == .resuming
+      }
+    }
+    publishPlaybackIntent(intendsActivePlayback)
     currentTime = .zero
     duration = nil
     isSeekable = false
@@ -400,6 +473,19 @@ extension Player {
     // generation carrying the outgoing media's capability — which would make
     // it distrust the poll for the rest of that media's lifetime.
     advanceCapabilityGeneration()
+  }
+
+  /// Re-applies the latest user intent to a media generation advanced by the
+  /// native callback lane. This is the authoritative close for a media switch
+  /// that occurs after `pause()` or `resume()` performs its final generation
+  /// read: adoption cannot clear the intent or leave the successor untouched.
+  func reconcilePauseControlAfterExternalMediaAdoption(
+    playbackGeneration: UInt64,
+    command: DeferredPauseCommand
+  ) {
+    guard !hasPauseControl(after: playbackGeneration) else { return }
+    setDeferredPauseCommand(command, playbackGeneration: playbackGeneration)
+    performDeferredPauseCommandIfNeeded()
   }
 
   /// Signals every observable whose value is read live from libVLC and

--- a/Sources/SwiftVLC/Player/Player+Pause.swift
+++ b/Sources/SwiftVLC/Player/Player+Pause.swift
@@ -1,0 +1,426 @@
+import CLibVLC
+
+extension Player {
+  /// Records a transition against an explicit generation. The explicit form
+  /// is required while a MediaListPlayer's callback lane is ahead of the main
+  /// actor's adopted `sessionGeneration`.
+  func setPauseTransition(
+    _ transition: PauseTransition?,
+    playbackGeneration: UInt64
+  ) {
+    pauseTransition = transition
+    pauseTransitionPlaybackGeneration = transition == nil ? nil : playbackGeneration
+  }
+
+  /// Records a deferred command without recapturing a newer callback-lane
+  /// generation when an older command is retried.
+  func setDeferredPauseCommand(
+    _ command: DeferredPauseCommand?,
+    playbackGeneration: UInt64
+  ) {
+    deferredPauseCommand = command
+    deferredPauseCommandPlaybackGeneration = command == nil ? nil : playbackGeneration
+  }
+
+  nonisolated static func pauseDecisionState(
+    cached: PlayerState,
+    native: PlayerState,
+    hasAttachedMediaListPlayer: Bool,
+    callbackLaneIsAhead: Bool,
+    mediaListPlaybackActive: Bool = false
+  ) -> PlayerState {
+    guard hasAttachedMediaListPlayer else { return cached }
+    // The cached state can describe the outgoing item both before and after
+    // `.mediaChanged` is adopted: the consumer deliberately yields before it
+    // handles the successor's queued state event. Prefer the native state in
+    // either window. When the callback lane is already on the successor but
+    // its shared handle is still idle, treat that startup gap as opening so a
+    // pause is retained for the new generation instead of being dropped.
+    if
+      callbackLaneIsAhead || mediaListPlaybackActive,
+      native == .idle || native == .stopped {
+      // The list player can report active before its shared media-player
+      // handle leaves a non-active state. This signal remains authoritative
+      // after the main actor adopts `.mediaChanged`, when the generation
+      // comparison alone no longer identifies the startup gap.
+      return .opening
+    }
+    // Otherwise retain an active cached state only for the narrow native
+    // `.idle` gap where the shared handle momentarily trails the observable
+    // state without either authoritative playlist-startup signal above.
+    if native != .idle || cached == .idle || cached == .stopped {
+      return native
+    }
+    return cached
+  }
+
+  /// Revalidates a playback generation after a native probe. A fresh user or
+  /// PiP pause follows the media that is current when the probe completes;
+  /// retrying an older deferred command stays bound to its original media and
+  /// is cancelled if the callback lane has already advanced.
+  nonisolated static func revalidatedPauseGeneration(
+    captured: UInt64,
+    current: UInt64,
+    followsCurrentGeneration: Bool
+  ) -> UInt64? {
+    guard captured != current else { return captured }
+    return followsCurrentGeneration ? current : nil
+  }
+
+  /// Pauses playback.
+  ///
+  /// If libVLC is visually playing but has not yet reached a stable,
+  /// pausable state, SwiftVLC keeps the pause request pending and issues
+  /// it once the native player reports that pausing is safe. With real
+  /// audio output, the first audio timestamp must also have advanced
+  /// beyond zero; pausing before that point can leave libVLC's aout
+  /// stream with stale pause timing.
+  public func pause() {
+    _ = issuePause()
+  }
+
+  /// Resumes playback from pause.
+  public func resume() {
+    _ = issueResume()
+  }
+
+  @discardableResult
+  func issuePause(playbackGeneration requestedGeneration: UInt64? = nil) -> Bool {
+    let followsCurrentGeneration = requestedGeneration == nil
+    let previousPlaybackControlIntent = playbackControlIntent
+    if followsCurrentGeneration {
+      playbackControlIntent = .pause
+    }
+    var playbackGeneration = requestedGeneration ?? eventBridge.currentPlaybackGeneration
+
+    // A playlist can advance again while the main actor is probing the shared
+    // native handle. Retry a bounded number of times to obtain a coherent
+    // generation/state/capability snapshot. If rapid advancement never
+    // stabilizes, retain the fresh request for the newest generation instead
+    // of spinning on the main actor or dropping it.
+    for probeAttempt in 0..<3 {
+      let generationBeforeProbe = eventBridge.currentPlaybackGeneration
+      guard
+        let revalidatedGeneration = Self.revalidatedPauseGeneration(
+          captured: playbackGeneration,
+          current: generationBeforeProbe,
+          followsCurrentGeneration: followsCurrentGeneration
+        )
+      else { return false }
+      playbackGeneration = revalidatedGeneration
+
+      guard pauseTransition == nil else {
+        retainDeferredPause(
+          playbackGeneration: playbackGeneration,
+          followsCurrentGeneration: followsCurrentGeneration
+        )
+        return false
+      }
+
+      // A MediaListPlayer drives this same native handle directly. Its native
+      // state can therefore advance before the event bridge has published the
+      // corresponding observable state on the main actor. Reconcile that lag
+      // before deciding an apparently idle player cannot be paused.
+      let listPlayer = attachedMediaListPlayer
+      let hasAttachedMediaListPlayer = listPlayer != nil
+      let nativeState = nativePlaybackState
+      let mediaListPlaybackActive = listPlayer?.isPlaying == true
+      #if DEBUG
+      _pauseProbeHookForTesting?(.state)
+      #endif
+      let generationAfterStateProbe = eventBridge.currentPlaybackGeneration
+      guard
+        let generationAfterStateProbe = Self.revalidatedPauseGeneration(
+          captured: playbackGeneration,
+          current: generationAfterStateProbe,
+          followsCurrentGeneration: followsCurrentGeneration
+        )
+      else { return false }
+      if generationAfterStateProbe != playbackGeneration {
+        playbackGeneration = generationAfterStateProbe
+        if probeAttempt < 2 {
+          continue
+        }
+        retainDeferredPause(
+          playbackGeneration: playbackGeneration,
+          followsCurrentGeneration: followsCurrentGeneration
+        )
+        return false
+      }
+
+      let isAheadOfAdoptedMedia = hasAttachedMediaListPlayer
+        && playbackGeneration != sessionGeneration
+      let effectiveState = Self.pauseDecisionState(
+        cached: state,
+        native: nativeState,
+        hasAttachedMediaListPlayer: hasAttachedMediaListPlayer,
+        callbackLaneIsAhead: isAheadOfAdoptedMedia,
+        mediaListPlaybackActive: mediaListPlaybackActive
+      )
+      switch effectiveState {
+      case .playing:
+        break
+      case .opening, .buffering:
+        retainDeferredPause(
+          playbackGeneration: playbackGeneration,
+          followsCurrentGeneration: followsCurrentGeneration
+        )
+        return false
+      case .paused:
+        if
+          deferredPauseCommand == .resume,
+          deferredPauseCommandPlaybackGeneration == playbackGeneration {
+          deferredPauseCommand = nil
+        }
+        publishPlaybackIntent(false)
+        return false
+      default:
+        if followsCurrentGeneration {
+          #if DEBUG
+          _pauseProbeHookForTesting?(.pauseRollback)
+          #endif
+          let didRestorePreviousIntent = eventBridge.performIfCurrentPlaybackGeneration(
+            playbackGeneration
+          ) {
+            playbackControlIntent = previousPlaybackControlIntent
+          }
+          if !didRestorePreviousIntent {
+            retainDeferredPause(
+              playbackGeneration: playbackGeneration,
+              followsCurrentGeneration: true
+            )
+          }
+        }
+        return false
+      }
+
+      // Keep this probe side-effect free until its generation is validated.
+      // Refreshing observable capabilities here could publish values from a
+      // successor under the outgoing media's generation.
+      let nativeCanPause = libvlc_media_player_can_pause(pointer)
+      let nativePauseIsSafe = canIssueNativePause
+      #if DEBUG
+      _pauseProbeHookForTesting?(.capability)
+      #endif
+      let generationAfterCapabilityProbe = eventBridge.currentPlaybackGeneration
+      guard
+        let generationAfterCapabilityProbe = Self.revalidatedPauseGeneration(
+          captured: playbackGeneration,
+          current: generationAfterCapabilityProbe,
+          followsCurrentGeneration: followsCurrentGeneration
+        )
+      else { return false }
+      if generationAfterCapabilityProbe != playbackGeneration {
+        playbackGeneration = generationAfterCapabilityProbe
+        if probeAttempt < 2 {
+          continue
+        }
+        retainDeferredPause(
+          playbackGeneration: playbackGeneration,
+          followsCurrentGeneration: followsCurrentGeneration
+        )
+        return false
+      }
+      guard nativeCanPause, nativePauseIsSafe else {
+        retainDeferredPause(
+          playbackGeneration: playbackGeneration,
+          followsCurrentGeneration: followsCurrentGeneration
+        )
+        return false
+      }
+
+      setPauseTransition(.pausing, playbackGeneration: playbackGeneration)
+      deferredPauseCommand = nil
+      publishPlaybackIntent(false)
+      libvlc_media_player_set_pause(pointer, 1)
+
+      // Close the final check-to-command race. The native pause may already
+      // have reached either side of the media boundary; retaining the request
+      // for a newly observed successor guarantees the latest media still
+      // settles paused after adoption clears the outgoing transition.
+      if followsCurrentGeneration {
+        let generationAfterPause = eventBridge.currentPlaybackGeneration
+        if generationAfterPause != playbackGeneration {
+          setDeferredPauseCommand(.pause, playbackGeneration: generationAfterPause)
+        }
+      }
+      return true
+    }
+    return false
+  }
+
+  /// Stores a fresh pause against the newest callback-lane generation, while
+  /// leaving an explicitly retried command bound to its original generation.
+  private func retainDeferredPause(
+    playbackGeneration: UInt64,
+    followsCurrentGeneration: Bool
+  ) {
+    let generation = followsCurrentGeneration
+      ? eventBridge.currentPlaybackGeneration
+      : playbackGeneration
+    setDeferredPauseCommand(.pause, playbackGeneration: generation)
+    publishPlaybackIntent(false)
+  }
+
+  @discardableResult
+  func issueResume(playbackGeneration requestedGeneration: UInt64? = nil) -> Bool {
+    let followsCurrentGeneration = requestedGeneration == nil
+    let previousPlaybackControlIntent = playbackControlIntent
+    if followsCurrentGeneration {
+      playbackControlIntent = .resume
+    }
+    var playbackGeneration = requestedGeneration ?? eventBridge.currentPlaybackGeneration
+
+    for probeAttempt in 0..<3 {
+      let generationBeforeProbe = eventBridge.currentPlaybackGeneration
+      guard
+        let revalidatedGeneration = Self.revalidatedPauseGeneration(
+          captured: playbackGeneration,
+          current: generationBeforeProbe,
+          followsCurrentGeneration: followsCurrentGeneration
+        )
+      else { return false }
+      playbackGeneration = revalidatedGeneration
+
+      guard pauseTransition == nil else {
+        let generation = followsCurrentGeneration
+          ? eventBridge.currentPlaybackGeneration
+          : playbackGeneration
+        setDeferredPauseCommand(.resume, playbackGeneration: generation)
+        publishPlaybackIntent(true)
+        return true
+      }
+
+      let nativeState = nativePlaybackState
+      #if DEBUG
+      _pauseProbeHookForTesting?(.resumeState)
+      #endif
+      let generationAfterProbe = eventBridge.currentPlaybackGeneration
+      guard
+        let generationAfterProbe = Self.revalidatedPauseGeneration(
+          captured: playbackGeneration,
+          current: generationAfterProbe,
+          followsCurrentGeneration: followsCurrentGeneration
+        )
+      else { return false }
+      if generationAfterProbe != playbackGeneration {
+        playbackGeneration = generationAfterProbe
+        if probeAttempt < 2 {
+          continue
+        }
+        setDeferredPauseCommand(.resume, playbackGeneration: playbackGeneration)
+        publishPlaybackIntent(true)
+        return true
+      }
+
+      if
+        deferredPauseCommand == .pause,
+        deferredPauseCommandPlaybackGeneration == playbackGeneration {
+        deferredPauseCommand = nil
+        if nativeState != .paused {
+          if
+            retainDeferredResumeIfPlaybackIsStillSettling(
+              nativeState: nativeState,
+              playbackGeneration: playbackGeneration
+            ) {
+            publishPlaybackIntent(true)
+            return true
+          }
+          publishPlaybackIntent(true)
+          return true
+        }
+      }
+
+      guard nativeState == .paused else {
+        if
+          retainDeferredResumeIfPlaybackIsStillSettling(
+            nativeState: nativeState,
+            playbackGeneration: playbackGeneration
+          ) {
+          publishPlaybackIntent(true)
+          return true
+        }
+        if state == .paused, nativeState.isActive {
+          if playbackGeneration == sessionGeneration {
+            publishPlaybackState(nativeState)
+          }
+          publishPlaybackIntent(true)
+          return true
+        }
+        if state.isActive {
+          publishPlaybackIntent(true)
+          return true
+        }
+        if followsCurrentGeneration {
+          #if DEBUG
+          _pauseProbeHookForTesting?(.resumeRollback)
+          #endif
+          let didRestorePreviousIntent = eventBridge.performIfCurrentPlaybackGeneration(
+            playbackGeneration
+          ) {
+            playbackControlIntent = previousPlaybackControlIntent
+          }
+          if !didRestorePreviousIntent {
+            setDeferredPauseCommand(
+              .resume,
+              playbackGeneration: eventBridge.currentPlaybackGeneration
+            )
+            publishPlaybackIntent(true)
+          }
+        }
+        return false
+      }
+
+      setPauseTransition(.resuming, playbackGeneration: playbackGeneration)
+      if deferredPauseCommandPlaybackGeneration == playbackGeneration {
+        deferredPauseCommand = nil
+      }
+      publishPlaybackIntent(true)
+      libvlc_media_player_set_pause(pointer, 0)
+
+      if followsCurrentGeneration {
+        let generationAfterResume = eventBridge.currentPlaybackGeneration
+        if generationAfterResume != playbackGeneration {
+          setDeferredPauseCommand(.resume, playbackGeneration: generationAfterResume)
+        }
+      }
+      return true
+    }
+    return false
+  }
+
+  /// A resume observed while the successor is still opening is not complete:
+  /// an earlier pause call may still settle after this probe. Keep the resume
+  /// generation-scoped until native playback confirms either playing or
+  /// paused, at which point the retry can finish or issue the unpause.
+  private func retainDeferredResumeIfPlaybackIsStillSettling(
+    nativeState: PlayerState,
+    playbackGeneration: UInt64
+  ) -> Bool {
+    let listStartupIsActive = attachedMediaListPlayer?.isPlaying == true
+    if
+      nativeState == .opening || nativeState == .buffering
+      || (listStartupIsActive && (nativeState == .idle || nativeState == .stopped)) {
+      setDeferredPauseCommand(.resume, playbackGeneration: playbackGeneration)
+      return true
+    }
+    return false
+  }
+
+  func cancelPendingPause() {
+    if deferredPauseCommand == .pause {
+      deferredPauseCommand = nil
+      setPlaybackControlIntent(.resume)
+    }
+  }
+
+  /// Retires every pause/resume command when an external owner of the shared
+  /// native handle accepts a stop. A stale deferred command must not survive
+  /// until a later list adoption and become authoritative again.
+  func clearPlaybackControlForExternalStop() {
+    pauseTransition = nil
+    deferredPauseCommand = nil
+    playbackControlIntent = nil
+    publishPlaybackIntent(false)
+  }
+}

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -456,8 +456,54 @@ public final class Player {
     case resume
   }
 
-  var pauseTransition: PauseTransition?
-  var deferredPauseCommand: DeferredPauseCommand?
+  /// Latest explicit transport intent. Unlike a generation-scoped deferred
+  /// command, this survives a native playlist boundary so adoption can carry
+  /// a pause or resume that raced with the media switch.
+  @ObservationIgnored
+  var playbackControlIntent: DeferredPauseCommand?
+
+  #if DEBUG
+  /// Lets deterministic tests advance the callback-lane generation at the
+  /// otherwise unschedulable boundaries between a native probe and its
+  /// generation revalidation. Compiled out of release builds.
+  enum PauseProbeStage {
+    case state
+    case capability
+    case pauseRollback
+    case resumeState
+    case resumeRollback
+  }
+
+  @ObservationIgnored
+  var _pauseProbeHookForTesting: ((PauseProbeStage) -> Void)?
+  @ObservationIgnored
+  var _nativePlaybackStateOverrideForTesting: PlayerState?
+  #endif
+
+  var pauseTransition: PauseTransition? {
+    didSet {
+      pauseTransitionPlaybackGeneration = pauseTransition == nil
+        ? nil
+        : eventBridge.currentPlaybackGeneration
+    }
+  }
+
+  /// Native playback generation the in-flight transition was issued against.
+  var pauseTransitionPlaybackGeneration: UInt64?
+  var deferredPauseCommand: DeferredPauseCommand? {
+    didSet {
+      deferredPauseCommandPlaybackGeneration = deferredPauseCommand == nil
+        ? nil
+        : eventBridge.currentPlaybackGeneration
+    }
+  }
+
+  /// Native playback generation the deferred command was accepted against.
+  /// The event bridge can advance before its media-change event reaches the
+  /// main actor, so this is more authoritative than `sessionGeneration` while
+  /// a MediaListPlayer is opening its next item.
+  var deferredPauseCommandPlaybackGeneration: UInt64?
+
   /// Shadow of the string last passed to `Marquee.setText`. libVLC's text
   /// renderer keys its glyph-bitmap cache on the text string, so a style-
   /// only write (color/opacity/fontSize) hits the cached entry and draws
@@ -652,6 +698,7 @@ public final class Player {
     currentMedia = media
     sessionGenerationMedia = media.pointer
     publishPlaybackStatus()
+    playbackControlIntent = nil
     resetMediaDerivedState()
     libvlc_media_player_set_media(pointer, media.pointer)
     notifyMediaDependentObservables()
@@ -695,6 +742,7 @@ public final class Player {
       // No `notifyMediaDependentObservables()` here: the swap already issued
       // it, and the keypaths it refreshes read from the native handle rather
       // than from `currentMedia`, so a second pass is pure churn.
+      playbackControlIntent = nil
       resetMediaDerivedState()
     } else {
       load(media)
@@ -727,13 +775,14 @@ public final class Player {
     try prepareDrawableForPlayback()
     didReachEnd = false
     if libvlc_media_player_play(pointer) == -1 {
+      playbackControlIntent = nil
       publishPlaybackIntent(false)
       publishPlaybackState(Self.stateAfterRejectedStart(previous: state))
       let reason = libvlc_errmsg().map { String(cString: $0) } ?? "unknown"
       throw .playbackFailed(reason: reason)
     }
     nativePlayerHasStartedPlayback = true
-    publishPlaybackIntent(true)
+    setPlaybackControlIntent(.resume)
   }
 
   /// The lifecycle state to publish when libVLC refuses to start.
@@ -750,98 +799,6 @@ public final class Player {
   /// is not something a test can force, including on an empty player.
   nonisolated static func stateAfterRejectedStart(previous: PlayerState) -> PlayerState {
     previous.isActive ? .error : previous
-  }
-
-  /// Pauses playback.
-  ///
-  /// If libVLC is visually playing but has not yet reached a stable,
-  /// pausable state, SwiftVLC keeps the pause request pending and issues
-  /// it once the native player reports that pausing is safe. With real
-  /// audio output, the first audio timestamp must also have advanced
-  /// beyond zero; pausing before that point can leave libVLC's aout
-  /// stream with stale pause timing.
-  public func pause() {
-    _ = issuePause()
-  }
-
-  /// Resumes playback from pause.
-  public func resume() {
-    _ = issueResume()
-  }
-
-  @discardableResult
-  func issuePause() -> Bool {
-    guard pauseTransition == nil else {
-      deferredPauseCommand = .pause
-      publishPlaybackIntent(false)
-      return false
-    }
-    switch state {
-    case .playing:
-      break
-    case .opening, .buffering:
-      deferredPauseCommand = .pause
-      publishPlaybackIntent(false)
-      return false
-    case .paused:
-      publishPlaybackIntent(false)
-      return false
-    default:
-      return false
-    }
-    refreshNativeStateIfNeeded()
-    guard isPausable, canIssueNativePause else {
-      deferredPauseCommand = .pause
-      publishPlaybackIntent(false)
-      return false
-    }
-
-    pauseTransition = .pausing
-    deferredPauseCommand = nil
-    publishPlaybackIntent(false)
-    libvlc_media_player_set_pause(pointer, 1)
-    return true
-  }
-
-  @discardableResult
-  func issueResume() -> Bool {
-    guard pauseTransition == nil else {
-      deferredPauseCommand = .resume
-      publishPlaybackIntent(true)
-      return true
-    }
-    if deferredPauseCommand == .pause {
-      deferredPauseCommand = nil
-      publishPlaybackIntent(true)
-      return true
-    }
-    cancelPendingPause()
-    let nativeState = nativePlaybackState
-    guard nativeState == .paused else {
-      if state == .paused, nativeState.isActive {
-        publishPlaybackState(nativeState)
-        publishPlaybackIntent(true)
-        return true
-      }
-      if state.isActive {
-        publishPlaybackIntent(true)
-        return true
-      }
-      return false
-    }
-
-    pauseTransition = .resuming
-    deferredPauseCommand = nil
-    publishPlaybackIntent(true)
-    libvlc_media_player_set_pause(pointer, 0)
-    return true
-  }
-
-  func cancelPendingPause() {
-    if deferredPauseCommand == .pause {
-      deferredPauseCommand = nil
-      publishPlaybackIntent(true)
-    }
   }
 
   var shouldResumeForExternalPlayRequest: Bool {
@@ -892,9 +849,7 @@ public final class Player {
     if shouldResumeNativePlayerBeforeStop {
       libvlc_media_player_set_pause(pointer, 0)
     }
-    pauseTransition = nil
-    deferredPauseCommand = nil
-    publishPlaybackIntent(false)
+    clearPlaybackControlForExternalStop()
     if nativePlayerHasHostedDrawable {
       nativePlayerNeedsReplacementBeforePlayback = true
       needsDrawableRebindForPlayback = true

--- a/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
+++ b/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
@@ -179,6 +179,9 @@ public final class MediaListPlayer {
   /// Starts playing the media list from the beginning.
   public func play() {
     libvlc_media_list_player_play(pointer)
+    if _mediaList?.isEmpty == false {
+      publishAcceptedPlayIntent()
+    }
   }
 
   /// Toggles between playing and paused. No-op in transient states
@@ -207,12 +210,26 @@ public final class MediaListPlayer {
 
   /// Pauses playback.
   public func pause() {
-    libvlc_media_list_player_set_pause(pointer, 1)
+    if let mediaPlayer = _mediaPlayer {
+      // The list-player "playing" flag can become true while the attached
+      // media player is still opening or waiting for its first audio
+      // timestamp. Sending the raw list-player pause in that window can be
+      // lost (and bypasses Player's audio-output safety gate). Route through
+      // the attached wrapper so its deferred-pause state machine retries the
+      // command as soon as the shared native handle is pausable.
+      mediaPlayer.pause()
+    } else {
+      libvlc_media_list_player_set_pause(pointer, 1)
+    }
   }
 
   /// Resumes playback.
   public func resume() {
-    libvlc_media_list_player_set_pause(pointer, 0)
+    if let mediaPlayer = _mediaPlayer {
+      mediaPlayer.resume()
+    } else {
+      libvlc_media_list_player_set_pause(pointer, 0)
+    }
   }
 
   /// Whether the list player is currently playing.
@@ -240,6 +257,7 @@ public final class MediaListPlayer {
     guard libvlc_media_list_player_play_item_at_index(pointer, index) == 0 else {
       throw .operationFailed("Play item at index \(index)")
     }
+    publishAcceptedPlayIntent()
   }
 
   /// Plays a specific media item from the list.
@@ -252,11 +270,13 @@ public final class MediaListPlayer {
     guard libvlc_media_list_player_play_item(pointer, media.pointer) == 0 else {
       throw .operationFailed("Play media item")
     }
+    publishAcceptedPlayIntent()
   }
 
   /// Stops playback asynchronously.
   public func stop() {
     libvlc_media_list_player_stop_async(pointer)
+    _mediaPlayer?.clearPlaybackControlForExternalStop()
   }
 
   /// Advances to the next item in the list.
@@ -265,6 +285,7 @@ public final class MediaListPlayer {
     guard libvlc_media_list_player_next(pointer) == 0 else {
       throw .operationFailed("Advance to next item")
     }
+    publishAcceptedPlayIntent()
   }
 
   /// Goes back to the previous item in the list.
@@ -273,6 +294,17 @@ public final class MediaListPlayer {
     guard libvlc_media_list_player_previous(pointer) == 0 else {
       throw .operationFailed("Go to previous item")
     }
+    publishAcceptedPlayIntent()
+  }
+
+  /// Records an accepted list play before reconciling the shared native
+  /// handle. Prepublishing resume makes a stable native-idle response preserve
+  /// the accepted command, while `issueResume` replaces an older deferred or
+  /// in-flight pause when list playback is already starting.
+  private func publishAcceptedPlayIntent() {
+    guard let mediaPlayer = _mediaPlayer else { return }
+    mediaPlayer.setPlaybackControlIntent(.resume)
+    mediaPlayer.resume()
   }
 
   /// Relinquishes a player that another list player is about to adopt. Keep

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
@@ -755,7 +755,7 @@ extension Integration {
     }
 
     @Test
-    func `macOS native PiP media controller defaults without player`() async {
+    func `macOS native PiP media controller defaults without player`() async throws {
       let mediaController = MacNativePiPMediaController()
       let didComplete = Box(false)
 
@@ -765,7 +765,7 @@ extension Integration {
         didComplete.value = true
       }
 
-      await Task.yield()
+      try #require(await poll(until: { didComplete.value }))
 
       #expect(didComplete.value)
       #expect(mediaController.mediaLength() == -1)
@@ -775,7 +775,7 @@ extension Integration {
     }
 
     @Test
-    func `macOS native PiP media controller reads player defaults and completes seek`() async {
+    func `macOS native PiP media controller reads player defaults and completes seek`() async throws {
       let player = Player(instance: TestInstance.shared)
       player._setStateForTesting(
         currentTime: .seconds(5),
@@ -793,7 +793,7 @@ extension Integration {
         didComplete.value = true
       }
 
-      await Task.yield()
+      try #require(await poll(until: { didComplete.value }))
       player.setPlaybackIntentFromExternalControl(false)
 
       #expect(didComplete.value)

--- a/Tests/SwiftVLCTests/Player/PlayerBranchCoverageTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerBranchCoverageTests.swift
@@ -129,6 +129,7 @@ extension Integration {
       player.cancelPendingPause()
 
       #expect(player.deferredPauseCommand == nil)
+      #expect(player.playbackControlIntent == .resume)
       #expect(player.isPlaybackRequestedActive)
     }
 

--- a/Tests/SwiftVLCTests/Playlist/MediaListPlayerExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Playlist/MediaListPlayerExtendedTests.swift
@@ -1,4 +1,5 @@
 @testable import SwiftVLC
+import Synchronization
 import Testing
 
 extension Integration {
@@ -124,8 +125,578 @@ extension Integration {
       listPlayer.play()
       try #require(await poll(until: { listPlayer.isPlaying }), "Waiting for: listPlayer.isPlaying")
       listPlayer.pause()
-      try #require(await poll(until: { listPlayer.state == .paused }), "Waiting for: listPlayer.state == .paused")
+      let immediateDiagnostic =
+        "after pause: list=\(listPlayer.state), player=\(player.state), native=\(player.nativePlaybackState), "
+          + "pausable=\(player.isPausable), deferred=\(String(describing: player.deferredPauseCommand)), "
+          + "transition=\(String(describing: player.pauseTransition)); "
+      let reachedPaused = try await poll(until: { listPlayer.state == .paused })
+      let diagnostic =
+        immediateDiagnostic
+          + "at timeout: list=\(listPlayer.state), player=\(player.state), native=\(player.nativePlaybackState), "
+          + "pausable=\(player.isPausable), deferred=\(String(describing: player.deferredPauseCommand)), "
+          + "transition=\(String(describing: player.pauseTransition))"
+      #expect(
+        reachedPaused,
+        Comment(rawValue: diagnostic)
+      )
       listPlayer.stop()
+    }
+
+    @Test
+    func `Pause while cached playback is opening is deferred`() {
+      let instance = TestInstance.shared
+      let player = Player(instance: instance)
+      player._setStateForTesting(state: .opening, isPlaybackRequestedActive: true)
+
+      player.pause()
+
+      #expect(player.deferredPauseCommand == .pause)
+      #expect(player.isPlaybackRequestedActive == false)
+    }
+
+    @Test
+    func `Resume cancels an attached player's deferred pause`() {
+      let instance = TestInstance.shared
+      let listPlayer = MediaListPlayer(instance: instance)
+      let player = Player(instance: instance)
+      listPlayer.mediaPlayer = player
+      player.setDeferredPauseCommand(.pause, playbackGeneration: player.sessionGeneration)
+      player.publishPlaybackIntent(false)
+
+      listPlayer.resume()
+
+      #expect(player.deferredPauseCommand == nil)
+      #expect(player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `List play and stop publish explicit transport intent only for a playable list`() throws {
+      let listPlayer = MediaListPlayer(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.shared)
+      listPlayer.mediaPlayer = player
+      player.setPlaybackControlIntent(.pause)
+
+      listPlayer.play()
+
+      #expect(player.playbackControlIntent == .pause)
+      #expect(!player.isPlaybackRequestedActive)
+
+      let list = MediaList()
+      try list.append(Media(url: TestMedia.twosecURL))
+      listPlayer.mediaList = list
+      listPlayer.play()
+
+      #expect(player.playbackControlIntent == .resume)
+      #expect(player.isPlaybackRequestedActive)
+
+      player.setPauseTransition(
+        .pausing,
+        playbackGeneration: player.eventBridge.currentPlaybackGeneration
+      )
+      player.setDeferredPauseCommand(
+        .pause,
+        playbackGeneration: player.eventBridge.currentPlaybackGeneration
+      )
+      player.setPlaybackControlIntent(.pause)
+      listPlayer.stop()
+
+      #expect(player.playbackControlIntent == nil)
+      #expect(player.pauseTransition == nil)
+      #expect(player.deferredPauseCommand == nil)
+      #expect(!player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `Idle pause rejection preserves the previous transport intent`() {
+      let player = Player(instance: TestInstance.shared)
+      player._nativePlaybackStateOverrideForTesting = .idle
+      player.setPlaybackControlIntent(.resume)
+
+      player.pause()
+
+      #expect(player.playbackControlIntent == .resume)
+      #expect(player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `Idle resume rejection preserves the previous transport intent`() {
+      let player = Player(instance: TestInstance.shared)
+      player._nativePlaybackStateOverrideForTesting = .idle
+      player.setPlaybackControlIntent(.pause)
+
+      player.resume()
+
+      #expect(player.playbackControlIntent == .pause)
+      #expect(!player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `Pause rollback cannot erase intent after callback-lane advancement`() {
+      let listPlayer = MediaListPlayer(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.shared)
+      listPlayer.mediaPlayer = player
+      player._nativePlaybackStateOverrideForTesting = .idle
+      player.setPlaybackControlIntent(.resume)
+      player._pauseProbeHookForTesting = { stage in
+        guard stage == .pauseRollback else { return }
+        _ = player.eventBridge.synchronizePlaybackGeneration(1, media: nil)
+      }
+
+      player.pause()
+
+      #expect(player.playbackControlIntent == .pause)
+      #expect(player.deferredPauseCommand == .pause)
+      #expect(player.deferredPauseCommandPlaybackGeneration == 1)
+      #expect(!player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `Resume rollback cannot erase intent after callback-lane advancement`() {
+      let listPlayer = MediaListPlayer(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.shared)
+      listPlayer.mediaPlayer = player
+      player._nativePlaybackStateOverrideForTesting = .idle
+      player.setPlaybackControlIntent(.pause)
+      player._pauseProbeHookForTesting = { stage in
+        guard stage == .resumeRollback else { return }
+        _ = player.eventBridge.synchronizePlaybackGeneration(1, media: nil)
+      }
+
+      player.resume()
+
+      #expect(player.playbackControlIntent == .resume)
+      #expect(player.deferredPauseCommand == .resume)
+      #expect(player.deferredPauseCommandPlaybackGeneration == 1)
+      #expect(player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `Accepted list play supersedes a deferred pause while opening`() throws {
+      let listPlayer = MediaListPlayer(instance: TestInstance.shared)
+      let player = Player(instance: TestInstance.shared)
+      listPlayer.mediaPlayer = player
+      let list = MediaList()
+      try list.append(Media(url: TestMedia.twosecURL))
+      listPlayer.mediaList = list
+      player._nativePlaybackStateOverrideForTesting = .opening
+      player.setDeferredPauseCommand(
+        .pause,
+        playbackGeneration: player.eventBridge.currentPlaybackGeneration
+      )
+      player.setPlaybackControlIntent(.pause)
+
+      listPlayer.play()
+
+      #expect(player.playbackControlIntent == .resume)
+      #expect(player.deferredPauseCommand == .resume)
+      #expect(
+        player.deferredPauseCommandPlaybackGeneration
+          == player.eventBridge.currentPlaybackGeneration
+      )
+      #expect(player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `Pause cancellation carries resume rather than stale pause into adoption`() {
+      let player = Player(instance: TestInstance.shared)
+      player._nativePlaybackStateOverrideForTesting = .playing
+      player.setDeferredPauseCommand(.pause, playbackGeneration: 0)
+      player.setPlaybackControlIntent(.pause)
+
+      player.cancelPendingPause()
+      _ = player.eventBridge.synchronizePlaybackGeneration(1, media: nil)
+      player.handleEvent(.mediaChanged, sourcePlaybackGeneration: 1)
+
+      #expect(player.playbackControlIntent == .resume)
+      #expect(player.deferredPauseCommand == nil)
+      #expect(player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `Media adoption preserves a pause accepted for its native generation`() {
+      let player = Player(instance: TestInstance.shared)
+      let adoptedGeneration: UInt64 = 1
+      player.sessionGeneration = adoptedGeneration
+      _ = player.eventBridge.synchronizePlaybackGeneration(adoptedGeneration, media: nil)
+      player.deferredPauseCommand = .pause
+
+      player.resetMediaDerivedState()
+
+      #expect(player.deferredPauseCommand == .pause)
+    }
+
+    @Test
+    func `Playlist pause decisions use successor native state while adoption is queued`() {
+      for staleState in [PlayerState.idle, .stopped, .playing] {
+        #expect(
+          Player.pauseDecisionState(
+            cached: staleState,
+            native: .opening,
+            hasAttachedMediaListPlayer: true,
+            callbackLaneIsAhead: true
+          ) == .opening
+        )
+      }
+      #expect(
+        Player.pauseDecisionState(
+          cached: .playing,
+          native: .idle,
+          hasAttachedMediaListPlayer: true,
+          callbackLaneIsAhead: true
+        ) == .opening
+      )
+      #expect(
+        Player.pauseDecisionState(
+          cached: .stopped,
+          native: .idle,
+          hasAttachedMediaListPlayer: true,
+          callbackLaneIsAhead: false,
+          mediaListPlaybackActive: true
+        ) == .opening
+      )
+      #expect(
+        Player.pauseDecisionState(
+          cached: .stopped,
+          native: .stopped,
+          hasAttachedMediaListPlayer: true,
+          callbackLaneIsAhead: false,
+          mediaListPlaybackActive: true
+        ) == .opening
+      )
+      #expect(
+        Player.pauseDecisionState(
+          cached: .stopped,
+          native: .idle,
+          hasAttachedMediaListPlayer: true,
+          callbackLaneIsAhead: false,
+          mediaListPlaybackActive: false
+        ) == .idle
+      )
+      #expect(
+        Player.pauseDecisionState(
+          cached: .stopped,
+          native: .opening,
+          hasAttachedMediaListPlayer: true,
+          callbackLaneIsAhead: false
+        ) == .opening
+      )
+      #expect(
+        Player.pauseDecisionState(
+          cached: .stopped,
+          native: .paused,
+          hasAttachedMediaListPlayer: true,
+          callbackLaneIsAhead: false
+        ) == .paused
+      )
+      #expect(
+        Player.pauseDecisionState(
+          cached: .stopped,
+          native: .opening,
+          hasAttachedMediaListPlayer: false,
+          callbackLaneIsAhead: true
+        ) == .stopped
+      )
+      #expect(
+        Player.pauseDecisionState(
+          cached: .playing,
+          native: .idle,
+          hasAttachedMediaListPlayer: true,
+          callbackLaneIsAhead: false
+        ) == .playing
+      )
+    }
+
+    @Test
+    func `Fresh pause control follows a generation that advances during native probes`() {
+      #expect(
+        Player.revalidatedPauseGeneration(
+          captured: 1,
+          current: 2,
+          followsCurrentGeneration: true
+        ) == 2
+      )
+      #expect(
+        Player.revalidatedPauseGeneration(
+          captured: 1,
+          current: 2,
+          followsCurrentGeneration: false
+        ) == nil
+      )
+    }
+
+    @Test
+    func `Fresh pause retains the newest generation after repeated state probe races`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .playing)
+      var generation: UInt64 = 0
+      player._pauseProbeHookForTesting = { stage in
+        guard stage == .state else { return }
+        generation &+= 1
+        _ = player.eventBridge.synchronizePlaybackGeneration(generation, media: nil)
+      }
+
+      #expect(!player.issuePause())
+      #expect(generation == 3)
+      #expect(player.deferredPauseCommand == .pause)
+      #expect(player.deferredPauseCommandPlaybackGeneration == generation)
+      #expect(!player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `Fresh pause retains the newest generation after repeated capability probe races`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(
+        state: .playing,
+        duration: .seconds(120),
+        isSeekable: true,
+        isPausable: true
+      )
+      let capabilityBeforeRace = player.capabilitySnapshot.withLock { $0 }
+      var generation: UInt64 = 0
+      player._pauseProbeHookForTesting = { stage in
+        guard stage == .capability else { return }
+        generation &+= 1
+        _ = player.eventBridge.synchronizePlaybackGeneration(generation, media: nil)
+      }
+
+      #expect(!player.issuePause())
+      #expect(generation == 3)
+      #expect(player.deferredPauseCommand == .pause)
+      #expect(player.deferredPauseCommandPlaybackGeneration == generation)
+      #expect(!player.isPlaybackRequestedActive)
+      #expect(player.capabilitySnapshot.withLock { $0 } == capabilityBeforeRace)
+    }
+
+    @Test
+    func `Fresh resume retains the newest generation after repeated state probe races`() {
+      let player = Player(instance: TestInstance.shared)
+      var generation: UInt64 = 0
+      player._pauseProbeHookForTesting = { stage in
+        guard stage == .resumeState else { return }
+        generation &+= 1
+        _ = player.eventBridge.synchronizePlaybackGeneration(generation, media: nil)
+      }
+
+      #expect(player.issueResume())
+      #expect(generation == 3)
+      #expect(player.deferredPauseCommand == .resume)
+      #expect(player.deferredPauseCommandPlaybackGeneration == generation)
+      #expect(player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `An outgoing resume retry cannot clear a successor pause`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .paused)
+      _ = player.eventBridge.synchronizePlaybackGeneration(1, media: nil)
+      player.setDeferredPauseCommand(.pause, playbackGeneration: 1)
+
+      #expect(!player.issueResume(playbackGeneration: 0))
+      #expect(player.deferredPauseCommand == .pause)
+      #expect(player.deferredPauseCommandPlaybackGeneration == 1)
+    }
+
+    @Test
+    func `Resume unpauses when a recovered successor pause already landed`() {
+      let player = Player(instance: TestInstance.shared)
+      let generation: UInt64 = 1
+      player.sessionGeneration = generation
+      _ = player.eventBridge.synchronizePlaybackGeneration(generation, media: nil)
+      player._nativePlaybackStateOverrideForTesting = .paused
+      player.setDeferredPauseCommand(.pause, playbackGeneration: generation)
+      player.publishPlaybackIntent(false)
+
+      #expect(player.issueResume())
+      #expect(player.deferredPauseCommand == nil)
+      #expect(player.pauseTransition == .resuming)
+      #expect(player.pauseTransitionPlaybackGeneration == generation)
+      #expect(player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `External media adoption carries pause intent to the successor`() {
+      let player = Player(instance: TestInstance.shared)
+      player._nativePlaybackStateOverrideForTesting = .opening
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      player.setPlaybackControlIntent(.pause)
+      _ = player.eventBridge.synchronizePlaybackGeneration(1, media: nil)
+
+      player.handleEvent(.mediaChanged, sourcePlaybackGeneration: 1)
+
+      #expect(player.sessionGeneration == 1)
+      #expect(player.deferredPauseCommand == .pause)
+      #expect(player.deferredPauseCommandPlaybackGeneration == 1)
+      #expect(!player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `External media adoption preserves active intent through its queued-state gap`() {
+      let player = Player(instance: TestInstance.shared)
+      player._nativePlaybackStateOverrideForTesting = .playing
+      player._setStateForTesting(state: .paused, isPlaybackRequestedActive: false)
+      player.setPlaybackControlIntent(.resume)
+      _ = player.eventBridge.synchronizePlaybackGeneration(1, media: nil)
+
+      player.handleEvent(.mediaChanged, sourcePlaybackGeneration: 1)
+
+      #expect(player.sessionGeneration == 1)
+      #expect(player.state == .playing)
+      #expect(player.deferredPauseCommand == nil)
+      #expect(player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `External media adoption retains resume until a late pause settles`() {
+      let player = Player(instance: TestInstance.shared)
+      player._nativePlaybackStateOverrideForTesting = .opening
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: false)
+      player.setPlaybackControlIntent(.resume)
+      _ = player.eventBridge.synchronizePlaybackGeneration(1, media: nil)
+
+      player.handleEvent(.mediaChanged, sourcePlaybackGeneration: 1)
+
+      #expect(player.deferredPauseCommand == .resume)
+      #expect(player.deferredPauseCommandPlaybackGeneration == 1)
+      #expect(player.isPlaybackRequestedActive)
+
+      player._nativePlaybackStateOverrideForTesting = .paused
+      player.performDeferredPauseCommandIfNeeded()
+
+      #expect(player.deferredPauseCommand == nil)
+      #expect(player.pauseTransition == .resuming)
+      #expect(player.pauseTransitionPlaybackGeneration == 1)
+      #expect(player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `Media adoption preserves an in-flight pause transition for its generation`() {
+      let player = Player(instance: TestInstance.shared)
+      let adoptedGeneration: UInt64 = 1
+      player.sessionGeneration = adoptedGeneration
+      _ = player.eventBridge.synchronizePlaybackGeneration(adoptedGeneration, media: nil)
+      player.setPauseTransition(.pausing, playbackGeneration: adoptedGeneration)
+
+      player.resetMediaDerivedState()
+
+      #expect(player.pauseTransition == .pausing)
+      #expect(player.pauseTransitionPlaybackGeneration == adoptedGeneration)
+      #expect(!player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `A queued pause overrides an older resume transition during adoption`() {
+      let player = Player(instance: TestInstance.shared)
+      let adoptedGeneration: UInt64 = 1
+      player.sessionGeneration = adoptedGeneration
+      _ = player.eventBridge.synchronizePlaybackGeneration(adoptedGeneration, media: nil)
+      player.setPauseTransition(.resuming, playbackGeneration: adoptedGeneration)
+      player.setDeferredPauseCommand(.pause, playbackGeneration: adoptedGeneration)
+      player.publishPlaybackIntent(true)
+
+      player.resetMediaDerivedState()
+
+      #expect(!player.isPlaybackRequestedActive)
+      #expect(player.pauseTransition == .resuming)
+      #expect(player.deferredPauseCommand == .pause)
+    }
+
+    @Test
+    func `A queued resume overrides an older pause transition during adoption`() {
+      let player = Player(instance: TestInstance.shared)
+      let adoptedGeneration: UInt64 = 1
+      player.sessionGeneration = adoptedGeneration
+      _ = player.eventBridge.synchronizePlaybackGeneration(adoptedGeneration, media: nil)
+      player.setPauseTransition(.pausing, playbackGeneration: adoptedGeneration)
+      player.setDeferredPauseCommand(.resume, playbackGeneration: adoptedGeneration)
+      player.publishPlaybackIntent(false)
+
+      player.resetMediaDerivedState()
+
+      #expect(player.isPlaybackRequestedActive)
+      #expect(player.pauseTransition == .pausing)
+      #expect(player.deferredPauseCommand == .resume)
+    }
+
+    @Test
+    func `An intermediate adoption preserves pause work for a later queued item`() {
+      let player = Player(instance: TestInstance.shared)
+      player.sessionGeneration = 1
+      _ = player.eventBridge.synchronizePlaybackGeneration(2, media: nil)
+      player.setPauseTransition(.pausing, playbackGeneration: 2)
+      player.setDeferredPauseCommand(.resume, playbackGeneration: 2)
+
+      player.resetMediaDerivedState()
+
+      #expect(player.pauseTransition == .pausing)
+      #expect(player.pauseTransitionPlaybackGeneration == 2)
+      #expect(player.deferredPauseCommand == .resume)
+      #expect(player.deferredPauseCommandPlaybackGeneration == 2)
+      #expect(player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `Pause cancels an older queued resume when cached playback is paused`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .paused, isPlaybackRequestedActive: true)
+      player.setDeferredPauseCommand(.resume, playbackGeneration: player.sessionGeneration)
+
+      player.pause()
+
+      #expect(player.deferredPauseCommand == nil)
+      #expect(player.deferredPauseCommandPlaybackGeneration == nil)
+      #expect(!player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `Media adoption cancels an outgoing in-flight pause transition`() {
+      let player = Player(instance: TestInstance.shared)
+      player.setPauseTransition(.pausing, playbackGeneration: 0)
+      let adoptedGeneration: UInt64 = 1
+      player.sessionGeneration = adoptedGeneration
+      _ = player.eventBridge.synchronizePlaybackGeneration(adoptedGeneration, media: nil)
+
+      player.resetMediaDerivedState()
+
+      #expect(player.pauseTransition == nil)
+      #expect(player.pauseTransitionPlaybackGeneration == nil)
+    }
+
+    @Test
+    func `Retrying an outgoing deferred command cancels before touching the successor`() {
+      let player = Player(instance: TestInstance.shared)
+      player._setStateForTesting(state: .opening)
+      player.setDeferredPauseCommand(.pause, playbackGeneration: 0)
+      _ = player.eventBridge.synchronizePlaybackGeneration(1, media: nil)
+
+      player.performDeferredPauseCommandIfNeeded()
+
+      #expect(player.deferredPauseCommand == nil)
+      #expect(player.deferredPauseCommandPlaybackGeneration == nil)
+    }
+
+    @Test
+    func `Outgoing terminal event preserves a successor pause command`() {
+      let player = Player(instance: TestInstance.shared)
+      _ = player.eventBridge.synchronizePlaybackGeneration(1, media: nil)
+      player.setDeferredPauseCommand(.pause, playbackGeneration: 1)
+
+      player._handleEventForTesting(.stateChanged(.stopped))
+
+      #expect(player.deferredPauseCommand == .pause)
+      #expect(player.deferredPauseCommandPlaybackGeneration == 1)
+    }
+
+    @Test
+    func `Media adoption cancels a pause from the outgoing generation`() {
+      let player = Player(instance: TestInstance.shared)
+      player.deferredPauseCommand = .pause
+      let adoptedGeneration: UInt64 = 1
+      player.sessionGeneration = adoptedGeneration
+      _ = player.eventBridge.synchronizePlaybackGeneration(adoptedGeneration, media: nil)
+
+      player.resetMediaDerivedState()
+
+      #expect(player.deferredPauseCommand == nil)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- route attached MediaListPlayer pause and resume commands through the shared Player state machine
- generation-scope deferred commands and in-flight transitions across list-driven media adoption
- carry the latest explicit transport intent through the final native-command/media-adoption race
- use side-effect-free native state and capability probes, revalidated against the callback-lane generation
- retain successor resume intent through startup until a late pause has either settled or been cancelled
- retire only outgoing pause work while preserving future-generation work through intermediate adoptions
- add deterministic coverage for every reviewed race boundary, command ordering, stable-idle rollback, and the original integration failure

Closes #164.

## Exact-head validation

Validated commit: `a8856b904cd96714175f1e5d49b855d2e66f66f3`

- full macOS package: 1,880 tests in 165 suites passed
- original real playlist pause integration: 100/100 isolated process runs passed
- focused playlist/player branch suite: 89/89 passed
- broader playlist/PiP/player-event surface: 188/188 passed
- prior PiP semantic regression: deterministic focused test passed
- CI-mode focused coverage: Player+Pause.swift 325/350 lines (92.86%)
- release build: passed
- strict SwiftLint: 0 violations
- strict SwiftFormat: clean
- exact-head GitHub CI: all required jobs passed, including the isolated tvOS rerun after one simulator-process exit
- exact-head Codecov: total 92.60%, patch 92.11%; both configured gates passed
- exact-head Codex review: no major issues; all review threads resolved
