### PR TITLE
Disable avcodec direct rendering by default

### DIFF
--- a/Sources/SwiftVLC/Core/VLCInstance.swift
+++ b/Sources/SwiftVLC/Core/VLCInstance.swift
@@ -53,9 +53,19 @@ public final class VLCInstance: Sendable {
   /// argument list to ``init(arguments:applicationName:httpUserAgent:)``
   /// if you need that mode
   /// (embedded contexts with tight memory budgets, CLI tools).
+  ///
+  /// Includes `--no-avcodec-dr`: with direct rendering, FFmpeg's software
+  /// decoders write straight into libVLC's tightly-sized picture buffers,
+  /// and half-pel motion compensation on frame-edge motion vectors reads
+  /// one byte past the end of the plane — a SIGSEGV in
+  /// `ff_put_pixels8_x2_neon` via `mpeg_motion` on MPEG-1/2/4 Part 2
+  /// streams. Without direct rendering FFmpeg allocates its own
+  /// edge-padded frames; the extra per-frame copy only affects
+  /// software-decoded codecs.
   public static let defaultArguments: [String] = [
     "--no-video-title-show",
-    "--no-snapshot-preview"
+    "--no-snapshot-preview",
+    "--no-avcodec-dr"
   ]
 
   nonisolated(unsafe) let pointer: OpaquePointer // libvlc_instance_t*

--- a/Tests/SwiftVLCTests/Core/VLCInstanceTests.swift
+++ b/Tests/SwiftVLCTests/Core/VLCInstanceTests.swift
@@ -120,11 +120,15 @@ extension Integration {
     @Test
     func `Default arguments contains expected values`() {
       let args = VLCInstance.defaultArguments
-      #expect(args.count == 2)
+      #expect(args.count == 3)
       #expect(!args.contains("--force-darwin-legacy-display"))
       #expect(!args.contains("--vout=macosx"))
       #expect(args.contains("--no-video-title-show"))
       #expect(args.contains("--no-snapshot-preview"))
+      // Direct rendering hands FFmpeg unpadded picture buffers; edge
+      // motion vectors then over-read the plane (SIGSEGV in
+      // ff_put_pixels8_x2_neon via mpeg_motion).
+      #expect(args.contains("--no-avcodec-dr"))
       #expect(!args.contains("--text-renderer=freetype"))
       // --no-stats is intentionally absent: it would zero every stats
       // counter every app ever reads. Opt in by passing it explicitly.


### PR DESCRIPTION
## Crash

Playing an MPEG-4 Part 2 (DivX-era) movie crashes with:

```
Thread 19 Crashed:
0  ff_put_pixels8_x2_neon + 8
1  mpeg_motion + 748
EXC_BAD_ACCESS KERN_INVALID_ADDRESS — byte read, exactly 1 byte past a
MALLOC_LARGE region sized width*height (288K for a 720×400 luma plane)
```

## Cause

With `avcodec-dr` (the default), FFmpeg's software decoders render into libVLC's picture buffers, which are tightly sized with no edge padding. Half-pel motion compensation on a frame-edge motion vector (`_x2` reads `src + 1`) then over-reads the plane by one byte. When the plane lands at the end of a VM region, that byte read faults.

## Fix

Add `--no-avcodec-dr` to `VLCInstance.defaultArguments` so FFmpeg allocates its own edge-padded frames. The cost is one extra copy per software-decoded frame; hardware paths (VideoToolbox) are unaffected. Apps that construct a custom instance can still opt back in by omitting the flag.

The `Default arguments contains expected values` test is updated to match. `swift build` and the `VLCInstanceTests` suite (24 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)