### PR TITLE
Expose bounded deferred PiP pause outcomes

### DIFF
--- a/Sources/SwiftVLC/PiP/PiPController+AudioSession.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+AudioSession.swift
@@ -166,7 +166,7 @@ extension PiPController {
       activateAudioSessionIfNeeded()
     }
     if reaction.pausesPlayback {
-      _ = playbackDriver.pause(nil)
+      _ = playbackDriver.pause(nil, true)
     }
   }
 

--- a/Sources/SwiftVLC/PiP/PiPController+AudioSession.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+AudioSession.swift
@@ -166,7 +166,7 @@ extension PiPController {
       activateAudioSessionIfNeeded()
     }
     if reaction.pausesPlayback {
-      _ = playbackDriver.pause()
+      _ = playbackDriver.pause(nil)
     }
   }
 

--- a/Sources/SwiftVLC/PiP/PiPController+DeferredPause.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+DeferredPause.swift
@@ -77,6 +77,19 @@ extension PiPController {
           setDeferredPauseOutcome(.cancelled)
           return
         }
+        if
+          let ownedPlaybackControlRevision,
+          player.didIssuePause(
+            playbackGeneration: playbackGeneration,
+            playbackControlRevision: ownedPlaybackControlRevision
+          ) {
+          // Player's event lane can retry a retained command while this task
+          // sleeps. That native acceptance belongs to this exact PiP command
+          // even though it did not come from the synchronous attempt below.
+          deferredPause = .issued
+          setDeferredPauseOutcome(.issued)
+          return
+        }
 
         switch player.state {
         case .playing:

--- a/Sources/SwiftVLC/PiP/PiPController+DeferredPause.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+DeferredPause.swift
@@ -1,0 +1,212 @@
+#if os(iOS) || os(macOS)
+
+extension PiPController {
+  /// Cancels any in-flight scheduled pause. This **only** cancels the
+  /// `.scheduled` task; an already-`.issued` pause is preserved —
+  /// `requestResumeIfNeeded` reads it to decide whether to issue a libVLC
+  /// resume.
+  func cancelDeferredPause() {
+    if case .scheduled(let task, _) = deferredPause {
+      task.cancel()
+      deferredPause = .idle
+      // A pause that is cancelled before it can be issued is a cancellation,
+      // whichever caller cancelled it. `scheduleDeferredPause` clears this
+      // again straight afterwards, so a supersede reads as "in flight"
+      // rather than as the superseded attempt's outcome.
+      setDeferredPauseOutcome(.cancelled)
+    }
+  }
+
+  /// Schedules a deferred pause, replacing any in-flight one. The task
+  /// sleeps for `pauseDebounce`, re-checks intent and player state on
+  /// wake, and either issues the libVLC pause (transitioning to
+  /// `.issued`) or exits cleanly (transitioning back to `.idle`).
+  func scheduleDeferredPause() {
+    cancelDeferredPause()
+    // A new attempt is in flight and has not finished yet. Without this the
+    // previous attempt's outcome would stay readable for the whole debounce,
+    // so a reader could not tell a settled result from a stale one.
+    setDeferredPauseOutcome(nil)
+
+    let generation = DeferredPauseState.nextGeneration(after: deferredPause)
+    // The native callback lane can advance before the main actor adopts the
+    // corresponding mediaChanged event. Bind the delayed command to that
+    // authoritative generation so an outgoing pause cannot reach a successor
+    // during the adoption gap.
+    let playbackGeneration = player.eventBridge.currentPlaybackGeneration
+    let startingPlaybackControlIntent = player.playbackControlIntent
+    let startingPlaybackControlRevision = player.playbackControlIntentRevision
+    let debounce = pauseDebounce
+    let task = Task { @MainActor [weak self] in
+      var attemptsRemaining = Self.maxDeferredPauseAttempts
+      // The first native attempt is the fresh PiP transport command. Later
+      // calls are retries of that same command and must not overwrite a newer
+      // playlist play/resume intent that arrived between attempts.
+      var hasAttemptedPlayerPause = false
+      var ownedPlaybackControlRevision: UInt64?
+      while !Task.isCancelled {
+        do {
+          try await Task.sleep(for: debounce)
+        } catch {
+          return
+        }
+
+        // Bind `self` after the suspension so the observer only keeps the
+        // controller alive while it is deciding whether to issue the pause.
+        guard let self else { return }
+        #if DEBUG
+        _deferredPauseRetryHookForTesting?()
+        #endif
+        guard !Task.isCancelled, currentDeferredPauseGeneration == generation, !pipPlaybackActive else { return }
+        let expectedPlaybackControlRevision = ownedPlaybackControlRevision
+          ?? startingPlaybackControlRevision
+        guard player.playbackControlIntentRevision == expectedPlaybackControlRevision else {
+          deferredPause = .idle
+          setDeferredPauseOutcome(.cancelled)
+          return
+        }
+        guard player.eventBridge.currentPlaybackGeneration == playbackGeneration else {
+          if let ownedPlaybackControlRevision {
+            playbackDriver.cancelPendingPause(
+              playbackGeneration,
+              ownedPlaybackControlRevision,
+              startingPlaybackControlIntent ?? .resume
+            )
+          }
+          deferredPause = .idle
+          setDeferredPauseOutcome(.cancelled)
+          return
+        }
+
+        switch player.state {
+        case .playing:
+          let recordsPlaybackControlIntent = !hasAttemptedPlayerPause
+          hasAttemptedPlayerPause = true
+          let attempt = playbackDriver.pause(
+            playbackGeneration,
+            recordsPlaybackControlIntent
+          )
+          if let playbackControlRevision = attempt.playbackControlRevision {
+            ownedPlaybackControlRevision = playbackControlRevision
+          }
+          if attempt.accepted {
+            deferredPause = .issued
+            setDeferredPauseOutcome(.issued)
+            return
+          }
+          // libVLC refused. Retry, but not forever.
+          attemptsRemaining -= 1
+        case .opening, .buffering:
+          // Avoid pausing libVLC while it is still stabilizing input state.
+          // Keep waiting unless AVKit changes its mind first — bounded, so an
+          // input that never stabilizes cannot retry indefinitely.
+          attemptsRemaining -= 1
+        default:
+          deferredPause = .idle
+          setDeferredPauseOutcome(.cancelled)
+          return
+        }
+
+        if attemptsRemaining <= 0 {
+          deferredPause = .idle
+          settleUnpausableInput(
+            playbackGeneration: playbackGeneration,
+            startingPlaybackControlIntent: startingPlaybackControlIntent,
+            startingPlaybackControlRevision: startingPlaybackControlRevision,
+            ownedPlaybackControlRevision: ownedPlaybackControlRevision
+          )
+          return
+        }
+      }
+    }
+    deferredPause = .scheduled(task: task, generation: generation)
+  }
+
+  /// How many debounce intervals a deferred pause may retry before the input
+  /// is treated as unpausable.
+  ///
+  /// At the default 250 ms debounce this is ten seconds — long enough for a
+  /// slow network open to stabilize, short enough that a permanently
+  /// unpausable input does not leave a paused UI over continuing playback
+  /// indefinitely.
+  static let maxDeferredPauseAttempts = 40
+
+  /// Reconciles after a deferred pause has been abandoned.
+  ///
+  /// The input never became pausable, so playback is still running. The
+  /// public intent was already published as inactive when PiP asked to pause;
+  /// leaving it there would show paused controls over playing media — the
+  /// visible half of this bug. Republish the truth on both surfaces.
+  private func settleUnpausableInput(
+    playbackGeneration: UInt64,
+    startingPlaybackControlIntent: Player.DeferredPauseCommand?,
+    startingPlaybackControlRevision: UInt64,
+    ownedPlaybackControlRevision: UInt64?
+  ) {
+    let expectedPlaybackControlRevision = ownedPlaybackControlRevision
+      ?? startingPlaybackControlRevision
+    guard
+      player.playbackControlIntentRevision == expectedPlaybackControlRevision,
+      startingPlaybackControlIntent != .pause,
+      ownedPlaybackControlRevision != nil || player.playbackControlIntent != .pause
+    else {
+      setDeferredPauseOutcome(.cancelled)
+      return
+    }
+    // `issuePause` can reject synchronously while retaining a player-owned
+    // deferred command for a later pausable/time event. Retire that command
+    // before publishing a terminal result, or it could pause playback after
+    // observers were told this attempt had been rejected.
+    playbackDriver.cancelPendingPause(
+      playbackGeneration,
+      ownedPlaybackControlRevision,
+      .resume
+    )
+    setDeferredPauseOutcome(.rejected)
+    guard player.state.isActive else { return }
+    player.setPlaybackIntentFromExternalControl(true)
+    pipPlaybackActive = true
+    invalidatePictureInPicturePlaybackState()
+  }
+
+  /// The generation id of an in-flight scheduled pause, or 0 if no
+  /// task is currently scheduled. Used by the deferred-pause loop to
+  /// detect when its scheduling slot has been replaced.
+  private var currentDeferredPauseGeneration: UInt64 {
+    if case .scheduled(_, let generation) = deferredPause {
+      generation
+    } else {
+      0
+    }
+  }
+
+  /// Clears the `.issued` flag without cancelling a scheduled pause.
+  /// Used when an external event (the user pressing play, the player
+  /// settling into `.playing` on its own) makes the PiP-issued pause
+  /// obsolete but we don't want to disturb a still-pending schedule.
+  func clearIssuedPauseFlag() {
+    if case .issued = deferredPause {
+      deferredPause = .idle
+    }
+  }
+
+  /// Returns whether PiP needs libVLC to resume, and whether the
+  /// playback driver accepted the resume request. Checks both the
+  /// `.issued` state (PiP actually paused libVLC) and the player's
+  /// own resume hint.
+  func requestResumeIfNeeded() -> (needed: Bool, accepted: Bool) {
+    let pipIssuedPause = if case .issued = deferredPause {
+      true
+    } else {
+      false
+    }
+    let shouldResume = pipIssuedPause || playbackDriver.shouldResume()
+    if pipIssuedPause {
+      deferredPause = .idle
+    }
+    guard shouldResume else { return (needed: false, accepted: false) }
+    return (needed: true, accepted: playbackDriver.resume())
+  }
+}
+
+#endif

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -884,6 +884,7 @@ public final class PiPController: NSObject {
     deferredPauseOutcome = nil
 
     let generation = DeferredPauseState.nextGeneration(after: deferredPause)
+    let playbackGeneration = player.generation
     let debounce = pauseDebounce
     let task = Task { @MainActor [weak self] in
       var attemptsRemaining = Self.maxDeferredPauseAttempts
@@ -898,6 +899,11 @@ public final class PiPController: NSObject {
         // controller alive while it is deciding whether to issue the pause.
         guard let self else { return }
         guard !Task.isCancelled, currentDeferredPauseGeneration == generation, !pipPlaybackActive else { return }
+        guard player.generation == playbackGeneration else {
+          deferredPause = .idle
+          deferredPauseOutcome = .cancelled
+          return
+        }
 
         switch player.state {
         case .playing:

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -61,14 +61,23 @@ public final class PiPController: NSObject {
   private nonisolated static let allowsPrivateMacOSAPIStorage = Atomic<Bool>(false)
 
   struct PlaybackDriver {
+    struct PauseAttempt {
+      let accepted: Bool
+      let playbackControlRevision: UInt64?
+    }
+
     /// `nil` follows the current media; a concrete value binds deferred work
     /// to the media generation that originally scheduled it.
     let pause: @MainActor (
       _ playbackGeneration: UInt64?,
       _ recordsPlaybackControlIntent: Bool
-    ) -> Bool
+    ) -> PauseAttempt
     let resume: @MainActor () -> Bool
-    let cancelPendingPause: @MainActor () -> Void
+    let cancelPendingPause: @MainActor (
+      _ playbackGeneration: UInt64?,
+      _ playbackControlRevision: UInt64?,
+      _ restoringPlaybackControlIntent: Player.DeferredPauseCommand
+    ) -> Void
     let shouldResume: @MainActor () -> Bool
     /// Relative rather than absolute: see ``PiPController/performSkip(on:by:)``
     /// for why the interval AVKit requested is preserved instead of being
@@ -78,13 +87,24 @@ public final class PiPController: NSObject {
     static func live(player: Player) -> Self {
       Self(
         pause: {
-          player.issuePause(
+          let revisionBeforePause = player.playbackControlIntentRevision
+          let accepted = player.issuePause(
             playbackGeneration: $0,
             recordsPlaybackControlIntent: $1
           )
+          return PauseAttempt(
+            accepted: accepted,
+            playbackControlRevision: $1 ? revisionBeforePause &+ 1 : nil
+          )
         },
         resume: { player.issueResume() },
-        cancelPendingPause: { player.cancelPendingPause() },
+        cancelPendingPause: {
+          player.cancelPendingPause(
+            playbackGeneration: $0,
+            playbackControlRevision: $1,
+            restoringPlaybackControlIntent: $2
+          )
+        },
         shouldResume: { player.shouldResumeForExternalPlayRequest },
         skip: { PiPController.performSkip(on: player, by: $0) }
       )
@@ -96,7 +116,11 @@ public final class PiPController: NSObject {
   @ObservationIgnored
   let playbackDriver: PlaybackDriver
   @ObservationIgnored
-  private let pauseDebounce: Duration
+  let pauseDebounce: Duration
+  #if DEBUG
+  @ObservationIgnored
+  var _deferredPauseRetryHookForTesting: (() -> Void)?
+  #endif
   @ObservationIgnored
   let renderer: PixelBufferRenderer
   @ObservationIgnored
@@ -303,7 +327,7 @@ public final class PiPController: NSObject {
   /// counter rides inside `.scheduled` so a late-firing wake-up from
   /// a cancelled task can detect that it is stale and exit cleanly.
   @ObservationIgnored
-  private var deferredPause: DeferredPauseState = .idle
+  var deferredPause: DeferredPauseState = .idle
 
   /// How a deferred PiP pause finished.
   ///
@@ -330,7 +354,11 @@ public final class PiPController: NSObject {
   /// active playback intent after exhausting the bounded retry window.
   public private(set) var deferredPauseOutcome: DeferredPauseOutcome?
 
-  fileprivate enum DeferredPauseState {
+  func setDeferredPauseOutcome(_ outcome: DeferredPauseOutcome?) {
+    deferredPauseOutcome = outcome
+  }
+
+  enum DeferredPauseState {
     /// No deferred pause in flight; libVLC matches PiP intent.
     case idle
     /// A deferred-pause task is sleeping. `task` is the in-flight task,
@@ -865,162 +893,6 @@ public final class PiPController: NSObject {
     pipController?.invalidatePlaybackState()
   }
 
-  /// Cancels any in-flight scheduled pause. This **only** cancels the
-  /// `.scheduled` task; an already-`.issued` pause is preserved —
-  /// `requestResumeIfNeeded` reads it to decide whether to issue a libVLC
-  /// resume.
-  private func cancelDeferredPause() {
-    if case .scheduled(let task, _) = deferredPause {
-      task.cancel()
-      deferredPause = .idle
-      // A pause that is cancelled before it can be issued is a cancellation,
-      // whichever caller cancelled it. `scheduleDeferredPause` clears this
-      // again straight afterwards, so a supersede reads as "in flight"
-      // rather than as the superseded attempt's outcome.
-      deferredPauseOutcome = .cancelled
-    }
-  }
-
-  /// Schedules a deferred pause, replacing any in-flight one. The task
-  /// sleeps for `pauseDebounce`, re-checks intent and player state on
-  /// wake, and either issues the libVLC pause (transitioning to
-  /// `.issued`) or exits cleanly (transitioning back to `.idle`).
-  private func scheduleDeferredPause() {
-    cancelDeferredPause()
-    // A new attempt is in flight and has not finished yet. Without this the
-    // previous attempt's outcome would stay readable for the whole debounce,
-    // so a reader could not tell a settled result from a stale one.
-    deferredPauseOutcome = nil
-
-    let generation = DeferredPauseState.nextGeneration(after: deferredPause)
-    // The native callback lane can advance before the main actor adopts the
-    // corresponding mediaChanged event. Bind the delayed command to that
-    // authoritative generation so an outgoing pause cannot reach a successor
-    // during the adoption gap.
-    let playbackGeneration = player.eventBridge.currentPlaybackGeneration
-    let debounce = pauseDebounce
-    let task = Task { @MainActor [weak self] in
-      var attemptsRemaining = Self.maxDeferredPauseAttempts
-      // The first native attempt is the fresh PiP transport command. Later
-      // calls are retries of that same command and must not overwrite a newer
-      // playlist play/resume intent that arrived between attempts.
-      var hasAttemptedPlayerPause = false
-      while !Task.isCancelled {
-        do {
-          try await Task.sleep(for: debounce)
-        } catch {
-          return
-        }
-
-        // Bind `self` after the suspension so the observer only keeps the
-        // controller alive while it is deciding whether to issue the pause.
-        guard let self else { return }
-        guard !Task.isCancelled, currentDeferredPauseGeneration == generation, !pipPlaybackActive else { return }
-        guard player.eventBridge.currentPlaybackGeneration == playbackGeneration else {
-          deferredPause = .idle
-          deferredPauseOutcome = .cancelled
-          return
-        }
-
-        switch player.state {
-        case .playing:
-          let recordsPlaybackControlIntent = !hasAttemptedPlayerPause
-          hasAttemptedPlayerPause = true
-          if playbackDriver.pause(playbackGeneration, recordsPlaybackControlIntent) {
-            deferredPause = .issued
-            deferredPauseOutcome = .issued
-            return
-          }
-          // libVLC refused. Retry, but not forever.
-          attemptsRemaining -= 1
-        case .opening, .buffering:
-          // Avoid pausing libVLC while it is still stabilizing input state.
-          // Keep waiting unless AVKit changes its mind first — bounded, so an
-          // input that never stabilizes cannot retry indefinitely.
-          attemptsRemaining -= 1
-        default:
-          deferredPause = .idle
-          deferredPauseOutcome = .cancelled
-          return
-        }
-
-        if attemptsRemaining <= 0 {
-          deferredPause = .idle
-          settleUnpausableInput()
-          return
-        }
-      }
-    }
-    deferredPause = .scheduled(task: task, generation: generation)
-  }
-
-  /// How many debounce intervals a deferred pause may retry before the input
-  /// is treated as unpausable.
-  ///
-  /// At the default 250 ms debounce this is ten seconds — long enough for a
-  /// slow network open to stabilize, short enough that a permanently
-  /// unpausable input does not leave a paused UI over continuing playback
-  /// indefinitely.
-  static let maxDeferredPauseAttempts = 40
-
-  /// Reconciles after a deferred pause has been abandoned.
-  ///
-  /// The input never became pausable, so playback is still running. The
-  /// public intent was already published as inactive when PiP asked to pause;
-  /// leaving it there would show paused controls over playing media — the
-  /// visible half of this bug. Republish the truth on both surfaces.
-  private func settleUnpausableInput() {
-    // `issuePause` can reject synchronously while retaining a player-owned
-    // deferred command for a later pausable/time event. Retire that command
-    // before publishing a terminal result, or it could pause playback after
-    // observers were told this attempt had been rejected.
-    playbackDriver.cancelPendingPause()
-    deferredPauseOutcome = .rejected
-    guard player.state.isActive else { return }
-    player.setPlaybackIntentFromExternalControl(true)
-    pipPlaybackActive = true
-    invalidatePictureInPicturePlaybackState()
-  }
-
-  /// The generation id of an in-flight scheduled pause, or 0 if no
-  /// task is currently scheduled. Used by the deferred-pause loop to
-  /// detect when its scheduling slot has been replaced.
-  private var currentDeferredPauseGeneration: UInt64 {
-    if case .scheduled(_, let generation) = deferredPause {
-      generation
-    } else {
-      0
-    }
-  }
-
-  /// Clears the `.issued` flag without cancelling a scheduled pause.
-  /// Used when an external event (the user pressing play, the player
-  /// settling into `.playing` on its own) makes the PiP-issued pause
-  /// obsolete but we don't want to disturb a still-pending schedule.
-  func clearIssuedPauseFlag() {
-    if case .issued = deferredPause {
-      deferredPause = .idle
-    }
-  }
-
-  /// Returns whether PiP needs libVLC to resume, and whether the
-  /// playback driver accepted the resume request. Checks both the
-  /// `.issued` state (PiP actually paused libVLC) and the player's
-  /// own resume hint.
-  private func requestResumeIfNeeded() -> (needed: Bool, accepted: Bool) {
-    let pipIssuedPause = if case .issued = deferredPause {
-      true
-    } else {
-      false
-    }
-    let shouldResume = pipIssuedPause || playbackDriver.shouldResume()
-    if pipIssuedPause {
-      deferredPause = .idle
-    }
-    guard shouldResume else { return (needed: false, accepted: false) }
-    return (needed: true, accepted: playbackDriver.resume())
-  }
-
   // MARK: - State Observation
 
   /// Keeps the renderer's frame cadence in step with the source.
@@ -1109,7 +981,7 @@ public final class PiPController: NSObject {
     pendingPiPPlaybackState = playing
 
     if playing {
-      playbackDriver.cancelPendingPause()
+      playbackDriver.cancelPendingPause(nil, nil, .resume)
       let resumeRequest = requestResumeIfNeeded()
       if resumeRequest.needed, !resumeRequest.accepted {
         pendingPiPPlaybackState = nil

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -302,7 +302,7 @@ public final class PiPController: NSObject {
   /// user-visible half of the outcome is reconciled onto
   /// ``Player/isPlaybackRequestedActive`` instead, which is already
   /// observable.
-  enum DeferredPauseOutcome: Equatable {
+  public enum DeferredPauseOutcome: Sendable, Equatable {
     /// libVLC accepted the pause.
     case issued
     /// Superseded, or the session left a pausable state before it could be
@@ -313,11 +313,13 @@ public final class PiPController: NSObject {
     case rejected
   }
 
-  /// The outcome of the most recent deferred pause, or `nil` while one is in
-  /// flight. Internal rather than public: it exists so the bound and the
-  /// reconciliation are assertable.
-  @ObservationIgnored
-  private(set) var deferredPauseOutcome: DeferredPauseOutcome?
+  /// The outcome of the most recent deferred pause.
+  ///
+  /// This property is `nil` before the first attempt and while a new attempt
+  /// is in flight. Observe it to learn whether libVLC accepted the pause,
+  /// whether another command cancelled it, or whether SwiftVLC restored
+  /// active playback intent after exhausting the bounded retry window.
+  public private(set) var deferredPauseOutcome: DeferredPauseOutcome?
 
   fileprivate enum DeferredPauseState {
     /// No deferred pause in flight; libVLC matches PiP intent.

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -298,10 +298,9 @@ public final class PiPController: NSObject {
   /// How a deferred PiP pause finished.
   ///
   /// Not surfaced on ``PiPEvent`` because that is a public non-frozen enum and
-  /// adding a case would be source-breaking for exhaustive switches. The
-  /// user-visible half of the outcome is reconciled onto
-  /// ``Player/isPlaybackRequestedActive`` instead, which is already
-  /// observable.
+  /// adding a case would be source-breaking for exhaustive switches. Observe
+  /// ``deferredPauseOutcome`` separately for this command result; playback
+  /// intent is also reconciled onto ``Player/isPlaybackRequestedActive``.
   public enum DeferredPauseOutcome: Sendable, Equatable {
     /// libVLC accepted the pause.
     case issued

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -63,7 +63,10 @@ public final class PiPController: NSObject {
   struct PlaybackDriver {
     /// `nil` follows the current media; a concrete value binds deferred work
     /// to the media generation that originally scheduled it.
-    let pause: @MainActor (_ playbackGeneration: UInt64?) -> Bool
+    let pause: @MainActor (
+      _ playbackGeneration: UInt64?,
+      _ recordsPlaybackControlIntent: Bool
+    ) -> Bool
     let resume: @MainActor () -> Bool
     let cancelPendingPause: @MainActor () -> Void
     let shouldResume: @MainActor () -> Bool
@@ -74,7 +77,12 @@ public final class PiPController: NSObject {
 
     static func live(player: Player) -> Self {
       Self(
-        pause: { player.issuePause(playbackGeneration: $0) },
+        pause: {
+          player.issuePause(
+            playbackGeneration: $0,
+            recordsPlaybackControlIntent: $1
+          )
+        },
         resume: { player.issueResume() },
         cancelPendingPause: { player.cancelPendingPause() },
         shouldResume: { player.shouldResumeForExternalPlayRequest },
@@ -893,6 +901,10 @@ public final class PiPController: NSObject {
     let debounce = pauseDebounce
     let task = Task { @MainActor [weak self] in
       var attemptsRemaining = Self.maxDeferredPauseAttempts
+      // The first native attempt is the fresh PiP transport command. Later
+      // calls are retries of that same command and must not overwrite a newer
+      // playlist play/resume intent that arrived between attempts.
+      var hasAttemptedPlayerPause = false
       while !Task.isCancelled {
         do {
           try await Task.sleep(for: debounce)
@@ -912,7 +924,9 @@ public final class PiPController: NSObject {
 
         switch player.state {
         case .playing:
-          if playbackDriver.pause(playbackGeneration) {
+          let recordsPlaybackControlIntent = !hasAttemptedPlayerPause
+          hasAttemptedPlayerPause = true
+          if playbackDriver.pause(playbackGeneration, recordsPlaybackControlIntent) {
             deferredPause = .issued
             deferredPauseOutcome = .issued
             return
@@ -956,6 +970,11 @@ public final class PiPController: NSObject {
   /// leaving it there would show paused controls over playing media — the
   /// visible half of this bug. Republish the truth on both surfaces.
   private func settleUnpausableInput() {
+    // `issuePause` can reject synchronously while retaining a player-owned
+    // deferred command for a later pausable/time event. Retire that command
+    // before publishing a terminal result, or it could pause playback after
+    // observers were told this attempt had been rejected.
+    playbackDriver.cancelPendingPause()
     deferredPauseOutcome = .rejected
     guard player.state.isActive else { return }
     player.setPlaybackIntentFromExternalControl(true)

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -61,7 +61,9 @@ public final class PiPController: NSObject {
   private nonisolated static let allowsPrivateMacOSAPIStorage = Atomic<Bool>(false)
 
   struct PlaybackDriver {
-    let pause: @MainActor () -> Bool
+    /// `nil` follows the current media; a concrete value binds deferred work
+    /// to the media generation that originally scheduled it.
+    let pause: @MainActor (_ playbackGeneration: UInt64?) -> Bool
     let resume: @MainActor () -> Bool
     let cancelPendingPause: @MainActor () -> Void
     let shouldResume: @MainActor () -> Bool
@@ -72,7 +74,7 @@ public final class PiPController: NSObject {
 
     static func live(player: Player) -> Self {
       Self(
-        pause: { player.issuePause() },
+        pause: { player.issuePause(playbackGeneration: $0) },
         resume: { player.issueResume() },
         cancelPendingPause: { player.cancelPendingPause() },
         shouldResume: { player.shouldResumeForExternalPlayRequest },
@@ -883,7 +885,11 @@ public final class PiPController: NSObject {
     deferredPauseOutcome = nil
 
     let generation = DeferredPauseState.nextGeneration(after: deferredPause)
-    let playbackGeneration = player.generation
+    // The native callback lane can advance before the main actor adopts the
+    // corresponding mediaChanged event. Bind the delayed command to that
+    // authoritative generation so an outgoing pause cannot reach a successor
+    // during the adoption gap.
+    let playbackGeneration = player.eventBridge.currentPlaybackGeneration
     let debounce = pauseDebounce
     let task = Task { @MainActor [weak self] in
       var attemptsRemaining = Self.maxDeferredPauseAttempts
@@ -898,7 +904,7 @@ public final class PiPController: NSObject {
         // controller alive while it is deciding whether to issue the pause.
         guard let self else { return }
         guard !Task.isCancelled, currentDeferredPauseGeneration == generation, !pipPlaybackActive else { return }
-        guard player.generation == playbackGeneration else {
+        guard player.eventBridge.currentPlaybackGeneration == playbackGeneration else {
           deferredPause = .idle
           deferredPauseOutcome = .cancelled
           return
@@ -906,7 +912,7 @@ public final class PiPController: NSObject {
 
         switch player.state {
         case .playing:
-          if playbackDriver.pause() {
+          if playbackDriver.pause(playbackGeneration) {
             deferredPause = .issued
             deferredPauseOutcome = .issued
             return

--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -36,6 +36,11 @@ extension Player {
   /// is disabled or not initialized, libVLC reports a negative volume
   /// sentinel and no aout stream participates in that assertion.
   var canIssueNativePause: Bool {
+    #if DEBUG
+    if let _nativePauseSafetyOverrideForTesting {
+      return _nativePauseSafetyOverrideForTesting
+    }
+    #endif
     if libvlc_media_player_get_time(pointer) > 0 {
       return true
     }
@@ -411,7 +416,10 @@ extension Player {
     deferredPauseCommand = nil
     switch command {
     case .pause:
-      _ = issuePause(playbackGeneration: playbackGeneration)
+      _ = issuePause(
+        playbackGeneration: playbackGeneration,
+        recordsPlaybackControlIntent: false
+      )
     case .resume:
       _ = issueResume(playbackGeneration: playbackGeneration)
     }

--- a/Sources/SwiftVLC/Player/Player+Pause.swift
+++ b/Sources/SwiftVLC/Player/Player+Pause.swift
@@ -269,6 +269,7 @@ extension Player {
         deferredPauseCommand = nil
       }
       publishPlaybackIntent(false)
+      let issuedPlaybackControlRevision = playbackControlIntentRevision
       libvlc_media_player_set_pause(pointer, 1)
       #if DEBUG
       _pauseProbeHookForTesting?(.nativePause)
@@ -305,6 +306,8 @@ extension Player {
         }
         return false
       }
+      lastIssuedPausePlaybackGeneration = playbackGeneration
+      lastIssuedPausePlaybackControlRevision = issuedPlaybackControlRevision
       return true
     }
     return false
@@ -491,15 +494,61 @@ extension Player {
     playbackControlRevision: UInt64? = nil,
     restoringPlaybackControlIntent: DeferredPauseCommand = .resume
   ) {
+    if let playbackControlRevision {
+      guard playbackControlIntentRevision == playbackControlRevision else { return }
+
+      // Exact command identity is stronger than the captured generation. A
+      // playlist adoption can migrate the same retained command onto its
+      // successor without changing this revision; requiring the obsolete
+      // generation in that case leaves the PiP-owned pause live after the
+      // controller has reported cancellation.
+      let ownsPendingPause = deferredPauseCommand == .pause
+      let ownsIssuedPause = didIssuePause(
+        playbackGeneration: nil,
+        playbackControlRevision: playbackControlRevision
+      )
+      guard ownsPendingPause || ownsIssuedPause else { return }
+
+      if ownsPendingPause {
+        deferredPauseCommand = nil
+      }
+      if ownsIssuedPause, restoringPlaybackControlIntent == .resume {
+        // The event lane may already have sent the pause while the controller
+        // slept. Queueing a resume through the normal state machine handles
+        // both an in-flight `.pausing` transition and an already-paused input.
+        _ = issueResume()
+      } else {
+        setPlaybackControlIntent(restoringPlaybackControlIntent)
+      }
+      return
+    }
+
     guard deferredPauseCommand == .pause else { return }
     if let playbackGeneration {
       guard deferredPauseCommandPlaybackGeneration == playbackGeneration else { return }
     }
-    if let playbackControlRevision {
-      guard playbackControlIntentRevision == playbackControlRevision else { return }
-    }
     deferredPauseCommand = nil
     setPlaybackControlIntent(restoringPlaybackControlIntent)
+  }
+
+  /// Whether an exact explicit pause reached the native player.
+  ///
+  /// Passing `nil` for `playbackGeneration` intentionally follows a command
+  /// that playlist adoption migrated to a successor. The revision still has
+  /// to be current, so an older PiP cleanup cannot classify or undo a newer
+  /// app pause.
+  func didIssuePause(
+    playbackGeneration: UInt64?,
+    playbackControlRevision: UInt64
+  ) -> Bool {
+    guard
+      playbackControlIntentRevision == playbackControlRevision,
+      lastIssuedPausePlaybackControlRevision == playbackControlRevision
+    else { return false }
+    if let playbackGeneration {
+      return lastIssuedPausePlaybackGeneration == playbackGeneration
+    }
+    return true
   }
 
   /// Retires every pause/resume command when an external owner of the shared

--- a/Sources/SwiftVLC/Player/Player+Pause.swift
+++ b/Sources/SwiftVLC/Player/Player+Pause.swift
@@ -333,7 +333,12 @@ extension Player {
   ) {
     guard recordsPlaybackControlIntent, !followsCurrentGeneration else { return }
     playbackControlIntent = previousPlaybackControlIntent
-    publishPlaybackIntent(previousPlaybackControlIntent == .resume || state.isActive)
+    let intendsActivePlayback = switch previousPlaybackControlIntent {
+    case .pause: false
+    case .resume: true
+    case nil: state.isActive
+    }
+    publishPlaybackIntent(intendsActivePlayback)
   }
 
   @discardableResult
@@ -481,11 +486,20 @@ extension Player {
     return false
   }
 
-  func cancelPendingPause() {
-    if deferredPauseCommand == .pause {
-      deferredPauseCommand = nil
-      setPlaybackControlIntent(.resume)
+  func cancelPendingPause(
+    playbackGeneration: UInt64? = nil,
+    playbackControlRevision: UInt64? = nil,
+    restoringPlaybackControlIntent: DeferredPauseCommand = .resume
+  ) {
+    guard deferredPauseCommand == .pause else { return }
+    if let playbackGeneration {
+      guard deferredPauseCommandPlaybackGeneration == playbackGeneration else { return }
     }
+    if let playbackControlRevision {
+      guard playbackControlIntentRevision == playbackControlRevision else { return }
+    }
+    deferredPauseCommand = nil
+    setPlaybackControlIntent(restoringPlaybackControlIntent)
   }
 
   /// Retires every pause/resume command when an external owner of the shared

--- a/Sources/SwiftVLC/Player/Player+Pause.swift
+++ b/Sources/SwiftVLC/Player/Player+Pause.swift
@@ -85,10 +85,13 @@ extension Player {
   }
 
   @discardableResult
-  func issuePause(playbackGeneration requestedGeneration: UInt64? = nil) -> Bool {
+  func issuePause(
+    playbackGeneration requestedGeneration: UInt64? = nil,
+    recordsPlaybackControlIntent: Bool = true
+  ) -> Bool {
     let followsCurrentGeneration = requestedGeneration == nil
     let previousPlaybackControlIntent = playbackControlIntent
-    if followsCurrentGeneration {
+    if recordsPlaybackControlIntent {
       playbackControlIntent = .pause
     }
     var playbackGeneration = requestedGeneration ?? eventBridge.currentPlaybackGeneration
@@ -106,7 +109,14 @@ extension Player {
           current: generationBeforeProbe,
           followsCurrentGeneration: followsCurrentGeneration
         )
-      else { return false }
+      else {
+        rollbackBoundPauseIntentIfNeeded(
+          recordsPlaybackControlIntent: recordsPlaybackControlIntent,
+          followsCurrentGeneration: followsCurrentGeneration,
+          previousPlaybackControlIntent: previousPlaybackControlIntent
+        )
+        return false
+      }
       playbackGeneration = revalidatedGeneration
 
       guard pauseTransition == nil else {
@@ -135,7 +145,14 @@ extension Player {
           current: generationAfterStateProbe,
           followsCurrentGeneration: followsCurrentGeneration
         )
-      else { return false }
+      else {
+        rollbackBoundPauseIntentIfNeeded(
+          recordsPlaybackControlIntent: recordsPlaybackControlIntent,
+          followsCurrentGeneration: followsCurrentGeneration,
+          previousPlaybackControlIntent: previousPlaybackControlIntent
+        )
+        return false
+      }
       if generationAfterStateProbe != playbackGeneration {
         playbackGeneration = generationAfterStateProbe
         if probeAttempt < 2 {
@@ -175,16 +192,22 @@ extension Player {
         publishPlaybackIntent(false)
         return false
       default:
-        if followsCurrentGeneration {
+        if recordsPlaybackControlIntent {
           #if DEBUG
           _pauseProbeHookForTesting?(.pauseRollback)
           #endif
-          let didRestorePreviousIntent = eventBridge.performIfCurrentPlaybackGeneration(
-            playbackGeneration
-          ) {
+          let didRestorePreviousIntent: Bool
+          if followsCurrentGeneration {
+            didRestorePreviousIntent = eventBridge.performIfCurrentPlaybackGeneration(
+              playbackGeneration
+            ) {
+              playbackControlIntent = previousPlaybackControlIntent
+            }
+          } else {
             playbackControlIntent = previousPlaybackControlIntent
+            didRestorePreviousIntent = true
           }
-          if !didRestorePreviousIntent {
+          if !didRestorePreviousIntent, followsCurrentGeneration {
             retainDeferredPause(
               playbackGeneration: playbackGeneration,
               followsCurrentGeneration: true
@@ -197,7 +220,12 @@ extension Player {
       // Keep this probe side-effect free until its generation is validated.
       // Refreshing observable capabilities here could publish values from a
       // successor under the outgoing media's generation.
+      #if DEBUG
+      let nativeCanPause = _nativeCanPauseOverrideForTesting
+        ?? libvlc_media_player_can_pause(pointer)
+      #else
       let nativeCanPause = libvlc_media_player_can_pause(pointer)
+      #endif
       let nativePauseIsSafe = canIssueNativePause
       #if DEBUG
       _pauseProbeHookForTesting?(.capability)
@@ -209,7 +237,14 @@ extension Player {
           current: generationAfterCapabilityProbe,
           followsCurrentGeneration: followsCurrentGeneration
         )
-      else { return false }
+      else {
+        rollbackBoundPauseIntentIfNeeded(
+          recordsPlaybackControlIntent: recordsPlaybackControlIntent,
+          followsCurrentGeneration: followsCurrentGeneration,
+          previousPlaybackControlIntent: previousPlaybackControlIntent
+        )
+        return false
+      }
       if generationAfterCapabilityProbe != playbackGeneration {
         playbackGeneration = generationAfterCapabilityProbe
         if probeAttempt < 2 {
@@ -230,19 +265,45 @@ extension Player {
       }
 
       setPauseTransition(.pausing, playbackGeneration: playbackGeneration)
-      deferredPauseCommand = nil
+      if deferredPauseCommandPlaybackGeneration == playbackGeneration {
+        deferredPauseCommand = nil
+      }
       publishPlaybackIntent(false)
       libvlc_media_player_set_pause(pointer, 1)
+      #if DEBUG
+      _pauseProbeHookForTesting?(.nativePause)
+      #endif
 
       // Close the final check-to-command race. The native pause may already
       // have reached either side of the media boundary; retaining the request
       // for a newly observed successor guarantees the latest media still
       // settles paused after adoption clears the outgoing transition.
-      if followsCurrentGeneration {
-        let generationAfterPause = eventBridge.currentPlaybackGeneration
-        if generationAfterPause != playbackGeneration {
+      let generationAfterPause = eventBridge.currentPlaybackGeneration
+      if generationAfterPause != playbackGeneration {
+        if followsCurrentGeneration {
           setDeferredPauseCommand(.pause, playbackGeneration: generationAfterPause)
+          return true
         }
+
+        // This request was deliberately bound to the captured media. The
+        // callback lane can still advance in the few instructions between the
+        // last check and `set_pause`. Undo a pause that may have reached the
+        // successor, retire only the outgoing transition, and let the latest
+        // persistent intent decide whether a fresh successor pause is queued.
+        libvlc_media_player_set_pause(pointer, 0)
+        clearPauseControlState(for: playbackGeneration)
+        if recordsPlaybackControlIntent {
+          playbackControlIntent = previousPlaybackControlIntent
+        }
+        if playbackControlIntent == .pause {
+          setDeferredPauseCommand(.pause, playbackGeneration: generationAfterPause)
+          publishPlaybackIntent(false)
+        } else {
+          publishPlaybackIntent(
+            playbackControlIntent == .resume || state.isActive
+          )
+        }
+        return false
       }
       return true
     }
@@ -260,6 +321,19 @@ extension Player {
       : playbackGeneration
     setDeferredPauseCommand(.pause, playbackGeneration: generation)
     publishPlaybackIntent(false)
+  }
+
+  /// A fresh command can be generation-bound (PiP debounce) without following
+  /// later media. If that bound is already stale, restore the transport intent
+  /// that existed before the command; retries do not own that global intent.
+  private func rollbackBoundPauseIntentIfNeeded(
+    recordsPlaybackControlIntent: Bool,
+    followsCurrentGeneration: Bool,
+    previousPlaybackControlIntent: DeferredPauseCommand?
+  ) {
+    guard recordsPlaybackControlIntent, !followsCurrentGeneration else { return }
+    playbackControlIntent = previousPlaybackControlIntent
+    publishPlaybackIntent(previousPlaybackControlIntent == .resume || state.isActive)
   }
 
   @discardableResult

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -460,7 +460,15 @@ public final class Player {
   /// command, this survives a native playlist boundary so adoption can carry
   /// a pause or resume that raced with the media switch.
   @ObservationIgnored
-  var playbackControlIntent: DeferredPauseCommand?
+  var playbackControlIntent: DeferredPauseCommand? {
+    didSet { playbackControlIntentRevision &+= 1 }
+  }
+
+  /// Monotonic identity of the latest explicit transport command. PiP uses
+  /// this to retire only the pause it owns without erasing a newer app command
+  /// that happens to target the same media generation.
+  @ObservationIgnored
+  var playbackControlIntentRevision: UInt64 = 0
 
   #if DEBUG
   /// Lets deterministic tests advance the callback-lane generation at the

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -470,6 +470,18 @@ public final class Player {
   @ObservationIgnored
   var playbackControlIntentRevision: UInt64 = 0
 
+  /// Receipt for the most recent pause that reached libVLC.
+  ///
+  /// A deferred pause can be issued by the event consumer while the PiP
+  /// controller is sleeping between retries. The intent revision alone says
+  /// which command is current, not whether that command actually crossed the
+  /// native boundary, so the controller needs this exact generation/revision
+  /// pair to distinguish an issued pause from a still-pending one.
+  @ObservationIgnored
+  var lastIssuedPausePlaybackGeneration: UInt64?
+  @ObservationIgnored
+  var lastIssuedPausePlaybackControlRevision: UInt64?
+
   #if DEBUG
   /// Lets deterministic tests advance the callback-lane generation at the
   /// otherwise unschedulable boundaries between a native probe and its

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -469,6 +469,7 @@ public final class Player {
   enum PauseProbeStage {
     case state
     case capability
+    case nativePause
     case pauseRollback
     case resumeState
     case resumeRollback
@@ -478,6 +479,10 @@ public final class Player {
   var _pauseProbeHookForTesting: ((PauseProbeStage) -> Void)?
   @ObservationIgnored
   var _nativePlaybackStateOverrideForTesting: PlayerState?
+  @ObservationIgnored
+  var _nativeCanPauseOverrideForTesting: Bool?
+  @ObservationIgnored
+  var _nativePauseSafetyOverrideForTesting: Bool?
   #endif
 
   var pauseTransition: PauseTransition? {

--- a/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
@@ -127,6 +127,16 @@ or controller reconstruction; each envelope carries the media and controller
 generation that owns the lifecycle. ``PiPController/pipEvents`` remains the
 unattributed compatibility stream.
 
+PiP pause requests can be deferred while libVLC is opening or buffering.
+Observe ``PiPController/deferredPauseOutcome`` when your UI needs the terminal
+result. It is `nil` while an attempt is in flight, becomes
+``PiPController/DeferredPauseOutcome/issued`` when libVLC accepts the pause,
+``PiPController/DeferredPauseOutcome/cancelled`` when the request is
+superseded, and ``PiPController/DeferredPauseOutcome/rejected`` when the input
+remains unpausable through the bounded retry window. A rejection also restores
+active playback intent, keeping observable controls consistent with continuing
+native playback.
+
 ``PiPController/layer`` uses `videoGravity = .resizeAspect`. Size the
 parent view to the aspect ratio you want. On macOS, the direct public
 sample-buffer path may reflect system support but is not the recommended
@@ -219,6 +229,7 @@ compile the PiP wrapper on visionOS. ``PiPController`` and
 - ``PiPController/isPossible``
 - ``PiPController/isActive``
 - ``PiPController/layer``
+- ``PiPController/deferredPauseOutcome``
 - ``PiPController/pipEventEnvelopes``
 - ``PiPController/pipSnapshots``
 

--- a/Sources/SwiftVLC/SwiftVLC.docc/SwiftVLC.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/SwiftVLC.md
@@ -130,6 +130,7 @@ audio and video overlay APIs.
 
 - ``PiPVideoView``
 - ``PiPController``
+- ``PiPController/DeferredPauseOutcome``
 
 ### Chapters, titles, and programs
 

--- a/Tests/SwiftVLCTests/PiP/PiPAudioSessionDisruptionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPAudioSessionDisruptionTests.swift
@@ -120,7 +120,7 @@ extension Integration {
 
       var driver: PiPController.PlaybackDriver {
         .init(
-          pause: {
+          pause: { _ in
             self.pauseCount += 1
             return true
           },

--- a/Tests/SwiftVLCTests/PiP/PiPAudioSessionDisruptionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPAudioSessionDisruptionTests.swift
@@ -122,10 +122,10 @@ extension Integration {
         .init(
           pause: { _, _ in
             self.pauseCount += 1
-            return true
+            return .init(accepted: true, playbackControlRevision: nil)
           },
           resume: { true },
-          cancelPendingPause: {},
+          cancelPendingPause: { _, _, _ in },
           shouldResume: { false },
           skip: { _ in .issued }
         )

--- a/Tests/SwiftVLCTests/PiP/PiPAudioSessionDisruptionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPAudioSessionDisruptionTests.swift
@@ -120,7 +120,7 @@ extension Integration {
 
       var driver: PiPController.PlaybackDriver {
         .init(
-          pause: { _ in
+          pause: { _, _ in
             self.pauseCount += 1
             return true
           },

--- a/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
@@ -29,7 +29,7 @@ extension Integration {
 
       var driver: PiPController.PlaybackDriver {
         .init(
-          pause: { _ in
+          pause: { _, _ in
             self.pauseCount += 1
             return self.pauseResult
           },

--- a/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
@@ -31,13 +31,13 @@ extension Integration {
         .init(
           pause: { _, _ in
             self.pauseCount += 1
-            return self.pauseResult
+            return .init(accepted: self.pauseResult, playbackControlRevision: nil)
           },
           resume: {
             self.resumeCount += 1
             return self.resumeResult
           },
-          cancelPendingPause: {
+          cancelPendingPause: { _, _, _ in
             self.cancelPendingPauseCount += 1
           },
           shouldResume: { self.shouldResume },

--- a/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
@@ -29,7 +29,7 @@ extension Integration {
 
       var driver: PiPController.PlaybackDriver {
         .init(
-          pause: {
+          pause: { _ in
             self.pauseCount += 1
             return self.pauseResult
           },

--- a/Tests/SwiftVLCTests/PiP/PiPControllerSkipTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerSkipTests.swift
@@ -17,7 +17,7 @@ extension Integration {
 
       var driver: PiPController.PlaybackDriver {
         .init(
-          pause: { _ in true },
+          pause: { _, _ in true },
           resume: { true },
           cancelPendingPause: {},
           shouldResume: { false },

--- a/Tests/SwiftVLCTests/PiP/PiPControllerSkipTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerSkipTests.swift
@@ -17,7 +17,7 @@ extension Integration {
 
       var driver: PiPController.PlaybackDriver {
         .init(
-          pause: { true },
+          pause: { _ in true },
           resume: { true },
           cancelPendingPause: {},
           shouldResume: { false },

--- a/Tests/SwiftVLCTests/PiP/PiPControllerSkipTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerSkipTests.swift
@@ -17,9 +17,9 @@ extension Integration {
 
       var driver: PiPController.PlaybackDriver {
         .init(
-          pause: { _, _ in true },
+          pause: { _, _ in .init(accepted: true, playbackControlRevision: nil) },
           resume: { true },
-          cancelPendingPause: {},
+          cancelPendingPause: { _, _, _ in },
           shouldResume: { false },
           skip: { interval in
             self.skipIntervals.append(interval)

--- a/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
@@ -28,13 +28,16 @@ extension Integration {
           pause: { _, recordsPlaybackControlIntent in
             self.pauseCount += 1
             self.pauseRecordsIntent.append(recordsPlaybackControlIntent)
-            return self.pauseSucceeds
+            return .init(
+              accepted: self.pauseSucceeds,
+              playbackControlRevision: nil
+            )
           },
           resume: {
             self.resumeCount += 1
             return true
           },
-          cancelPendingPause: {
+          cancelPendingPause: { _, _, _ in
             self.cancelPendingPauseCount += 1
           },
           shouldResume: { self.shouldResume },
@@ -219,6 +222,113 @@ extension Integration {
       #expect(controller.deferredPauseOutcome == .cancelled)
       #expect(player.pauseTransition == nil)
       #expect(player.deferredPauseCommand == nil)
+    }
+
+    @Test
+    func `Media advancement after a retained PiP pause retires only that command`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let scheduledGeneration = player.eventBridge.currentPlaybackGeneration
+      player._nativePlaybackStateOverrideForTesting = .playing
+      player._nativeCanPauseOverrideForTesting = false
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: .live(player: player),
+        pauseDebounce: .milliseconds(1)
+      )
+      var retryCount = 0
+      controller._deferredPauseRetryHookForTesting = {
+        retryCount += 1
+        guard retryCount == 2 else { return }
+        controller._deferredPauseRetryHookForTesting = nil
+        _ = player.eventBridge.synchronizePlaybackGeneration(
+          scheduledGeneration + 1,
+          media: nil
+        )
+      }
+
+      controller._setPlayingForTesting(false)
+
+      #expect(await awaitDeferredPauseOutcome(controller))
+      #expect(controller.deferredPauseOutcome == .cancelled)
+      #expect(player.deferredPauseCommand == nil)
+      #expect(player.deferredPauseCommandPlaybackGeneration == nil)
+      #expect(player.playbackControlIntent == .resume)
+      #expect(player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `A newer resume aborts the next PiP retry before it can pause`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._nativePlaybackStateOverrideForTesting = .playing
+      player._nativeCanPauseOverrideForTesting = false
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: .live(player: player),
+        pauseDebounce: .milliseconds(1)
+      )
+      var retryCount = 0
+      controller._deferredPauseRetryHookForTesting = {
+        retryCount += 1
+        guard retryCount == 2 else { return }
+        controller._deferredPauseRetryHookForTesting = nil
+        player.resume()
+      }
+
+      controller._setPlayingForTesting(false)
+
+      #expect(await awaitDeferredPauseOutcome(controller))
+      #expect(controller.deferredPauseOutcome == .cancelled)
+      #expect(player.deferredPauseCommand == nil)
+      #expect(player.playbackControlIntent == .resume)
+      #expect(player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `A newer app pause supersedes PiP cleanup without being erased`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._nativePlaybackStateOverrideForTesting = .opening
+      player._setStateForTesting(state: .opening, isPlaybackRequestedActive: true)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: .live(player: player),
+        pauseDebounce: .milliseconds(1)
+      )
+      controller._deferredPauseRetryHookForTesting = {
+        controller._deferredPauseRetryHookForTesting = nil
+        player.pause()
+      }
+
+      controller._setPlayingForTesting(false)
+
+      #expect(await awaitDeferredPauseOutcome(controller))
+      #expect(controller.deferredPauseOutcome == .cancelled)
+      #expect(player.deferredPauseCommand == .pause)
+      #expect(player.playbackControlIntent == .pause)
+      #expect(!player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `Bounded PiP cleanup preserves a pause that predated the attempt`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._nativePlaybackStateOverrideForTesting = .playing
+      player._nativeCanPauseOverrideForTesting = false
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: false)
+      player.setPlaybackControlIntent(.pause)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: .live(player: player),
+        pauseDebounce: .milliseconds(1)
+      )
+
+      controller._setPlayingForTesting(false)
+
+      #expect(await awaitDeferredPauseOutcome(controller))
+      #expect(controller.deferredPauseOutcome == .cancelled)
+      #expect(player.deferredPauseCommand == .pause)
+      #expect(player.playbackControlIntent == .pause)
+      #expect(!player.isPlaybackRequestedActive)
     }
 
     /// A rejection that clears must still pause: the bound exists to stop

--- a/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
@@ -24,7 +24,7 @@ extension Integration {
 
       var driver: PiPController.PlaybackDriver {
         .init(
-          pause: {
+          pause: { _ in
             self.pauseCount += 1
             return self.pauseSucceeds
           },
@@ -132,6 +132,59 @@ extension Integration {
       #expect(settled)
       #expect(controller.deferredPauseOutcome == .cancelled)
       #expect(recorder.pauseCount == 0, "the outgoing media's pause reached its successor")
+    }
+
+    @Test
+    func `Callback-lane media advancement cancels pause before main-actor adoption`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = PlaybackRecorder()
+      player._setStateForTesting(state: .playing)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(20)
+      )
+
+      controller._setPlayingForTesting(false)
+      let adoptedGeneration = player.eventBridge.currentPlaybackGeneration + 1
+      _ = player.eventBridge.synchronizePlaybackGeneration(
+        adoptedGeneration,
+        media: nil
+      )
+
+      let settled = await awaitDeferredPauseOutcome(controller)
+      #expect(settled)
+      #expect(player.generation.value < adoptedGeneration)
+      #expect(controller.deferredPauseOutcome == .cancelled)
+      #expect(recorder.pauseCount == 0, "the outgoing media's pause reached the callback-lane successor")
+    }
+
+    @Test
+    func `Media advancement inside the live pause probe cancels the old command`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(state: .playing)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: .live(player: player),
+        pauseDebounce: .milliseconds(1)
+      )
+      let scheduledGeneration = player.eventBridge.currentPlaybackGeneration
+      player._pauseProbeHookForTesting = { stage in
+        guard stage == .state else { return }
+        player._pauseProbeHookForTesting = nil
+        _ = player.eventBridge.synchronizePlaybackGeneration(
+          scheduledGeneration + 1,
+          media: nil
+        )
+      }
+
+      controller._setPlayingForTesting(false)
+
+      let settled = await awaitDeferredPauseOutcome(controller)
+      #expect(settled)
+      #expect(controller.deferredPauseOutcome == .cancelled)
+      #expect(player.pauseTransition == nil)
+      #expect(player.deferredPauseCommand == nil)
     }
 
     /// A rejection that clears must still pause: the bound exists to stop

--- a/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
@@ -13,6 +13,7 @@ extension Integration {
     @MainActor
     final class PlaybackRecorder {
       var pauseCount = 0
+      var pauseRecordsIntent: [Bool] = []
       var resumeCount = 0
       var cancelPendingPauseCount = 0
       var shouldResume = false
@@ -24,8 +25,9 @@ extension Integration {
 
       var driver: PiPController.PlaybackDriver {
         .init(
-          pause: { _ in
+          pause: { _, recordsPlaybackControlIntent in
             self.pauseCount += 1
+            self.pauseRecordsIntent.append(recordsPlaybackControlIntent)
             return self.pauseSucceeds
           },
           resume: {
@@ -81,6 +83,38 @@ extension Integration {
         "intent stayed inactive while playback continued — paused UI over playing media"
       )
       #expect(controller._pipPlaybackActiveForTesting())
+      #expect(recorder.cancelPendingPauseCount == 1)
+      #expect(recorder.pauseRecordsIntent.first == true)
+      #expect(
+        recorder.pauseRecordsIntent.dropFirst().allSatisfy { !$0 },
+        "a retry was incorrectly promoted to a fresh transport command"
+      )
+    }
+
+    /// A live player can retain a pause that native capability checks reject.
+    /// Terminal rejection must retire that player-owned command before the
+    /// public outcome becomes visible, or a later capability event can execute
+    /// a pause after the controller has declared the request finished.
+    @Test
+    func `Terminal rejection retires the player-owned deferred pause`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._nativePlaybackStateOverrideForTesting = .playing
+      player._nativeCanPauseOverrideForTesting = false
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: .live(player: player),
+        pauseDebounce: .milliseconds(1)
+      )
+
+      controller._setPlayingForTesting(false)
+
+      #expect(await awaitDeferredPauseOutcome(controller))
+      #expect(controller.deferredPauseOutcome == .rejected)
+      #expect(player.deferredPauseCommand == nil)
+      #expect(player.deferredPauseCommandPlaybackGeneration == nil)
+      #expect(player.playbackControlIntent == .resume)
+      #expect(player.isPlaybackRequestedActive)
     }
 
     /// Apps need to react when a deferred pause settles, rather than polling

--- a/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
@@ -195,9 +195,29 @@ extension Integration {
       )
     }
 
-    /// Leaving a pausable state cancels the retry rather than exhausting it.
     @Test
-    func `Leaving a playing state cancels the deferred pause`() async {
+    func `A newer play command cancels the pending pause with no native call`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = PlaybackRecorder()
+      player._setStateForTesting(state: .playing)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(20)
+      )
+
+      controller._setPlayingForTesting(false)
+      controller._setPlayingForTesting(true)
+
+      #expect(controller.deferredPauseOutcome == .cancelled)
+      try? await Task.sleep(for: .milliseconds(60))
+      #expect(recorder.pauseCount == 0, "a cancelled task issued a late duplicate pause")
+    }
+
+    /// `.stopped` represents both an explicit stop and natural end of media,
+    /// so this pins both terminal paths required by the issue.
+    @Test
+    func `Stop or end cancels the deferred pause`() async {
       let player = Player(instance: TestInstance.makeAudioOnly())
       let recorder = PlaybackRecorder()
       recorder.pauseSucceeds = false

--- a/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
@@ -83,6 +83,36 @@ extension Integration {
       #expect(controller._pipPlaybackActiveForTesting())
     }
 
+    /// Apps need to react when a deferred pause settles, rather than polling
+    /// an internal diagnostic while playback intent has already changed.
+    @Test
+    func `Deferred pause outcome invalidates observation when it settles`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = PlaybackRecorder()
+      recorder.pauseSucceeds = false
+      player._setStateForTesting(state: .playing)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(1)
+      )
+
+      controller._setPlayingForTesting(false)
+      #expect(controller.deferredPauseOutcome == nil)
+
+      let fired = Mutex(false)
+      withObservationTracking {
+        _ = controller.deferredPauseOutcome
+      } onChange: {
+        fired.withLock { $0 = true }
+      }
+
+      let settled = await awaitDeferredPauseOutcome(controller)
+      #expect(settled)
+      #expect(controller.deferredPauseOutcome == .rejected)
+      #expect(fired.withLock { $0 }, "settled outcome did not invalidate Observation")
+    }
+
     /// A rejection that clears must still pause: the bound exists to stop
     /// runaway retries, not to give up on a slow input.
     @Test

--- a/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
@@ -113,6 +113,27 @@ extension Integration {
       #expect(fired.withLock { $0 }, "settled outcome did not invalidate Observation")
     }
 
+    @Test
+    func `Media replacement cancels a deferred pause before it reaches the successor`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = PlaybackRecorder()
+      player._setStateForTesting(state: .playing)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(20)
+      )
+
+      controller._setPlayingForTesting(false)
+      let replacement = try Media(url: TestMedia.silenceURL)
+      player.load(replacement)
+
+      let settled = await awaitDeferredPauseOutcome(controller)
+      #expect(settled)
+      #expect(controller.deferredPauseOutcome == .cancelled)
+      #expect(recorder.pauseCount == 0, "the outgoing media's pause reached its successor")
+    }
+
     /// A rejection that clears must still pause: the bound exists to stop
     /// runaway retries, not to give up on a slow input.
     @Test

--- a/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
@@ -258,6 +258,97 @@ extension Integration {
     }
 
     @Test
+    func `Migrated retained pause is retired by its exact command revision`() {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let outgoingGeneration = player.eventBridge.currentPlaybackGeneration
+      player.setPlaybackControlIntent(.pause)
+      let ownedRevision = player.playbackControlIntentRevision
+
+      // Model playlist adoption carrying the same command onto its successor:
+      // generation changes, but exact command identity does not.
+      player.setDeferredPauseCommand(
+        .pause,
+        playbackGeneration: outgoingGeneration + 1
+      )
+      player.cancelPendingPause(
+        playbackGeneration: outgoingGeneration,
+        playbackControlRevision: ownedRevision,
+        restoringPlaybackControlIntent: .resume
+      )
+
+      #expect(player.deferredPauseCommand == nil)
+      #expect(player.deferredPauseCommandPlaybackGeneration == nil)
+      #expect(player.playbackControlIntent == .resume)
+      #expect(player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `Migrated issued pause is followed by a resume during cleanup`() {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let outgoingGeneration = player.eventBridge.currentPlaybackGeneration
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: false)
+      player.setPlaybackControlIntent(.pause)
+      let ownedRevision = player.playbackControlIntentRevision
+      let successorGeneration = outgoingGeneration + 1
+      _ = player.eventBridge.synchronizePlaybackGeneration(
+        successorGeneration,
+        media: nil
+      )
+
+      // Model the event lane having sent this exact pause after playlist
+      // adoption moved it to the successor. Cleanup must not merely clear a
+      // now-absent deferred command; it owes the successor a resume.
+      player.lastIssuedPausePlaybackGeneration = successorGeneration
+      player.lastIssuedPausePlaybackControlRevision = ownedRevision
+      player.setPauseTransition(
+        .pausing,
+        playbackGeneration: successorGeneration
+      )
+      player.cancelPendingPause(
+        playbackGeneration: outgoingGeneration,
+        playbackControlRevision: ownedRevision,
+        restoringPlaybackControlIntent: .resume
+      )
+
+      #expect(player.playbackControlIntent == .resume)
+      #expect(player.deferredPauseCommand == .resume)
+      #expect(player.deferredPauseCommandPlaybackGeneration == successorGeneration)
+      #expect(player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `Event-lane pause issued between retries settles as issued`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._nativePlaybackStateOverrideForTesting = .playing
+      player._nativeCanPauseOverrideForTesting = false
+      player._nativePauseSafetyOverrideForTesting = true
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: .live(player: player),
+        pauseDebounce: .milliseconds(1)
+      )
+      var retryCount = 0
+      controller._deferredPauseRetryHookForTesting = {
+        retryCount += 1
+        guard retryCount == 2 else { return }
+        controller._deferredPauseRetryHookForTesting = nil
+        player._nativeCanPauseOverrideForTesting = true
+        player.performDeferredPauseCommandIfNeeded()
+      }
+
+      controller._setPlayingForTesting(false)
+
+      #expect(await awaitDeferredPauseOutcome(controller))
+      #expect(controller.deferredPauseOutcome == .issued)
+      #expect(player.deferredPauseCommand == nil)
+      #expect(
+        player.lastIssuedPausePlaybackControlRevision
+          == player.playbackControlIntentRevision
+      )
+    }
+
+    @Test
     func `A newer resume aborts the next PiP retry before it can pause`() async {
       let player = Player(instance: TestInstance.makeAudioOnly())
       player._nativePlaybackStateOverrideForTesting = .playing

--- a/Tests/SwiftVLCTests/Playlist/MediaListPlayerExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Playlist/MediaListPlayerExtendedTests.swift
@@ -485,6 +485,57 @@ extension Integration {
     }
 
     @Test
+    func `A generation-bound fresh PiP pause replaces stale list resume intent`() {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let generation: UInt64 = 1
+      _ = player.eventBridge.synchronizePlaybackGeneration(generation, media: nil)
+      player._nativePlaybackStateOverrideForTesting = .playing
+      player._nativeCanPauseOverrideForTesting = true
+      player._nativePauseSafetyOverrideForTesting = true
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      player.setPlaybackControlIntent(.resume)
+
+      #expect(player.issuePause(playbackGeneration: generation))
+      #expect(player.playbackControlIntent == .pause)
+      #expect(!player.isPlaybackRequestedActive)
+
+      player.handleEvent(.mediaChanged, sourcePlaybackGeneration: generation)
+
+      #expect(
+        player.playbackControlIntent == .pause,
+        "media adoption resurrected the list resume that preceded the PiP pause"
+      )
+      #expect(!player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `A generation-bound pause repairs advancement during the native command`() {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let capturedGeneration: UInt64 = 1
+      _ = player.eventBridge.synchronizePlaybackGeneration(capturedGeneration, media: nil)
+      player._nativePlaybackStateOverrideForTesting = .playing
+      player._nativeCanPauseOverrideForTesting = true
+      player._nativePauseSafetyOverrideForTesting = true
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      player.setPlaybackControlIntent(.resume)
+      player._pauseProbeHookForTesting = { stage in
+        guard stage == .nativePause else { return }
+        player._pauseProbeHookForTesting = nil
+        _ = player.eventBridge.synchronizePlaybackGeneration(
+          capturedGeneration + 1,
+          media: nil
+        )
+      }
+
+      #expect(!player.issuePause(playbackGeneration: capturedGeneration))
+      #expect(player.pauseTransition == nil)
+      #expect(player.pauseTransitionPlaybackGeneration == nil)
+      #expect(player.deferredPauseCommand == nil)
+      #expect(player.playbackControlIntent == .resume)
+      #expect(player.isPlaybackRequestedActive)
+    }
+
+    @Test
     func `An outgoing resume retry cannot clear a successor pause`() {
       let player = Player(instance: TestInstance.shared)
       player._setStateForTesting(state: .paused)

--- a/Tests/SwiftVLCTests/Playlist/MediaListPlayerExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Playlist/MediaListPlayerExtendedTests.swift
@@ -425,6 +425,114 @@ extension Integration {
     }
 
     @Test
+    func `A stale generation-bound fresh pause restores the preceding intent`() {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      player.setPlaybackControlIntent(.resume)
+      _ = player.eventBridge.synchronizePlaybackGeneration(1, media: nil)
+
+      #expect(!player.issuePause(playbackGeneration: 0))
+      #expect(player.playbackControlIntent == .resume)
+      #expect(player.isPlaybackRequestedActive)
+      #expect(player.deferredPauseCommand == nil)
+    }
+
+    @Test
+    func `A bound pause that reaches a terminal state restores the preceding intent`() {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let generation: UInt64 = 1
+      _ = player.eventBridge.synchronizePlaybackGeneration(generation, media: nil)
+      player._setStateForTesting(state: .stopped, isPlaybackRequestedActive: false)
+      player.setPlaybackControlIntent(.resume)
+
+      #expect(!player.issuePause(playbackGeneration: generation))
+      #expect(player.playbackControlIntent == .resume)
+      #expect(player.isPlaybackRequestedActive)
+      #expect(player.deferredPauseCommand == nil)
+    }
+
+    @Test
+    func `A generation-bound fresh pause restores intent after a capability probe race`() {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let capturedGeneration: UInt64 = 1
+      _ = player.eventBridge.synchronizePlaybackGeneration(capturedGeneration, media: nil)
+      player._nativePlaybackStateOverrideForTesting = .playing
+      player._nativeCanPauseOverrideForTesting = true
+      player._nativePauseSafetyOverrideForTesting = true
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      player.setPlaybackControlIntent(.resume)
+      player._pauseProbeHookForTesting = { stage in
+        guard stage == .capability else { return }
+        player._pauseProbeHookForTesting = nil
+        _ = player.eventBridge.synchronizePlaybackGeneration(
+          capturedGeneration + 1,
+          media: nil
+        )
+      }
+
+      #expect(!player.issuePause(playbackGeneration: capturedGeneration))
+      #expect(player.playbackControlIntent == .resume)
+      #expect(player.isPlaybackRequestedActive)
+      #expect(player.deferredPauseCommand == nil)
+    }
+
+    @Test
+    func `A current-following pause carries its command across a native pause race`() {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let capturedGeneration: UInt64 = 1
+      _ = player.eventBridge.synchronizePlaybackGeneration(capturedGeneration, media: nil)
+      player._nativePlaybackStateOverrideForTesting = .playing
+      player._nativeCanPauseOverrideForTesting = true
+      player._nativePauseSafetyOverrideForTesting = true
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      player.setDeferredPauseCommand(.pause, playbackGeneration: capturedGeneration)
+      player._pauseProbeHookForTesting = { stage in
+        guard stage == .nativePause else { return }
+        player._pauseProbeHookForTesting = nil
+        _ = player.eventBridge.synchronizePlaybackGeneration(
+          capturedGeneration + 1,
+          media: nil
+        )
+      }
+
+      #expect(player.issuePause())
+      #expect(player.deferredPauseCommand == .pause)
+      #expect(player.deferredPauseCommandPlaybackGeneration == capturedGeneration + 1)
+      #expect(!player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `A bound pause retry carries a persistent pause intent to the successor`() {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let capturedGeneration: UInt64 = 1
+      _ = player.eventBridge.synchronizePlaybackGeneration(capturedGeneration, media: nil)
+      player._nativePlaybackStateOverrideForTesting = .playing
+      player._nativeCanPauseOverrideForTesting = true
+      player._nativePauseSafetyOverrideForTesting = true
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: false)
+      player.setPlaybackControlIntent(.pause)
+      player._pauseProbeHookForTesting = { stage in
+        guard stage == .nativePause else { return }
+        player._pauseProbeHookForTesting = nil
+        _ = player.eventBridge.synchronizePlaybackGeneration(
+          capturedGeneration + 1,
+          media: nil
+        )
+      }
+
+      #expect(
+        !player.issuePause(
+          playbackGeneration: capturedGeneration,
+          recordsPlaybackControlIntent: false
+        )
+      )
+      #expect(player.deferredPauseCommand == .pause)
+      #expect(player.deferredPauseCommandPlaybackGeneration == capturedGeneration + 1)
+      #expect(player.playbackControlIntent == .pause)
+      #expect(!player.isPlaybackRequestedActive)
+    }
+
+    @Test
     func `Fresh pause retains the newest generation after repeated state probe races`() {
       let player = Player(instance: TestInstance.shared)
       player._setStateForTesting(state: .playing)

--- a/Tests/SwiftVLCTests/Playlist/MediaListPlayerExtendedTests.swift
+++ b/Tests/SwiftVLCTests/Playlist/MediaListPlayerExtendedTests.swift
@@ -438,6 +438,39 @@ extension Integration {
     }
 
     @Test
+    func `Restoring a preceding pause keeps published intent inactive`() {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: false)
+      player.setPlaybackControlIntent(.pause)
+      _ = player.eventBridge.synchronizePlaybackGeneration(1, media: nil)
+
+      #expect(!player.issuePause(playbackGeneration: 0))
+      #expect(player.playbackControlIntent == .pause)
+      #expect(!player.isPlaybackRequestedActive)
+    }
+
+    @Test
+    func `Scoped PiP cancellation preserves a newer pause on the same generation`() {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let generation: UInt64 = 1
+      _ = player.eventBridge.synchronizePlaybackGeneration(generation, media: nil)
+      player.setDeferredPauseCommand(.pause, playbackGeneration: generation)
+      player.setPlaybackControlIntent(.pause)
+      let piPRevision = player.playbackControlIntentRevision
+      player.setPlaybackControlIntent(.pause)
+
+      player.cancelPendingPause(
+        playbackGeneration: generation,
+        playbackControlRevision: piPRevision
+      )
+
+      #expect(player.deferredPauseCommand == .pause)
+      #expect(player.deferredPauseCommandPlaybackGeneration == generation)
+      #expect(player.playbackControlIntent == .pause)
+      #expect(!player.isPlaybackRequestedActive)
+    }
+
+    @Test
     func `A bound pause that reaches a terminal state restores the preceding intent`() {
       let player = Player(instance: TestInstance.makeAudioOnly())
       let generation: UInt64 = 1


### PR DESCRIPTION
## Summary

- expose the deferred PiP pause result as an observable public `DeferredPauseOutcome`
- bound permanently rejected pause retries and reconcile PiP plus player intent back to active playback
- cancel pending pauses on replacement, callback-lane generation advancement, terminal state, and newer commands
- bind delayed native pause attempts to the playback generation that scheduled them so they cannot follow a replacement
- acknowledge pauses issued by Player's event lane between controller retries, and retire migrated pending/issued commands by exact revision
- document the public outcome and add deterministic coverage for rejection, recovery, observation, cancellation, and race boundaries

Advances issue 103. The code acceptance criteria are covered here; physical-device PiP reconciliation remains part of the v1.1.0 release qualification matrix.

## Exact-head validation

Validated commit: `de3d8ec377dfe4d64aaae6a6f155059e535cdf42`

- full macOS package: 1,902 tests in 165 suites passed on exact head
- focused PiP, playlist, and native-lifecycle sweep: 329 tests in 23 suites passed
- exact migrated-pending, migrated-issued, and event-lane-issued regressions: 3/3 passed
- release build: passed
- strict SwiftLint: 0 violations across 472 files
- strict SwiftFormat: 0 of 254 files require formatting (16 excluded)
- public documentation coverage: 784/784 symbols (100%)
- patch manifest, release integrity, and engine patch coverage: passed
- exact-head GitHub CI: passed (package tests, iOS build, tvOS tests, AddressSanitizer, ThreadSanitizer, lint, dynamic-host fixtures, and every platform showcase)
- exact-head Codecov: both patch and playback-gated checks passed
- exact-head Codex review: no major issues found; all review threads resolved
