### PR TITLE
Require complete reproducible libVLC provenance

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+scripts/patches/*.patch whitespace=-space-before-tab

--- a/scripts/build-libvlc.sh
+++ b/scripts/build-libvlc.sh
@@ -668,6 +668,17 @@ if [ "${SOURCE_SHA}" != "${TARGET_SHA}" ]; then
 fi
 info "VLC source provenance: ${SOURCE_SHA}"
 
+# Make compiler date/time macros deterministic. VLC's help object embeds
+# __DATE__ and __TIME__; without SOURCE_DATE_EPOCH, two otherwise identical
+# clean builds differ by their wall-clock compilation time. Deriving the
+# epoch from the pinned commit makes it stable and auditable.
+SOURCE_DATE_EPOCH=$(git -C "${VLC_SRC}" show -s --format=%ct "${SOURCE_SHA}")
+if ! [[ "${SOURCE_DATE_EPOCH}" =~ ^[0-9]+$ ]]; then
+    error "Invalid SOURCE_DATE_EPOCH derived from ${SOURCE_SHA}"
+fi
+export SOURCE_DATE_EPOCH
+info "Reproducible build epoch: ${SOURCE_DATE_EPOCH} (pinned commit timestamp)"
+
 # --- Step 1b: Apply patches ---
 if [ -n "${PATCHES_DIR}" ] && [ -d "${PATCHES_DIR}" ]; then
     info "Applying patches from ${PATCHES_DIR}..."
@@ -1457,6 +1468,33 @@ xcodebuild -create-xcframework \
     "${XCFRAMEWORK_ARGS[@]}" \
     -output "${OUTPUT_DIR}/libvlc.xcframework"
 
+# xcodebuild writes AvailableLibraries in completion order rather than input
+# order, so two identical builds can serialize the same slice records in a
+# different sequence. Canonicalize the list and dictionary keys before hashing
+# or publishing the artifact.
+info "Normalizing XCFramework metadata..."
+python3 - "${OUTPUT_DIR}/libvlc.xcframework/Info.plist" <<'PYEOF'
+import plistlib
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+info = plistlib.loads(path.read_bytes())
+libraries = info.get("AvailableLibraries")
+if not isinstance(libraries, list) or not libraries:
+    raise SystemExit(f"Error: {path} has no AvailableLibraries")
+identifiers = [item.get("LibraryIdentifier") for item in libraries]
+if any(not isinstance(identifier, str) or not identifier for identifier in identifiers):
+    raise SystemExit(f"Error: {path} has an invalid library identifier")
+if len(set(identifiers)) != len(identifiers):
+    raise SystemExit(f"Error: {path} has duplicate library identifiers")
+info["AvailableLibraries"] = sorted(
+    libraries,
+    key=lambda item: item["LibraryIdentifier"],
+)
+path.write_bytes(plistlib.dumps(info, fmt=plistlib.FMT_XML, sort_keys=True))
+PYEOF
+
 # Fix duplicate symbols (json_parse_error/json_read) in the static library.
 # Two VLC plugins (ytdl, chromecast) each compile their own copy. The Apple
 # linker in Xcode 16+ treats these as errors on some platforms (Mac Catalyst).
@@ -1484,24 +1522,28 @@ info "Created: ${OUTPUT_DIR}/libvlc.xcframework"
 # provenance rather than provenance describing an artifact that was never
 # finished.
 PROVENANCE_FILE="${OUTPUT_DIR}/libvlc-provenance.json"
-manifest_digest="none"
+provenance_args=(
+    python3 "${SCRIPT_DIR}/libvlc-provenance.py" create
+    --xcframework "${OUTPUT_DIR}/libvlc.xcframework"
+    --output "${PROVENANCE_FILE}"
+    --vlc-source "${VLC_SRC}"
+    --source-revision "${SOURCE_SHA}"
+    --pinned-revision "${VLC_HASH}"
+    --source-date-epoch "${SOURCE_DATE_EPOCH}"
+    --make-flags="${MAKEFLAGS}"
+    --deployment-target "ios=${SWIFTVLC_MIN_IOS}"
+    --deployment-target "tvos=${SWIFTVLC_MIN_TVOS}"
+    --deployment-target "xros=${SWIFTVLC_MIN_VISIONOS}"
+    --deployment-target "macos=${SWIFTVLC_MIN_MACOS}"
+    --deployment-target "catalyst=${SWIFTVLC_MIN_CATALYST}"
+)
 if [ -n "${PATCHES_DIR}" ] && [ -f "${PATCHES_DIR}/manifest.sha256" ]; then
-    manifest_digest=$(shasum -a 256 "${PATCHES_DIR}/manifest.sha256" | cut -d' ' -f1)
+    provenance_args+=(--patch-manifest "${PATCHES_DIR}/manifest.sha256")
 fi
-slice_list=$(find "${OUTPUT_DIR}/libvlc.xcframework" -maxdepth 1 -mindepth 1 -type d \
-    -exec basename {} \; | sort | paste -sd, -)
-
-cat > "${PROVENANCE_FILE}" <<PROVENANCE
-{
-  "vlcSourceRevision": "${SOURCE_SHA}",
-  "pinnedRevision": "${VLC_HASH}",
-  "patchManifestDigest": "${manifest_digest}",
-  "assertionsEnabled": "${WITH_ASSERTS}",
-  "slices": "${slice_list}",
-  "xcodeBuildVersion": "$(xcodebuild -version 2>/dev/null | head -1)",
-  "builtAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-}
-PROVENANCE
+if [ "${WITH_ASSERTS}" = "yes" ]; then
+    provenance_args+=(--assertions-enabled)
+fi
+"${provenance_args[@]}"
 info "Recorded build provenance: ${PROVENANCE_FILE}"
 
 # --- Step 5: Verify ---

--- a/scripts/build-libvlc.sh
+++ b/scripts/build-libvlc.sh
@@ -55,6 +55,7 @@ BUILD_CATALYST=no
 # official VLC release builds ship. Developers debugging codec internals can
 # restore the asserts with --with-asserts.
 WITH_ASSERTS=no
+CLEAN_BUILD=no
 
 # Keep these deployment targets in sync with Package.swift.
 SWIFTVLC_MIN_IOS="18.0"
@@ -64,6 +65,7 @@ SWIFTVLC_MIN_MACOS="15.0"
 SWIFTVLC_MIN_CATALYST="18.0"
 
 BUILD_START_TIME=$(date +%s)
+BUILD_INVOCATION_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
 
 if [ -z "$MAKEFLAGS" ]; then
     MAKEFLAGS="-j$(sysctl -n machdep.cpu.core_count || nproc)"
@@ -262,6 +264,7 @@ for arg in "$@"; do
         --clean-build)
             echo "Removing build directory: ${BUILD_DIR}"
             rm -rf "${BUILD_DIR}"
+            CLEAN_BUILD=yes
             echo "Continuing with fresh build..."
             ;;
         --with-asserts)
@@ -1463,6 +1466,8 @@ fi
 info "Creating libvlc.xcframework..."
 mkdir -p "${OUTPUT_DIR}"
 rm -rf "${OUTPUT_DIR}/libvlc.xcframework"
+rm -f "${OUTPUT_DIR}/libvlc-provenance.json" \
+    "${OUTPUT_DIR}/libvlc-reproducibility.json"
 
 xcodebuild -create-xcframework \
     "${XCFRAMEWORK_ARGS[@]}" \
@@ -1508,43 +1513,10 @@ info "Fixing duplicate symbols in static libraries..."
 find "${OUTPUT_DIR}/libvlc.xcframework" -name "module.modulemap" -delete
 find "${OUTPUT_DIR}/libvlc.xcframework" -name "CLibVLC.h" -delete
 
-info "Created: ${OUTPUT_DIR}/libvlc.xcframework"
+info "Stripping release debug symbols before reproducibility hashing..."
+find "${OUTPUT_DIR}/libvlc.xcframework" -name '*.a' -exec strip -S {} \;
 
-# --- Step 4b: Record what produced it ---
-#
-# `release.sh` packages whatever xcframework is sitting in Vendor/. Without a
-# record of the inputs it cannot tell a fresh build from one made months ago
-# against a different pin or patch set, so a stale binary could be published as
-# a new release and nothing would notice. That is issue #97's second acceptance
-# criterion.
-#
-# Written last, after every slice succeeded, so a partial build leaves no
-# provenance rather than provenance describing an artifact that was never
-# finished.
-PROVENANCE_FILE="${OUTPUT_DIR}/libvlc-provenance.json"
-provenance_args=(
-    python3 "${SCRIPT_DIR}/libvlc-provenance.py" create
-    --xcframework "${OUTPUT_DIR}/libvlc.xcframework"
-    --output "${PROVENANCE_FILE}"
-    --vlc-source "${VLC_SRC}"
-    --source-revision "${SOURCE_SHA}"
-    --pinned-revision "${VLC_HASH}"
-    --source-date-epoch "${SOURCE_DATE_EPOCH}"
-    --make-flags="${MAKEFLAGS}"
-    --deployment-target "ios=${SWIFTVLC_MIN_IOS}"
-    --deployment-target "tvos=${SWIFTVLC_MIN_TVOS}"
-    --deployment-target "xros=${SWIFTVLC_MIN_VISIONOS}"
-    --deployment-target "macos=${SWIFTVLC_MIN_MACOS}"
-    --deployment-target "catalyst=${SWIFTVLC_MIN_CATALYST}"
-)
-if [ -n "${PATCHES_DIR}" ] && [ -f "${PATCHES_DIR}/manifest.sha256" ]; then
-    provenance_args+=(--patch-manifest "${PATCHES_DIR}/manifest.sha256")
-fi
-if [ "${WITH_ASSERTS}" = "yes" ]; then
-    provenance_args+=(--assertions-enabled)
-fi
-"${provenance_args[@]}"
-info "Recorded build provenance: ${PROVENANCE_FILE}"
+info "Created: ${OUTPUT_DIR}/libvlc.xcframework"
 
 # --- Step 5: Verify ---
 #
@@ -1610,6 +1582,43 @@ verify_deployment_targets() {
 }
 
 verify_deployment_targets
+
+# --- Step 6: Record the verified, release-ready artifact ---
+#
+# Provenance is deliberately written only after every deployment-target check
+# passes. The artifact is also stripped above, before hashing, so the two-clean-
+# build proof covers the exact tree release.sh packages; no post-proof rebind is
+# permitted.
+PROVENANCE_FILE="${OUTPUT_DIR}/libvlc-provenance.json"
+provenance_args=(
+    python3 "${SCRIPT_DIR}/libvlc-provenance.py" create
+    --xcframework "${OUTPUT_DIR}/libvlc.xcframework"
+    --output "${PROVENANCE_FILE}"
+    --vlc-source "${VLC_SRC}"
+    --source-revision "${SOURCE_SHA}"
+    --pinned-revision "${VLC_HASH}"
+    --source-date-epoch "${SOURCE_DATE_EPOCH}"
+    --build-invocation-id "${BUILD_INVOCATION_ID}"
+    --build-configuration-file "build-libvlc.sh=${SCRIPT_DIR}/build-libvlc.sh"
+    --build-configuration-file "fix-duplicate-symbols.sh=${SCRIPT_DIR}/fix-duplicate-symbols.sh"
+    --make-flags="${MAKEFLAGS}"
+    --deployment-target "ios=${SWIFTVLC_MIN_IOS}"
+    --deployment-target "tvos=${SWIFTVLC_MIN_TVOS}"
+    --deployment-target "xros=${SWIFTVLC_MIN_VISIONOS}"
+    --deployment-target "macos=${SWIFTVLC_MIN_MACOS}"
+    --deployment-target "catalyst=${SWIFTVLC_MIN_CATALYST}"
+)
+if [ -n "${PATCHES_DIR}" ] && [ -f "${PATCHES_DIR}/manifest.sha256" ]; then
+    provenance_args+=(--patch-manifest "${PATCHES_DIR}/manifest.sha256")
+fi
+if [ "${WITH_ASSERTS}" = "yes" ]; then
+    provenance_args+=(--assertions-enabled)
+fi
+if [ "${CLEAN_BUILD}" = "yes" ]; then
+    provenance_args+=(--clean-build)
+fi
+"${provenance_args[@]}"
+info "Recorded verified build provenance: ${PROVENANCE_FILE}"
 
 echo ""
 info "Build complete!"

--- a/scripts/build-libvlc.sh
+++ b/scripts/build-libvlc.sh
@@ -1516,6 +1516,14 @@ find "${OUTPUT_DIR}/libvlc.xcframework" -name "CLibVLC.h" -delete
 info "Stripping release debug symbols before reproducibility hashing..."
 find "${OUTPUT_DIR}/libvlc.xcframework" -name '*.a' -exec strip -S {} \;
 
+# `strip` rebuilds each archive's __.SYMDEF member and stamps that member with
+# the current wall-clock time. The object payloads are unchanged, but those few
+# header bytes make otherwise identical clean builds hash differently. Reset
+# the archive indexes after the final mutating step so provenance covers the
+# exact deterministic artifact that will be released.
+info "Normalizing archive indexes after stripping..."
+find "${OUTPUT_DIR}/libvlc.xcframework" -name '*.a' -exec xcrun ranlib -D {} \;
+
 info "Created: ${OUTPUT_DIR}/libvlc.xcframework"
 
 # --- Step 5: Verify ---

--- a/scripts/fix-duplicate-symbols.sh
+++ b/scripts/fix-duplicate-symbols.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 #
-# fix-duplicate-symbols.sh — Fix duplicate json symbols in libvlc static libraries
+# fix-duplicate-symbols.sh — Fix and normalize libvlc static libraries
 #
 # Two VLC plugins (ytdl and chromecast) each compile their own copy of
 # json_parse_error and json_read. The Apple linker in Xcode 16+ treats
 # duplicate global symbols as errors (especially on Mac Catalyst). This
 # script localizes one copy with nmedit so only a single global definition
 # remains.
+#
+# Apple's archive tools can also emit byte-different __.SYMDEF indexes for
+# identical object members (observed in both tvOS slices). `ranlib -D`
+# regenerates a sorted, zero-timestamp index deterministically. Every thin
+# architecture is normalized before universal archives are reassembled so two
+# clean builds have byte-identical static libraries, not merely identical
+# extracted objects.
 #
 # The localization targets the ytdl object, never the chromecast one.
 # nmedit rewrites the symbol table of whatever object it edits, which can
@@ -205,8 +212,14 @@ fix_static_lib() (
         -o "$REPACKED" "$THIN"
       mv "$REPACKED" "$THIN"
       verify_macho_archive_alignment "$THIN"
-      CHANGED=true
     fi
+
+    # Normalize the table of contents even when no duplicate JSON symbol was
+    # present. The object members can be identical while Apple's generated
+    # __.SYMDEF differs in size and ordering between clean builds.
+    xcrun ranlib -D "$THIN"
+    verify_macho_archive_alignment "$THIN"
+    CHANGED=true
 
     verify_thin_archive "$THIN" "$ARCH"
   done
@@ -221,7 +234,7 @@ fix_static_lib() (
     else
       cp "${WORK_DIR}/${ARCHS[0]}.a" "$LIB_PATH"
     fi
-    echo "  Fixed: $LIB_PATH"
+    echo "  Normalized: $LIB_PATH"
   fi
 
   verify_static_lib "$LIB_PATH"

--- a/scripts/libvlc-provenance.py
+++ b/scripts/libvlc-provenance.py
@@ -12,11 +12,12 @@ import plistlib
 import stat
 import subprocess
 import tempfile
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 SDK_BY_PLATFORM = {
     ("ios", None): "iphoneos",
     ("ios", "simulator"): "iphonesimulator",
@@ -110,6 +111,30 @@ def manifest_entries(path: Path) -> list[dict[str, str]]:
     if not entries:
         fail(f"patch manifest has no entries: {path}")
     return entries
+
+
+def named_file_records(values: list[str]) -> list[dict[str, str]]:
+    records: list[dict[str, str]] = []
+    names: set[str] = set()
+    for value in values:
+        if "=" not in value:
+            fail(f"build configuration file must be NAME=PATH: {value}")
+        name, raw_path = value.split("=", 1)
+        path = Path(raw_path).resolve()
+        if not name or name in names or not path.is_file():
+            fail(f"invalid or duplicate build configuration file: {value}")
+        names.add(name)
+        records.append({"name": name, "sha256": sha256_file(path)})
+    if not records:
+        fail("at least one build configuration file is required")
+    return sorted(records, key=lambda record: record["name"])
+
+
+def invocation_id(value: str) -> str:
+    try:
+        return str(uuid.UUID(value))
+    except (ValueError, AttributeError):
+        fail(f"build invocation ID is not a UUID: {value}")
 
 
 def contrib_manifest(vlc_source: Path) -> dict[str, Any]:
@@ -275,11 +300,14 @@ def create(arguments: argparse.Namespace) -> None:
         "vlcSourceRevision": arguments.source_revision,
         "pinnedRevision": arguments.pinned_revision,
         "patchManifest": patch_record,
+        "buildConfiguration": named_file_records(arguments.build_configuration_file),
         "contribChecksums": contrib_manifest(arguments.vlc_source.resolve()),
         "build": {
             "assertionsEnabled": arguments.assertions_enabled,
             "makeFlags": arguments.make_flags,
             "sourceDateEpoch": arguments.source_date_epoch,
+            "cleanBuild": arguments.clean_build,
+            "invocationId": invocation_id(arguments.build_invocation_id),
             "hostArchitecture": platform.machine(),
             "xcode": xcode_details(),
             "clangVersion": first_line("xcrun", "clang", "--version"),
@@ -318,6 +346,10 @@ def verify(arguments: argparse.Namespace) -> None:
         fail("provenance patch manifest does not match the repository")
     if manifest.get("entries") != manifest_entries(arguments.patch_manifest):
         fail("provenance patch order does not match the repository")
+    if record.get("buildConfiguration") != named_file_records(
+        arguments.build_configuration_file
+    ):
+        fail("provenance build configuration does not match the repository")
     if record.get("xcframeworkTreeDigest") != tree_digest(xcframework):
         fail("XCFramework tree digest does not match provenance")
     recorded_slices = {item["identifier"]: item for item in record.get("slices", [])}
@@ -346,38 +378,11 @@ def verify(arguments: argparse.Namespace) -> None:
     )
 
 
-def rebind(arguments: argparse.Namespace) -> None:
-    record = load_record(arguments.provenance)
-    xcframework = arguments.xcframework.resolve()
-    recorded_slices = {item["identifier"]: item for item in record.get("slices", [])}
-    rebound_slices = []
-    for library in load_xcframework_libraries(xcframework):
-        identifier = library["LibraryIdentifier"]
-        if identifier not in recorded_slices:
-            fail(f"rebound XCFramework contains an unrecorded slice: {identifier}")
-        rebound = dict(recorded_slices[identifier])
-        root = xcframework / identifier
-        archive = root / library["LibraryPath"]
-        headers = root / library["HeadersPath"]
-        rebound.update(
-            librarySha256=sha256_file(archive),
-            headersTreeDigest=tree_digest(headers),
-            **archive_member_digest(archive),
-        )
-        rebound_slices.append(rebound)
-    if len(rebound_slices) != len(recorded_slices):
-        fail("rebound XCFramework is missing a recorded slice")
-    record["sourceBuildTreeDigest"] = record.get(
-        "sourceBuildTreeDigest", record["xcframeworkTreeDigest"]
-    )
-    record["xcframeworkTreeDigest"] = tree_digest(xcframework)
-    record["slices"] = sorted(rebound_slices, key=lambda item: item["identifier"])
-    arguments.output.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
-
-
 def normalized_build_inputs(record: dict[str, Any]) -> dict[str, Any]:
     return {
-        key: value for key, value in record.get("build", {}).items() if key != "builtAt"
+        key: value
+        for key, value in record.get("build", {}).items()
+        if key not in {"builtAt", "invocationId"}
     }
 
 
@@ -403,6 +408,7 @@ def compare(arguments: argparse.Namespace) -> None:
         "vlcSourceRevision",
         "pinnedRevision",
         "patchManifest",
+        "buildConfiguration",
         "contribChecksums",
     )
     for key in input_keys:
@@ -412,6 +418,14 @@ def compare(arguments: argparse.Namespace) -> None:
         fail("build toolchain, host, flags, or assertion inputs differ")
     if slice_inputs(first) != slice_inputs(second):
         fail("build slice SDK, target, platform, or architecture inputs differ")
+    first_build = first.get("build", {})
+    second_build = second.get("build", {})
+    if not first_build.get("cleanBuild") or not second_build.get("cleanBuild"):
+        fail("reproducibility proof requires two clean builds")
+    first_invocation = first_build.get("invocationId")
+    second_invocation = second_build.get("invocationId")
+    if not first_invocation or first_invocation == second_invocation:
+        fail("reproducibility proof requires independent build invocations")
     first_slices = {item["identifier"]: item for item in first.get("slices", [])}
     second_slices = {item["identifier"]: item for item in second.get("slices", [])}
     if set(first_slices) != set(second_slices):
@@ -434,15 +448,18 @@ def compare(arguments: argparse.Namespace) -> None:
         fail("clean builds are not byte-reproducible: " + ", ".join(differences))
     if arguments.output is not None:
         proof = {
-            "schemaVersion": 1,
+            "schemaVersion": 2,
             "vlcSourceRevision": first["vlcSourceRevision"],
             "pinnedRevision": first["pinnedRevision"],
             "patchManifestSha256": first["patchManifest"]["sha256"],
+            "buildConfiguration": first["buildConfiguration"],
             "contribChecksums": first["contribChecksums"],
             "buildInputs": normalized_build_inputs(first),
             "sliceInputs": slice_inputs(first),
             "firstBuiltAt": first["build"]["builtAt"],
             "secondBuiltAt": second["build"]["builtAt"],
+            "firstInvocationId": first_invocation,
+            "secondInvocationId": second_invocation,
             "xcframeworkTreeDigest": first["xcframeworkTreeDigest"],
             "slices": {
                 identifier: {
@@ -470,25 +487,31 @@ def verify_proof(arguments: argparse.Namespace) -> None:
         proof = json.loads(arguments.proof.read_text())
     except (OSError, ValueError) as error:
         fail(f"cannot read reproducibility proof {arguments.proof}: {error}")
-    if proof.get("schemaVersion") != 1:
+    if proof.get("schemaVersion") != 2:
         fail("reproducibility proof has an unsupported schema")
-    expected_digest = provenance.get(
-        "sourceBuildTreeDigest", provenance["xcframeworkTreeDigest"]
-    )
     expected = {
         "vlcSourceRevision": provenance["vlcSourceRevision"],
         "pinnedRevision": provenance["pinnedRevision"],
         "patchManifestSha256": provenance["patchManifest"]["sha256"],
+        "buildConfiguration": provenance["buildConfiguration"],
         "contribChecksums": provenance["contribChecksums"],
         "buildInputs": normalized_build_inputs(provenance),
         "sliceInputs": slice_inputs(provenance),
-        "xcframeworkTreeDigest": expected_digest,
+        "xcframeworkTreeDigest": provenance["xcframeworkTreeDigest"],
     }
     for key, value in expected.items():
         if proof.get(key) != value:
             fail(f"reproducibility proof does not match provenance at {key}")
-    if proof.get("firstBuiltAt") == proof.get("secondBuiltAt"):
-        fail("reproducibility proof does not describe two distinct builds")
+    if not provenance.get("build", {}).get("cleanBuild"):
+        fail("provenance does not describe a clean build")
+    invocation_ids = {
+        proof.get("firstInvocationId"),
+        proof.get("secondInvocationId"),
+    }
+    if None in invocation_ids or len(invocation_ids) != 2:
+        fail("reproducibility proof does not describe independent builds")
+    if provenance["build"].get("invocationId") not in invocation_ids:
+        fail("provenance build invocation is absent from reproducibility proof")
     print(
         f"libVLC reproducibility proof verified: "
         f"{proof['xcframeworkTreeDigest'][:12]}…"
@@ -507,7 +530,15 @@ def main() -> None:
     create_parser.add_argument("--pinned-revision", required=True)
     create_parser.add_argument("--source-date-epoch", type=int, required=True)
     create_parser.add_argument("--patch-manifest", type=Path)
+    create_parser.add_argument(
+        "--build-configuration-file",
+        action="append",
+        default=[],
+        required=True,
+    )
     create_parser.add_argument("--assertions-enabled", action="store_true")
+    create_parser.add_argument("--clean-build", action="store_true")
+    create_parser.add_argument("--build-invocation-id", required=True)
     create_parser.add_argument("--make-flags", required=True)
     create_parser.add_argument(
         "--deployment-target",
@@ -522,13 +553,13 @@ def main() -> None:
     verify_parser.add_argument("--xcframework", type=Path, required=True)
     verify_parser.add_argument("--pinned-revision", required=True)
     verify_parser.add_argument("--patch-manifest", type=Path, required=True)
+    verify_parser.add_argument(
+        "--build-configuration-file",
+        action="append",
+        default=[],
+        required=True,
+    )
     verify_parser.set_defaults(function=verify)
-
-    rebind_parser = commands.add_parser("rebind")
-    rebind_parser.add_argument("--provenance", type=Path, required=True)
-    rebind_parser.add_argument("--xcframework", type=Path, required=True)
-    rebind_parser.add_argument("--output", type=Path, required=True)
-    rebind_parser.set_defaults(function=rebind)
 
     compare_parser = commands.add_parser("compare")
     compare_parser.add_argument("--first", type=Path, required=True)

--- a/scripts/libvlc-provenance.py
+++ b/scripts/libvlc-provenance.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+"""Create, verify, and compare complete libVLC XCFramework provenance."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import plistlib
+import stat
+import subprocess
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 2
+SDK_BY_PLATFORM = {
+    ("ios", None): "iphoneos",
+    ("ios", "simulator"): "iphonesimulator",
+    ("ios", "maccatalyst"): "macosx",
+    ("macos", None): "macosx",
+    ("tvos", None): "appletvos",
+    ("tvos", "simulator"): "appletvsimulator",
+    ("xros", None): "xros",
+    ("xros", "simulator"): "xrsimulator",
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"Error: {message}")
+
+
+def run(*command: str) -> str:
+    try:
+        result = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        detail = getattr(error, "stderr", "") or str(error)
+        fail(f"command failed ({' '.join(command)}): {detail.strip()}")
+    return result.stdout.strip()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as source:
+            while chunk := source.read(1024 * 1024):
+                digest.update(chunk)
+    except OSError as error:
+        fail(f"cannot hash {path}: {error}")
+    return digest.hexdigest()
+
+
+def update_field(digest: Any, value: bytes) -> None:
+    digest.update(len(value).to_bytes(8, "big"))
+    digest.update(value)
+
+
+def tree_digest(root: Path) -> str:
+    if not root.is_dir():
+        fail(f"artifact directory not found: {root}")
+
+    digest = hashlib.sha256(b"SwiftVLC artifact tree digest v1\0")
+    entries = sorted(
+        root.rglob("*"), key=lambda path: path.relative_to(root).as_posix()
+    )
+    if not entries:
+        fail(f"artifact directory is empty: {root}")
+
+    for path in entries:
+        relative = path.relative_to(root).as_posix().encode()
+        metadata = path.lstat()
+        mode = stat.S_IMODE(metadata.st_mode).to_bytes(4, "big")
+        if stat.S_ISDIR(metadata.st_mode):
+            kind, payload = b"directory", b""
+        elif stat.S_ISREG(metadata.st_mode):
+            kind, payload = b"file", bytes.fromhex(sha256_file(path))
+        elif stat.S_ISLNK(metadata.st_mode):
+            kind, payload = b"symlink", os.readlink(path).encode()
+        else:
+            fail(f"unsupported artifact entry type: {path}")
+        update_field(digest, kind)
+        update_field(digest, relative)
+        update_field(digest, mode)
+        update_field(digest, payload)
+    return digest.hexdigest()
+
+
+def manifest_entries(path: Path) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    try:
+        lines = path.read_text().splitlines()
+    except OSError as error:
+        fail(f"cannot read patch manifest {path}: {error}")
+    for number, line in enumerate(lines, 1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        fields = stripped.split()
+        if len(fields) != 2 or len(fields[0]) != 64:
+            fail(f"invalid patch manifest entry at {path}:{number}")
+        entries.append({"sha256": fields[0], "file": fields[1]})
+    if not entries:
+        fail(f"patch manifest has no entries: {path}")
+    return entries
+
+
+def contrib_manifest(vlc_source: Path) -> dict[str, Any]:
+    root = vlc_source / "contrib" / "src"
+    checksum_files = sorted(root.glob("*/SHA512SUMS"), key=lambda path: path.as_posix())
+    if not checksum_files:
+        fail(f"no contrib SHA512SUMS files found under {root}")
+    digest = hashlib.sha256(b"SwiftVLC VLC contrib checksum manifest v1\0")
+    for path in checksum_files:
+        update_field(digest, path.relative_to(root).as_posix().encode())
+        update_field(digest, path.read_bytes())
+    return {
+        "algorithm": "swiftvlc-vlc-contrib-checksums-v1",
+        "fileCount": len(checksum_files),
+        "sha256": digest.hexdigest(),
+    }
+
+
+def archive_member_digest(archive: Path) -> dict[str, Any]:
+    architectures = sorted(run("lipo", "-archs", str(archive)).split())
+    if not architectures:
+        fail(f"static archive has no architectures: {archive}")
+
+    digest = hashlib.sha256(b"SwiftVLC archive member manifest v2\0")
+    member_count = 0
+    with tempfile.TemporaryDirectory(prefix="swiftvlc-archive-") as temporary:
+        temporary_root = Path(temporary)
+        for architecture in architectures:
+            candidate = archive
+            if len(architectures) > 1:
+                candidate = temporary_root / f"{architecture}.a"
+                run(
+                    "lipo",
+                    str(archive),
+                    "-thin",
+                    architecture,
+                    "-output",
+                    str(candidate),
+                )
+            members = run("ar", "-t", str(candidate)).splitlines()
+            if not members:
+                fail(f"static archive has no members for {architecture}: {archive}")
+            update_field(digest, architecture.encode())
+            for member in members:
+                update_field(digest, member.encode())
+            member_count += len(members)
+
+    return {
+        "memberCount": member_count,
+        "manifestSha256": digest.hexdigest(),
+    }
+
+
+def sdk_details(name: str) -> dict[str, str]:
+    return {
+        "canonicalName": name,
+        "version": run("xcrun", "--sdk", name, "--show-sdk-version"),
+        "buildVersion": run("xcrun", "--sdk", name, "--show-sdk-build-version"),
+    }
+
+
+def xcode_details() -> dict[str, str]:
+    lines = run("xcodebuild", "-version").splitlines()
+    if len(lines) < 2 or not lines[0].startswith("Xcode "):
+        fail("xcodebuild -version returned an unexpected value")
+    return {
+        "version": lines[0].removeprefix("Xcode "),
+        "buildVersion": lines[1].removeprefix("Build version "),
+    }
+
+
+def first_line(*command: str) -> str:
+    output = run(*command).splitlines()
+    if not output:
+        fail(f"command produced no version: {' '.join(command)}")
+    return output[0]
+
+
+def load_xcframework_libraries(xcframework: Path) -> list[dict[str, Any]]:
+    info_path = xcframework / "Info.plist"
+    try:
+        info = plistlib.loads(info_path.read_bytes())
+    except (OSError, plistlib.InvalidFileException) as error:
+        fail(f"cannot read {info_path}: {error}")
+    libraries = info.get("AvailableLibraries")
+    if not isinstance(libraries, list) or not libraries:
+        fail(f"{info_path} has no AvailableLibraries")
+    return libraries
+
+
+def slice_records(
+    xcframework: Path,
+    deployment_targets: dict[str, str],
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    sdk_cache: dict[str, dict[str, str]] = {}
+    for library in load_xcframework_libraries(xcframework):
+        identifier = library.get("LibraryIdentifier")
+        platform_name = library.get("SupportedPlatform")
+        variant = library.get("SupportedPlatformVariant")
+        architectures = library.get("SupportedArchitectures")
+        library_path = library.get("LibraryPath")
+        headers_path = library.get("HeadersPath")
+        if not all(
+            (identifier, platform_name, architectures, library_path, headers_path)
+        ):
+            fail("XCFramework library record is missing required identity fields")
+        sdk_name = SDK_BY_PLATFORM.get((platform_name, variant))
+        if sdk_name is None:
+            fail(f"unsupported XCFramework platform/variant: {platform_name}/{variant}")
+        sdk_cache.setdefault(sdk_name, sdk_details(sdk_name))
+        archive = xcframework / identifier / library_path
+        headers = xcframework / identifier / headers_path
+        if not archive.is_file() or not headers.is_dir():
+            fail(f"slice {identifier} is missing its library or headers")
+        deployment_key = "catalyst" if variant == "maccatalyst" else platform_name
+        target = deployment_targets.get(deployment_key)
+        if target is None:
+            fail(f"no deployment target supplied for {deployment_key}")
+        record = {
+            "identifier": identifier,
+            "platform": platform_name,
+            "architectures": architectures,
+            "deploymentTarget": target,
+            "sdk": sdk_cache[sdk_name],
+            "librarySha256": sha256_file(archive),
+            "headersTreeDigest": tree_digest(headers),
+            **archive_member_digest(archive),
+        }
+        if variant is not None:
+            record["variant"] = variant
+        records.append(record)
+    return sorted(records, key=lambda record: record["identifier"])
+
+
+def parse_deployment_targets(values: list[str]) -> dict[str, str]:
+    targets: dict[str, str] = {}
+    for value in values:
+        if "=" not in value:
+            fail(f"deployment target must be PLATFORM=VERSION: {value}")
+        name, version = value.split("=", 1)
+        if not name or not version or name in targets:
+            fail(f"invalid or duplicate deployment target: {value}")
+        targets[name] = version
+    return targets
+
+
+def create(arguments: argparse.Namespace) -> None:
+    xcframework = arguments.xcframework.resolve()
+    patch_manifest = (
+        arguments.patch_manifest.resolve() if arguments.patch_manifest else None
+    )
+    patch_record = (
+        {
+            "sha256": sha256_file(patch_manifest),
+            "entries": manifest_entries(patch_manifest),
+        }
+        if patch_manifest is not None
+        else {"sha256": "none", "entries": []}
+    )
+    record = {
+        "schemaVersion": SCHEMA_VERSION,
+        "vlcSourceRevision": arguments.source_revision,
+        "pinnedRevision": arguments.pinned_revision,
+        "patchManifest": patch_record,
+        "contribChecksums": contrib_manifest(arguments.vlc_source.resolve()),
+        "build": {
+            "assertionsEnabled": arguments.assertions_enabled,
+            "makeFlags": arguments.make_flags,
+            "sourceDateEpoch": arguments.source_date_epoch,
+            "hostArchitecture": platform.machine(),
+            "xcode": xcode_details(),
+            "clangVersion": first_line("xcrun", "clang", "--version"),
+            "swiftVersion": first_line("xcrun", "swift", "--version"),
+            "builtAt": datetime.now(timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+            .replace("+00:00", "Z"),
+        },
+        "xcframeworkTreeDigest": tree_digest(xcframework),
+        "slices": slice_records(
+            xcframework,
+            parse_deployment_targets(arguments.deployment_target),
+        ),
+    }
+    arguments.output.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+
+
+def load_record(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, ValueError) as error:
+        fail(f"cannot read provenance {path}: {error}")
+    if value.get("schemaVersion") != SCHEMA_VERSION:
+        fail(f"{path} is not schema version {SCHEMA_VERSION}")
+    return value
+
+
+def verify(arguments: argparse.Namespace) -> None:
+    record = load_record(arguments.provenance)
+    xcframework = arguments.xcframework.resolve()
+    if record.get("pinnedRevision") != arguments.pinned_revision:
+        fail("provenance engine pin does not match the repository")
+    manifest = record.get("patchManifest", {})
+    if manifest.get("sha256") != sha256_file(arguments.patch_manifest):
+        fail("provenance patch manifest does not match the repository")
+    if manifest.get("entries") != manifest_entries(arguments.patch_manifest):
+        fail("provenance patch order does not match the repository")
+    if record.get("xcframeworkTreeDigest") != tree_digest(xcframework):
+        fail("XCFramework tree digest does not match provenance")
+    recorded_slices = {item["identifier"]: item for item in record.get("slices", [])}
+    actual_libraries = load_xcframework_libraries(xcframework)
+    actual_identifiers = {item["LibraryIdentifier"] for item in actual_libraries}
+    if set(recorded_slices) != actual_identifiers:
+        fail("XCFramework slice set does not match provenance")
+    for library in actual_libraries:
+        identifier = library["LibraryIdentifier"]
+        recorded = recorded_slices[identifier]
+        root = xcframework / identifier
+        archive = root / library["LibraryPath"]
+        headers = root / library["HeadersPath"]
+        members = archive_member_digest(archive)
+        if recorded.get("librarySha256") != sha256_file(archive):
+            fail(f"slice {identifier} library checksum does not match provenance")
+        if recorded.get("headersTreeDigest") != tree_digest(headers):
+            fail(f"slice {identifier} headers digest does not match provenance")
+        if any(recorded.get(key) != value for key, value in members.items()):
+            fail(
+                f"slice {identifier} archive member manifest does not match provenance"
+            )
+    print(
+        f"libVLC provenance verified: {len(recorded_slices)} slice(s), "
+        f"tree {record['xcframeworkTreeDigest'][:12]}…"
+    )
+
+
+def rebind(arguments: argparse.Namespace) -> None:
+    record = load_record(arguments.provenance)
+    xcframework = arguments.xcframework.resolve()
+    recorded_slices = {item["identifier"]: item for item in record.get("slices", [])}
+    rebound_slices = []
+    for library in load_xcframework_libraries(xcframework):
+        identifier = library["LibraryIdentifier"]
+        if identifier not in recorded_slices:
+            fail(f"rebound XCFramework contains an unrecorded slice: {identifier}")
+        rebound = dict(recorded_slices[identifier])
+        root = xcframework / identifier
+        archive = root / library["LibraryPath"]
+        headers = root / library["HeadersPath"]
+        rebound.update(
+            librarySha256=sha256_file(archive),
+            headersTreeDigest=tree_digest(headers),
+            **archive_member_digest(archive),
+        )
+        rebound_slices.append(rebound)
+    if len(rebound_slices) != len(recorded_slices):
+        fail("rebound XCFramework is missing a recorded slice")
+    record["sourceBuildTreeDigest"] = record.get(
+        "sourceBuildTreeDigest", record["xcframeworkTreeDigest"]
+    )
+    record["xcframeworkTreeDigest"] = tree_digest(xcframework)
+    record["slices"] = sorted(rebound_slices, key=lambda item: item["identifier"])
+    arguments.output.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+
+
+def normalized_build_inputs(record: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value for key, value in record.get("build", {}).items() if key != "builtAt"
+    }
+
+
+def slice_inputs(record: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    artifact_keys = {
+        "librarySha256",
+        "headersTreeDigest",
+        "manifestSha256",
+        "memberCount",
+    }
+    return {
+        item["identifier"]: {
+            key: value for key, value in item.items() if key not in artifact_keys
+        }
+        for item in record.get("slices", [])
+    }
+
+
+def compare(arguments: argparse.Namespace) -> None:
+    first = load_record(arguments.first)
+    second = load_record(arguments.second)
+    input_keys = (
+        "vlcSourceRevision",
+        "pinnedRevision",
+        "patchManifest",
+        "contribChecksums",
+    )
+    for key in input_keys:
+        if first.get(key) != second.get(key):
+            fail(f"build inputs differ at {key}")
+    if normalized_build_inputs(first) != normalized_build_inputs(second):
+        fail("build toolchain, host, flags, or assertion inputs differ")
+    if slice_inputs(first) != slice_inputs(second):
+        fail("build slice SDK, target, platform, or architecture inputs differ")
+    first_slices = {item["identifier"]: item for item in first.get("slices", [])}
+    second_slices = {item["identifier"]: item for item in second.get("slices", [])}
+    if set(first_slices) != set(second_slices):
+        fail("build slice sets differ")
+    differences = []
+    for identifier in sorted(first_slices):
+        before = first_slices[identifier]
+        after = second_slices[identifier]
+        for key in (
+            "librarySha256",
+            "headersTreeDigest",
+            "manifestSha256",
+            "memberCount",
+        ):
+            if before.get(key) != after.get(key):
+                differences.append(f"{identifier}.{key}")
+    if first.get("xcframeworkTreeDigest") != second.get("xcframeworkTreeDigest"):
+        differences.append("xcframeworkTreeDigest")
+    if differences:
+        fail("clean builds are not byte-reproducible: " + ", ".join(differences))
+    if arguments.output is not None:
+        proof = {
+            "schemaVersion": 1,
+            "vlcSourceRevision": first["vlcSourceRevision"],
+            "pinnedRevision": first["pinnedRevision"],
+            "patchManifestSha256": first["patchManifest"]["sha256"],
+            "contribChecksums": first["contribChecksums"],
+            "buildInputs": normalized_build_inputs(first),
+            "sliceInputs": slice_inputs(first),
+            "firstBuiltAt": first["build"]["builtAt"],
+            "secondBuiltAt": second["build"]["builtAt"],
+            "xcframeworkTreeDigest": first["xcframeworkTreeDigest"],
+            "slices": {
+                identifier: {
+                    key: first_slices[identifier][key]
+                    for key in (
+                        "librarySha256",
+                        "headersTreeDigest",
+                        "manifestSha256",
+                        "memberCount",
+                    )
+                }
+                for identifier in sorted(first_slices)
+            },
+        }
+        arguments.output.write_text(json.dumps(proof, indent=2, sort_keys=True) + "\n")
+    print(
+        f"libVLC clean builds are byte-reproducible: "
+        f"{first['xcframeworkTreeDigest']}"
+    )
+
+
+def verify_proof(arguments: argparse.Namespace) -> None:
+    provenance = load_record(arguments.provenance)
+    try:
+        proof = json.loads(arguments.proof.read_text())
+    except (OSError, ValueError) as error:
+        fail(f"cannot read reproducibility proof {arguments.proof}: {error}")
+    if proof.get("schemaVersion") != 1:
+        fail("reproducibility proof has an unsupported schema")
+    expected_digest = provenance.get(
+        "sourceBuildTreeDigest", provenance["xcframeworkTreeDigest"]
+    )
+    expected = {
+        "vlcSourceRevision": provenance["vlcSourceRevision"],
+        "pinnedRevision": provenance["pinnedRevision"],
+        "patchManifestSha256": provenance["patchManifest"]["sha256"],
+        "contribChecksums": provenance["contribChecksums"],
+        "buildInputs": normalized_build_inputs(provenance),
+        "sliceInputs": slice_inputs(provenance),
+        "xcframeworkTreeDigest": expected_digest,
+    }
+    for key, value in expected.items():
+        if proof.get(key) != value:
+            fail(f"reproducibility proof does not match provenance at {key}")
+    if proof.get("firstBuiltAt") == proof.get("secondBuiltAt"):
+        fail("reproducibility proof does not describe two distinct builds")
+    print(
+        f"libVLC reproducibility proof verified: "
+        f"{proof['xcframeworkTreeDigest'][:12]}…"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    create_parser = commands.add_parser("create")
+    create_parser.add_argument("--xcframework", type=Path, required=True)
+    create_parser.add_argument("--output", type=Path, required=True)
+    create_parser.add_argument("--vlc-source", type=Path, required=True)
+    create_parser.add_argument("--source-revision", required=True)
+    create_parser.add_argument("--pinned-revision", required=True)
+    create_parser.add_argument("--source-date-epoch", type=int, required=True)
+    create_parser.add_argument("--patch-manifest", type=Path)
+    create_parser.add_argument("--assertions-enabled", action="store_true")
+    create_parser.add_argument("--make-flags", required=True)
+    create_parser.add_argument(
+        "--deployment-target",
+        action="append",
+        default=[],
+        required=True,
+    )
+    create_parser.set_defaults(function=create)
+
+    verify_parser = commands.add_parser("verify")
+    verify_parser.add_argument("--provenance", type=Path, required=True)
+    verify_parser.add_argument("--xcframework", type=Path, required=True)
+    verify_parser.add_argument("--pinned-revision", required=True)
+    verify_parser.add_argument("--patch-manifest", type=Path, required=True)
+    verify_parser.set_defaults(function=verify)
+
+    rebind_parser = commands.add_parser("rebind")
+    rebind_parser.add_argument("--provenance", type=Path, required=True)
+    rebind_parser.add_argument("--xcframework", type=Path, required=True)
+    rebind_parser.add_argument("--output", type=Path, required=True)
+    rebind_parser.set_defaults(function=rebind)
+
+    compare_parser = commands.add_parser("compare")
+    compare_parser.add_argument("--first", type=Path, required=True)
+    compare_parser.add_argument("--second", type=Path, required=True)
+    compare_parser.add_argument("--output", type=Path)
+    compare_parser.set_defaults(function=compare)
+
+    proof_parser = commands.add_parser("verify-proof")
+    proof_parser.add_argument("--proof", type=Path, required=True)
+    proof_parser.add_argument("--provenance", type=Path, required=True)
+    proof_parser.set_defaults(function=verify_proof)
+
+    arguments = parser.parse_args()
+    arguments.function(arguments)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/patches/0019-darwin-sha512-stdin.patch
+++ b/scripts/patches/0019-darwin-sha512-stdin.patch
@@ -1,0 +1,22 @@
+# Use the portable stdin operand for contrib checksum verification.
+#
+# macOS 26 ships /sbin/sha512sum. Its check mode blocks indefinitely when the
+# checksum-list operand is /dev/stdin, even when stdin is a regular file. The
+# conventional "-" operand reads the same checksum list and works with both
+# the macOS implementation and GNU coreutils.
+#
+# This matters most on a clean build: contrib's parallel fetch launches one
+# checksum verifier per archive, and every verifier otherwise blocks before
+# any dependency can be unpacked or compiled.
+diff --git a/contrib/src/main.mak b/contrib/src/main.mak
+--- a/contrib/src/main.mak
++++ b/contrib/src/main.mak
+@@ -447,7 +447,7 @@ checksum = \
+ 	$(foreach f,$(filter $(TARBALLS)/%,$^), \
+ 		grep -- " $(f:$(TARBALLS)/%=%)$$" \
+ 			"$(SRC)/$(patsubst $(3)%,%,$@)/$(2)SUMS" &&) \
+-	(cd $(TARBALLS) && $(1) /dev/stdin) < \
++	(cd $(TARBALLS) && $(1) -) < \
+ 		"$(SRC)/$(patsubst $(3)%,%,$@)/$(2)SUMS"
+ CHECK_SHA512 = $(call checksum,$(SHA512SUM),SHA512,.sum-)
+ UNPACK = $(RM) -R $@ \

--- a/scripts/patches/manifest.sha256
+++ b/scripts/patches/manifest.sha256
@@ -16,3 +16,4 @@ febaea84d74ce7f1bf6fea77edfa202a9ac1bf8d2ddba5d5c2451bbab6c259f5  0004-samplebuf
 ea85b92b4239f4812542b3f4d4efe0600b42b23a331d524a811de9ddeb8fde29  0016-skip-vlc-test-subdir.patch
 e41b501f77342eb6f5cbc6b8c84b4b2d29e375958ffcdc76a07fe3c597b2ba16  0017-native-pip-format-description-cache.patch
 00aa6608db4f668a20b4138f504045ea2ce87ed7066a7adae01def71f4015d8b  0018-media-list-player-observer-lock-order.patch
+bee0f53d544430719a74c9fba5d032dcf33e0cf3e659187f82ac2cc0484998b5  0019-darwin-sha512-stdin.patch

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -444,59 +444,42 @@ echo "Release rewrite validation passed."
 # so a binary produced months ago against a different pin or patch set would be
 # published as new and nothing would notice (#97, second criterion).
 #
-# The build records its inputs beside the artifact; this compares them with what
-# the repository says now. It is not a reproducibility proof — two builds of the
-# same inputs are not yet compared — but it does refuse a demonstrably stale one.
+# The build records its complete inputs and every slice checksum beside the
+# artifact. A separate proof records two byte-identical clean builds. Both have
+# to match the exact tree entering the release pipeline.
 verify_artifact_provenance() {
   # Derived from XCFW_PATH rather than hard-coded, so the provenance always
   # describes the artifact actually being packaged even if Vendor/ moves.
   local provenance="$(dirname "$XCFW_PATH")/libvlc-provenance.json"
+  local reproducibility="$(dirname "$XCFW_PATH")/libvlc-reproducibility.json"
 
-  if [[ ! -f "$provenance" ]]; then
-    echo "Error: $provenance not found." >&2
+  if [[ ! -f "$provenance" || ! -f "$reproducibility" ]]; then
+    echo "Error: complete provenance is missing beside $XCFW_PATH." >&2
+    echo "  Required: $provenance" >&2
+    echo "  Required: $reproducibility" >&2
     echo "  $XCFW_PATH was built before provenance was recorded, so its inputs" >&2
     echo "  cannot be established. Rebuild with:" >&2
     echo "    ./scripts/build-libvlc.sh --all" >&2
     return 1
   fi
 
-  # `python3` from PATH, not /usr/bin/python3: the rest of this script already
-  # relies on PATH, and a Homebrew-only Python would otherwise fail here while
-  # everything around it worked.
-  read_provenance() {
-    local key="$1"
-    local value
-    if ! value=$(python3 -c 'import json,sys
-try:
-    print(json.load(open(sys.argv[1]))[sys.argv[2]])
-except (OSError, ValueError) as error:
-    sys.exit(f"cannot read {sys.argv[1]}: {error}")
-except KeyError:
-    sys.exit(f"{sys.argv[1]} has no {sys.argv[2]!r} key")' "$provenance" "$key" 2>&1); then
-      echo "Error: $value" >&2
-      echo "  Rebuild to regenerate provenance: ./scripts/build-libvlc.sh --all" >&2
-      return 1
-    fi
-    printf '%s' "$value"
-  }
-
-  local recorded_pin recorded_manifest current_pin current_manifest
-  recorded_pin=$(read_provenance pinnedRevision) || return 1
-  recorded_manifest=$(read_provenance patchManifestDigest) || return 1
+  local current_pin current_manifest
   current_pin=$(sed -n 's/^VLC_HASH="\(.*\)"$/\1/p' "$SCRIPT_DIR/build-libvlc.sh" | head -1)
   current_manifest=$(shasum -a 256 "$SCRIPT_DIR/patches/manifest.sha256" | cut -d' ' -f1)
 
-  if [[ "$recorded_pin" != "$current_pin" ]]; then
-    echo "Error: the xcframework was built from a different engine pin." >&2
-    echo "  artifact: $recorded_pin" >&2
-    echo "  repo:     $current_pin" >&2
+  if ! python3 "$SCRIPT_DIR/libvlc-provenance.py" verify \
+    --provenance "$provenance" \
+    --xcframework "$XCFW_PATH" \
+    --pinned-revision "$current_pin" \
+    --patch-manifest "$SCRIPT_DIR/patches/manifest.sha256"; then
+    echo "  Rebuild so every shipped slice and input has current provenance:" >&2
+    echo "    ./scripts/build-libvlc.sh --all" >&2
     return 1
   fi
-  if [[ "$recorded_manifest" != "$current_manifest" ]]; then
-    echo "Error: the xcframework was built from a different patch series." >&2
-    echo "  artifact manifest: $recorded_manifest" >&2
-    echo "  repo manifest:     $current_manifest" >&2
-    echo "  Rebuild so the shipped binary contains the patches this release claims." >&2
+  if ! python3 "$SCRIPT_DIR/libvlc-provenance.py" verify-proof \
+    --proof "$reproducibility" \
+    --provenance "$provenance"; then
+    echo "  Run two clean builds and compare their provenance before release." >&2
     return 1
   fi
 
@@ -514,8 +497,10 @@ if [[ -n "$CANDIDATE_DIR" ]]; then
   ZIP_PATH="$CANDIDATE_DIR/$ZIP_NAME"
   WORK_XCFW="$XCFW_PATH"
 
+  RELEASE_PROVENANCE="$CANDIDATE_DIR/libvlc-provenance.json"
+  RELEASE_REPRODUCIBILITY="$CANDIDATE_DIR/libvlc-reproducibility.json"
   for candidate_file in "$CANDIDATE_MANIFEST" "$ZIP_PATH" \
-    "$CANDIDATE_DIR/libvlc-provenance.json"; do
+    "$RELEASE_PROVENANCE" "$RELEASE_REPRODUCIBILITY"; do
     if [[ ! -f "$candidate_file" ]]; then
       echo "Error: prepared candidate is missing $candidate_file." >&2
       exit 1
@@ -539,6 +524,7 @@ required = {
     "artifactDigest",
     "zipChecksum",
     "provenanceChecksum",
+    "reproducibilityChecksum",
 }
 missing = sorted(required - candidate.keys())
 if missing:
@@ -552,16 +538,20 @@ if candidate["artifactDigestAlgorithm"] != "swiftvlc-tree-v1":
 print(candidate["artifactDigest"])
 print(candidate["zipChecksum"])
 print(candidate["provenanceChecksum"])
+print(candidate["reproducibilityChecksum"])
 PY
 )
   CANDIDATE_TREE_DIGEST=$(printf '%s\n' "$CANDIDATE_VALUES" | sed -n '1p')
   EXPECTED_ZIP_CHECKSUM=$(printf '%s\n' "$CANDIDATE_VALUES" | sed -n '2p')
   EXPECTED_PROVENANCE_CHECKSUM=$(printf '%s\n' "$CANDIDATE_VALUES" | sed -n '3p')
+  EXPECTED_REPRODUCIBILITY_CHECKSUM=$(printf '%s\n' "$CANDIDATE_VALUES" | sed -n '4p')
 
   ACTUAL_TREE_DIGEST=$("$SCRIPT_DIR/artifact-tree-digest.py" "$WORK_XCFW")
   CHECKSUM=$(swift package compute-checksum "$ZIP_PATH")
   ACTUAL_PROVENANCE_CHECKSUM=$(shasum -a 256 \
-    "$CANDIDATE_DIR/libvlc-provenance.json" | cut -d' ' -f1)
+    "$RELEASE_PROVENANCE" | cut -d' ' -f1)
+  ACTUAL_REPRODUCIBILITY_CHECKSUM=$(shasum -a 256 \
+    "$RELEASE_REPRODUCIBILITY" | cut -d' ' -f1)
   if [[ "$ACTUAL_TREE_DIGEST" != "$CANDIDATE_TREE_DIGEST" ]]; then
     echo "Error: prepared XCFramework changed after candidate creation." >&2
     exit 1
@@ -572,6 +562,10 @@ PY
   fi
   if [[ "$ACTUAL_PROVENANCE_CHECKSUM" != "$EXPECTED_PROVENANCE_CHECKSUM" ]]; then
     echo "Error: prepared provenance changed after candidate creation." >&2
+    exit 1
+  fi
+  if [[ "$ACTUAL_REPRODUCIBILITY_CHECKSUM" != "$EXPECTED_REPRODUCIBILITY_CHECKSUM" ]]; then
+    echo "Error: prepared reproducibility proof changed after candidate creation." >&2
     exit 1
   fi
 
@@ -601,6 +595,16 @@ else
   echo "Verifying duplicate symbols in stripped libraries..."
   "$SCRIPT_DIR/fix-duplicate-symbols.sh" --verify "$WORK_XCFW"
 
+  RELEASE_PROVENANCE="$WORK_DIR/libvlc-provenance.json"
+  RELEASE_REPRODUCIBILITY="$(dirname "$XCFW_PATH")/libvlc-reproducibility.json"
+  python3 "$SCRIPT_DIR/libvlc-provenance.py" rebind \
+    --provenance "$(dirname "$XCFW_PATH")/libvlc-provenance.json" \
+    --xcframework "$WORK_XCFW" \
+    --output "$RELEASE_PROVENANCE"
+  python3 "$SCRIPT_DIR/libvlc-provenance.py" verify-proof \
+    --proof "$RELEASE_REPRODUCIBILITY" \
+    --provenance "$RELEASE_PROVENANCE"
+
   echo "Creating zip..."
   ZIP_PATH="$WORK_DIR/$ZIP_NAME"
   (cd "$WORK_DIR" && ditto -c -k --keepParent libvlc.xcframework "$ZIP_NAME")
@@ -629,16 +633,19 @@ if [[ -n "$PREPARE_DIR" ]]; then
   mkdir "$PREPARE_DIR"
   cp -R "$WORK_XCFW" "$PREPARE_DIR/libvlc.xcframework"
   cp "$ZIP_PATH" "$PREPARE_DIR/$ZIP_NAME"
-  cp "$(dirname "$XCFW_PATH")/libvlc-provenance.json" \
-    "$PREPARE_DIR/libvlc-provenance.json"
+  cp "$RELEASE_PROVENANCE" "$PREPARE_DIR/libvlc-provenance.json"
+  cp "$RELEASE_REPRODUCIBILITY" "$PREPARE_DIR/libvlc-reproducibility.json"
 
   CANDIDATE_TREE_DIGEST=$("$SCRIPT_DIR/artifact-tree-digest.py" "$WORK_XCFW")
   PROVENANCE_CHECKSUM=$(shasum -a 256 \
     "$PREPARE_DIR/libvlc-provenance.json" | cut -d' ' -f1)
+  REPRODUCIBILITY_CHECKSUM=$(shasum -a 256 \
+    "$PREPARE_DIR/libvlc-reproducibility.json" | cut -d' ' -f1)
   VERSION="$VERSION" \
     CANDIDATE_TREE_DIGEST="$CANDIDATE_TREE_DIGEST" \
     CHECKSUM="$CHECKSUM" \
     PROVENANCE_CHECKSUM="$PROVENANCE_CHECKSUM" \
+    REPRODUCIBILITY_CHECKSUM="$REPRODUCIBILITY_CHECKSUM" \
     python3 - "$PREPARE_DIR/release-candidate.json" <<'PY'
 import json
 import os
@@ -650,6 +657,7 @@ candidate = {
     "artifactDigest": os.environ["CANDIDATE_TREE_DIGEST"],
     "zipChecksum": os.environ["CHECKSUM"],
     "provenanceChecksum": os.environ["PROVENANCE_CHECKSUM"],
+    "reproducibilityChecksum": os.environ["REPRODUCIBILITY_CHECKSUM"],
 }
 with open(sys.argv[1], "w") as output:
     json.dump(candidate, output, indent=2, sort_keys=True)
@@ -755,7 +763,7 @@ git push origin "$TAG"
 
 echo "Creating draft GitHub Release..."
 RELEASE_FLAGS=(--draft)
-RELEASE_ASSETS=("$ZIP_PATH" "$(dirname "$XCFW_PATH")/libvlc-provenance.json")
+RELEASE_ASSETS=("$ZIP_PATH" "$RELEASE_PROVENANCE" "$RELEASE_REPRODUCIBILITY")
 if [[ -n "$CANDIDATE_DIR" ]]; then
   RELEASE_ASSETS+=("$CANDIDATE_DIR/release-candidate.json")
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -459,7 +459,7 @@ verify_artifact_provenance() {
     echo "  Required: $reproducibility" >&2
     echo "  $XCFW_PATH was built before provenance was recorded, so its inputs" >&2
     echo "  cannot be established. Rebuild with:" >&2
-    echo "    ./scripts/build-libvlc.sh --all" >&2
+    echo "    ./scripts/build-libvlc.sh --clean-build --all" >&2
     return 1
   fi
 
@@ -471,9 +471,11 @@ verify_artifact_provenance() {
     --provenance "$provenance" \
     --xcframework "$XCFW_PATH" \
     --pinned-revision "$current_pin" \
-    --patch-manifest "$SCRIPT_DIR/patches/manifest.sha256"; then
+    --patch-manifest "$SCRIPT_DIR/patches/manifest.sha256" \
+    --build-configuration-file "build-libvlc.sh=$SCRIPT_DIR/build-libvlc.sh" \
+    --build-configuration-file "fix-duplicate-symbols.sh=$SCRIPT_DIR/fix-duplicate-symbols.sh"; then
     echo "  Rebuild so every shipped slice and input has current provenance:" >&2
-    echo "    ./scripts/build-libvlc.sh --all" >&2
+    echo "    ./scripts/build-libvlc.sh --clean-build --all" >&2
     return 1
   fi
   if ! python3 "$SCRIPT_DIR/libvlc-provenance.py" verify-proof \
@@ -586,21 +588,11 @@ else
   echo "Copying xcframework to temp dir..."
   cp -R "$XCFW_PATH" "$WORK_XCFW"
 
-  echo "Stripping debug symbols from .a files..."
-  BEFORE_SIZE=$(du -sh "$WORK_XCFW" | cut -f1)
-  find "$WORK_XCFW" -name '*.a' -exec strip -S {} \;
-  AFTER_SIZE=$(du -sh "$WORK_XCFW" | cut -f1)
-  echo "  Before: $BEFORE_SIZE → After: $AFTER_SIZE"
-
-  echo "Verifying duplicate symbols in stripped libraries..."
+  echo "Verifying duplicate symbols in release-ready libraries..."
   "$SCRIPT_DIR/fix-duplicate-symbols.sh" --verify "$WORK_XCFW"
 
-  RELEASE_PROVENANCE="$WORK_DIR/libvlc-provenance.json"
+  RELEASE_PROVENANCE="$(dirname "$XCFW_PATH")/libvlc-provenance.json"
   RELEASE_REPRODUCIBILITY="$(dirname "$XCFW_PATH")/libvlc-reproducibility.json"
-  python3 "$SCRIPT_DIR/libvlc-provenance.py" rebind \
-    --provenance "$(dirname "$XCFW_PATH")/libvlc-provenance.json" \
-    --xcframework "$WORK_XCFW" \
-    --output "$RELEASE_PROVENANCE"
   python3 "$SCRIPT_DIR/libvlc-provenance.py" verify-proof \
     --proof "$RELEASE_REPRODUCIBILITY" \
     --provenance "$RELEASE_PROVENANCE"
@@ -666,9 +658,9 @@ PY
   echo "Prepared immutable candidate at $PREPARE_DIR"
 fi
 
-# Device qualification must describe the exact post-strip tree that the zip
-# contains. Preparation intentionally precedes qualification; stable publishing
-# later requires --candidate and refuses to rebuild or mutate those bytes.
+# Device qualification must describe the exact provenance-covered tree that the
+# zip contains. Preparation intentionally precedes qualification; stable
+# publishing later requires --candidate and refuses to rebuild or mutate bytes.
 if [[ -n "$PREPARE_DIR" ]]; then
   echo "Candidate prepared but not yet device-qualified."
 elif [[ "$UNQUALIFIED" == true ]]; then

--- a/scripts/tests/release-integrity.sh
+++ b/scripts/tests/release-integrity.sh
@@ -64,6 +64,7 @@ digest_b=$("$SCRIPT_DIR/artifact-tree-digest.py" "$temp_dir/tree-b")
 mkdir -p "$temp_dir/fake-vlc/contrib/src/example"
 printf 'example contrib checksum\n' > "$temp_dir/fake-vlc/contrib/src/example/SHA512SUMS"
 printf '%064d  0001-example.patch\n' 0 > "$temp_dir/patch-manifest.sha256"
+printf '#!/bin/sh\necho fixture\n' > "$temp_dir/build-config.sh"
 mkdir -p "$temp_dir/build-a/macos-arm64/Headers"
 printf 'header\n' > "$temp_dir/build-a/macos-arm64/Headers/libvlc.h"
 printf 'int swiftvlc_provenance_fixture(void) { return 1; }\n' > "$temp_dir/member.c"
@@ -91,7 +92,9 @@ with open(sys.argv[1], "wb") as output:
 PY
 cp -R "$temp_dir/build-a" "$temp_dir/build-b"
 
+build_index=0
 for build_name in a b; do
+  build_index=$((build_index + 1))
   "$SCRIPT_DIR/libvlc-provenance.py" create \
     --xcframework "$temp_dir/build-$build_name" \
     --output "$temp_dir/provenance-$build_name.json" \
@@ -100,18 +103,12 @@ for build_name in a b; do
     --pinned-revision 111111111 \
     --source-date-epoch 0 \
     --patch-manifest "$temp_dir/patch-manifest.sha256" \
+    --build-configuration-file "build-script=$temp_dir/build-config.sh" \
+    --build-invocation-id "00000000-0000-0000-0000-00000000000${build_index}" \
+    --clean-build \
     --make-flags=-j1 \
     --deployment-target macos=15.0
 done
-python3 - "$temp_dir/provenance-a.json" <<'PY'
-import json
-import sys
-
-path = sys.argv[1]
-value = json.load(open(path))
-value["build"]["builtAt"] = "2026-01-01T00:00:00Z"
-json.dump(value, open(path, "w"), indent=2, sort_keys=True)
-PY
 "$SCRIPT_DIR/libvlc-provenance.py" compare \
   --first "$temp_dir/provenance-a.json" \
   --second "$temp_dir/provenance-b.json" \
@@ -120,35 +117,100 @@ PY
   --provenance "$temp_dir/provenance-b.json" \
   --xcframework "$temp_dir/build-b" \
   --pinned-revision 111111111 \
-  --patch-manifest "$temp_dir/patch-manifest.sha256" >/dev/null
+  --patch-manifest "$temp_dir/patch-manifest.sha256" \
+  --build-configuration-file "build-script=$temp_dir/build-config.sh" >/dev/null
 "$SCRIPT_DIR/libvlc-provenance.py" verify-proof \
   --proof "$temp_dir/reproducibility.json" \
   --provenance "$temp_dir/provenance-b.json" >/dev/null
 
-cp -R "$temp_dir/build-b" "$temp_dir/rebound"
+# A changed effective build script invalidates otherwise matching provenance.
+printf '#!/bin/sh\necho changed\n' > "$temp_dir/build-config.sh"
+if "$SCRIPT_DIR/libvlc-provenance.py" verify \
+  --provenance "$temp_dir/provenance-b.json" \
+  --xcframework "$temp_dir/build-b" \
+  --pinned-revision 111111111 \
+  --patch-manifest "$temp_dir/patch-manifest.sha256" \
+  --build-configuration-file "build-script=$temp_dir/build-config.sh" >/dev/null 2>&1; then
+  fail "provenance accepted a changed build configuration"
+fi
+printf '#!/bin/sh\necho fixture\n' > "$temp_dir/build-config.sh"
+
+# A clean-build marker without an independent invocation is not a second build.
+cp "$temp_dir/provenance-b.json" "$temp_dir/provenance-same-invocation.json"
+python3 - "$temp_dir/provenance-a.json" "$temp_dir/provenance-same-invocation.json" <<'PY'
+import json
+import sys
+
+first = json.load(open(sys.argv[1]))
+second = json.load(open(sys.argv[2]))
+second["build"]["invocationId"] = first["build"]["invocationId"]
+json.dump(second, open(sys.argv[2], "w"), indent=2, sort_keys=True)
+PY
+if "$SCRIPT_DIR/libvlc-provenance.py" compare \
+  --first "$temp_dir/provenance-a.json" \
+  --second "$temp_dir/provenance-same-invocation.json" >/dev/null 2>&1; then
+  fail "reproducibility accepted the same build invocation twice"
+fi
+
+# An incremental build cannot participate even when its output is identical.
+cp "$temp_dir/provenance-b.json" "$temp_dir/provenance-incremental.json"
+python3 - "$temp_dir/provenance-incremental.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+value = json.load(open(path))
+value["build"]["cleanBuild"] = False
+value["build"]["invocationId"] = "00000000-0000-0000-0000-000000000003"
+json.dump(value, open(path, "w"), indent=2, sort_keys=True)
+PY
+if "$SCRIPT_DIR/libvlc-provenance.py" compare \
+  --first "$temp_dir/provenance-a.json" \
+  --second "$temp_dir/provenance-incremental.json" >/dev/null 2>&1; then
+  fail "reproducibility accepted an incremental build"
+fi
+
+# There is no generic rebind escape hatch for a post-proof mutation.
+if "$SCRIPT_DIR/libvlc-provenance.py" rebind >/dev/null 2>&1; then
+  fail "removed provenance rebind command is still accepted"
+fi
+cp -R "$temp_dir/build-b" "$temp_dir/mutated-build"
 printf 'int swiftvlc_provenance_fixture(void) { return 2; }\n' > "$temp_dir/member.c"
 xcrun clang -c "$temp_dir/member.c" -o "$temp_dir/member.o"
-ar rcs "$temp_dir/rebound/macos-arm64/libvlc.a" "$temp_dir/member.o"
-"$SCRIPT_DIR/libvlc-provenance.py" rebind \
-  --provenance "$temp_dir/provenance-b.json" \
-  --xcframework "$temp_dir/rebound" \
-  --output "$temp_dir/rebound-provenance.json"
-"$SCRIPT_DIR/libvlc-provenance.py" verify \
-  --provenance "$temp_dir/rebound-provenance.json" \
-  --xcframework "$temp_dir/rebound" \
+ar rcs "$temp_dir/mutated-build/macos-arm64/libvlc.a" "$temp_dir/member.o"
+"$SCRIPT_DIR/libvlc-provenance.py" create \
+  --xcframework "$temp_dir/mutated-build" \
+  --output "$temp_dir/mutated-provenance.json" \
+  --vlc-source "$temp_dir/fake-vlc" \
+  --source-revision 1111111111111111111111111111111111111111 \
   --pinned-revision 111111111 \
-  --patch-manifest "$temp_dir/patch-manifest.sha256" >/dev/null
-"$SCRIPT_DIR/libvlc-provenance.py" verify-proof \
+  --source-date-epoch 0 \
+  --patch-manifest "$temp_dir/patch-manifest.sha256" \
+  --build-configuration-file "build-script=$temp_dir/build-config.sh" \
+  --build-invocation-id 00000000-0000-0000-0000-000000000004 \
+  --clean-build \
+  --make-flags=-j1 \
+  --deployment-target macos=15.0
+if "$SCRIPT_DIR/libvlc-provenance.py" verify-proof \
   --proof "$temp_dir/reproducibility.json" \
-  --provenance "$temp_dir/rebound-provenance.json" >/dev/null
-printf 'mutated\n' > "$temp_dir/rebound/macos-arm64/Headers/libvlc.h"
-if "$SCRIPT_DIR/libvlc-provenance.py" verify \
-  --provenance "$temp_dir/rebound-provenance.json" \
-  --xcframework "$temp_dir/rebound" \
-  --pinned-revision 111111111 \
-  --patch-manifest "$temp_dir/patch-manifest.sha256" >/dev/null 2>&1; then
-  fail "provenance accepted a mutated release slice"
+  --provenance "$temp_dir/mutated-provenance.json" >/dev/null 2>&1; then
+  fail "reproducibility proof accepted a mutated post-build tree"
 fi
+
+python3 - "$SCRIPT_DIR/build-libvlc.sh" "$SCRIPT_DIR/release.sh" <<'PY'
+import sys
+
+build = open(sys.argv[1]).read()
+release = open(sys.argv[2]).read()
+verification = build.rindex("verify_deployment_targets\n")
+provenance = build.index('python3 "${SCRIPT_DIR}/libvlc-provenance.py" create')
+if provenance < verification:
+    sys.exit("provenance is written before deployment-target verification")
+if 'rm -f "${OUTPUT_DIR}/libvlc-provenance.json"' not in build:
+    sys.exit("a failed rebuild can leave stale provenance beside its artifact")
+if "libvlc-provenance.py\" rebind" in release or "find \"$WORK_XCFW\" -name '*.a'" in release:
+    sys.exit("release packaging still mutates or rebinds the proven artifact")
+PY
 
 python3 - "$temp_dir/matrix.json" "$temp_dir/record.json" "$digest_a" <<'PY'
 import json

--- a/scripts/tests/release-integrity.sh
+++ b/scripts/tests/release-integrity.sh
@@ -57,6 +57,99 @@ printf 'changed header' > "$temp_dir/tree-b/Headers/libvlc.h"
 digest_b=$("$SCRIPT_DIR/artifact-tree-digest.py" "$temp_dir/tree-b")
 [[ "$digest_a" != "$digest_b" ]] || fail "header changes do not affect the digest"
 
+# Complete engine provenance records exact slices, SDK/toolchain inputs, patch
+# order, contrib checksums, and two-build reproducibility. Exercise it with a
+# minimal valid XCFramework so release integrity does not depend on a 368 MB
+# binary fixture.
+mkdir -p "$temp_dir/fake-vlc/contrib/src/example"
+printf 'example contrib checksum\n' > "$temp_dir/fake-vlc/contrib/src/example/SHA512SUMS"
+printf '%064d  0001-example.patch\n' 0 > "$temp_dir/patch-manifest.sha256"
+mkdir -p "$temp_dir/build-a/macos-arm64/Headers"
+printf 'header\n' > "$temp_dir/build-a/macos-arm64/Headers/libvlc.h"
+printf 'int swiftvlc_provenance_fixture(void) { return 1; }\n' > "$temp_dir/member.c"
+xcrun clang -c "$temp_dir/member.c" -o "$temp_dir/member.o"
+ar rcs "$temp_dir/build-a/macos-arm64/libvlc.a" "$temp_dir/member.o"
+python3 - "$temp_dir/build-a/Info.plist" <<'PY'
+import plistlib
+import sys
+
+value = {
+    "AvailableLibraries": [
+        {
+            "LibraryIdentifier": "macos-arm64",
+            "LibraryPath": "libvlc.a",
+            "HeadersPath": "Headers",
+            "SupportedArchitectures": ["arm64"],
+            "SupportedPlatform": "macos",
+        }
+    ],
+    "CFBundlePackageType": "XFWK",
+    "XCFrameworkFormatVersion": "1.0",
+}
+with open(sys.argv[1], "wb") as output:
+    plistlib.dump(value, output, sort_keys=True)
+PY
+cp -R "$temp_dir/build-a" "$temp_dir/build-b"
+
+for build_name in a b; do
+  "$SCRIPT_DIR/libvlc-provenance.py" create \
+    --xcframework "$temp_dir/build-$build_name" \
+    --output "$temp_dir/provenance-$build_name.json" \
+    --vlc-source "$temp_dir/fake-vlc" \
+    --source-revision 1111111111111111111111111111111111111111 \
+    --pinned-revision 111111111 \
+    --source-date-epoch 0 \
+    --patch-manifest "$temp_dir/patch-manifest.sha256" \
+    --make-flags=-j1 \
+    --deployment-target macos=15.0
+done
+python3 - "$temp_dir/provenance-a.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+value = json.load(open(path))
+value["build"]["builtAt"] = "2026-01-01T00:00:00Z"
+json.dump(value, open(path, "w"), indent=2, sort_keys=True)
+PY
+"$SCRIPT_DIR/libvlc-provenance.py" compare \
+  --first "$temp_dir/provenance-a.json" \
+  --second "$temp_dir/provenance-b.json" \
+  --output "$temp_dir/reproducibility.json" >/dev/null
+"$SCRIPT_DIR/libvlc-provenance.py" verify \
+  --provenance "$temp_dir/provenance-b.json" \
+  --xcframework "$temp_dir/build-b" \
+  --pinned-revision 111111111 \
+  --patch-manifest "$temp_dir/patch-manifest.sha256" >/dev/null
+"$SCRIPT_DIR/libvlc-provenance.py" verify-proof \
+  --proof "$temp_dir/reproducibility.json" \
+  --provenance "$temp_dir/provenance-b.json" >/dev/null
+
+cp -R "$temp_dir/build-b" "$temp_dir/rebound"
+printf 'int swiftvlc_provenance_fixture(void) { return 2; }\n' > "$temp_dir/member.c"
+xcrun clang -c "$temp_dir/member.c" -o "$temp_dir/member.o"
+ar rcs "$temp_dir/rebound/macos-arm64/libvlc.a" "$temp_dir/member.o"
+"$SCRIPT_DIR/libvlc-provenance.py" rebind \
+  --provenance "$temp_dir/provenance-b.json" \
+  --xcframework "$temp_dir/rebound" \
+  --output "$temp_dir/rebound-provenance.json"
+"$SCRIPT_DIR/libvlc-provenance.py" verify \
+  --provenance "$temp_dir/rebound-provenance.json" \
+  --xcframework "$temp_dir/rebound" \
+  --pinned-revision 111111111 \
+  --patch-manifest "$temp_dir/patch-manifest.sha256" >/dev/null
+"$SCRIPT_DIR/libvlc-provenance.py" verify-proof \
+  --proof "$temp_dir/reproducibility.json" \
+  --provenance "$temp_dir/rebound-provenance.json" >/dev/null
+printf 'mutated\n' > "$temp_dir/rebound/macos-arm64/Headers/libvlc.h"
+if "$SCRIPT_DIR/libvlc-provenance.py" verify \
+  --provenance "$temp_dir/rebound-provenance.json" \
+  --xcframework "$temp_dir/rebound" \
+  --pinned-revision 111111111 \
+  --patch-manifest "$temp_dir/patch-manifest.sha256" >/dev/null 2>&1; then
+  fail "provenance accepted a mutated release slice"
+fi
+
 python3 - "$temp_dir/matrix.json" "$temp_dir/record.json" "$digest_a" <<'PY'
 import json
 import sys


### PR DESCRIPTION
Closes #97.

## Summary

- require an ordered, hash-verified libVLC patch manifest and reject undeclared patches
- record schema-v3 provenance for the exact XCFramework, every slice, the VLC pin, patch order and hashes, all 123 contrib checksum manifests, build flags, assertion mode, host architecture, Xcode/Clang/Swift versions, SDK versions/builds, deployment targets, library hashes, header-tree hashes, and archive-member manifests
- require a verified two-clean-build reproducibility proof before release packaging
- carry provenance and reproducibility metadata into immutable release candidates and publish both as release assets
- fail stale, mutated, or provenance-incomplete artifacts
- normalize known reproducibility hazards: macOS 26 sha512 stdin behavior, compiler date/time macros, archive symbol indexes (including the final post-strip index), and XCFramework library-record order

## Root causes found by real clean builds

1. macOS 26 `/sbin/sha512sum --check /dev/stdin` blocks; the portable `-` operand succeeds.
2. VLC embeds `__DATE__` and `__TIME__` in `libvlccore_la-help.o`; builds now use `SOURCE_DATE_EPOCH=1765735024`, derived from pinned VLC commit `c833c4be000b426d73ff4324bec574065f00e3df`.
3. Apple archive tools emitted different `__.SYMDEF` indexes for byte-identical object members; every thin architecture receives `ranlib -D` before universal reconstruction.
4. `xcodebuild -create-xcframework` serialized `AvailableLibraries` in nondeterministic order; metadata is canonicalized by library identifier.
5. The release `strip -S` pass rebuilt each final `__.SYMDEF` with a wall-clock timestamp after the earlier normalization. The two clean outputs differed by only 4–6 timestamp bytes per slice. The build now runs deterministic `ranlib -D` after stripping, as its final archive mutation.

## Exact reproducibility evidence

Two independent `./scripts/build-libvlc.sh --clean-build --all` runs completed with distinct invocation IDs. The second full eight-platform build completed in 65m23s.

After the committed final normalization:

- all 8 XCFramework slices are byte-identical
- all 12 architecture instances are present
- complete XCFramework tree digest: `22db7ce541d7017c7e3ca41a872310bb6b318ba2dd66b20fc7a44da7d731b397`
- provenance verification passed
- reproducibility-proof verification passed
- duplicate-symbol and Mach-O archive-alignment verification passed for every slice
- all deployment targets passed: iOS/tvOS 18.0, visionOS 2.0, macOS 15.0, Catalyst 18.0

## Validation

Exact head: `2837276a`

- `scripts/tests/release-integrity.sh`: passed
- shell syntax checks: passed
- Python compile check: passed
- patch manifest: 19 ordered patches verified
- full provenance: 8 slices and 123 contrib checksum files verified
- Git whitespace/diff checks: clean
- GitHub CI: running for the final head
