### PR TITLE
fix: Expose an authoritative track refresh

### DIFF
--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -972,7 +972,13 @@ public final class Player {
 
   // MARK: - Track Refresh
 
-  func refreshTracks() {
+  /// Refreshes all observable track lists from the native player.
+  ///
+  /// The track arrays are asynchronously mirrored snapshots. Receiving the payload-free
+  /// ``PlayerEvent/tracksChanged`` or ``PlayerEvent/mediaChanged`` event does not guarantee
+  /// they are updated; consumers requiring an immediate native read should call this
+  /// method after either event. This also invalidates selected-track observations.
+  public func refreshTracks() {
     audioTracks = fetchTracks(type: .audio)
     videoTracks = fetchTracks(type: .video)
     subtitleTracks = fetchTracks(type: .subtitle)

--- a/Tests/SwiftVLCTests/Player/PlayerPublicTrackRefreshTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerPublicTrackRefreshTests.swift
@@ -1,0 +1,16 @@
+import SwiftVLC
+import Testing
+
+@Suite(.tags(.mainActor))
+@MainActor struct PlayerPublicTrackRefreshTests {
+  @Test
+  func `refreshTracks without media leaves public track lists empty`() {
+    let player = Player()
+
+    player.refreshTracks()
+
+    #expect(player.audioTracks.isEmpty)
+    #expect(player.videoTracks.isEmpty)
+    #expect(player.subtitleTracks.isEmpty)
+  }
+}


### PR DESCRIPTION
`EventBridge` offers the internal sourced event before the public event, but the independent async consumers can resume in either order. A public consumer can therefore receive `.tracksChanged` or `.mediaChanged` before `Player`'s main-actor consumer has refreshed `audioTracks`, `videoTracks`, and `subtitleTracks`. Those event cases carry no track payload, and the existing native `refreshTracks()` operation is not public, so clients currently have no authoritative way to close that race. The issue is open, unassigned, maintainer-authored, and has no prior or competing pull request in the supplied evidence.

## Validation

- On a newly created player with no media, call the public `refreshTracks()` method and verify all three track arrays remain empty without failure.
- From a test source that uses ordinary `import SwiftVLC`, compile and invoke `refreshTracks()` to guard the public API visibility required by external event consumers.
- Preserve the existing `.tracksChanged` and `.mediaChanged` handler behavior: both continue to call the same refresh operation, fetching audio, video, and subtitle tracks and invalidating selected-track observations.
- Verify documentation makes the ordering edge explicit: observing either payload-free track-related event does not itself guarantee the mirrored arrays have updated, while calling `refreshTracks()` on the player actor provides the fresh-read path.

## Summary

Promote the existing main-actor `Player.refreshTracks()` operation to public API instead of changing `PlayerEvent` associated values, which would force source changes across every event switch. Document that the observable track arrays are asynchronously mirrored snapshots and that raw-event consumers should call `refreshTracks()` after `.tracksChanged` or `.mediaChanged` when they require an immediate native read. Keep the existing implementation and internal event-handler call sites as the single behavior path so public and automatic refreshes fetch all three track types and invalidate selected-track observations identically.

Closes #72
