### PR TITLE
Fix native list teardown and cache PiP formats

### DIFF
--- a/scripts/benchmark-native-format-cache.sh
+++ b/scripts/benchmark-native-format-cache.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Compare the pinned per-frame CoreMedia path with the patched native cache.
+# Optional xctrace recordings make the allocation and CPU profiles inspectable:
+#   SWIFTVLC_PROFILE_DIR=/tmp/native-cache-profiles \
+#     ./scripts/benchmark-native-format-cache.sh VLC_SOURCE_ROOT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VLC_SOURCE_ROOT="${1:?usage: benchmark-native-format-cache.sh VLC_SOURCE_ROOT}"
+HEADER_DIR="${VLC_SOURCE_ROOT}/modules/video_output/apple"
+HEADER="${HEADER_DIR}/VLCSampleBufferFormatDescriptionCache.h"
+PROBE="${SCRIPT_DIR}/patches/validation/native-format-description-cache-benchmark.m"
+SECONDS_PER_CASE="${SWIFTVLC_BENCHMARK_SECONDS:-60}"
+REPETITIONS="${SWIFTVLC_BENCHMARK_REPETITIONS:-25}"
+PROFILE_DIR="${SWIFTVLC_PROFILE_DIR:-}"
+PROFILE_TIME_LIMIT="${SWIFTVLC_PROFILE_TIME_LIMIT:-10s}"
+
+if [ ! -f "$HEADER" ]; then
+  echo "Native format-description cache header not found: $HEADER" >&2
+  exit 1
+fi
+
+BENCHMARK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/swiftvlc-format-cache-benchmark.XXXXXX")
+trap 'rm -rf "$BENCHMARK_DIR"' EXIT
+BENCHMARK="$BENCHMARK_DIR/native-format-description-cache-benchmark"
+
+xcrun --sdk macosx clang \
+  -O2 \
+  -fmodules \
+  -Wall -Wextra -Werror \
+  -I "$HEADER_DIR" \
+  "$PROBE" \
+  -framework CoreMedia \
+  -framework CoreVideo \
+  -o "$BENCHMARK"
+
+if [ -n "$PROFILE_DIR" ]; then
+  mkdir -p "$PROFILE_DIR"
+fi
+
+echo "mode,width,height,fps,seconds,repetitions,iterations,description_creations,reuses,cpu_ms,wall_ms"
+for dimensions in 1280x720 1920x1080 3840x2160; do
+  width=${dimensions%x*}
+  height=${dimensions#*x}
+  for fps in 24 30 60; do
+    for mode in baseline cached; do
+      "$BENCHMARK" "$mode" "$width" "$height" "$fps" \
+        "$SECONDS_PER_CASE" "$REPETITIONS"
+
+      if [ -n "$PROFILE_DIR" ]; then
+        profile_name="${mode}-${dimensions}-${fps}fps"
+        xcrun xctrace record --quiet --no-prompt \
+          --template Allocations \
+          --time-limit "$PROFILE_TIME_LIMIT" \
+          --output "$PROFILE_DIR/${profile_name}-allocations.trace" \
+          --launch -- "$BENCHMARK" "$mode" "$width" "$height" "$fps" \
+          "$SECONDS_PER_CASE" "$REPETITIONS" >/dev/null
+        xcrun xctrace record --quiet --no-prompt \
+          --template "Time Profiler" \
+          --time-limit "$PROFILE_TIME_LIMIT" \
+          --output "$PROFILE_DIR/${profile_name}-time.trace" \
+          --launch -- "$BENCHMARK" "$mode" "$width" "$height" "$fps" \
+          "$SECONDS_PER_CASE" "$REPETITIONS" >/dev/null
+      fi
+    done
+  done
+done

--- a/scripts/build-libvlc.sh
+++ b/scripts/build-libvlc.sh
@@ -805,6 +805,14 @@ if [ -n "${PATCHES_DIR}" ] && [ -d "${PATCHES_DIR}" ]; then
     cd "${BUILD_DIR}"
 fi
 
+# Exercise the exact production helper whenever this patch is in the engine
+# source. CI links a released xcframework and cannot cover a newly added native
+# patch until its beta exists, so engine builds themselves own this regression.
+if [ -f "${VLC_SRC}/modules/video_output/apple/VLCSampleBufferFormatDescriptionCache.h" ]; then
+    info "Validating native format-description cache reuse and invalidation..."
+    "${SCRIPT_DIR}/validate-native-format-cache.sh" "${VLC_SRC}"
+fi
+
 # --- Step 1c: Patch VLC snapshot conversion owner ---
 # VLC's snapshot path can convert a hardware/opaque picture to RGBA in order
 # to blend a rendered subpicture into the saved PNG. At the pinned libVLC

--- a/scripts/patches/0017-native-pip-format-description-cache.patch
+++ b/scripts/patches/0017-native-pip-format-description-cache.patch
@@ -1,0 +1,179 @@
+# Cache compatible CoreMedia format descriptions in the native PiP display.
+#
+# NOT an upstream backport. SwiftVLC's native sample-buffer display is built by
+# patches 0002-0004; its RenderPicture callback currently calls
+# CMVideoFormatDescriptionCreateForImageBuffer for every decoded frame. At 60
+# fps that creates 3,600 equivalent CoreMedia objects per minute for a steady
+# stream even though the direct Swift renderer already reuses compatible
+# descriptions.
+#
+# This patch scopes one cache to each VLCSampleBufferDisplay (and therefore to
+# one vout generation). Every frame is checked with
+# CMVideoFormatDescriptionMatchesImageBuffer before reuse, so dimensions,
+# pixel format, colour metadata, HDR attachments, and other format-defining
+# image-buffer properties invalidate the cached description. close clears it
+# under the same displayLayerLock used by lookup. The render path receives its
+# own retain, keeping an in-flight frame safe if close clears the cache after
+# lookup.
+#
+# The cache algorithm lives in a small header so the engine build can execute
+# scripts/patches/validation/native-format-description-cache.m against the
+# exact production helper. That regression proves steady-frame reuse plus
+# invalidation on resolution, pixel-format, colour-metadata, and vout-generation
+# changes.
+diff --git a/modules/video_output/apple/VLCSampleBufferDisplay.m b/modules/video_output/apple/VLCSampleBufferDisplay.m
+index ebe5a3be95..94ce31d04c 100644
+--- a/modules/video_output/apple/VLCSampleBufferDisplay.m
++++ b/modules/video_output/apple/VLCSampleBufferDisplay.m
+@@ -42,6 +42,7 @@
+ 
+ #include "../../codec/vt_utils.h"
+ #include "vlc_pip_controller.h"
++#include "VLCSampleBufferFormatDescriptionCache.h"
+ #include "VLCSampleBufferGeometry.h"
+ 
+ #import <VideoToolbox/VideoToolbox.h>
+@@ -712,6 +713,7 @@ @interface VLCSampleBufferDisplay: NSObject
+     filter_t *converter;
+     atomic_uint geometryFailureCount;
+     CMSampleBufferRef pendingSampleBuffer;
++    vlc_samplebuffer_format_description_cache formatDescriptionCache;
+ }
+     @property (nonatomic, readonly, weak) VLCView *window;
+     @property (nonatomic, readonly) vout_display_t *vd;
+@@ -919,6 +921,8 @@ - (void)close {
+             CFRelease(pendingSampleBuffer);
+             pendingSampleBuffer = NULL;
+         }
++        vlc_samplebuffer_format_description_cache_Clear(
++            &formatDescriptionCache);
+     }
+     dispatch_async(dispatch_get_main_queue(), ^{
+         [sys.displayClipView removeFromSuperview];
+@@ -969,6 +973,32 @@ static void ReportGeometryFailure(vout_display_t *vd,
+                  reason, occurrence);
+ }
+ 
++/* Returns an owned description that matches every property CoreMedia derives
++ * from the image buffer. The display instance is scoped to one vout
++ * generation, so replacement naturally drops the cache; format, dimensions,
++ * colour metadata, and HDR attachment changes invalidate it within a
++ * generation. Retaining the returned value keeps an in-flight render safe if
++ * close releases the cache concurrently. */
++static CMVideoFormatDescriptionRef
++CopyCompatibleFormatDescription(vout_display_t *vd,
++                                VLCSampleBufferDisplay *sys,
++                                CVImageBufferRef imageBuffer)
++{
++    CMVideoFormatDescriptionRef result = NULL;
++
++    @synchronized(sys.displayLayerLock) {
++        if (sys.displayClosed)
++            return NULL;
++
++        OSStatus status = vlc_samplebuffer_format_description_cache_Copy(
++            &sys->formatDescriptionCache, imageBuffer, &result, NULL);
++        if (status != noErr)
++            msg_Err(vd, "Image buffer format description creation failed!");
++    }
++
++    return result;
++}
++
+ static void RenderPicture(vout_display_t *vd, picture_t *pic, vlc_tick_t date) {
+     VLCSampleBufferDisplay *sys;
+     sys = (__bridge VLCSampleBufferDisplay*)vd->sys;
+@@ -1159,10 +1189,9 @@ static void RenderPicture(vout_display_t *vd, picture_t *pic, vlc_tick_t date) {
+                           kCVAttachmentMode_ShouldPropagate);
+ 
+     CMSampleBufferRef sampleBuffer = NULL;
+-    CMVideoFormatDescriptionRef formatDesc = NULL;
+-    OSStatus err = CMVideoFormatDescriptionCreateForImageBuffer(kCFAllocatorDefault, pixelBuffer, &formatDesc);
+-    if (err != noErr) {
+-        msg_Err(vd, "Image buffer format description creation failed!");
++    CMVideoFormatDescriptionRef formatDesc =
++        CopyCompatibleFormatDescription(vd, sys, pixelBuffer);
++    if (formatDesc == NULL) {
+         CVPixelBufferRelease(pixelBuffer);
+         return;
+     }
+@@ -1178,7 +1207,7 @@ static void RenderPicture(vout_display_t *vd, picture_t *pic, vlc_tick_t date) {
+         .presentationTimeStamp = CMTimeMakeWithSeconds(ca_date, 1000000)
+     };
+ 
+-    err = CMSampleBufferCreateReadyWithImageBuffer(kCFAllocatorDefault, pixelBuffer, formatDesc, &sampleTimingInfo, &sampleBuffer);
++    OSStatus err = CMSampleBufferCreateReadyWithImageBuffer(kCFAllocatorDefault, pixelBuffer, formatDesc, &sampleTimingInfo, &sampleBuffer);
+     CFRelease(formatDesc);
+     CVPixelBufferRelease(pixelBuffer);
+     if (err != noErr) {
+diff --git a/modules/video_output/apple/VLCSampleBufferFormatDescriptionCache.h b/modules/video_output/apple/VLCSampleBufferFormatDescriptionCache.h
+new file mode 100644
+index 0000000000..20679fa63d
+--- /dev/null
++++ b/modules/video_output/apple/VLCSampleBufferFormatDescriptionCache.h
+@@ -0,0 +1,65 @@
++/*****************************************************************************
++ * VLCSampleBufferFormatDescriptionCache.h: compatible CoreMedia description
++ *****************************************************************************
++ * Copyright (C) 2026 VLC authors and VideoLAN
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *****************************************************************************/
++
++#ifndef VLC_SAMPLEBUFFER_FORMAT_DESCRIPTION_CACHE_H
++#define VLC_SAMPLEBUFFER_FORMAT_DESCRIPTION_CACHE_H
++
++#import <CoreMedia/CoreMedia.h>
++
++typedef struct vlc_samplebuffer_format_description_cache
++{
++    CMVideoFormatDescriptionRef description;
++} vlc_samplebuffer_format_description_cache;
++
++static inline void
++vlc_samplebuffer_format_description_cache_Clear(
++    vlc_samplebuffer_format_description_cache *cache)
++{
++    if (cache->description != NULL)
++    {
++        CFRelease(cache->description);
++        cache->description = NULL;
++    }
++}
++
++/* The caller serializes access to cache. The returned description is owned by
++ * the caller, so it remains valid if another serialized operation clears the
++ * cache while that description is in use. */
++static inline OSStatus
++vlc_samplebuffer_format_description_cache_Copy(
++    vlc_samplebuffer_format_description_cache *cache,
++    CVImageBufferRef imageBuffer,
++    CMVideoFormatDescriptionRef *description,
++    bool *reused)
++{
++    if (cache == NULL || imageBuffer == NULL || description == NULL)
++        return -50; /* paramErr */
++
++    *description = NULL;
++    bool matches = cache->description != NULL &&
++        CMVideoFormatDescriptionMatchesImageBuffer(cache->description,
++                                                    imageBuffer);
++    if (!matches)
++    {
++        vlc_samplebuffer_format_description_cache_Clear(cache);
++        OSStatus status = CMVideoFormatDescriptionCreateForImageBuffer(
++            kCFAllocatorDefault, imageBuffer, &cache->description);
++        if (status != noErr)
++            return status;
++    }
++
++    if (reused != NULL)
++        *reused = matches;
++    *description = CFRetain(cache->description);
++    return noErr;
++}
++
++#endif /* VLC_SAMPLEBUFFER_FORMAT_DESCRIPTION_CACHE_H */

--- a/scripts/patches/0018-media-list-player-observer-lock-order.patch
+++ b/scripts/patches/0018-media-list-player-observer-lock-order.patch
@@ -1,0 +1,85 @@
+# Serialize deferred playlist advancement with public list-player operations.
+#
+# NOT an upstream backport. The pinned libVLC playlist thread holds only
+# mp_callback_lock while set_current_playing_item() detaches the stopped-event
+# observer. That detach deliberately drops mp_callback_lock while waiting for
+# callbacks. A concurrent public stop or media-player replacement can then
+# enter under object_lock, detach the same observer, and make the first detach
+# hit libvlc_event_detach()'s unconditional missing-observer abort.
+#
+# The public order is object_lock -> mp_callback_lock. Capture and clear the
+# queued offset under mp_callback_lock, then reacquire in that order before
+# changing the item. Public operations advance a generation under both locks;
+# if one overtakes the handoff, the now-stale automatic advance is discarded
+# so it cannot skip the explicit selection. This keeps callback accumulation
+# lossless, preserves shutdown wakeups and command precedence, and prevents two
+# operations from uninstalling the same observer concurrently.
+diff --git a/lib/media_list_player.c b/lib/media_list_player.c
+index 0cc53613f0..ff04e42a1c 100644
+--- a/lib/media_list_player.c
++++ b/lib/media_list_player.c
+@@ -62,6 +62,7 @@ struct libvlc_media_list_player_t
+ {
+     libvlc_event_manager_t      event_manager;
+     int                         seek_offset;
++    uint64_t                    operation_generation;
+     bool                        dead;
+     /* Protect access to this structure. */
+     vlc_mutex_t                 object_lock;
+@@ -94,7 +95,7 @@ static void stop(libvlc_media_list_player_t * p_mlp);
+ /**************************************************************************
+  * Shortcuts
+  **************************************************************************/
+-static inline void lock(libvlc_media_list_player_t * p_mlp)
++static inline void lock_internal(libvlc_media_list_player_t * p_mlp)
+ {
+     // Obtain an access to this structure
+     vlc_mutex_lock(&p_mlp->object_lock);
+@@ -103,6 +104,12 @@ static inline void lock(libvlc_media_list_player_t * p_mlp)
+     vlc_mutex_lock(&p_mlp->mp_callback_lock);
+ }
+
++static inline void lock(libvlc_media_list_player_t * p_mlp)
++{
++    lock_internal(p_mlp);
++    p_mlp->operation_generation++;
++}
++
+ static inline void unlock(libvlc_media_list_player_t * p_mlp)
+ {
+     vlc_mutex_unlock(&p_mlp->mp_callback_lock);
+@@ -338,12 +345,28 @@ static void *playlist_thread(void *data)
+ 
+     while (!mlp->dead)
+     {
+-        if (mlp->seek_offset != 0)
+-        {
+-            set_relative_playlist_position_and_play(mlp, mlp->seek_offset);
+-            mlp->seek_offset = 0;
+-        }
+-        vlc_cond_wait(&mlp->seek_pending, &mlp->mp_callback_lock);
++        while (mlp->seek_offset == 0 && !mlp->dead)
++            vlc_cond_wait(&mlp->seek_pending, &mlp->mp_callback_lock);
++
++        if (mlp->dead)
++            break;
++
++        int seek_offset = mlp->seek_offset;
++        uint64_t operation_generation = mlp->operation_generation;
++        mlp->seek_offset = 0;
++
++        /* Public operations acquire object_lock before mp_callback_lock.
++         * Follow that same order here so uninstall_media_player_observer(),
++         * which temporarily drops the callback lock around event_detach(),
++         * cannot race another stop, item change, or media-player replacement
++         * and detach the same observer twice. */
++        vlc_mutex_unlock(&mlp->mp_callback_lock);
++        lock_internal(mlp);
++        if (!mlp->dead &&
++            operation_generation == mlp->operation_generation)
++            set_relative_playlist_position_and_play(mlp, seek_offset);
++        unlock(mlp);
++        vlc_mutex_lock(&mlp->mp_callback_lock);
+     }
+ 
+     vlc_mutex_unlock(&mlp->mp_callback_lock);

--- a/scripts/patches/manifest.sha256
+++ b/scripts/patches/manifest.sha256
@@ -14,3 +14,5 @@ febaea84d74ce7f1bf6fea77edfa202a9ac1bf8d2ddba5d5c2451bbab6c259f5  0004-samplebuf
 2e0806024707d460d88c200aacb4a65fd560408a56aa633c817cff30f4d1a0f4  0014-decoder-out-state-pause-ack.patch
 15aa21d96c157bbc47d3161dace39a55fbefcb7cc614d16eef1cdc76f56645b6  0015-expose-stopping-reason.patch
 ea85b92b4239f4812542b3f4d4efe0600b42b23a331d524a811de9ddeb8fde29  0016-skip-vlc-test-subdir.patch
+e41b501f77342eb6f5cbc6b8c84b4b2d29e375958ffcdc76a07fe3c597b2ba16  0017-native-pip-format-description-cache.patch
+00aa6608db4f668a20b4138f504045ea2ce87ed7066a7adae01def71f4015d8b  0018-media-list-player-observer-lock-order.patch

--- a/scripts/patches/validation/native-format-description-cache-benchmark.m
+++ b/scripts/patches/validation/native-format-description-cache-benchmark.m
@@ -1,0 +1,129 @@
+#import <CoreMedia/CoreMedia.h>
+#import <CoreVideo/CoreVideo.h>
+
+#include "VLCSampleBufferFormatDescriptionCache.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <time.h>
+
+static void Fail(const char *message)
+{
+    fprintf(stderr, "native format-description benchmark failed: %s\n", message);
+    exit(EXIT_FAILURE);
+}
+
+static long ParsePositive(const char *value, const char *name)
+{
+    errno = 0;
+    char *end = NULL;
+    long result = strtol(value, &end, 10);
+    if (errno != 0 || end == value || *end != '\0' || result <= 0)
+    {
+        fprintf(stderr, "invalid %s: %s\n", name, value);
+        exit(EXIT_FAILURE);
+    }
+    return result;
+}
+
+static double Milliseconds(struct timeval value)
+{
+    return value.tv_sec * 1000.0 + value.tv_usec / 1000.0;
+}
+
+static double MonotonicMilliseconds(void)
+{
+    struct timespec value;
+    if (clock_gettime(CLOCK_MONOTONIC_RAW, &value) != 0)
+        Fail("clock_gettime");
+    return value.tv_sec * 1000.0 + value.tv_nsec / 1000000.0;
+}
+
+int main(int argc, const char *argv[])
+{
+    if (argc != 7)
+    {
+        fprintf(stderr,
+                "usage: %s baseline|cached width height fps seconds repetitions\n",
+                argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    bool cached;
+    if (strcmp(argv[1], "baseline") == 0)
+        cached = false;
+    else if (strcmp(argv[1], "cached") == 0)
+        cached = true;
+    else
+        Fail("mode must be baseline or cached");
+
+    size_t width = (size_t)ParsePositive(argv[2], "width");
+    size_t height = (size_t)ParsePositive(argv[3], "height");
+    long fps = ParsePositive(argv[4], "fps");
+    long seconds = ParsePositive(argv[5], "seconds");
+    long repetitions = ParsePositive(argv[6], "repetitions");
+    unsigned long frames = (unsigned long)fps * (unsigned long)seconds;
+    unsigned long iterations = frames * (unsigned long)repetitions;
+
+    CVPixelBufferRef buffer = NULL;
+    CVReturn bufferStatus = CVPixelBufferCreate(
+        kCFAllocatorDefault, width, height, kCVPixelFormatType_32BGRA, NULL,
+        &buffer);
+    if (bufferStatus != kCVReturnSuccess || buffer == NULL)
+        Fail("CVPixelBufferCreate");
+    CVBufferSetAttachment(buffer, kCVImageBufferColorPrimariesKey,
+                          kCVImageBufferColorPrimaries_ITU_R_709_2,
+                          kCVAttachmentMode_ShouldPropagate);
+
+    vlc_samplebuffer_format_description_cache cache = { 0 };
+    unsigned long creations = 0;
+    unsigned long reuses = 0;
+    struct rusage usageBefore;
+    struct rusage usageAfter;
+    if (getrusage(RUSAGE_SELF, &usageBefore) != 0)
+        Fail("getrusage before");
+    double wallBefore = MonotonicMilliseconds();
+
+    for (unsigned long index = 0; index < iterations; ++index)
+    {
+        CMVideoFormatDescriptionRef description = NULL;
+        OSStatus status;
+        if (cached)
+        {
+            bool reused = false;
+            status = vlc_samplebuffer_format_description_cache_Copy(
+                &cache, buffer, &description, &reused);
+            if (reused)
+                ++reuses;
+            else
+                ++creations;
+        }
+        else
+        {
+            status = CMVideoFormatDescriptionCreateForImageBuffer(
+                kCFAllocatorDefault, buffer, &description);
+            ++creations;
+        }
+        if (status != noErr || description == NULL)
+            Fail("format-description creation");
+        CFRelease(description);
+    }
+
+    double wallAfter = MonotonicMilliseconds();
+    if (getrusage(RUSAGE_SELF, &usageAfter) != 0)
+        Fail("getrusage after");
+    double cpuMilliseconds =
+        Milliseconds(usageAfter.ru_utime) + Milliseconds(usageAfter.ru_stime) -
+        Milliseconds(usageBefore.ru_utime) - Milliseconds(usageBefore.ru_stime);
+
+    printf("%s,%zu,%zu,%ld,%ld,%ld,%lu,%lu,%lu,%.3f,%.3f\n",
+           argv[1], width, height, fps, seconds, repetitions, iterations,
+           creations, reuses, cpuMilliseconds, wallAfter - wallBefore);
+
+    vlc_samplebuffer_format_description_cache_Clear(&cache);
+    CVPixelBufferRelease(buffer);
+    return EXIT_SUCCESS;
+}

--- a/scripts/patches/validation/native-format-description-cache.m
+++ b/scripts/patches/validation/native-format-description-cache.m
@@ -1,0 +1,104 @@
+#import <CoreMedia/CoreMedia.h>
+#import <CoreVideo/CoreVideo.h>
+
+#include "VLCSampleBufferFormatDescriptionCache.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static void Require(bool condition, const char *message)
+{
+    if (condition)
+        return;
+    fprintf(stderr, "native format-description cache validation failed: %s\n",
+            message);
+    exit(EXIT_FAILURE);
+}
+
+static CVPixelBufferRef MakePixelBuffer(size_t width, size_t height,
+                                        OSType pixelFormat,
+                                        CFStringRef colourPrimaries)
+{
+    CVPixelBufferRef buffer = NULL;
+    CVReturn status = CVPixelBufferCreate(kCFAllocatorDefault, width, height,
+                                          pixelFormat, NULL, &buffer);
+    Require(status == kCVReturnSuccess && buffer != NULL,
+            "CVPixelBufferCreate");
+    CVBufferSetAttachment(buffer, kCVImageBufferColorPrimariesKey,
+                          colourPrimaries,
+                          kCVAttachmentMode_ShouldPropagate);
+    return buffer;
+}
+
+static CMVideoFormatDescriptionRef
+CopyDescription(vlc_samplebuffer_format_description_cache *cache,
+                CVPixelBufferRef buffer, bool expectedReuse)
+{
+    CMVideoFormatDescriptionRef description = NULL;
+    bool reused = !expectedReuse;
+    OSStatus status = vlc_samplebuffer_format_description_cache_Copy(
+        cache, buffer, &description, &reused);
+    Require(status == noErr && description != NULL, "description creation");
+    Require(reused == expectedReuse, expectedReuse
+        ? "compatible buffer was not reused"
+        : "incompatible buffer incorrectly reused the cache");
+    Require(CMVideoFormatDescriptionMatchesImageBuffer(description, buffer),
+            "returned description does not match its image buffer");
+    return description;
+}
+
+int main(void)
+{
+    vlc_samplebuffer_format_description_cache cache = { 0 };
+    CVPixelBufferRef original = MakePixelBuffer(
+        1920, 1080, kCVPixelFormatType_32BGRA,
+        kCVImageBufferColorPrimaries_ITU_R_709_2);
+    CMVideoFormatDescriptionRef first =
+        CopyDescription(&cache, original, false);
+    CMVideoFormatDescriptionRef reused =
+        CopyDescription(&cache, original, true);
+    Require(first == reused, "compatible frame returned a new description");
+
+    CVPixelBufferRef resized = MakePixelBuffer(
+        1280, 720, kCVPixelFormatType_32BGRA,
+        kCVImageBufferColorPrimaries_ITU_R_709_2);
+    CMVideoFormatDescriptionRef afterResize =
+        CopyDescription(&cache, resized, false);
+    Require(afterResize != first, "resolution change retained old description");
+
+    CVPixelBufferRef reformatted = MakePixelBuffer(
+        1280, 720, kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
+        kCVImageBufferColorPrimaries_ITU_R_709_2);
+    CMVideoFormatDescriptionRef afterPixelFormat =
+        CopyDescription(&cache, reformatted, false);
+    Require(afterPixelFormat != afterResize,
+            "pixel-format change retained old description");
+
+    CVPixelBufferRef recoloured = MakePixelBuffer(
+        1280, 720, kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
+        kCVImageBufferColorPrimaries_P3_D65);
+    CMVideoFormatDescriptionRef afterColour =
+        CopyDescription(&cache, recoloured, false);
+    Require(afterColour != afterPixelFormat,
+            "colour-metadata change retained old description");
+
+    vlc_samplebuffer_format_description_cache_Clear(&cache);
+    CMVideoFormatDescriptionRef afterClear =
+        CopyDescription(&cache, recoloured, false);
+    Require(afterClear != afterColour,
+            "generation clear retained old description");
+
+    vlc_samplebuffer_format_description_cache_Clear(&cache);
+    CFRelease(first);
+    CFRelease(reused);
+    CFRelease(afterResize);
+    CFRelease(afterPixelFormat);
+    CFRelease(afterColour);
+    CFRelease(afterClear);
+    CVPixelBufferRelease(original);
+    CVPixelBufferRelease(resized);
+    CVPixelBufferRelease(reformatted);
+    CVPixelBufferRelease(recoloured);
+    puts("native format-description cache validation passed");
+    return EXIT_SUCCESS;
+}

--- a/scripts/validate-native-format-cache.sh
+++ b/scripts/validate-native-format-cache.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Compile and execute the native PiP format-description cache regression
+# against the exact helper in an already-patched VLC source checkout.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VLC_SOURCE_ROOT="${1:?usage: validate-native-format-cache.sh VLC_SOURCE_ROOT}"
+HEADER_DIR="${VLC_SOURCE_ROOT}/modules/video_output/apple"
+HEADER="${HEADER_DIR}/VLCSampleBufferFormatDescriptionCache.h"
+PROBE="${SCRIPT_DIR}/patches/validation/native-format-description-cache.m"
+
+if [ ! -f "$HEADER" ]; then
+  echo "Native format-description cache header not found: $HEADER" >&2
+  exit 1
+fi
+
+VALIDATION_DIR=$(mktemp -d "${TMPDIR:-/tmp}/swiftvlc-format-cache.XXXXXX")
+trap 'rm -rf "$VALIDATION_DIR"' EXIT
+
+xcrun --sdk macosx clang \
+  -fmodules \
+  -Wall -Wextra -Werror \
+  -I "$HEADER_DIR" \
+  "$PROBE" \
+  -framework CoreMedia \
+  -framework CoreVideo \
+  -o "$VALIDATION_DIR/native-format-description-cache"
+
+"$VALIDATION_DIR/native-format-description-cache"


### PR DESCRIPTION
## Summary

- serialize deferred libVLC playlist advancement with public MediaListPlayer operations, preventing concurrent removal of the same stopped-event observer
- cache compatible CoreMedia format descriptions in the native sample-buffer PiP renderer
- invalidate the cache on image-format changes and display teardown
- add an exact-production-helper validator and repeatable performance benchmark to the engine build tooling

Closes #79
Closes #94

## Correctness evidence

The teardown abort was reproduced on unchanged main in libvlc_event_detach. LLDB showed the same MediaPlayerStopped observer tuple being detached concurrently by the playlist thread and stop_async. The playlist thread held only mp_callback_lock, while observer removal temporarily releases that lock; public operations use object_lock then mp_callback_lock. The patch makes deferred advancement use that established order while capturing and clearing the accumulated seek offset under the callback lock.

Validation against the rebuilt universal macOS XCFramework:

- 92 selected MediaListPlayer, ownership, teardown, and memory-pressure tests passed
- 20 additional consecutive stress passes passed (1,840 tests)
- 1,932 selected tests passed in total including the initial pass
- no abort, deadlock, teardown failure, or leak assertion
- arm64 and x86_64 engine build completed with release assertions disabled
- all 18 patch hashes and release provenance checks passed

## Performance evidence

The benchmark compares the pinned per-frame CoreMedia path with the production cache helper. Across 720p, 1080p, and 4K at 24/30/60 fps, the cache created one description and reused it for every remaining compatible frame. CPU time decreased in all nine cases. Examples from a fresh 10-second, 10-repetition matrix:

| Case | Baseline CPU | Cached CPU | Description creations |
| --- | ---: | ---: | ---: |
| 720p24 | 8.376 ms | 5.844 ms | 2,400 -> 1 |
| 1080p60 | 11.310 ms | 10.215 ms | 6,000 -> 1 |
| 4K60 | 11.606 ms | 10.503 ms | 6,000 -> 1 |

The validator also proves reuse plus invalidation for resolution, pixel format, color metadata, and display-generation teardown. It is compiled with warnings as errors against the exact helper applied to VLC.

## Review boundary

Treat reproducible correctness, stability, performance-regression, release-integrity, and test-gap findings as actionable. Style-only or speculative alternatives are non-blocking once the objective checks above and repository CI are green.
