### PR TITLE
Settle PiP skips on native seek evidence

### DIFF
--- a/Sources/SwiftVLC/PiP/PiPController+Skip.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Skip.swift
@@ -8,15 +8,64 @@ extension PiPController {
   /// AVKit's contract is that the completion handler runs once the skip
   /// operation finishes or fails — never twice, and never not at all. Naming
   /// the outcomes makes "exactly once" checkable rather than assumed.
-  enum SkipOutcome: Equatable {
-    /// libVLC accepted the relative jump.
-    case issued
+  enum SkipOutcome: Equatable, Sendable {
+    /// libVLC accepted the relative jump and landing is still pending.
+    case pending
     /// There was no session to seek in, or libVLC refused the request. The
     /// published timeline is left exactly as it was.
     case rejected
+    /// The matching seek ended and its landed clock reached the observable timeline.
+    case settled
+    /// libVLC accepted the jump but emitted no landed timer point before the
+    /// bounded settlement window elapsed.
+    case timedOut
+    /// A newer jump or media lifecycle transition replaced this request.
+    case superseded
     /// AVKit handed over an interval that cannot be expressed in libVLC's
     /// millisecond unit — infinite, NaN, or out of range.
     case unrepresentableInterval
+  }
+
+  /// Initial dispatch classification plus one shared terminal result.
+  struct SkipRequest: Sendable {
+    private enum Resolution: Sendable {
+      case resolved(SkipOutcome)
+      case seek(SeekRequest)
+    }
+
+    let initialOutcome: SkipOutcome
+    private let resolution: Resolution
+
+    var outcome: SkipOutcome {
+      get async {
+        switch resolution {
+        case .resolved(let outcome): outcome
+        case .seek(let seekRequest):
+          switch await seekRequest.outcome {
+          case .pending: preconditionFailure("a terminal seek outcome cannot be pending")
+          case .rejected: .rejected
+          case .settled: .settled
+          case .timedOut: .timedOut
+          case .superseded: .superseded
+          }
+        }
+      }
+    }
+
+    init(resolved outcome: SkipOutcome) {
+      precondition(outcome != .pending)
+      initialOutcome = switch outcome {
+      case .rejected, .unrepresentableInterval: outcome
+      case .settled, .timedOut, .superseded: .pending
+      case .pending: preconditionFailure("pending is not terminal")
+      }
+      resolution = .resolved(outcome)
+    }
+
+    init(seekRequest: SeekRequest) {
+      initialOutcome = seekRequest.initialOutcome == .rejected ? .rejected : .pending
+      resolution = .seek(seekRequest)
+    }
   }
 
   /// Routes an AVKit skip through the player's relative jump.
@@ -37,14 +86,13 @@ extension PiPController {
   /// The interval is therefore preserved and handed to libVLC as a relative
   /// offset.
   @MainActor
-  static func performSkip(on player: Player, by interval: CMTime) -> SkipOutcome {
+  static func performSkip(on player: Player, by interval: CMTime) -> SkipRequest {
     guard let offsetMilliseconds = skipOffsetMilliseconds(interval) else {
-      return .unrepresentableInterval
+      return SkipRequest(resolved: .unrepresentableInterval)
     }
-    guard player.jump(by: .milliseconds(offsetMilliseconds)) else {
-      return .rejected
-    }
-    return .issued
+    return SkipRequest(
+      seekRequest: player.requestJump(by: .milliseconds(offsetMilliseconds))
+    )
   }
 
   /// Whether this outcome means the timeline actually moved.
@@ -53,7 +101,7 @@ extension PiPController {
   /// time as though it had landed puts the transport controls ahead of the
   /// media, and the next native clock sample then yanks them back.
   static func skipMovedTimeline(_ outcome: SkipOutcome) -> Bool {
-    outcome == .issued
+    outcome == .settled
   }
 }
 

--- a/Sources/SwiftVLC/PiP/PiPController+StateObserver.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+StateObserver.swift
@@ -112,6 +112,7 @@ extension PiPController {
       rate: rate,
       lastRate: lastObservedRate,
       hasTimebase: timebase != nil,
+      isSkipPending: pendingSkipCount > 0,
       secondsSinceSkip: CFAbsoluteTimeGetCurrent() - lastSkipTimestamp,
       playerSeconds: Double(time.components.seconds)
         + Double(time.components.attoseconds) / 1e18,
@@ -166,6 +167,7 @@ extension PiPController {
     rate: Float,
     lastRate: Float,
     hasTimebase: Bool,
+    isSkipPending: Bool,
     secondsSinceSkip: Double,
     playerSeconds: Double,
     timebaseSeconds: Double
@@ -179,7 +181,10 @@ extension PiPController {
     if retracking.adoptsRate {
       retracking.setsRate = rate
     }
-    if secondsSinceSkip > 1.0, abs(playerSeconds - timebaseSeconds) > 2.0 {
+    if
+      !isSkipPending,
+      secondsSinceSkip > 1.0,
+      abs(playerSeconds - timebaseSeconds) > 2.0 {
       retracking.setsTime = playerSeconds
     }
     return retracking

--- a/Sources/SwiftVLC/PiP/PiPController+Testing.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Testing.swift
@@ -72,18 +72,26 @@ extension PiPController {
     lastSkipTimestamp != 0
   }
 
-  func _skipByIntervalForTesting(_ skipInterval: CMTime) {
-    handleSkip(by: skipInterval) {}
+  func _skipByIntervalForTesting(_ skipInterval: CMTime) async {
+    await withCheckedContinuation { continuation in
+      handleSkip(by: skipInterval) { continuation.resume() }
+    }
   }
 
   /// Returns how many times the completion handler ran, so "exactly once" is
   /// assertable rather than assumed.
-  func _skipCompletionCountForTesting(_ skipInterval: CMTime) -> Int {
+  func _skipCompletionCountForTesting(_ skipInterval: CMTime) async -> Int {
     // `handleSkip`'s completion is `@Sendable`, so the counter has to be
     // shared state rather than a captured `var`. It is called synchronously on
     // this actor today; the lock keeps the helper correct if that changes.
     let count = Mutex(0)
-    handleSkip(by: skipInterval) { count.withLock { $0 += 1 } }
+    await withCheckedContinuation { continuation in
+      handleSkip(by: skipInterval) {
+        count.withLock { $0 += 1 }
+        continuation.resume()
+      }
+    }
+    await Task.yield()
     return count.withLock { $0 }
   }
 

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -82,7 +82,7 @@ public final class PiPController: NSObject {
     /// Relative rather than absolute: see ``PiPController/performSkip(on:by:)``
     /// for why the interval AVKit requested is preserved instead of being
     /// converted into a target.
-    let skip: @MainActor (CMTime) -> SkipOutcome
+    let skip: @MainActor (CMTime) -> SkipRequest
 
     static func live(player: Player) -> Self {
       Self(
@@ -386,6 +386,11 @@ public final class PiPController: NSObject {
   /// `currentTime` data that hasn't caught up to the seek yet.
   @ObservationIgnored
   var lastSkipTimestamp: CFAbsoluteTime = 0
+  /// Number of AVKit skips still waiting for a terminal native seek outcome.
+  /// Overlapping requests are counted so completion of a superseded request
+  /// cannot re-enable timebase retracking while its successor is still pending.
+  @ObservationIgnored
+  var pendingSkipCount = 0
 
   /// Whether PiP can be started right now.
   ///
@@ -1142,32 +1147,41 @@ public final class PiPController: NSObject {
       return
     }
 
-    let outcome = playbackDriver.skip(skipInterval)
+    let request = playbackDriver.skip(skipInterval)
+    let tracksPendingSkip = request.initialOutcome == .pending
+    if tracksPendingSkip {
+      pendingSkipCount += 1
+    }
+    Task { @MainActor [weak self] in
+      let outcome = await request.outcome
+      guard let self else {
+        completionHandler()
+        return
+      }
+      if tracksPendingSkip {
+        pendingSkipCount = Swift.max(0, pendingSkipCount - 1)
+      }
 
-    // A refused skip leaves the timeline untouched. Moving the timebase to a
-    // target the media never reached would put the transport controls ahead of
-    // playback until the next native clock sample yanked them back.
-    guard Self.skipMovedTimeline(outcome) else {
+      // A refused, timed-out, or superseded skip leaves the timebase alone.
+      // Publishing the requested estimate as authoritative before native
+      // landing evidence would put AVKit ahead of playback.
+      if Self.skipMovedTimeline(outcome) {
+        lastSkipTimestamp = CFAbsoluteTimeGetCurrent()
+
+        // Apple docs: "the control timebase should reflect the current
+        // playback time and rate when the closure is invoked". Read it back
+        // only after the matching native clock event has been applied.
+        if let tb = controlTimebase {
+          CMTimebaseSetTime(tb, time: CMTime(
+            seconds: Double(player.currentTime.milliseconds) / 1000.0,
+            preferredTimescale: 1000
+          ))
+          CMTimebaseSetRate(tb, rate: player.isActive ? Float64(player.rate) : 0.0)
+        }
+      }
+
       completionHandler()
-      return
     }
-
-    lastSkipTimestamp = CFAbsoluteTimeGetCurrent()
-
-    // Apple docs: "the control timebase should reflect the current
-    // playback time and rate when the closure is invoked". Read it back from
-    // the player rather than from a locally computed target: `jump(by:)` has
-    // already published its own clamped estimate, and recomputing one here
-    // could disagree with it.
-    if let tb = controlTimebase {
-      CMTimebaseSetTime(tb, time: CMTime(
-        seconds: Double(player.currentTime.milliseconds) / 1000.0,
-        preferredTimescale: 1000
-      ))
-      CMTimebaseSetRate(tb, rate: player.isActive ? Float64(player.rate) : 0.0)
-    }
-
-    completionHandler()
   }
 
   /// Sets the controlTimebase time to the player's current position.

--- a/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+MacPrivate.swift
@@ -653,12 +653,13 @@ final class MacNativePiPMediaController: NSObject, @unchecked Sendable {
       // One relative-jump path for every PiP backend: see
       // PiPController.performSkip(on:by:). The interval is preserved rather
       // than converted to an absolute target, so live and timeshift DVR
-      // windows skip correctly, and completion runs exactly once whether the
-      // jump was accepted or refused.
-      _ = PiPController.performSkip(
+      // windows skip correctly. Completion waits for the shared request's
+      // landed, rejected, timed-out, or superseded terminal result.
+      let request = PiPController.performSkip(
         on: player,
         by: CMTime(value: offset, timescale: 1000)
       )
+      _ = await request.outcome
       completion?()
     }
   }

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -1172,12 +1172,13 @@ final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling,
       // One relative-jump path for every PiP backend: see
       // PiPController.performSkip(on:by:). The interval is preserved rather
       // than converted to an absolute target, so live and timeshift DVR
-      // windows skip correctly, and completion runs exactly once whether the
-      // jump was accepted or refused.
-      _ = PiPController.performSkip(
+      // windows skip correctly. Completion waits for the shared request's
+      // landed, rejected, timed-out, or superseded terminal result.
+      let request = PiPController.performSkip(
         on: player,
         by: CMTime(value: offset, timescale: 1000)
       )
+      _ = await request.outcome
       completion?()
     }
   }

--- a/Sources/SwiftVLC/Player/EventBridge+Mapping.swift
+++ b/Sources/SwiftVLC/Player/EventBridge+Mapping.swift
@@ -1,0 +1,135 @@
+import CLibVLC
+
+/// Maps a single libVLC `libvlc_event_t` to a typed `PlayerEvent`.
+///
+/// Internal rather than `private` so unit tests can synthesize each
+/// event variant with hand-built `libvlc_event_t` values. Most of
+/// these events don't fire in a headless test environment, so full
+/// switch coverage is impossible without direct invocation.
+func mapEvent(_ event: libvlc_event_t) -> PlayerEvent? {
+  let type = libvlc_event_e(rawValue: UInt32(event.type))
+
+  switch type {
+  case libvlc_MediaPlayerNothingSpecial:
+    return .stateChanged(.idle)
+
+  case libvlc_MediaPlayerOpening:
+    return .stateChanged(.opening)
+
+  case libvlc_MediaPlayerBuffering:
+    let pct = event.u.media_player_buffering.new_cache / 100.0
+    return .bufferingProgress(pct)
+
+  case libvlc_MediaPlayerPlaying:
+    return .stateChanged(.playing)
+
+  case libvlc_MediaPlayerPaused:
+    return .stateChanged(.paused)
+
+  case libvlc_MediaPlayerStopped:
+    return .stateChanged(.stopped)
+
+  case libvlc_MediaPlayerStopping:
+    return .stateChanged(.stopping)
+
+  case libvlc_MediaPlayerEncounteredError:
+    return .encounteredError
+
+  case libvlc_MediaPlayerTimeChanged:
+    let ms = event.u.media_player_time_changed.new_time
+    return .timeChanged(.milliseconds(ms))
+
+  case libvlc_MediaPlayerPositionChanged:
+    let pos = event.u.media_player_position_changed.new_position
+    return .positionChanged(pos)
+
+  case libvlc_MediaPlayerSeekableChanged:
+    let seekable = event.u.media_player_seekable_changed.new_seekable != 0
+    return .seekableChanged(seekable)
+
+  case libvlc_MediaPlayerPausableChanged:
+    let pausable = event.u.media_player_pausable_changed.new_pausable != 0
+    return .pausableChanged(pausable)
+
+  case libvlc_MediaPlayerLengthChanged:
+    let ms = event.u.media_player_length_changed.new_length
+    return .lengthChanged(.milliseconds(ms))
+
+  case libvlc_MediaPlayerVout:
+    let count = event.u.media_player_vout.new_count
+    return .voutChanged(Int(count))
+
+  case libvlc_MediaPlayerESAdded,
+       libvlc_MediaPlayerESDeleted,
+       libvlc_MediaPlayerESSelected,
+       libvlc_MediaPlayerESUpdated:
+    return .tracksChanged
+
+  case libvlc_MediaPlayerMediaChanged:
+    return .mediaChanged
+
+  case libvlc_MediaPlayerMuted:
+    return .muted
+
+  case libvlc_MediaPlayerUnmuted:
+    return .unmuted
+
+  case libvlc_MediaPlayerCorked:
+    return .corked
+
+  case libvlc_MediaPlayerUncorked:
+    return .uncorked
+
+  case libvlc_MediaPlayerAudioVolume:
+    let vol = event.u.media_player_audio_volume.volume
+    return .volumeChanged(vol)
+
+  case libvlc_MediaPlayerAudioDevice:
+    let device = event.u.media_player_audio_device.device.map { String(cString: $0) }
+    return .audioDeviceChanged(device)
+
+  case libvlc_MediaPlayerMediaStopping:
+    return .mediaStopping
+
+  case libvlc_MediaPlayerChapterChanged:
+    let chapter = event.u.media_player_chapter_changed.new_chapter
+    return .chapterChanged(Int(chapter))
+
+  case libvlc_MediaPlayerRecordChanged:
+    let recording = event.u.media_player_record_changed.recording
+    let path = event.u.media_player_record_changed.recorded_file_path
+      .map { String(cString: $0) }
+    return .recordingChanged(isRecording: recording, filePath: path)
+
+  case libvlc_MediaPlayerTitleListChanged:
+    return .titleListChanged
+
+  case libvlc_MediaPlayerTitleSelectionChanged:
+    let index = event.u.media_player_title_selection_changed.index
+    return .titleSelectionChanged(Int(index))
+
+  case libvlc_MediaPlayerSnapshotTaken:
+    let path = String(cString: event.u.media_player_snapshot_taken.psz_filename)
+    return .snapshotTaken(path)
+
+  case libvlc_MediaPlayerProgramAdded:
+    let id = event.u.media_player_program_changed.i_id
+    return .programAdded(Int(id))
+
+  case libvlc_MediaPlayerProgramDeleted:
+    let id = event.u.media_player_program_changed.i_id
+    return .programDeleted(Int(id))
+
+  case libvlc_MediaPlayerProgramSelected:
+    let unselected = event.u.media_player_program_selection_changed.i_unselected_id
+    let selected = event.u.media_player_program_selection_changed.i_selected_id
+    return .programSelected(unselectedId: Int(unselected), selectedId: Int(selected))
+
+  case libvlc_MediaPlayerProgramUpdated:
+    let id = event.u.media_player_program_changed.i_id
+    return .programUpdated(Int(id))
+
+  default:
+    return nil
+  }
+}

--- a/Sources/SwiftVLC/Player/EventBridge.swift
+++ b/Sources/SwiftVLC/Player/EventBridge.swift
@@ -192,12 +192,14 @@ final class EventBridge: Sendable {
   func updateAuthoritativeTimeline(
     time: Duration,
     position: Double?,
-    playbackGeneration: UInt64
+    playbackGeneration: UInt64,
+    timelineRevision: UInt64
   ) {
     context.updateAuthoritativeTimeline(
       time: time,
       position: position,
-      playbackGeneration: playbackGeneration
+      playbackGeneration: playbackGeneration,
+      timelineRevision: timelineRevision
     )
   }
 
@@ -215,8 +217,9 @@ final class EventBridge: Sendable {
     )
   }
 
-  /// Marks a new authoritative timeline. Clock samples emitted before this
-  /// point carry a lower revision and are discarded by the consumer.
+  /// Marks a new authoritative timeline after native dispatch accepts.
+  /// Clock samples stamped before this lock-linearized point carry a lower
+  /// revision and are discarded by the consumer.
   @discardableResult
   func advanceTimelineRevision() -> UInt64 {
     context.advanceTimelineRevision()
@@ -228,12 +231,14 @@ final class EventBridge: Sendable {
   func _broadcastForTesting(
     _ event: PlayerEvent,
     nativeHandleGeneration: UInt64,
-    playbackGeneration: UInt64? = nil
+    playbackGeneration: UInt64? = nil,
+    emittedTimelineRevision: UInt64? = nil
   ) {
     context.broadcast(
       event,
       nativeHandleGeneration: nativeHandleGeneration,
-      playbackGeneration: playbackGeneration
+      playbackGeneration: playbackGeneration,
+      emittedTimelineRevision: emittedTimelineRevision
     )
   }
 
@@ -361,6 +366,7 @@ private final class EventBridgeCallbackContext: Sendable {
     var position: Double = 0
     var bufferFill: Float = 0
     var activeVideoOutputs = 0
+    var timelineRevision: UInt64 = 0
 
     var publicValue: PlaybackFinalTimeline {
       PlaybackFinalTimeline(
@@ -491,7 +497,8 @@ private final class EventBridgeCallbackContext: Sendable {
   func updateAuthoritativeTimeline(
     time: Duration,
     position: Double?,
-    playbackGeneration: UInt64
+    playbackGeneration: UInt64,
+    timelineRevision: UInt64
   ) {
     playbackLifecycle.withLock { state in
       guard
@@ -499,10 +506,12 @@ private final class EventBridgeCallbackContext: Sendable {
         playbackGeneration > state.lastEmittedGeneration
       else { return }
       var snapshot = state.snapshots[playbackGeneration] ?? TimelineSnapshot()
+      guard timelineRevision >= snapshot.timelineRevision else { return }
       snapshot.time = time
       if let position {
         snapshot.position = position
       }
+      snapshot.timelineRevision = timelineRevision
       state.snapshots[playbackGeneration] = snapshot
     }
   }
@@ -528,10 +537,16 @@ private final class EventBridgeCallbackContext: Sendable {
   func broadcast(
     _ event: PlayerEvent,
     nativeHandleGeneration: UInt64,
-    playbackGeneration: UInt64? = nil
+    playbackGeneration: UInt64? = nil,
+    emittedTimelineRevision: UInt64? = nil
   ) {
     let playbackGeneration = playbackGeneration ?? currentPlaybackGeneration
-    recordTimeline(event, generation: playbackGeneration)
+    let emittedTimelineRevision = emittedTimelineRevision ?? captureTimelineRevision()
+    recordTimeline(
+      event,
+      generation: playbackGeneration,
+      timelineRevision: emittedTimelineRevision
+    )
     // Each broadcaster is gated on its own emptiness so a libVLC event
     // with no consumers costs neither the lock-and-snapshot nor the
     // sourced-wrapper construction. The sourced broadcast (the player's
@@ -544,7 +559,7 @@ private final class EventBridgeCallbackContext: Sendable {
           nativeHandleGeneration: nativeHandleGeneration,
           playbackGeneration: playbackGeneration,
           event: event,
-          timelineRevision: timelineRevision.withLock { $0 }
+          timelineRevision: emittedTimelineRevision
         )
       )
     }
@@ -567,6 +582,12 @@ private final class EventBridgeCallbackContext: Sendable {
       revision &+= 1
       return revision
     }
+  }
+
+  /// Captures authority at native callback entry, before event classification
+  /// or lifecycle bookkeeping can delay delivery past a seek boundary.
+  func captureTimelineRevision() -> UInt64 {
+    timelineRevision.withLock { $0 }
   }
 
   /// Permanently closes both broadcasters, so streams handed out after this
@@ -738,14 +759,25 @@ private final class EventBridgeCallbackContext: Sendable {
     }
   }
 
-  private func recordTimeline(_ event: PlayerEvent, generation: UInt64) {
+  private func recordTimeline(
+    _ event: PlayerEvent,
+    generation: UInt64,
+    timelineRevision: UInt64
+  ) {
     guard generation > 0 else { return }
     playbackLifecycle.withLock { state in
+      guard generation > state.lastEmittedGeneration else { return }
       var snapshot = state.snapshots[generation] ?? TimelineSnapshot()
       switch event {
-      case .timeChanged(let time): snapshot.time = time
+      case .timeChanged(let time):
+        guard timelineRevision >= snapshot.timelineRevision else { return }
+        snapshot.time = time
+        snapshot.timelineRevision = timelineRevision
       case .lengthChanged(let duration): snapshot.duration = duration
-      case .positionChanged(let position): snapshot.position = position
+      case .positionChanged(let position):
+        guard timelineRevision >= snapshot.timelineRevision else { return }
+        snapshot.position = position
+        snapshot.timelineRevision = timelineRevision
       case .bufferingProgress(let fill): snapshot.bufferFill = fill
       case .voutChanged(let count): snapshot.activeVideoOutputs = count
       default: break
@@ -795,6 +827,11 @@ private func playerEventCallback(
   let attachment = Unmanaged<EventBridgeCallbackAttachment>.fromOpaque(opaque)
     .takeUnretainedValue()
   let context = attachment.context
+  // This lock acquisition and `advanceTimelineRevision()` form the evidence
+  // boundary. A callback that entered before native dispatch returned keeps
+  // the outgoing stamp even if mapping or lifecycle bookkeeping finishes
+  // after the accepted seek publishes its revision.
+  let emittedTimelineRevision = context.captureTimelineRevision()
 
   guard let mapped = mapEvent(event.pointee) else { return }
   let coordinator = context.endCoordinator
@@ -850,147 +887,15 @@ private func playerEventCallback(
   context.broadcast(
     mapped,
     nativeHandleGeneration: attachment.nativeHandleGeneration,
-    playbackGeneration: playbackGeneration
+    playbackGeneration: playbackGeneration,
+    emittedTimelineRevision: emittedTimelineRevision
   )
   if shouldSynthesizeEnd {
     context.broadcast(
       .endReached,
       nativeHandleGeneration: attachment.nativeHandleGeneration,
-      playbackGeneration: playbackGeneration
+      playbackGeneration: playbackGeneration,
+      emittedTimelineRevision: emittedTimelineRevision
     )
-  }
-}
-
-/// Maps a single libVLC `libvlc_event_t` to a typed `PlayerEvent`.
-///
-/// Internal rather than `private` so unit tests can synthesize each
-/// event variant with hand-built `libvlc_event_t` values. Most of
-/// these events don't fire in a headless test environment, so full
-/// switch coverage is impossible without direct invocation.
-func mapEvent(_ event: libvlc_event_t) -> PlayerEvent? {
-  let type = libvlc_event_e(rawValue: UInt32(event.type))
-
-  switch type {
-  case libvlc_MediaPlayerNothingSpecial:
-    return .stateChanged(.idle)
-
-  case libvlc_MediaPlayerOpening:
-    return .stateChanged(.opening)
-
-  case libvlc_MediaPlayerBuffering:
-    let pct = event.u.media_player_buffering.new_cache / 100.0
-    return .bufferingProgress(pct)
-
-  case libvlc_MediaPlayerPlaying:
-    return .stateChanged(.playing)
-
-  case libvlc_MediaPlayerPaused:
-    return .stateChanged(.paused)
-
-  case libvlc_MediaPlayerStopped:
-    return .stateChanged(.stopped)
-
-  case libvlc_MediaPlayerStopping:
-    return .stateChanged(.stopping)
-
-  case libvlc_MediaPlayerEncounteredError:
-    return .encounteredError
-
-  case libvlc_MediaPlayerTimeChanged:
-    let ms = event.u.media_player_time_changed.new_time
-    return .timeChanged(.milliseconds(ms))
-
-  case libvlc_MediaPlayerPositionChanged:
-    let pos = event.u.media_player_position_changed.new_position
-    return .positionChanged(pos)
-
-  case libvlc_MediaPlayerSeekableChanged:
-    let seekable = event.u.media_player_seekable_changed.new_seekable != 0
-    return .seekableChanged(seekable)
-
-  case libvlc_MediaPlayerPausableChanged:
-    let pausable = event.u.media_player_pausable_changed.new_pausable != 0
-    return .pausableChanged(pausable)
-
-  case libvlc_MediaPlayerLengthChanged:
-    let ms = event.u.media_player_length_changed.new_length
-    return .lengthChanged(.milliseconds(ms))
-
-  case libvlc_MediaPlayerVout:
-    let count = event.u.media_player_vout.new_count
-    return .voutChanged(Int(count))
-
-  case libvlc_MediaPlayerESAdded,
-       libvlc_MediaPlayerESDeleted,
-       libvlc_MediaPlayerESSelected,
-       libvlc_MediaPlayerESUpdated:
-    return .tracksChanged
-
-  case libvlc_MediaPlayerMediaChanged:
-    return .mediaChanged
-
-  case libvlc_MediaPlayerMuted:
-    return .muted
-
-  case libvlc_MediaPlayerUnmuted:
-    return .unmuted
-
-  case libvlc_MediaPlayerCorked:
-    return .corked
-
-  case libvlc_MediaPlayerUncorked:
-    return .uncorked
-
-  case libvlc_MediaPlayerAudioVolume:
-    let vol = event.u.media_player_audio_volume.volume
-    return .volumeChanged(vol)
-
-  case libvlc_MediaPlayerAudioDevice:
-    let device = event.u.media_player_audio_device.device.map { String(cString: $0) }
-    return .audioDeviceChanged(device)
-
-  case libvlc_MediaPlayerMediaStopping:
-    return .mediaStopping
-
-  case libvlc_MediaPlayerChapterChanged:
-    let chapter = event.u.media_player_chapter_changed.new_chapter
-    return .chapterChanged(Int(chapter))
-
-  case libvlc_MediaPlayerRecordChanged:
-    let recording = event.u.media_player_record_changed.recording
-    let path = event.u.media_player_record_changed.recorded_file_path
-      .map { String(cString: $0) }
-    return .recordingChanged(isRecording: recording, filePath: path)
-
-  case libvlc_MediaPlayerTitleListChanged:
-    return .titleListChanged
-
-  case libvlc_MediaPlayerTitleSelectionChanged:
-    let index = event.u.media_player_title_selection_changed.index
-    return .titleSelectionChanged(Int(index))
-
-  case libvlc_MediaPlayerSnapshotTaken:
-    let path = String(cString: event.u.media_player_snapshot_taken.psz_filename)
-    return .snapshotTaken(path)
-
-  case libvlc_MediaPlayerProgramAdded:
-    let id = event.u.media_player_program_changed.i_id
-    return .programAdded(Int(id))
-
-  case libvlc_MediaPlayerProgramDeleted:
-    let id = event.u.media_player_program_changed.i_id
-    return .programDeleted(Int(id))
-
-  case libvlc_MediaPlayerProgramSelected:
-    let unselected = event.u.media_player_program_selection_changed.i_unselected_id
-    let selected = event.u.media_player_program_selection_changed.i_selected_id
-    return .programSelected(unselectedId: Int(unselected), selectedId: Int(selected))
-
-  case libvlc_MediaPlayerProgramUpdated:
-    let id = event.u.media_player_program_changed.i_id
-    return .programUpdated(Int(id))
-
-  default:
-    return nil
   }
 }

--- a/Sources/SwiftVLC/Player/NativeSeekMonitor.swift
+++ b/Sources/SwiftVLC/Player/NativeSeekMonitor.swift
@@ -1,0 +1,285 @@
+import CLibVLC
+import Synchronization
+
+struct NativeSeekLanding: Sendable {
+  let token: UInt64
+  let timeMilliseconds: Int64
+  let position: Double
+}
+
+/// Correlates wrapper-issued seeks with libVLC's authoritative seek-end
+/// callback. Time events alone are not causal: ordinary playback ticks can be
+/// delivered on either side of the native dispatch call.
+final class NativeSeekMonitor: Sendable {
+  fileprivate final class Attachment: Sendable {
+    let context: Context
+    let timelineGeneration: UInt64
+
+    init(context: Context, timelineGeneration: UInt64) {
+      self.context = context
+      self.timelineGeneration = timelineGeneration
+    }
+  }
+
+  fileprivate final class Context: Sendable {
+    private struct State: Sendable {
+      var nextToken: UInt64 = 0
+      var timelineGeneration: UInt64 = 1
+      var stagedTokens: [UInt64] = []
+      var activeToken: UInt64?
+      var awaitingUpdateToken: UInt64?
+      var handler: (@Sendable (NativeSeekLanding) -> Void)?
+      var seekEndedHandler: (@Sendable (UInt64) -> Void)?
+    }
+
+    private let state = Mutex(State())
+
+    func stageCommand() -> UInt64 {
+      state.withLock { state in
+        precondition(state.nextToken < UInt64.max, "Native seek token exhausted")
+        state.nextToken += 1
+        state.stagedTokens.append(state.nextToken)
+        return state.nextToken
+      }
+    }
+
+    func cancelStagedCommand(_ token: UInt64) {
+      state.withLock { state in
+        if let index = state.stagedTokens.firstIndex(of: token) {
+          state.stagedTokens.remove(at: index)
+        }
+      }
+    }
+
+    func noteSeekStarted(timelineGeneration: UInt64) {
+      state.withLock { state in
+        guard timelineGeneration == state.timelineGeneration else { return }
+        state.activeToken = state.stagedTokens.isEmpty
+          ? nil
+          : state.stagedTokens.removeFirst()
+        state.awaitingUpdateToken = nil
+      }
+    }
+
+    func noteSeekEnded(timelineGeneration: UInt64) {
+      let delivery = state.withLock { state -> (UInt64, @Sendable (UInt64) -> Void)? in
+        guard timelineGeneration == state.timelineGeneration else { return nil }
+        guard let token = state.activeToken else {
+          state.awaitingUpdateToken = nil
+          return nil
+        }
+        state.awaitingUpdateToken = token
+        state.activeToken = nil
+        guard let handler = state.seekEndedHandler else { return nil }
+        return (token, handler)
+      }
+      if let delivery {
+        delivery.1(delivery.0)
+      }
+    }
+
+    func noteTimeUpdated(
+      timeMilliseconds: Int64,
+      position: Double,
+      timelineGeneration: UInt64
+    ) {
+      let delivery = state.withLock { state -> (NativeSeekLanding, @Sendable (NativeSeekLanding) -> Void)? in
+        guard
+          timelineGeneration == state.timelineGeneration,
+          timeMilliseconds >= 0,
+          let token = state.awaitingUpdateToken,
+          let handler = state.handler
+        else {
+          return nil
+        }
+        state.awaitingUpdateToken = nil
+        return (
+          NativeSeekLanding(
+            token: token,
+            timeMilliseconds: timeMilliseconds,
+            position: position
+          ),
+          handler
+        )
+      }
+      if let delivery {
+        delivery.1(delivery.0)
+      }
+    }
+
+    func resetForTimelineReplacement() -> UInt64 {
+      state.withLock { state in
+        precondition(state.timelineGeneration < UInt64.max, "Native seek timeline exhausted")
+        state.timelineGeneration += 1
+        state.stagedTokens.removeAll(keepingCapacity: true)
+        state.activeToken = nil
+        state.awaitingUpdateToken = nil
+        return state.timelineGeneration
+      }
+    }
+
+    func currentTimelineGeneration() -> UInt64 {
+      state.withLock { $0.timelineGeneration }
+    }
+
+    func setHandler(_ handler: (@Sendable (NativeSeekLanding) -> Void)?) {
+      state.withLock { $0.handler = handler }
+    }
+
+    func setSeekEndedHandler(_ handler: (@Sendable (UInt64) -> Void)?) {
+      state.withLock { $0.seekEndedHandler = handler }
+    }
+  }
+
+  private nonisolated(unsafe) var player: OpaquePointer
+  private nonisolated(unsafe) var contextOpaque: UnsafeMutableRawPointer?
+  private nonisolated(unsafe) var isAttached: Bool
+  private let context: Context
+  private let invalidated = Mutex(false)
+
+  init(player: OpaquePointer) {
+    self.player = player
+    let context = Context()
+    self.context = context
+    let attachment = Attachment(
+      context: context,
+      timelineGeneration: context.currentTimelineGeneration()
+    )
+    let opaque = Unmanaged.passRetained(attachment).toOpaque()
+    contextOpaque = opaque
+    isAttached = Self.attach(to: player, opaque: opaque) == 0
+  }
+
+  deinit {
+    invalidate()
+  }
+
+  func setHandler(_ handler: @escaping @Sendable (NativeSeekLanding) -> Void) {
+    context.setHandler(handler)
+  }
+
+  func setSeekEndedHandler(_ handler: @escaping @Sendable (UInt64) -> Void) {
+    context.setSeekEndedHandler(handler)
+  }
+
+  func stageCommand() -> UInt64 {
+    context.stageCommand()
+  }
+
+  func cancelStagedCommand(_ token: UInt64) {
+    context.cancelStagedCommand(token)
+  }
+
+  func reattach(to newPlayer: OpaquePointer) {
+    replaceAttachment(on: newPlayer)
+  }
+
+  func invalidate() {
+    let shouldInvalidate = invalidated.withLock { invalidated in
+      guard !invalidated else { return false }
+      invalidated = true
+      return true
+    }
+    guard shouldInvalidate, let contextOpaque else { return }
+    context.setHandler(nil)
+    context.setSeekEndedHandler(nil)
+    if isAttached {
+      libvlc_media_player_unwatch_time(player)
+      isAttached = false
+    }
+    self.contextOpaque = nil
+    Unmanaged<Attachment>.fromOpaque(contextOpaque).release()
+  }
+
+  func resetForTimelineReplacement() {
+    replaceAttachment(on: player)
+  }
+
+  /// A watch attachment captures the media timeline it belongs to. Rotating
+  /// the opaque attachment makes a callback that was already in flight before
+  /// `unwatch_time` distinguishable from callbacks produced after a same-handle
+  /// media replacement.
+  private func replaceAttachment(on newPlayer: OpaquePointer) {
+    guard !invalidated.withLock({ $0 }), let oldOpaque = contextOpaque else { return }
+    if isAttached {
+      libvlc_media_player_unwatch_time(player)
+    }
+    let timelineGeneration = context.resetForTimelineReplacement()
+    Unmanaged<Attachment>.fromOpaque(oldOpaque).release()
+    let attachment = Attachment(context: context, timelineGeneration: timelineGeneration)
+    let newOpaque = Unmanaged.passRetained(attachment).toOpaque()
+    player = newPlayer
+    contextOpaque = newOpaque
+    isAttached = Self.attach(to: newPlayer, opaque: newOpaque) == 0
+  }
+
+  private static func attach(to player: OpaquePointer, opaque: UnsafeMutableRawPointer) -> Int32 {
+    libvlc_media_player_watch_time(
+      player,
+      250_000,
+      nativeSeekTimeUpdate,
+      nil,
+      nativeSeekStateChanged,
+      opaque
+    )
+  }
+
+  #if DEBUG
+  var _timelineGenerationForTesting: UInt64 {
+    context.currentTimelineGeneration()
+  }
+
+  func _noteSeekStartedForTesting(timelineGeneration: UInt64? = nil) {
+    context.noteSeekStarted(
+      timelineGeneration: timelineGeneration ?? context.currentTimelineGeneration()
+    )
+  }
+
+  func _noteSeekEndedForTesting(timelineGeneration: UInt64? = nil) {
+    context.noteSeekEnded(
+      timelineGeneration: timelineGeneration ?? context.currentTimelineGeneration()
+    )
+  }
+
+  func _noteTimeUpdatedForTesting(
+    timeMilliseconds: Int64,
+    position: Double,
+    timelineGeneration: UInt64? = nil
+  ) {
+    context.noteTimeUpdated(
+      timeMilliseconds: timeMilliseconds,
+      position: position,
+      timelineGeneration: timelineGeneration ?? context.currentTimelineGeneration()
+    )
+  }
+  #endif
+}
+
+private func nativeSeekTimeUpdate(
+  _ point: UnsafePointer<libvlc_media_player_time_point_t>?,
+  _ opaque: UnsafeMutableRawPointer?
+) {
+  guard let point, let opaque else { return }
+  let attachment = Unmanaged<NativeSeekMonitor.Attachment>.fromOpaque(opaque)
+    .takeUnretainedValue()
+  let timeMicroseconds = point.pointee.ts_us
+  attachment.context.noteTimeUpdated(
+    timeMilliseconds: timeMicroseconds >= 0 ? timeMicroseconds / 1000 : -1,
+    position: point.pointee.position,
+    timelineGeneration: attachment.timelineGeneration
+  )
+}
+
+private func nativeSeekStateChanged(
+  _ point: UnsafePointer<libvlc_media_player_time_point_t>?,
+  _ opaque: UnsafeMutableRawPointer?
+) {
+  guard let opaque else { return }
+  let attachment = Unmanaged<NativeSeekMonitor.Attachment>.fromOpaque(opaque)
+    .takeUnretainedValue()
+  if point == nil {
+    attachment.context.noteSeekEnded(timelineGeneration: attachment.timelineGeneration)
+  } else {
+    attachment.context.noteSeekStarted(timelineGeneration: attachment.timelineGeneration)
+  }
+}

--- a/Sources/SwiftVLC/Player/Player+Drawable.swift
+++ b/Sources/SwiftVLC/Player/Player+Drawable.swift
@@ -301,6 +301,7 @@ extension Player {
     // Reattachment detaches the retiring generation, clears its pending
     // terminal cause, then installs the successor generation as one operation.
     eventBridge.reattach(to: newEventManager)
+    nativeSeekMonitor.reattach(to: newPointer)
     // The old handle's terminal events are unobservable from here on; a
     // pending stop/error cause would otherwise outlive its `Stopped` and
     // suppress the next genuine natural end. The same applies to its

--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -92,7 +92,7 @@ extension Player {
     }
     guard sourcedEvent.playbackGeneration == sessionGeneration else { return }
     guard isTimelineSampleCurrent(sourcedEvent) else { return }
-    handleEvent(sourcedEvent.event)
+    handleEvent(sourcedEvent.event, sourceTimelineRevision: sourcedEvent.timelineRevision)
   }
 
   /// Whether a clock sample still describes the authoritative timeline.
@@ -119,13 +119,20 @@ extension Player {
   /// `startEventConsumer`'s loop on every event the bridge yields.
   func handleEvent(
     _ event: PlayerEvent,
-    sourcePlaybackGeneration: UInt64? = nil
+    sourcePlaybackGeneration: UInt64? = nil,
+    sourceTimelineRevision: UInt64? = nil
   ) {
     let interval = Signposts.signposter.beginInterval("Player.handleEvent")
     defer { Signposts.signposter.endInterval("Player.handleEvent", interval) }
     switch event {
     case .stateChanged(let newState):
       publishPlaybackState(newState)
+      switch newState {
+      case .idle, .stopped, .stopping, .error:
+        supersedePendingSeekSettlement(ifNotPredating: sourceTimelineRevision)
+      case .opening, .buffering, .playing, .paused:
+        break
+      }
       updatePauseTransition(for: newState)
       reconcilePlaybackIntent(for: newState)
       if case .stopped = newState {
@@ -184,6 +191,7 @@ extension Player {
       let previousSessionGeneration = sessionGeneration
       let playbackControlIntent = playbackControlIntent
       syncCurrentMediaFromNative()
+      let changedMediaIdentity = currentMedia?.pointer != sessionGenerationMedia
       // A media change the wrapper did not initiate still has to supersede
       // whatever was restoring the previous session: a `MediaListPlayer`
       // advancing the list calls `libvlc_media_list_player_next` directly, so
@@ -198,7 +206,7 @@ extension Player {
         sessionGeneration = sourcePlaybackGeneration
         sessionGenerationMedia = currentMedia?.pointer
         publishPlaybackStatus()
-      } else if currentMedia?.pointer != sessionGenerationMedia {
+      } else if changedMediaIdentity {
         if sourcePlaybackGeneration == nil {
           sessionGeneration = eventBridge.synchronizePlaybackGeneration(
             sessionGeneration &+ 1,
@@ -212,7 +220,19 @@ extension Player {
       }
       let adoptedExternalGeneration = sessionGeneration > previousSessionGeneration
       let carriesPlaybackControl = adoptedExternalGeneration && playbackControlIntent != nil
-      resetMediaDerivedState(preservingPlaybackIntent: carriesPlaybackControl)
+      // `load(_:)` establishes the new generation and resets its timeline
+      // before calling `set_media`. The resulting native MediaChanged echo is
+      // stamped with that already-adopted generation, but can remain queued
+      // while a same-turn seek is accepted. Resetting on the echo would then
+      // supersede that valid seek and rotate away its native monitor token.
+      // Events without source attribution retain the conservative legacy
+      // behavior; sourced external changes always advance or replace identity.
+      let replacedTimeline = adoptedExternalGeneration
+        || changedMediaIdentity
+        || sourcePlaybackGeneration == nil
+      if replacedTimeline {
+        resetMediaDerivedState(preservingPlaybackIntent: carriesPlaybackControl)
+      }
       if adoptedExternalGeneration, let playbackControlIntent {
         reconcilePauseControlAfterExternalMediaAdoption(
           playbackGeneration: sessionGeneration,
@@ -224,6 +244,7 @@ extension Player {
 
     case .encounteredError:
       publishPlaybackState(.error)
+      supersedePendingSeekSettlement(ifNotPredating: sourceTimelineRevision)
       clearPauseControlState(for: sessionGeneration)
       reconcilePlaybackIntent(for: .error)
 
@@ -431,6 +452,8 @@ extension Player {
   /// times, duration, seek/pause flags, buffer fill. Called when media
   /// is loaded or replaced.
   func resetMediaDerivedState(preservingPlaybackIntent: Bool = false) {
+    supersedePendingSeekSettlement()
+    nativeSeekMonitor.resetForTimelineReplacement()
     // New media, new timeline: clock samples still queued from the previous
     // one describe a media that is no longer loaded and must not be applied.
     acceptedTimelineRevision = eventBridge.advanceTimelineRevision()
@@ -475,6 +498,12 @@ extension Player {
     withMutation(keyPath: \.position) {
       _position = 0
     }
+    eventBridge.updateAuthoritativeTimeline(
+      time: .zero,
+      position: 0,
+      playbackGeneration: sessionGeneration,
+      timelineRevision: acceptedTimelineRevision
+    )
     isSuppressingCapabilityPublish = false
     // New media, new capability generation. The bump and the reset values are
     // written under one lock acquisition, so a reader can never see the new

--- a/Sources/SwiftVLC/Player/Player+Seek.swift
+++ b/Sources/SwiftVLC/Player/Player+Seek.swift
@@ -1,9 +1,57 @@
 import CLibVLC
 
+#if DEBUG
+struct PlayerSeekTestOverrides {
+  var jumpTime: ((Int64) -> Int32)?
+  var setPosition: ((Double, Bool) -> Int32)?
+  var readLanding: (() -> (timeMilliseconds: Int64, position: Double))?
+}
+#endif
+
 /// Seeking: strict absolute/relative seeks for VOD scrubbers, lenient
 /// best-effort seeks for live and unknown-duration media, and
 /// frame-by-frame stepping.
 extension Player {
+  struct PendingSeekSettlement {
+    let playbackGeneration: UInt64
+    let timelineRevision: UInt64
+    let nativeSeekToken: UInt64
+    let resolver: SeekOutcomeResolver
+    var timeoutTask: Task<Void, Never>?
+  }
+
+  #if DEBUG
+  var _nativeJumpTimeOverrideForTesting: ((Int64) -> Int32)? {
+    get { _seekOverridesForTesting.jumpTime }
+    set { _seekOverridesForTesting.jumpTime = newValue }
+  }
+
+  var _nativeSetPositionOverrideForTesting: ((Double, Bool) -> Int32)? {
+    get { _seekOverridesForTesting.setPosition }
+    set { _seekOverridesForTesting.setPosition = newValue }
+  }
+
+  var _nativeSeekLandingOverrideForTesting:
+    (() -> (timeMilliseconds: Int64, position: Double))? {
+    get { _seekOverridesForTesting.readLanding }
+    set { _seekOverridesForTesting.readLanding = newValue }
+  }
+
+  #endif
+
+  func configureNativeSeekMonitor() {
+    nativeSeekMonitor.setHandler { [weak self] landing in
+      Task { @MainActor [weak self] in
+        self?.nativeSeekDidLand(landing)
+      }
+    }
+    nativeSeekMonitor.setSeekEndedHandler { [weak self] token in
+      Task { @MainActor [weak self] in
+        self?.nativeSeekDidEnd(token: token)
+      }
+    }
+  }
+
   // MARK: - Strict Seeking
 
   /// Seeks to an absolute time in the current media.
@@ -25,18 +73,19 @@ extension Player {
   ///   outside libVLC's millisecond range, or beyond known duration.
   public func seek(to time: Duration, fast: Bool = false) throws(VLCError) {
     let milliseconds = try checkedSeekMilliseconds(for: time, parameter: "time")
-    // Reserved *before* the native call: libVLC delivers events on its own
-    // thread, so a post-seek clock sample emitted while `set_time` is still
-    // returning would otherwise be stamped with the previous revision and
-    // then discarded as stale — losing the position the seek actually landed
-    // on, which after a fast (keyframe) seek is not the requested one.
+    // Reserve before native dispatch so synchronous seek callbacks carry the
+    // revision this accepted command can adopt. Rejection leaves the existing
+    // accepted revision and pending request untouched.
     let revision = eventBridge.advanceTimelineRevision()
+    let nativeSeekToken = nativeSeekMonitor.stageCommand()
     // Publishing before checking the result reported a target libVLC had
     // refused, leaving the observable timeline describing a position playback
     // never reached.
     guard libvlc_media_player_set_time(pointer, milliseconds, fast) == 0 else {
+      nativeSeekMonitor.cancelStagedCommand(nativeSeekToken)
       throw .operationFailed("Seek to \(milliseconds) ms")
     }
+    supersedePendingSeekSettlement()
     commitSeekTarget(milliseconds: milliseconds, revision: revision)
   }
 
@@ -89,12 +138,13 @@ extension Player {
       targetMs = Swift.min(targetMs, durationMs)
     }
 
-    // See `seek(to:fast:)`: reserved before the native call so a post-seek
-    // sample cannot be stamped with the outgoing revision.
     let revision = eventBridge.advanceTimelineRevision()
+    let nativeSeekToken = nativeSeekMonitor.stageCommand()
     guard libvlc_media_player_set_time(pointer, targetMs, fast) == 0 else {
+      nativeSeekMonitor.cancelStagedCommand(nativeSeekToken)
       throw .operationFailed("Jump to \(targetMs) ms")
     }
+    supersedePendingSeekSettlement()
     commitSeekTarget(milliseconds: targetMs, revision: revision)
   }
 
@@ -106,11 +156,9 @@ extension Player {
   /// samples are applied afterwards and snap the published time back — and
   /// while paused no later native event is guaranteed to repair it.
   ///
-  /// `revision` is reserved by the caller *before* it issues the native seek,
-  /// so it is only adopted here once libVLC has accepted the request. A
-  /// rejected seek leaves `acceptedTimelineRevision` alone; the reserved
-  /// value is simply never adopted, which keeps clock samples flowing exactly
-  /// as they did before the refused request.
+  /// `revision` is reserved before native dispatch, then adopted only after
+  /// libVLC accepts. A rejected seek therefore leaves
+  /// `acceptedTimelineRevision` and any older pending request alone.
   func commitSeekTarget(milliseconds: Int64, revision: UInt64) {
     acceptedTimelineRevision = revision
     currentTime = .milliseconds(milliseconds)
@@ -140,14 +188,13 @@ extension Player {
   @discardableResult
   public func seek(toPosition position: PlaybackPosition, fast: Bool = false) -> Bool {
     guard hasLenientSeekSession else { return false }
-    // Reserved before the native call for the same reason as the strict
-    // paths, and adopted only once libVLC accepts: a lenient seek publishes a
-    // position the same way a strict one does, so pre-seek samples must not
-    // overwrite it either.
     let revision = eventBridge.advanceTimelineRevision()
-    guard libvlc_media_player_set_position(pointer, position.rawValue, fast) == 0 else {
+    let nativeSeekToken = nativeSeekMonitor.stageCommand()
+    guard issueNativeSeek(toPosition: position.rawValue, fast: fast) == 0 else {
+      nativeSeekMonitor.cancelStagedCommand(nativeSeekToken)
       return false
     }
+    supersedePendingSeekSettlement()
     acceptedTimelineRevision = revision
     withMutation(keyPath: \.position) {
       _position = position.rawValue
@@ -184,24 +231,76 @@ extension Player {
   ///   call is then a no-op.
   @discardableResult
   public func jump(by offset: Duration) -> Bool {
-    guard hasLenientSeekSession else { return false }
+    issueRelativeJump(by: offset, publishesEstimate: true, nativeSeekToken: nil) != nil
+  }
+
+  /// Requests a relative jump and exposes when it actually lands.
+  ///
+  /// This is the authoritative counterpart to ``jump(by:)``. The synchronous
+  /// ``SeekRequest/initialOutcome`` reports native acceptance. Await
+  /// ``SeekRequest/outcome`` before telling an asynchronous transport client
+  /// (such as AVKit Picture in Picture) that the operation finished.
+  ///
+  /// Native landing evidence after libVLC's matching seek-end callback settles
+  /// the request: normally a watched timer point, or a direct post-end clock
+  /// read for paused audio-only playback. A newer seek, media replacement,
+  /// terminal playback state, or player teardown supersedes it. If libVLC
+  /// accepts the command but publishes no authoritative landing, SwiftVLC
+  /// returns ``SeekOutcome/timedOut`` after a bounded interval.
+  ///
+  /// - Parameter offset: The native relative offset. Negative values rewind;
+  ///   positive values fast-forward.
+  /// - Returns: A request whose initial result is either pending or rejected.
+  public func requestJump(by offset: Duration) -> SeekRequest {
+    let nativeSeekToken = nativeSeekMonitor.stageCommand()
+    guard
+      let revision = issueRelativeJump(
+        by: offset,
+        publishesEstimate: false,
+        nativeSeekToken: nativeSeekToken
+      ) else {
+      nativeSeekMonitor.cancelStagedCommand(nativeSeekToken)
+      return SeekRequest(resolved: .rejected)
+    }
+    return registerPendingSeekSettlement(
+      playbackGeneration: sessionGeneration,
+      timelineRevision: revision,
+      nativeSeekToken: nativeSeekToken
+    )
+  }
+
+  /// One native relative-jump path shared by the legacy acceptance-only API
+  /// and the authoritative request API. Keeping settlement allocation out of
+  /// ``jump(by:)`` preserves its lightweight behavior for callers that only
+  /// need dispatch acceptance.
+  private func issueRelativeJump(
+    by offset: Duration,
+    publishesEstimate: Bool,
+    nativeSeekToken: UInt64?
+  ) -> UInt64? {
+    guard hasLenientSeekSession else { return nil }
     guard let offsetMs = try? offset.checkedMilliseconds(parameter: "offset") else {
-      return false
+      return nil
     }
-    // Reserved before the native call and adopted only once libVLC accepts,
-    // exactly as the absolute paths do. A relative jump needs this more than
-    // they do, not less: it is issued while playback is running and clock
-    // samples are in flight, so without it a sample produced just before the
-    // jump lands afterwards and snaps the published time back to where
-    // playback used to be. A refused jump must not consume the reservation,
-    // or every later sample would be judged stale against a revision nothing
-    // adopted.
     let revision = eventBridge.advanceTimelineRevision()
-    guard libvlc_media_player_jump_time(pointer, offsetMs) == 0 else {
-      return false
+    let commandToken = nativeSeekToken ?? nativeSeekMonitor.stageCommand()
+    guard issueNativeJump(byMilliseconds: offsetMs) == 0 else {
+      nativeSeekMonitor.cancelStagedCommand(commandToken)
+      return nil
     }
+    #if DEBUG
+    if nativeSeekToken != nil, _nativeJumpTimeOverrideForTesting != nil {
+      nativeSeekMonitor._noteSeekStartedForTesting()
+    }
+    #endif
+    // Only an accepted replacement supersedes the prior request. If libVLC
+    // rejects this jump, the earlier accepted command can still land and must
+    // retain both its timeline authority and its terminal result.
+    supersedePendingSeekSettlement()
     acceptedTimelineRevision = revision
-    if let currentMs = try? currentTime.checkedMilliseconds(parameter: "currentTime") {
+    if
+      publishesEstimate,
+      let currentMs = try? currentTime.checkedMilliseconds(parameter: "currentTime") {
       let targetResult = currentMs.addingReportingOverflow(offsetMs)
       if !targetResult.overflow {
         var targetMs = Swift.max(0, targetResult.partialValue)
@@ -215,8 +314,178 @@ extension Player {
         recordAuthoritativeTimeline(position: position)
       }
     }
-    return true
+    return revision
   }
+
+  /// Calls libVLC through a narrow deterministic test seam.
+  private func issueNativeSeek(toPosition position: Double, fast: Bool) -> Int32 {
+    #if DEBUG
+    if let _nativeSetPositionOverrideForTesting {
+      return _nativeSetPositionOverrideForTesting(position, fast)
+    }
+    #endif
+    return libvlc_media_player_set_position(pointer, position, fast)
+  }
+
+  /// Calls libVLC through a narrow deterministic test seam.
+  private func issueNativeJump(byMilliseconds offset: Int64) -> Int32 {
+    #if DEBUG
+    if let _nativeJumpTimeOverrideForTesting {
+      return _nativeJumpTimeOverrideForTesting(offset)
+    }
+    #endif
+    return libvlc_media_player_jump_time(pointer, offset)
+  }
+
+  /// Creates the single pending request and starts its bounded timeout.
+  private func registerPendingSeekSettlement(
+    playbackGeneration: UInt64,
+    timelineRevision: UInt64,
+    nativeSeekToken: UInt64
+  ) -> SeekRequest {
+    let resolver = SeekOutcomeResolver()
+    pendingSeekSettlement = PendingSeekSettlement(
+      playbackGeneration: playbackGeneration,
+      timelineRevision: timelineRevision,
+      nativeSeekToken: nativeSeekToken,
+      resolver: resolver,
+      timeoutTask: nil
+    )
+    let timeoutTask = Task { @MainActor [weak self, weak resolver] in
+      do {
+        try await Task.sleep(for: .seconds(2))
+      } catch {
+        return
+      }
+      guard let resolver else { return }
+      self?.resolvePendingSeekSettlement(resolver: resolver, as: .timedOut)
+    }
+    pendingSeekSettlement?.timeoutTask = timeoutTask
+    return SeekRequest(resolver: resolver)
+  }
+
+  /// Applies libVLC's authoritative landed point after the matching seek ends.
+  /// Ordinary pre-seek and in-flight time callbacks cannot produce this token.
+  func nativeSeekDidLand(_ landing: NativeSeekLanding) {
+    guard
+      let pendingSeekSettlement,
+      pendingSeekSettlement.nativeSeekToken == landing.token,
+      pendingSeekSettlement.playbackGeneration == sessionGeneration
+    else { return }
+
+    let nativeTime = landing.timeMilliseconds
+    guard nativeTime >= 0 else { return }
+    // The landing itself is a new authority boundary. Native event callbacks
+    // that entered after dispatch but before seek-start still carry the
+    // accepted request revision; advancing here prevents those queued old
+    // clock samples from overwriting the landed point after settlement.
+    acceptedTimelineRevision = eventBridge.advanceTimelineRevision()
+    currentTime = .milliseconds(nativeTime)
+    let nativePosition = landing.position
+    let authoritativePosition: Double?
+    if nativePosition.isFinite, (0.0...1.0).contains(nativePosition) {
+      withMutation(keyPath: \.position) {
+        _position = nativePosition
+      }
+      authoritativePosition = nativePosition
+    } else {
+      authoritativePosition = publishPosition(forTargetMilliseconds: nativeTime)
+    }
+    eventBridge.updateAuthoritativeTimeline(
+      time: currentTime,
+      position: authoritativePosition,
+      playbackGeneration: sessionGeneration,
+      timelineRevision: acceptedTimelineRevision
+    )
+    resolvePendingSeekSettlement(
+      resolver: pendingSeekSettlement.resolver,
+      as: .settled
+    )
+  }
+
+  /// A paused audio-only input may emit seek-end without another watched time
+  /// point. Read the authoritative native clock after leaving the C callback,
+  /// on the main actor, so those requests can settle without waiting for
+  /// playback to resume. Video and actively playing sessions may still settle
+  /// through the watched point first; token matching makes the paths idempotent.
+  func nativeSeekDidEnd(token: UInt64) {
+    guard
+      let pendingSeekSettlement,
+      pendingSeekSettlement.nativeSeekToken == token,
+      pendingSeekSettlement.playbackGeneration == sessionGeneration,
+      nativePlaybackState == .paused
+    else { return }
+
+    let landing: NativeSeekLanding
+    #if DEBUG
+    if let override = _nativeSeekLandingOverrideForTesting {
+      let point = override()
+      landing = NativeSeekLanding(
+        token: token,
+        timeMilliseconds: point.timeMilliseconds,
+        position: point.position
+      )
+    } else {
+      landing = NativeSeekLanding(
+        token: token,
+        timeMilliseconds: libvlc_media_player_get_time(pointer),
+        position: libvlc_media_player_get_position(pointer)
+      )
+    }
+    #else
+    landing = NativeSeekLanding(
+      token: token,
+      timeMilliseconds: libvlc_media_player_get_time(pointer),
+      position: libvlc_media_player_get_position(pointer)
+    )
+    #endif
+    nativeSeekDidLand(landing)
+  }
+
+  /// Invalidates the current request before another timeline owner is
+  /// established.
+  func supersedePendingSeekSettlement(ifNotPredating timelineRevision: UInt64? = nil) {
+    guard let pendingSeekSettlement else { return }
+    if let timelineRevision, timelineRevision < pendingSeekSettlement.timelineRevision {
+      return
+    }
+    resolvePendingSeekSettlement(resolver: pendingSeekSettlement.resolver, as: .superseded)
+  }
+
+  private func resolvePendingSeekSettlement(
+    resolver: SeekOutcomeResolver,
+    as outcome: SeekOutcome
+  ) {
+    guard
+      let pendingSeekSettlement,
+      pendingSeekSettlement.resolver === resolver
+    else { return }
+    self.pendingSeekSettlement = nil
+    pendingSeekSettlement.timeoutTask?.cancel()
+    resolver.resolve(outcome)
+  }
+
+  #if DEBUG
+  /// Deterministic timeout seam; production uses the bounded task above.
+  func _expirePendingSeekForTesting() {
+    guard let resolver = pendingSeekSettlement?.resolver else { return }
+    resolvePendingSeekSettlement(resolver: resolver, as: .timedOut)
+  }
+
+  func _completePendingSeekForTesting(
+    time: Duration,
+    position: Double? = nil,
+    token: UInt64? = nil
+  ) {
+    guard let pendingSeekSettlement else { return }
+    let milliseconds = try? time.checkedMilliseconds(parameter: "time")
+    nativeSeekDidLand(NativeSeekLanding(
+      token: token ?? pendingSeekSettlement.nativeSeekToken,
+      timeMilliseconds: milliseconds ?? -1,
+      position: position ?? -.infinity
+    ))
+  }
+  #endif
 
   /// Whether the player is in a lifecycle state where a lenient seek can
   /// take effect. libVLC 4's seek entry points queue the request under
@@ -248,6 +517,7 @@ extension Player {
   /// Requires the current media to be pausable (see ``isPausable``).
   /// Calling repeatedly yields frame-by-frame stepping.
   public func nextFrame() {
+    supersedePendingSeekSettlement()
     libvlc_media_player_next_frame(pointer)
     // libVLC doesn't emit `MediaPlayerTimeChanged` after a next-frame
     // step while paused: the decoder advances one frame but the event
@@ -255,6 +525,10 @@ extension Player {
     // `currentTime` reflects the step.
     let ms = libvlc_media_player_get_time(pointer)
     if ms >= 0 {
+      // The direct read is the frame step's authority boundary. Reject clock
+      // callbacks that entered before it and could otherwise overwrite the
+      // stepped point after this main-actor turn.
+      acceptedTimelineRevision = eventBridge.advanceTimelineRevision()
       currentTime = .milliseconds(ms)
       recordAuthoritativeTimeline(position: nil)
     }
@@ -291,7 +565,7 @@ extension Player {
   /// target. libVLC emits no `positionChanged` while paused, so without
   /// this the ``position`` shadow would stay stale until playback resumes.
   @discardableResult
-  private func publishPosition(forTargetMilliseconds targetMs: Int64) -> Double? {
+  func publishPosition(forTargetMilliseconds targetMs: Int64) -> Double? {
     guard
       let duration,
       let durationMs = try? duration.checkedNonnegativeMilliseconds(parameter: "duration"),
@@ -310,7 +584,8 @@ extension Player {
     eventBridge.updateAuthoritativeTimeline(
       time: currentTime,
       position: position,
-      playbackGeneration: sessionGeneration
+      playbackGeneration: sessionGeneration,
+      timelineRevision: acceptedTimelineRevision
     )
   }
 }

--- a/Sources/SwiftVLC/Player/Player+Teardown.swift
+++ b/Sources/SwiftVLC/Player/Player+Teardown.swift
@@ -219,6 +219,7 @@ extension Player {
     // `nativePlaybackState` afterwards loses the race signal.
     let resumeBeforeRelease = shouldResumeNativePlayerBeforeStop
     publishPlaybackIntent(false)
+    supersedePendingSeekSettlement()
     pauseTransition = nil
     deferredPauseCommand = nil
     eventBridge.finishCurrentPlaybackGeneration(
@@ -239,6 +240,7 @@ extension Player {
     libvlc_media_player_set_nsobject(pointer, nil)
 
     let bridge = eventBridge
+    let seekMonitor = nativeSeekMonitor
     nonisolated(unsafe) let drawables =
       drawable.map { retainedDrawablesUntilNativePlayerRelease + [$0] }
         ?? retainedDrawablesUntilNativePlayerRelease
@@ -266,6 +268,7 @@ extension Player {
           p,
           lifetime: lifetime,
           bridge: bridge,
+          seekMonitor: seekMonitor,
           retainedDrawables: drawables,
           resumeBeforeStop: resumeBeforeRelease
         )
@@ -292,12 +295,14 @@ extension Player {
     _ pointer: OpaquePointer,
     lifetime: NativePlayerHandleLifetime,
     bridge: EventBridge,
+    seekMonitor: NativeSeekMonitor,
     retainedDrawables: [AnyObject],
     resumeBeforeStop: Bool
   ) {
     precondition(lifetime.pointer == pointer)
     lifetime.retainUntilReleased(retainedDrawables)
     bridge.invalidate()
+    seekMonitor.invalidate()
     stopNativePlayerBeforeRelease(pointer, resumeBeforeStop: resumeBeforeStop)
     libvlc_media_player_release(pointer)
     lifetime.initialOwnerDidRelease()

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -413,6 +413,7 @@ public final class Player {
   var directPiPVideoCallbackGeneration: UInt64 = 0
   #endif
   let eventBridge: EventBridge
+  let nativeSeekMonitor: NativeSeekMonitor
   nonisolated let endCoordinator = PlaybackEndCoordinator()
   nonisolated let playbackIntentBridge: Broadcaster<Bool>
   /// Carries normalized lifecycle transitions. See ``stateTransitions``.
@@ -503,6 +504,8 @@ public final class Player {
   var _nativeCanPauseOverrideForTesting: Bool?
   @ObservationIgnored
   var _nativePauseSafetyOverrideForTesting: Bool?
+  @ObservationIgnored
+  var _seekOverridesForTesting = PlayerSeekTestOverrides()
   #endif
 
   var pauseTransition: PauseTransition? {
@@ -592,9 +595,14 @@ public final class Player {
   /// media load. Clock samples stamped older than this are stale and are
   /// dropped rather than allowed to overwrite the seek target.
   var acceptedTimelineRevision: UInt64 = 0
+  /// The only seek still allowed to publish a terminal result.
+  var pendingSeekSettlement: PendingSeekSettlement?
   /// Bumped when ``recast(to:)`` is superseded so suspended work rejects stale restoration.
   var sessionGeneration: UInt64 = 0 {
     didSet {
+      if sessionGeneration != oldValue {
+        supersedePendingSeekSettlement()
+      }
       #if os(iOS) || os(macOS)
       refreshNativeHandleSnapshots()
       #endif
@@ -624,7 +632,9 @@ public final class Player {
       eventManager: libvlc_media_player_event_manager(p)!,
       endCoordinator: endCoordinator
     )
+    nativeSeekMonitor = NativeSeekMonitor(player: p)
     playbackIntentBridge = Broadcaster<Bool>(defaultBufferSize: 16)
+    configureNativeSeekMonitor()
     startEventConsumer()
     // Seeded so `playbackStatus` opens with the current pair from the moment
     // the player exists: a subscriber attaching before any state change would
@@ -640,6 +650,7 @@ public final class Player {
   }
 
   isolated deinit {
+    supersedePendingSeekSettlement()
     eventBridge.finishCurrentPlaybackGeneration(
       cause: .cancellation,
       playbackGeneration: sessionGeneration
@@ -679,6 +690,7 @@ public final class Player {
     // pointer is a plain value. invalidate() MUST run before release()
     // so the event manager is still valid when detaching callbacks.
     let bridge = eventBridge
+    let seekMonitor = nativeSeekMonitor
     // `AnyObject?` is not `Sendable` under Swift 6, but the capture is
     // write-once-read-never — the closure only holds the view alive,
     // it never reads or mutates it. `nonisolated(unsafe)` is the
@@ -696,6 +708,7 @@ public final class Player {
         p,
         lifetime: lifetime,
         bridge: bridge,
+        seekMonitor: seekMonitor,
         retainedDrawables: drawables,
         resumeBeforeStop: resumeBeforeRelease
       )
@@ -871,6 +884,7 @@ public final class Player {
   /// teardown must not race the audio/video output drain (for example
   /// before deactivating a shared `AVAudioSession`).
   public func stop() {
+    supersedePendingSeekSettlement()
     if shouldResumeNativePlayerBeforeStop {
       libvlc_media_player_set_pause(pointer, 0)
     }

--- a/Sources/SwiftVLC/Player/SeekRequest.swift
+++ b/Sources/SwiftVLC/Player/SeekRequest.swift
@@ -1,0 +1,121 @@
+import Synchronization
+
+/// The lifecycle state of an authoritative seek request.
+///
+/// A native seek is asynchronous. ``pending`` means libVLC accepted the
+/// command but SwiftVLC has not yet published authoritative native landing
+/// evidence. This is normally the first watched timer point after seek end;
+/// paused audio-only input instead uses a direct post-end clock read because
+/// it may not produce another point until playback resumes. Every request
+/// eventually reaches one of the other, terminal cases.
+public enum SeekOutcome: Hashable, Sendable {
+  /// libVLC accepted the request and it is waiting for native landing evidence.
+  case pending
+  /// The request was invalid for the current playback session or libVLC
+  /// refused it. The observable timeline was not changed.
+  case rejected
+  /// The accepted seek ended and its authoritative landed clock reached the mirror.
+  case settled
+  /// No authoritative landed clock arrived within SwiftVLC's bounded settlement window.
+  case timedOut
+  /// A newer seek, media replacement, terminal playback state, or teardown
+  /// made this request no longer authoritative.
+  case superseded
+}
+
+/// An accepted-or-rejected seek together with its authoritative result.
+///
+/// Inspect ``initialOutcome`` synchronously to learn whether libVLC accepted
+/// the command. If it is ``SeekOutcome/pending``, await ``outcome`` for the
+/// eventual landing, timeout, or supersession. Waiting is cancellation-safe:
+/// cancelling one waiter does not cancel or reclassify the underlying seek.
+public struct SeekRequest: Sendable {
+  private enum Resolution: Sendable {
+    case resolved(SeekOutcome)
+    case pending(SeekOutcomeResolver)
+  }
+
+  /// The result known when the native seek call returns.
+  ///
+  /// This is either ``SeekOutcome/pending`` or ``SeekOutcome/rejected``.
+  public let initialOutcome: SeekOutcome
+
+  private let resolution: Resolution
+
+  /// The authoritative terminal result.
+  ///
+  /// Rejected requests return immediately. Accepted requests suspend until
+  /// the matching seek publishes its native landing, the request times out, or
+  /// newer work supersedes it.
+  public var outcome: SeekOutcome {
+    get async {
+      switch resolution {
+      case .resolved(let outcome): outcome
+      case .pending(let resolver): await resolver.outcome()
+      }
+    }
+  }
+
+  init(resolved outcome: SeekOutcome) {
+    precondition(outcome != .pending)
+    initialOutcome = outcome == .rejected ? .rejected : .pending
+    resolution = .resolved(outcome)
+  }
+
+  init(resolver: SeekOutcomeResolver) {
+    initialOutcome = .pending
+    resolution = .pending(resolver)
+  }
+}
+
+/// Single-assignment promise shared by Player's main-actor state machine and
+/// every task awaiting a copied ``SeekRequest``.
+///
+/// Multiple waiters register under one lock and are resumed with the same
+/// value. Cancelling a waiter cannot cancel the seek, and accidental duplicate
+/// settlement is harmless.
+final class SeekOutcomeResolver: Sendable {
+  private struct State: Sendable {
+    var outcome: SeekOutcome?
+    var waiters: [CheckedContinuation<SeekOutcome, Never>] = []
+  }
+
+  private let state = Mutex(State())
+
+  func outcome() async -> SeekOutcome {
+    await withCheckedContinuation { continuation in
+      let immediate = state.withLock { state -> SeekOutcome? in
+        guard let outcome = state.outcome else {
+          state.waiters.append(continuation)
+          return nil
+        }
+        return outcome
+      }
+      if let immediate {
+        continuation.resume(returning: immediate)
+      }
+    }
+  }
+
+  @discardableResult
+  func resolve(_ outcome: SeekOutcome) -> Bool {
+    precondition(outcome != .pending)
+    let waiters = state.withLock { state -> [CheckedContinuation<SeekOutcome, Never>]? in
+      guard state.outcome == nil else { return nil }
+      state.outcome = outcome
+      defer { state.waiters.removeAll(keepingCapacity: false) }
+      return state.waiters
+    }
+    guard let waiters else { return false }
+    for waiter in waiters {
+      waiter.resume(returning: outcome)
+    }
+    return true
+  }
+
+  #if DEBUG
+  var resolvedOutcome: SeekOutcome? {
+    state.withLock { $0.outcome }
+  }
+  #endif
+}

--- a/Sources/SwiftVLC/SwiftVLC.docc/PlaybackEssentials.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/PlaybackEssentials.md
@@ -129,6 +129,25 @@ player.seek(toPosition: 0.95, fast: true)  // raw fractional seek
 player.jump(by: .seconds(-10))             // native relative jump
 ```
 
+`jump(by:)` reports whether libVLC accepted the command. When a client must
+know when the asynchronous jump actually lands, use
+``Player/requestJump(by:)`` and await its terminal result:
+
+```swift
+let request = player.requestJump(by: .seconds(30))
+guard request.initialOutcome == .pending else { return }
+
+switch await request.outcome {
+case .settled: updateTransportUI()
+case .timedOut, .superseded, .rejected: recoverTransportUI()
+case .pending: break // `outcome` is always terminal
+}
+```
+
+The request is generation- and timeline-revision-bound. A matching native
+time sample settles it; a newer seek or media lifecycle change reports
+`.superseded`; and a missing sample reports `.timedOut` after a bounded wait.
+
 ## The raw event stream
 
 The observable properties cover typical playback UI. When you need
@@ -187,6 +206,9 @@ See <doc:ConcurrencyModel> for the full isolation story.
 - ``Player/seek(by:fast:)``
 - ``Player/seek(toPosition:fast:)``
 - ``Player/jump(by:)``
+- ``Player/requestJump(by:)``
+- ``SeekRequest``
+- ``SeekOutcome``
 - ``Player/nextFrame()``
 
 ### Observable properties

--- a/Sources/SwiftVLC/SwiftVLC.docc/SwiftVLC.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/SwiftVLC.md
@@ -84,6 +84,8 @@ audio and video overlay APIs.
 - ``PlayerState``
 - ``PlayerEvent``
 - ``PlayerRole``
+- ``SeekRequest``
+- ``SeekOutcome``
 - ``VLCInstance``
 
 ### Media

--- a/Sources/SwiftVLC/SwiftVLC.docc/VLCKitPortingGuide.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/VLCKitPortingGuide.md
@@ -54,6 +54,11 @@ player.position = 0.95
 let accepted = player.seek(toPosition: PlaybackPosition(0.95))
 ```
 
+For delegate APIs that owe an asynchronous completion, dispatch acceptance is
+not enough. ``Player/requestJump(by:)`` returns a ``SeekRequest`` whose
+``SeekRequest/outcome`` distinguishes native rejection, authoritative landing,
+bounded timeout, and supersession by a newer timeline command.
+
 ## The .ended state
 
 VLCKit reported natural end-of-media as its own state,
@@ -344,6 +349,9 @@ Two ways to get "off unless the user asks":
 - ``Player/selectedSubtitleTrack``
 - ``Player/seek(toPosition:fast:)``
 - ``Player/jump(by:)``
+- ``Player/requestJump(by:)``
+- ``SeekRequest``
+- ``SeekOutcome``
 - ``PlayerEvent/endReached-enum.case``
 - ``Player/didReachEnd``
 - ``Player/recast(to:)``

--- a/Tests/SwiftVLCTests/PiP/PiPAudioSessionDisruptionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPAudioSessionDisruptionTests.swift
@@ -127,7 +127,7 @@ extension Integration {
           resume: { true },
           cancelPendingPause: { _, _, _ in },
           shouldResume: { false },
-          skip: { _ in .issued }
+          skip: { _ in .init(resolved: .settled) }
         )
       }
     }

--- a/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
@@ -25,7 +25,7 @@ extension Integration {
       var shouldResume = false
       var resumeResult = true
       var skipIntervals: [CMTime] = []
-      var skipOutcome: PiPController.SkipOutcome = .issued
+      var skipOutcome: PiPController.SkipOutcome = .settled
 
       var driver: PiPController.PlaybackDriver {
         .init(
@@ -43,7 +43,7 @@ extension Integration {
           shouldResume: { self.shouldResume },
           skip: { interval in
             self.skipIntervals.append(interval)
-            return self.skipOutcome
+            return .init(resolved: self.skipOutcome)
           }
         )
       }
@@ -545,7 +545,7 @@ extension Integration {
     }
 
     @Test
-    func `playback delegate proxy forwards skip to owner`() {
+    func `playback delegate proxy forwards skip to owner`() async {
       let player = Player(instance: TestInstance.shared)
       player._setStateForTesting(currentTime: .seconds(5), duration: .seconds(20))
       let recorder = PlaybackRecorder()
@@ -555,17 +555,17 @@ extension Integration {
         pauseDebounce: .milliseconds(250)
       )
       guard let pip = makePictureInPictureController(for: controller) else { return }
-      let didComplete = Mutex(false)
+      // The generated async import calls the Objective-C completion-based
+      // delegate method without retaining `pip` past this await. AVKit's class
+      // has not adopted Sendable, so make that immutable crossing explicit.
+      nonisolated(unsafe) let unsafePiP = pip
 
-      controller._playbackDelegateForTesting.pictureInPictureController(
-        pip,
+      await controller._playbackDelegateForTesting.pictureInPictureController(
+        unsafePiP,
         skipByInterval: CMTime(seconds: 2, preferredTimescale: 1000)
-      ) {
-        didComplete.withLock { $0 = true }
-      }
+      )
 
       expectNoDifference(recorder.skipIntervals.map(\.seconds), [2])
-      #expect(didComplete.withLock { $0 })
     }
 
     @Test

--- a/Tests/SwiftVLCTests/PiP/PiPControllerSkipTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerSkipTests.swift
@@ -3,6 +3,7 @@
 import AVKit
 import CoreMedia
 import CustomDump
+import Synchronization
 import Testing
 
 /// Covers PiP skip: how AVKit's requested interval reaches the player, and
@@ -13,7 +14,8 @@ extension Integration {
     @MainActor
     final class PlaybackRecorder {
       var skipIntervals: [CMTime] = []
-      var skipOutcome: PiPController.SkipOutcome = .issued
+      var skipOutcome: PiPController.SkipOutcome = .settled
+      var skipRequest: PiPController.SkipRequest?
 
       var driver: PiPController.PlaybackDriver {
         .init(
@@ -23,7 +25,7 @@ extension Integration {
           shouldResume: { false },
           skip: { interval in
             self.skipIntervals.append(interval)
-            return self.skipOutcome
+            return self.skipRequest ?? .init(resolved: self.skipOutcome)
           }
         )
       }
@@ -41,7 +43,7 @@ extension Integration {
     /// resolved against the input's own clock instead, and bounds are libVLC's
     /// to enforce.
     @Test
-    func `A backwards skip from zero passes the interval through unclamped`() {
+    func `A backwards skip from zero passes the interval through unclamped`() async {
       let player = Player(instance: TestInstance.shared)
       let recorder = PlaybackRecorder()
       let controller = PiPController(
@@ -50,14 +52,14 @@ extension Integration {
         pauseDebounce: .milliseconds(10)
       )
 
-      controller._skipByIntervalForTesting(CMTime(seconds: -10, preferredTimescale: 1000))
+      await controller._skipByIntervalForTesting(CMTime(seconds: -10, preferredTimescale: 1000))
 
       expectNoDifference(recorder.skipIntervals.map(\.seconds), [-10])
     }
 
     /// An overshoot past a known duration is libVLC's to bound, not PiP's.
     @Test
-    func `A skip past duration passes the interval through unclamped`() {
+    func `A skip past duration passes the interval through unclamped`() async {
       let player = Player(instance: TestInstance.shared)
       player._setStateForTesting(
         currentTime: .seconds(9),
@@ -70,14 +72,14 @@ extension Integration {
         pauseDebounce: .milliseconds(10)
       )
 
-      controller._skipByIntervalForTesting(CMTime(seconds: 60, preferredTimescale: 1000))
+      await controller._skipByIntervalForTesting(CMTime(seconds: 60, preferredTimescale: 1000))
 
       expectNoDifference(recorder.skipIntervals.map(\.seconds), [60])
     }
 
     /// A mid-range skip fires exactly one jump carrying the requested offset.
     @Test
-    func `A skip within bounds issues one jump with the requested interval`() {
+    func `A skip within bounds issues one jump with the requested interval`() async {
       let player = Player(instance: TestInstance.shared)
       player._setStateForTesting(
         currentTime: .seconds(5),
@@ -90,7 +92,7 @@ extension Integration {
         pauseDebounce: .milliseconds(10)
       )
 
-      controller._skipByIntervalForTesting(CMTime(seconds: 3, preferredTimescale: 1000))
+      await controller._skipByIntervalForTesting(CMTime(seconds: 3, preferredTimescale: 1000))
 
       expectNoDifference(recorder.skipIntervals.map(\.seconds), [3])
     }
@@ -103,7 +105,7 @@ extension Integration {
     /// the corrector for a second over a timeline that never moved — precisely
     /// when it should be free to correct.
     @Test
-    func `A rejected skip is not recorded as a skip`() {
+    func `A rejected skip is not recorded as a skip`() async {
       let player = Player(instance: TestInstance.shared)
       player._setStateForTesting(currentTime: .seconds(5), duration: .seconds(60))
       let recorder = PlaybackRecorder()
@@ -114,7 +116,7 @@ extension Integration {
         pauseDebounce: .milliseconds(10)
       )
 
-      controller._skipByIntervalForTesting(CMTime(seconds: 30, preferredTimescale: 1000))
+      await controller._skipByIntervalForTesting(CMTime(seconds: 30, preferredTimescale: 1000))
 
       #expect(
         controller._didRecordSkipForTesting() == false,
@@ -125,7 +127,7 @@ extension Integration {
     /// The accepted counterpart, so the test above is proving a difference
     /// rather than an always-false property.
     @Test
-    func `An accepted skip is recorded`() {
+    func `A settled skip is recorded`() async {
       let player = Player(instance: TestInstance.shared)
       player._setStateForTesting(currentTime: .seconds(5), duration: .seconds(60))
       let recorder = PlaybackRecorder()
@@ -135,7 +137,7 @@ extension Integration {
         pauseDebounce: .milliseconds(10)
       )
 
-      controller._skipByIntervalForTesting(CMTime(seconds: 30, preferredTimescale: 1000))
+      await controller._skipByIntervalForTesting(CMTime(seconds: 30, preferredTimescale: 1000))
 
       #expect(controller._didRecordSkipForTesting())
     }
@@ -144,7 +146,7 @@ extension Integration {
     /// fails. Never twice, and never not at all — a missing call leaves the PiP
     /// transport spinning.
     @Test
-    func `A skip calls its completion handler exactly once`() {
+    func `A skip calls its completion handler exactly once`() async {
       let player = Player(instance: TestInstance.shared)
       player._setStateForTesting(currentTime: .seconds(5), duration: .seconds(60))
       let recorder = PlaybackRecorder()
@@ -155,11 +157,11 @@ extension Integration {
       )
       let interval = CMTime(seconds: 3, preferredTimescale: 1000)
 
-      #expect(controller._skipCompletionCountForTesting(interval) == 1)
+      #expect(await controller._skipCompletionCountForTesting(interval) == 1)
 
       recorder.skipOutcome = .rejected
       #expect(
-        controller._skipCompletionCountForTesting(interval) == 1,
+        await controller._skipCompletionCountForTesting(interval) == 1,
         "a refused skip must still complete, exactly once"
       )
 
@@ -168,43 +170,132 @@ extension Integration {
       // `performSkip` classifies that case, and is tested directly below.
     }
 
+    /// Dispatch acceptance is not completion. AVKit must stay pending until
+    /// the matching native clock sample proves that the jump landed.
+    @Test
+    func `Completion waits for authoritative settlement`() async {
+      let player = Player(instance: TestInstance.shared)
+      let recorder = PlaybackRecorder()
+      let resolver = SeekOutcomeResolver()
+      recorder.skipRequest = .init(seekRequest: SeekRequest(resolver: resolver))
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(10)
+      )
+      let completionCount = Mutex(0)
+
+      controller.handleSkip(
+        by: CMTime(seconds: 3, preferredTimescale: 1000)
+      ) { completionCount.withLock { $0 += 1 } }
+      await Task.yield()
+
+      #expect(completionCount.withLock { $0 } == 0)
+      #expect(controller._didRecordSkipForTesting() == false)
+      #expect(controller.pendingSkipCount == 1)
+
+      resolver.resolve(.settled)
+      for _ in 0..<20 where completionCount.withLock({ $0 }) == 0 {
+        await Task.yield()
+      }
+
+      #expect(completionCount.withLock { $0 } == 1)
+      #expect(controller._didRecordSkipForTesting())
+      #expect(controller.pendingSkipCount == 0)
+    }
+
+    /// A bounded failure still discharges AVKit's completion debt, but does
+    /// not claim that the timeline moved.
+    @Test
+    func `A timed out skip completes without recording a landing`() async {
+      let player = Player(instance: TestInstance.shared)
+      let recorder = PlaybackRecorder()
+      let resolver = SeekOutcomeResolver()
+      recorder.skipRequest = .init(seekRequest: SeekRequest(resolver: resolver))
+      let controller = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(10)
+      )
+      let completionCount = Mutex(0)
+
+      controller.handleSkip(
+        by: CMTime(seconds: 3, preferredTimescale: 1000)
+      ) { completionCount.withLock { $0 += 1 } }
+      resolver.resolve(.timedOut)
+      for _ in 0..<20 where completionCount.withLock({ $0 }) == 0 {
+        await Task.yield()
+      }
+
+      #expect(completionCount.withLock { $0 } == 1)
+      #expect(controller._didRecordSkipForTesting() == false)
+    }
+
+    /// The task waiting for native settlement deliberately holds the
+    /// controller weakly. Dropping the owner must still discharge AVKit's
+    /// completion debt after the request reaches a terminal result.
+    @Test
+    func `A pending skip still completes after the controller is released`() async {
+      let player = Player(instance: TestInstance.shared)
+      let recorder = PlaybackRecorder()
+      let resolver = SeekOutcomeResolver()
+      recorder.skipRequest = .init(seekRequest: SeekRequest(resolver: resolver))
+      var controller: PiPController? = PiPController(
+        player: player,
+        playbackDriver: recorder.driver,
+        pauseDebounce: .milliseconds(10)
+      )
+      let completionCount = Mutex(0)
+
+      controller?.handleSkip(
+        by: CMTime(seconds: 3, preferredTimescale: 1000)
+      ) { completionCount.withLock { $0 += 1 } }
+      await Task.yield()
+      controller = nil
+
+      resolver.resolve(.superseded)
+      for _ in 0..<20 where completionCount.withLock({ $0 }) == 0 {
+        await Task.yield()
+      }
+
+      #expect(completionCount.withLock { $0 } == 1)
+    }
+
     /// The interval classification lives in `performSkip`, so it is tested
     /// against the real function rather than through the stub driver — the stub
     /// returns a canned outcome and never converts an interval, so routing
     /// these through it would assert nothing.
     @Test
-    func `An unrepresentable interval is classified without reaching the player`() {
+    func `An unrepresentable interval is classified without reaching the player`() async {
       let player = Player(instance: TestInstance.shared)
 
-      #expect(PiPController.performSkip(on: player, by: .invalid) == .unrepresentableInterval)
-      #expect(PiPController.performSkip(on: player, by: .indefinite) == .unrepresentableInterval)
-      #expect(
-        PiPController.performSkip(on: player, by: .positiveInfinity) == .unrepresentableInterval
-      )
-      #expect(
-        PiPController.performSkip(on: player, by: .negativeInfinity) == .unrepresentableInterval
-      )
+      for interval in [CMTime.invalid, .indefinite, .positiveInfinity, .negativeInfinity] {
+        let request = PiPController.performSkip(on: player, by: interval)
+        #expect(request.initialOutcome == .unrepresentableInterval)
+        #expect(await request.outcome == .unrepresentableInterval)
+      }
     }
 
     /// A representable interval with no session to seek in is a rejection, not
     /// an unrepresentable interval. Distinguishing the two is the point of the
     /// typed outcome.
     @Test
-    func `A representable interval without a session is rejected`() {
+    func `A representable interval without a session is rejected`() async {
       let player = Player(instance: TestInstance.shared)
 
-      let outcome = PiPController.performSkip(
+      let request = PiPController.performSkip(
         on: player,
         by: CMTime(seconds: 3, preferredTimescale: 1000)
       )
 
-      #expect(outcome == .rejected)
+      #expect(request.initialOutcome == .rejected)
+      #expect(await request.outcome == .rejected)
     }
 
     /// Completion still has to run exactly once when the interval cannot be
     /// converted — that path returns before the driver is consulted at all.
     @Test
-    func `An unrepresentable interval still completes exactly once`() {
+    func `An unrepresentable interval still completes exactly once`() async {
       let player = Player(instance: TestInstance.shared)
       let recorder = PlaybackRecorder()
       let controller = PiPController(
@@ -213,7 +304,7 @@ extension Integration {
         pauseDebounce: .milliseconds(10)
       )
 
-      #expect(controller._skipCompletionCountForTesting(.invalid) == 1)
+      #expect(await controller._skipCompletionCountForTesting(.invalid) == 1)
       #expect(recorder.skipIntervals.isEmpty, "an unconvertible interval reached the driver")
     }
   }

--- a/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
@@ -18,7 +18,7 @@ extension Integration {
       var cancelPendingPauseCount = 0
       var shouldResume = false
       var skipIntervals: [CMTime] = []
-      var skipOutcome: PiPController.SkipOutcome = .issued
+      var skipOutcome: PiPController.SkipOutcome = .settled
       /// Models an input libVLC refuses to pause, so the deferred-pause retry
       /// bound can be exercised.
       var pauseSucceeds = true
@@ -43,7 +43,7 @@ extension Integration {
           shouldResume: { self.shouldResume },
           skip: { interval in
             self.skipIntervals.append(interval)
-            return self.skipOutcome
+            return .init(resolved: self.skipOutcome)
           }
         )
       }
@@ -739,7 +739,7 @@ extension Integration {
       )
 
       controller._setPlayingForTesting(false)
-      controller._skipByIntervalForTesting(CMTime(seconds: 1, preferredTimescale: 1000))
+      await controller._skipByIntervalForTesting(CMTime(seconds: 1, preferredTimescale: 1000))
       controller._setPlayingForTesting(true)
       try? await Task.sleep(for: .milliseconds(80))
 

--- a/Tests/SwiftVLCTests/PiP/PiPStateObserverLaneTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPStateObserverLaneTests.swift
@@ -14,6 +14,7 @@ struct PiPTimebaseRetrackingTests {
     rate: Float = 1.0,
     lastRate: Float = 1.0,
     hasTimebase: Bool = true,
+    isSkipPending: Bool = false,
     secondsSinceSkip: Double = 5.0,
     playerSeconds: Double = 0,
     timebaseSeconds: Double = 0
@@ -24,6 +25,7 @@ struct PiPTimebaseRetrackingTests {
       rate: rate,
       lastRate: lastRate,
       hasTimebase: hasTimebase,
+      isSkipPending: isSkipPending,
       secondsSinceSkip: secondsSinceSkip,
       playerSeconds: playerSeconds,
       timebaseSeconds: timebaseSeconds
@@ -69,6 +71,21 @@ struct PiPTimebaseRetrackingTests {
   @Test
   func `A recent skip suppresses the resync`() {
     #expect(retracking(secondsSinceSkip: 0.5, playerSeconds: 40, timebaseSeconds: 10).setsTime == nil)
+  }
+
+  /// Settlement can legitimately outlast the historical one-second grace
+  /// period. Pending state, not elapsed time, keeps the optimistic Player
+  /// estimate from leaking into AVKit.
+  @Test
+  func `A pending skip suppresses resync beyond the grace period`() {
+    #expect(
+      retracking(
+        isSkipPending: true,
+        secondsSinceSkip: 5,
+        playerSeconds: 40,
+        timebaseSeconds: 10
+      ).setsTime == nil
+    )
   }
 
   /// Small drift is normal between a decoded clock and a host timebase.

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
@@ -797,7 +797,7 @@ extension Integration {
       player.setPlaybackIntentFromExternalControl(false)
 
       #expect(didComplete.value)
-      #expect(player.currentTime == .zero)
+      #expect(player.currentTime == .seconds(5))
       #expect(mediaController.mediaLength() >= -1)
       #expect(mediaController.mediaTime() >= 0)
       _ = mediaController.isMediaSeekable()

--- a/Tests/SwiftVLCTests/Player/PlaybackTerminalOutcomeTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlaybackTerminalOutcomeTests.swift
@@ -40,6 +40,70 @@ extension Integration {
     }
 
     @Test
+    func `A stale clock callback cannot overwrite an authoritative terminal snapshot`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let generation = player.sessionGeneration
+      let nativeGeneration = player.eventBridge.currentNativeHandleGeneration
+      let staleRevision = player.acceptedTimelineRevision
+      let authoritativeRevision = player.eventBridge.advanceTimelineRevision()
+      player.eventBridge.updateAuthoritativeTimeline(
+        time: .seconds(40),
+        position: 0.4,
+        playbackGeneration: generation,
+        timelineRevision: authoritativeRevision
+      )
+
+      player.eventBridge._broadcastForTesting(
+        .timeChanged(.seconds(11)),
+        nativeHandleGeneration: nativeGeneration,
+        playbackGeneration: generation,
+        emittedTimelineRevision: staleRevision
+      )
+      player.eventBridge._broadcastForTesting(
+        .positionChanged(0.11),
+        nativeHandleGeneration: nativeGeneration,
+        playbackGeneration: generation,
+        emittedTimelineRevision: staleRevision
+      )
+
+      let outcome = firstOutcome(from: player.terminalOutcomes)
+      try player.load(Media(url: TestMedia.silenceURL))
+      let value = try #require(await outcome.value)
+      #expect(value.finalTimeline.time == .seconds(40))
+      #expect(value.finalTimeline.position == 0.4)
+    }
+
+    @Test
+    func `A previous media clock cannot seed its successor terminal snapshot`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let staleRevision = player.acceptedTimelineRevision
+      try player.load(Media(url: TestMedia.silenceURL))
+      let successorGeneration = player.sessionGeneration
+      let nativeGeneration = player.eventBridge.currentNativeHandleGeneration
+
+      player.eventBridge._broadcastForTesting(
+        .timeChanged(.seconds(11)),
+        nativeHandleGeneration: nativeGeneration,
+        playbackGeneration: successorGeneration,
+        emittedTimelineRevision: staleRevision
+      )
+      player.eventBridge._broadcastForTesting(
+        .positionChanged(0.11),
+        nativeHandleGeneration: nativeGeneration,
+        playbackGeneration: successorGeneration,
+        emittedTimelineRevision: staleRevision
+      )
+
+      let outcome = firstOutcome(from: player.terminalOutcomes)
+      try player.load(Media(url: TestMedia.sparseURL))
+      let value = try #require(await outcome.value)
+      #expect(value.finalTimeline.time == .zero)
+      #expect(value.finalTimeline.position == 0)
+    }
+
+    @Test
     func `An explicit stop intent outranks a following media replacement`() async throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
       try player.load(Media(url: TestMedia.twosecURL))

--- a/Tests/SwiftVLCTests/Player/PlayerLenientSeekTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerLenientSeekTests.swift
@@ -136,6 +136,24 @@ extension Integration {
     }
 
     @Test(.enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
+    func `authoritative jump settles from the post-seek native timer point`() async throws {
+      let player = Player(instance: TestInstance.makePlayback())
+      try player.play(url: TestMedia.twosecURL)
+      try #require(
+        await poll(until: { player.currentTime >= .milliseconds(800) }),
+        "Waiting for: currentTime >= 800ms"
+      )
+
+      let preJump = player.currentTime
+      let request = player.requestJump(by: .milliseconds(-500))
+
+      #expect(request.initialOutcome == .pending)
+      #expect(await request.outcome == .settled)
+      #expect(player.currentTime < preJump)
+      player.stop()
+    }
+
+    @Test(.enabled(if: TestCondition.canPlayMedia), .timeLimit(.minutes(1)))
     func `jump publishes currentTime immediately while paused`() async throws {
       let player = Player(instance: TestInstance.makePlayback())
       try player.play(url: TestMedia.twosecURL)

--- a/Tests/SwiftVLCTests/Player/PlayerSeekAuthorityTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerSeekAuthorityTests.swift
@@ -1,5 +1,6 @@
 @testable import SwiftVLC
 import Foundation
+import Synchronization
 import Testing
 
 /// A seek target, once accepted, is the authoritative timeline.
@@ -134,26 +135,21 @@ extension Integration {
     /// playback actually landed on, which is not the requested one.
     ///
     /// This pins the boundary condition of the filter — that the comparison is
-    /// `>=` and not `>`. It does **not** prove the reserve-before-native-call
-    /// ordering: which revision libVLC's event thread stamps a concurrent
-    /// sample with is not observable from here, and the test passes under
-    /// either ordering.
+    /// `>=` and not `>`.
     @Test
     func `A sample carrying the seek's own revision is applied`() throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
       try player.load(Media(url: TestMedia.twosecURL))
       player._setStateForTesting(state: .paused, duration: .seconds(100), isSeekable: true)
 
-      // Stamped with the revision the bridge hands out for this seek, which
-      // is what a sample emitted during the native call would carry.
-      let concurrentRevision = player.eventBridge.advanceTimelineRevision() + 1
       try player.seek(to: .seconds(42), fast: true)
+      let acceptedRevision = player.acceptedTimelineRevision
 
       let landed = SourcedPlayerEvent(
         nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
         playbackGeneration: player.sessionGeneration,
         event: .timeChanged(.seconds(40)),
-        timelineRevision: concurrentRevision
+        timelineRevision: acceptedRevision
       )
       player.handleSourcedEvent(landed)
 
@@ -254,6 +250,730 @@ extension Integration {
       #expect(player.jump(by: .seconds(5)) == false)
 
       #expect(player.acceptedTimelineRevision == before)
+    }
+
+    /// Conversion failure is a typed rejection and never reaches libVLC or
+    /// consumes timeline authority.
+    @Test
+    func `An out-of-range jump offset is rejected before native dispatch`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      let before = player.acceptedTimelineRevision
+      var nativeDispatchCount = 0
+      player._nativeJumpTimeOverrideForTesting = { _ in
+        nativeDispatchCount += 1
+        return 0
+      }
+
+      let request = player.requestJump(by: .seconds(Int64.max))
+
+      #expect(request.initialOutcome == .rejected)
+      #expect(await request.outcome == .rejected)
+      #expect(nativeDispatchCount == 0)
+      #expect(player.acceptedTimelineRevision == before)
+    }
+
+    /// Native dispatch is only the pending state. Ordinary clock samples can
+    /// update the mirror, but settlement needs seek end followed by a timer point.
+    @Test
+    func `An accepted jump settles after its post-seek timer point`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(
+        state: .paused,
+        isPlaybackRequestedActive: true,
+        currentTime: .seconds(10),
+        duration: .seconds(100)
+      )
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+
+      let request = player.requestJump(by: .seconds(30))
+      let revision = player.acceptedTimelineRevision
+
+      #expect(request.initialOutcome == .pending)
+      #expect(player.currentTime == .seconds(10))
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+
+      player.handleSourcedEvent(SourcedPlayerEvent(
+        nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
+        playbackGeneration: player.sessionGeneration,
+        event: .timeChanged(.seconds(41)),
+        timelineRevision: revision
+      ))
+
+      #expect(player.currentTime == .seconds(41))
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+
+      player.nativeSeekMonitor._noteTimeUpdatedForTesting(
+        timeMilliseconds: 40000,
+        position: 0.4
+      )
+      await Task.yield()
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+
+      player.nativeSeekMonitor._noteSeekEndedForTesting()
+      await Task.yield()
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+      player.nativeSeekMonitor._noteTimeUpdatedForTesting(
+        timeMilliseconds: 41000,
+        position: 0.41
+      )
+      for _ in 0..<50 where player.pendingSeekSettlement != nil {
+        await Task.yield()
+      }
+
+      #expect(await request.outcome == .settled)
+      #expect(player.currentTime == .seconds(41))
+      #expect(abs(player.position - 0.41) < 0.000_001)
+    }
+
+    /// libVLC permits an unknown clock sentinel for live inputs. That point
+    /// proves only that seeking ended, not where the relative jump landed.
+    @Test
+    func `An unknown post-seek clock does not settle the jump`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(
+        state: .playing,
+        isPlaybackRequestedActive: true,
+        currentTime: .seconds(10)
+      )
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+
+      let request = player.requestJump(by: .seconds(30))
+      player.nativeSeekMonitor._noteSeekEndedForTesting()
+      player.nativeSeekMonitor._noteTimeUpdatedForTesting(
+        timeMilliseconds: -1,
+        position: 0.63
+      )
+      await Task.yield()
+
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+      #expect(player.currentTime == .seconds(10))
+
+      let token = try #require(player.pendingSeekSettlement?.nativeSeekToken)
+      player.nativeSeekDidLand(NativeSeekLanding(
+        token: token,
+        timeMilliseconds: -1,
+        position: 0.63
+      ))
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+
+      player.nativeSeekMonitor._noteTimeUpdatedForTesting(
+        timeMilliseconds: 41000,
+        position: 0.63
+      )
+      #expect(await request.outcome == .settled)
+      #expect(player.currentTime == .seconds(41))
+    }
+
+    /// Paused audio has no decoded video frame to produce a watched timer
+    /// point. Seek-end therefore reads the native clock outside the callback
+    /// and resolves the request without waiting for playback to resume.
+    @Test
+    func `A paused audio seek settles from its authoritative end read`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(
+        state: .paused,
+        isPlaybackRequestedActive: true,
+        currentTime: .seconds(10)
+      )
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+      player._nativePlaybackStateOverrideForTesting = .paused
+      player._nativeSeekLandingOverrideForTesting = { (40000, 0.4) }
+
+      let request = player.requestJump(by: .seconds(30))
+      player.nativeSeekMonitor._noteSeekEndedForTesting()
+
+      #expect(await request.outcome == .settled)
+      #expect(player.currentTime == .seconds(40))
+      #expect(abs(player.position - 0.4) < 0.000_001)
+    }
+
+    /// Native start callbacks consume command tokens in dispatch order. A
+    /// later staged command must never be attributed to an earlier landing.
+    @Test
+    func `Staged native seek tokens preserve command order`() {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let deliveries = Mutex<[NativeSeekLanding]>([])
+      player.nativeSeekMonitor.setHandler { landing in
+        deliveries.withLock { $0.append(landing) }
+      }
+      let first = player.nativeSeekMonitor.stageCommand()
+      let second = player.nativeSeekMonitor.stageCommand()
+
+      player.nativeSeekMonitor._noteSeekStartedForTesting()
+      player.nativeSeekMonitor._noteSeekEndedForTesting()
+      player.nativeSeekMonitor._noteTimeUpdatedForTesting(
+        timeMilliseconds: 10000,
+        position: 0.1
+      )
+      player.nativeSeekMonitor._noteSeekStartedForTesting()
+      player.nativeSeekMonitor._noteSeekEndedForTesting()
+      player.nativeSeekMonitor._noteTimeUpdatedForTesting(
+        timeMilliseconds: 20000,
+        position: 0.2
+      )
+
+      let tokens = deliveries.withLock { $0.map(\.token) }
+      #expect(tokens == [first, second])
+    }
+
+    /// Replacing media on the same native handle gives its time watch a fresh
+    /// attachment. A callback already in flight from the outgoing media must
+    /// not consume the successor command's token.
+    @Test
+    func `Media reset quarantines outgoing native seek callbacks`() {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let deliveries = Mutex<[NativeSeekLanding]>([])
+      player.nativeSeekMonitor.setHandler { landing in
+        deliveries.withLock { $0.append(landing) }
+      }
+      let outgoingGeneration = player.nativeSeekMonitor._timelineGenerationForTesting
+      _ = player.nativeSeekMonitor.stageCommand()
+
+      player.resetMediaDerivedState()
+      let successor = player.nativeSeekMonitor.stageCommand()
+
+      player.nativeSeekMonitor._noteSeekStartedForTesting(
+        timelineGeneration: outgoingGeneration
+      )
+      player.nativeSeekMonitor._noteSeekEndedForTesting(
+        timelineGeneration: outgoingGeneration
+      )
+      player.nativeSeekMonitor._noteTimeUpdatedForTesting(
+        timeMilliseconds: 10000,
+        position: 0.1,
+        timelineGeneration: outgoingGeneration
+      )
+      let outgoingWasQuarantined = deliveries.withLock { $0.isEmpty }
+      #expect(outgoingWasQuarantined)
+
+      player.nativeSeekMonitor._noteSeekStartedForTesting()
+      player.nativeSeekMonitor._noteSeekEndedForTesting()
+      player.nativeSeekMonitor._noteTimeUpdatedForTesting(
+        timeMilliseconds: 20000,
+        position: 0.2
+      )
+
+      let tokens = deliveries.withLock { $0.map(\.token) }
+      #expect(tokens == [successor])
+    }
+
+    /// `load(_:)` has already adopted and reset the wrapper-owned generation
+    /// before libVLC's MediaChanged echo reaches the main-actor event lane. A
+    /// seek accepted in between belongs to that generation and must survive
+    /// the delayed echo.
+    @Test
+    func `A wrapper media-change echo preserves a newer seek`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      player._setStateForTesting(
+        state: .playing,
+        isPlaybackRequestedActive: true,
+        currentTime: .seconds(10)
+      )
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+      let generation = player.sessionGeneration
+
+      let request = player.requestJump(by: .seconds(5))
+      player.handleEvent(.mediaChanged, sourcePlaybackGeneration: generation)
+
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+      player._completePendingSeekForTesting(time: .seconds(15), position: 0.15)
+      #expect(await request.outcome == .settled)
+    }
+
+    /// Acceptance-only jumps still occupy their native callback slot. A
+    /// delayed start for one must not consume the later request's token and
+    /// let the legacy landing settle that request against the wrong timeline.
+    @Test
+    func `A legacy jump cannot steal a later request token`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(
+        state: .playing,
+        isPlaybackRequestedActive: true,
+        currentTime: .seconds(10)
+      )
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+
+      #expect(player.jump(by: .seconds(5)))
+      let request = player.requestJump(by: .seconds(30))
+
+      // requestJump's deterministic test seam emits one seek-start. It must
+      // consume the older legacy slot, so that landing cannot resolve the
+      // tracked request.
+      player.nativeSeekMonitor._noteSeekEndedForTesting()
+      player.nativeSeekMonitor._noteTimeUpdatedForTesting(
+        timeMilliseconds: 15000,
+        position: 0.15
+      )
+      await Task.yield()
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+
+      player.nativeSeekMonitor._noteSeekStartedForTesting()
+      player.nativeSeekMonitor._noteSeekEndedForTesting()
+      player.nativeSeekMonitor._noteTimeUpdatedForTesting(
+        timeMilliseconds: 45000,
+        position: 0.45
+      )
+
+      #expect(await request.outcome == .settled)
+      #expect(player.currentTime == .seconds(45))
+    }
+
+    /// Even if a tiny input lands before the C call returns, delivery is deferred
+    /// to the main actor until the request has installed its waiter.
+    @Test
+    func `Synchronous native completion is retained until request registration`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      player._nativeJumpTimeOverrideForTesting = { _ in
+        player.nativeSeekMonitor._noteSeekStartedForTesting()
+        player.nativeSeekMonitor._noteSeekEndedForTesting()
+        player.nativeSeekMonitor._noteTimeUpdatedForTesting(
+          timeMilliseconds: 20000,
+          position: 0.2
+        )
+        return 0
+      }
+
+      let request = player.requestJump(by: .seconds(10))
+
+      #expect(await request.outcome == .settled)
+      #expect(player.currentTime == .seconds(20))
+      #expect(abs(player.position - 0.2) < 0.000_001)
+    }
+
+    /// Unknown-duration inputs cannot derive a fraction from the clock. The
+    /// native fraction still has to reach observers before the waiter resumes.
+    @Test
+    func `Native completion publishes position before settlement`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(
+        state: .paused,
+        isPlaybackRequestedActive: true,
+        currentTime: .seconds(10),
+        position: 0.2
+      )
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+
+      let request = player.requestJump(by: .seconds(30))
+      player._completePendingSeekForTesting(time: .seconds(41), position: 0.63)
+
+      #expect(await request.outcome == .settled)
+      #expect(player.currentTime == .seconds(41))
+      #expect(abs(player.position - 0.63) < 0.000_001)
+    }
+
+    /// A synchronous callback emitted by the native call belongs to the new
+    /// timeline and must not be discarded, but it also cannot prove landing.
+    @Test
+    func `A clock callback racing native dispatch cannot settle the jump`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(
+        state: .paused,
+        isPlaybackRequestedActive: true,
+        currentTime: .seconds(10),
+        duration: .seconds(100)
+      )
+      let bridge = player.eventBridge
+      let nativeGeneration = bridge.currentNativeHandleGeneration
+      let playbackGeneration = player.sessionGeneration
+      player._nativeJumpTimeOverrideForTesting = { _ in
+        bridge._broadcastForTesting(
+          .timeChanged(.seconds(11)),
+          nativeHandleGeneration: nativeGeneration,
+          playbackGeneration: playbackGeneration
+        )
+        return 0
+      }
+
+      let request = player.requestJump(by: .seconds(30))
+      player._nativeJumpTimeOverrideForTesting = nil
+      let revision = player.acceptedTimelineRevision
+      bridge._broadcastForTesting(
+        .stateChanged(.playing),
+        nativeHandleGeneration: nativeGeneration,
+        playbackGeneration: playbackGeneration
+      )
+      for _ in 0..<50 where player.state != .playing {
+        await Task.yield()
+      }
+
+      #expect(player.state == .playing, "the event-lane sentinel did not drain")
+      #expect(player.currentTime == .seconds(11))
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+
+      player.handleSourcedEvent(SourcedPlayerEvent(
+        nativeHandleGeneration: nativeGeneration,
+        playbackGeneration: playbackGeneration,
+        event: .timeChanged(.seconds(41)),
+        timelineRevision: revision
+      ))
+
+      #expect(player.currentTime == .seconds(41))
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+      player._completePendingSeekForTesting(time: .seconds(41), position: 0.41)
+      #expect(await request.outcome == .settled)
+    }
+
+    /// A stale sample can neither overwrite the target nor falsely discharge
+    /// the settlement promise.
+    @Test
+    func `A pre-jump sample does not settle the request`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(
+        state: .playing,
+        isPlaybackRequestedActive: true,
+        currentTime: .seconds(10),
+        duration: .seconds(100)
+      )
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+      let staleRevision = player.acceptedTimelineRevision
+      let request = player.requestJump(by: .seconds(5))
+      let acceptedRevision = player.acceptedTimelineRevision
+
+      player.handleSourcedEvent(SourcedPlayerEvent(
+        nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
+        playbackGeneration: player.sessionGeneration,
+        event: .timeChanged(.seconds(10)),
+        timelineRevision: staleRevision
+      ))
+
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+      #expect(player.currentTime == .seconds(10))
+
+      // Neither an accepted-revision position nor time sample can impersonate
+      // libVLC's causal seek end and following native timer point.
+      player.handleSourcedEvent(SourcedPlayerEvent(
+        nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
+        playbackGeneration: player.sessionGeneration,
+        event: .positionChanged(0.16),
+        timelineRevision: acceptedRevision
+      ))
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+
+      player.handleSourcedEvent(SourcedPlayerEvent(
+        nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
+        playbackGeneration: player.sessionGeneration,
+        event: .timeChanged(.seconds(16)),
+        timelineRevision: acceptedRevision
+      ))
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+
+      player._completePendingSeekForTesting(time: .seconds(16), position: 0.16)
+      #expect(await request.outcome == .settled)
+    }
+
+    /// A terminal event queued before the command cannot terminate a newer
+    /// request merely because the main actor applies it after native dispatch.
+    @Test
+    func `A stale terminal event does not supersede a newer jump`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+      let staleRevision = player.acceptedTimelineRevision
+
+      let request = player.requestJump(by: .seconds(10))
+      player.handleSourcedEvent(SourcedPlayerEvent(
+        nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
+        playbackGeneration: player.sessionGeneration,
+        event: .stateChanged(.stopped),
+        timelineRevision: staleRevision
+      ))
+
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+      player._completePendingSeekForTesting(time: .seconds(10))
+      #expect(await request.outcome == .settled)
+    }
+
+    /// An error callback can enter before a seek and wait in the control lane
+    /// until afterwards. Its older revision cannot cancel the newer command.
+    @Test
+    func `A stale encountered error does not supersede a newer jump`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+      let staleRevision = player.acceptedTimelineRevision
+
+      let request = player.requestJump(by: .seconds(10))
+      player.handleSourcedEvent(SourcedPlayerEvent(
+        nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
+        playbackGeneration: player.sessionGeneration,
+        event: .encounteredError,
+        timelineRevision: staleRevision
+      ))
+
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+      player._completePendingSeekForTesting(time: .seconds(20), position: 0.2)
+      #expect(await request.outcome == .settled)
+    }
+
+    /// Applying the causal landing advances authority beyond callbacks that
+    /// entered after dispatch but before the native seek began.
+    @Test
+    func `A queued pre-landing clock cannot overwrite the settled timeline`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(
+        state: .paused,
+        isPlaybackRequestedActive: true,
+        currentTime: .seconds(10)
+      )
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+
+      let request = player.requestJump(by: .seconds(30))
+      let acceptedRevision = player.acceptedTimelineRevision
+      player._completePendingSeekForTesting(time: .seconds(40), position: 0.4)
+      #expect(await request.outcome == .settled)
+      #expect(player.acceptedTimelineRevision > acceptedRevision)
+
+      player.handleSourcedEvent(SourcedPlayerEvent(
+        nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
+        playbackGeneration: player.sessionGeneration,
+        event: .timeChanged(.seconds(11)),
+        timelineRevision: acceptedRevision
+      ))
+
+      #expect(player.currentTime == .seconds(40))
+      #expect(abs(player.position - 0.4) < 0.000_001)
+    }
+
+    /// Native completion is scoped to the exact wrapper-issued seek token.
+    @Test
+    func `Settlement ignores a different native seek token`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+
+      let request = player.requestJump(by: .seconds(10))
+      let token = try #require(player.pendingSeekSettlement?.nativeSeekToken)
+
+      player._completePendingSeekForTesting(time: .seconds(10), token: token &+ 1)
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+
+      player._completePendingSeekForTesting(time: .seconds(10), token: token)
+      #expect(await request.outcome == .settled)
+    }
+
+    /// Rapid alternating skip controls must give every displaced request an
+    /// explicit result while leaving only the newest one able to settle.
+    @Test
+    func `A newer jump supersedes the previous request`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(
+        state: .buffering,
+        isPlaybackRequestedActive: true,
+        currentTime: .seconds(50),
+        duration: .seconds(100)
+      )
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+
+      let first = player.requestJump(by: .seconds(10))
+      let firstRevision = player.acceptedTimelineRevision
+      let second = player.requestJump(by: .seconds(-20))
+      let secondRevision = player.acceptedTimelineRevision
+
+      #expect(await first.outcome == .superseded)
+
+      player.handleSourcedEvent(SourcedPlayerEvent(
+        nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
+        playbackGeneration: player.sessionGeneration,
+        event: .timeChanged(.seconds(60)),
+        timelineRevision: firstRevision
+      ))
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+
+      player.handleSourcedEvent(SourcedPlayerEvent(
+        nativeHandleGeneration: player.eventBridge.currentNativeHandleGeneration,
+        playbackGeneration: player.sessionGeneration,
+        event: .timeChanged(.seconds(40)),
+        timelineRevision: secondRevision
+      ))
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+
+      player._completePendingSeekForTesting(time: .seconds(40), position: 0.4)
+      #expect(await second.outcome == .settled)
+      #expect(player.currentTime == .seconds(40))
+    }
+
+    /// A rejected replacement changes no native timeline. The previous
+    /// accepted request remains authoritative and can still settle normally.
+    @Test
+    func `A rejected newer jump preserves the previous request`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+
+      let first = player.requestJump(by: .seconds(10))
+      let firstRevision = player.acceptedTimelineRevision
+      player._nativeJumpTimeOverrideForTesting = { _ in -1 }
+      let rejected = player.requestJump(by: .seconds(20))
+
+      #expect(rejected.initialOutcome == .rejected)
+      #expect(await rejected.outcome == .rejected)
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+      #expect(player.acceptedTimelineRevision == firstRevision)
+
+      player.nativeSeekMonitor._noteSeekEndedForTesting()
+      player.nativeSeekMonitor._noteTimeUpdatedForTesting(
+        timeMilliseconds: 10000,
+        position: -.infinity
+      )
+      #expect(await first.outcome == .settled)
+    }
+
+    /// Position seeking follows the same transactional replacement rule as a
+    /// relative jump: rejection preserves the old request; acceptance owns the
+    /// new timeline and only then supersedes it.
+    @Test
+    func `A position seek supersedes pending work only after native acceptance`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+
+      let first = player.requestJump(by: .seconds(10))
+      let firstRevision = player.acceptedTimelineRevision
+      player._nativeSetPositionOverrideForTesting = { _, _ in -1 }
+
+      #expect(!player.seek(toPosition: PlaybackPosition(0.4)))
+      #expect(player.acceptedTimelineRevision == firstRevision)
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+
+      player._nativeSetPositionOverrideForTesting = { _, _ in 0 }
+      #expect(player.seek(toPosition: PlaybackPosition(0.5)))
+      #expect(await first.outcome == .superseded)
+      #expect(player.acceptedTimelineRevision > firstRevision)
+      #expect(player.position == 0.5)
+    }
+
+    /// The native return code is authoritative. A refusal is typed and does
+    /// not publish either the requested estimate or a new accepted revision.
+    @Test
+    func `A native-rejected jump leaves the timeline unchanged`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(
+        state: .playing,
+        isPlaybackRequestedActive: true,
+        currentTime: .seconds(12),
+        duration: .seconds(100)
+      )
+      player._nativeJumpTimeOverrideForTesting = { _ in -1 }
+      let acceptedRevision = player.acceptedTimelineRevision
+
+      let request = player.requestJump(by: .seconds(30))
+
+      #expect(request.initialOutcome == .rejected)
+      #expect(await request.outcome == .rejected)
+      #expect(player.acceptedTimelineRevision == acceptedRevision)
+      #expect(player.currentTime == .seconds(12))
+    }
+
+    /// An accepted command that never produces native completion cannot leave an
+    /// AVKit completion suspended indefinitely.
+    @Test
+    func `An accepted jump has a bounded timeout result`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(
+        state: .playing,
+        isPlaybackRequestedActive: true,
+        currentTime: .seconds(12),
+        duration: .seconds(100),
+        position: 0.12
+      )
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+
+      let request = player.requestJump(by: .seconds(30))
+      player._expirePendingSeekForTesting()
+
+      #expect(await request.outcome == .timedOut)
+      #expect(player.pendingSeekSettlement == nil)
+      #expect(player.currentTime == .seconds(12))
+      #expect(abs(player.position - 0.12) < 0.000_001)
+    }
+
+    /// Media replacement establishes a new generation and makes the outgoing
+    /// request explicitly superseded, even if its old event arrives later.
+    @Test
+    func `A media reset supersedes a pending jump`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+
+      let request = player.requestJump(by: .seconds(10))
+      player.resetMediaDerivedState()
+
+      #expect(await request.outcome == .superseded)
+    }
+
+    /// Renderer recast establishes a successor playback generation without a
+    /// media reset. That generation boundary must terminate the outgoing seek
+    /// immediately rather than leaving it to time out.
+    @Test
+    func `A playback generation change supersedes a pending jump`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+
+      let request = player.requestJump(by: .seconds(10))
+      player.sessionGeneration &+= 1
+
+      #expect(await request.outcome == .superseded)
+    }
+
+    /// An explicit stop is authoritative immediately; completion does not
+    /// wait for libVLC's asynchronous stopped event before discharging a skip.
+    @Test
+    func `Stopping supersedes a pending jump synchronously`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+
+      let request = player.requestJump(by: .seconds(10))
+      player._nativePlaybackStateOverrideForTesting = .idle
+      player.stop()
+
+      #expect(await request.outcome == .superseded)
+    }
+
+    /// Cancelling an observer does not cancel or misclassify the shared seek.
+    @Test
+    func `Cancelling one waiter does not cancel the seek`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+      let request = player.requestJump(by: .seconds(10))
+      let waiter = Task { await request.outcome }
+
+      waiter.cancel()
+      await Task.yield()
+      #expect(player.pendingSeekSettlement?.resolver.resolvedOutcome == nil)
+
+      player._completePendingSeekForTesting(time: .seconds(10))
+
+      #expect(await waiter.value == .settled)
+    }
+
+    /// Relative jumping changes only the timeline; it does not synthesize the
+    /// pause/mute transport sequence that previously left PiP playback stuck.
+    @Test
+    func `A jump preserves pause intent and mute state`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(
+        state: .paused,
+        isPlaybackRequestedActive: false,
+        currentTime: .seconds(5),
+        duration: .seconds(100)
+      )
+      player.isMuted = true
+      player._nativePlaybackStateOverrideForTesting = .paused
+      player._nativeJumpTimeOverrideForTesting = { _ in 0 }
+
+      let request = player.requestJump(by: .seconds(5))
+      player._completePendingSeekForTesting(time: .seconds(10), position: 0.1)
+
+      #expect(await request.outcome == .settled)
+      #expect(player.state == .paused)
+      #expect(player.isPlaybackRequestedActive == false)
+      #expect(player.isMuted)
     }
   }
 }


### PR DESCRIPTION
## Summary

- add an authoritative relative-seek request API with pending, rejected, settled, timed-out, and superseded outcomes
- settle accepted requests only after the matching native time sample has updated the observable Player timeline
- route sample-buffer, macOS native, and iOS native PiP skips through the same settlement contract
- preserve the lightweight legacy jump path while preventing stale samples, lifecycle changes, and overlapping seeks from falsely completing AVKit work
- document the new public API and add focused lifecycle, timeout, rejection, supersession, and exactly-once tests

## Root cause

PiP skip completions were discharged when libVLC accepted dispatch, before any authoritative landing evidence reached Player. That could let AVKit publish an optimistic timeline as final, while stale clock events or a refused seek left playback elsewhere.

## Impact

PiP transport completion now reflects actual native settlement or a bounded typed failure. Existing source-compatible jump callers retain their synchronous acceptance-only behavior and avoid settlement allocation.

Closes #76
Closes #77

## Validation

- CI=true ./scripts/ci-run-with-timeouts.py 600 180 swift test --no-parallel --enable-code-coverage: 1,915 tests in 165 suites passed
- swift build -c release
- swiftformat --lint --strict .
- swiftlint lint --strict
- ./scripts/tests/release-integrity.sh
- ./scripts/verify-patch-manifest.sh
- ./scripts/check-engine-coverage.sh
- public documentation coverage: 794 / 794 symbols, 100%
