### PR TITLE
Expose generation-scoped playback health

### DIFF
--- a/Sources/SwiftVLC/Core/Broadcaster.swift
+++ b/Sources/SwiftVLC/Core/Broadcaster.swift
@@ -207,6 +207,15 @@ final class Broadcaster<Element: Sendable>: Sendable {
     Signposts.signposter.endInterval("Broadcaster.broadcast", interval, "subs=\(delivered)")
   }
 
+  /// Removes the value retained for future replaying subscribers without
+  /// affecting existing subscriptions or terminating the broadcaster.
+  ///
+  /// Use at an identity boundary where the previous value is still valid for
+  /// consumers that already received it, but must not seed a new subscriber.
+  func clearReplay() {
+    state.withLock { $0.latest = nil }
+  }
+
   private enum Snapshot {
     case none
     case single(Subscriber)

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -743,7 +743,11 @@ public final class PiPController: NSObject {
   }
 
   private func attachCallbacks() {
-    let registration = DirectPiPVideoCallbackRegistration(renderer: renderer)
+    let bridge = player.eventBridge
+    let registration = DirectPiPVideoCallbackRegistration(
+      renderer: renderer,
+      playbackGeneration: { bridge.currentPlaybackGeneration }
+    )
     callbackRegistration = registration
     player.claimDirectPiPVideoCallbacks(registration)
     // Publish the handle the AVKit callback threads will interrogate. Until

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer+Enqueue.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer+Enqueue.swift
@@ -131,9 +131,20 @@ struct PixelBufferDisplayLayerAPI: @unchecked Sendable {
 }
 
 extension PixelBufferRenderer {
-  func canEnqueueFrame(generation: UInt64, on layer: AVSampleBufferDisplayLayer) -> Bool {
-    state.withLock {
-      $0.renderGeneration == generation && $0.displayLayer.layer === layer
+  func canEnqueueFrame(
+    generation: UInt64,
+    on layer: AVSampleBufferDisplayLayer,
+    playbackGeneration: UInt64? = nil,
+    voutGeneration: UInt64? = nil
+  ) -> Bool {
+    let acceptsRendererIdentity = state.withLock { state in
+      state.renderGeneration == generation
+        && state.displayLayer.layer === layer
+        && playbackGeneration.map { $0 == (state.playbackGeneration ?? 0) } != false
+    }
+    guard acceptsRendererIdentity else { return false }
+    return enqueueState.withLock { state in
+      voutGeneration.map { $0 == state.latestVoutGeneration } != false
     }
   }
 
@@ -154,7 +165,23 @@ extension PixelBufferRenderer {
       playbackGeneration: playbackGeneration,
       voutGeneration: voutGeneration
     )
-    let shouldSchedule = enqueueState.withLock { state -> Bool in
+    // `beginPlaybackGeneration` publishes the new identity and clears the
+    // pending slot under this same mutex. A producer therefore either claims
+    // the slot first and is cleared by the boundary, or observes the new
+    // generation and is rejected. It never waits behind AVFoundation's
+    // potentially slow enqueue operation.
+    let shouldSchedule = enqueueState.withLock { state -> Bool? in
+      if
+        let latestPlaybackGeneration = state.latestPlaybackGeneration,
+        latestPlaybackGeneration != playbackGeneration {
+        return nil
+      }
+      // Vout generations are issued monotonically. Once a successor has
+      // appeared, a delayed callback from the retired vout is stale even if
+      // it has the same media and render generation.
+      if let latest = state.latestVoutGeneration, voutGeneration < latest {
+        return nil
+      }
       state.enqueuedFrameCount &+= 1
       state.lastEnqueuedAt = .now
       state.latestPlaybackGeneration = playbackGeneration
@@ -172,7 +199,7 @@ extension PixelBufferRenderer {
       return true
     }
 
-    guard shouldSchedule else { return }
+    guard shouldSchedule == true else { return }
     enqueueQueue.async { [self] in
       drainPendingSamples()
     }
@@ -261,14 +288,28 @@ extension PixelBufferRenderer {
     _ pending: EnqueuedSampleBuffer
   )
     -> PixelBufferSampleDisposition {
-    guard canEnqueueFrame(generation: pending.generation, on: pending.layer) else {
+    guard
+      canEnqueueFrame(
+        generation: pending.generation,
+        on: pending.layer,
+        playbackGeneration: pending.playbackGeneration,
+        voutGeneration: pending.voutGeneration
+      )
+    else {
       return endFlushRecovery()
     }
 
     let shouldFlush = displayLayerAPI.status(pending.layer) == .failed
       || displayLayerAPI.requiresFlush(pending.layer)
     if shouldFlush {
-      guard canEnqueueFrame(generation: pending.generation, on: pending.layer) else {
+      guard
+        canEnqueueFrame(
+          generation: pending.generation,
+          on: pending.layer,
+          playbackGeneration: pending.playbackGeneration,
+          voutGeneration: pending.voutGeneration
+        )
+      else {
         return endFlushRecovery()
       }
       displayLayerAPI.flush(pending.layer)
@@ -309,8 +350,13 @@ extension PixelBufferRenderer {
     let delivered = state.withLock { state -> Bool in
       guard
         state.renderGeneration == pending.generation,
-        state.displayLayer.layer === pending.layer
+        state.displayLayer.layer === pending.layer,
+        (state.playbackGeneration ?? 0) == pending.playbackGeneration
       else { return false }
+      let acceptsVoutGeneration = enqueueState.withLock {
+        $0.latestVoutGeneration == pending.voutGeneration
+      }
+      guard acceptsVoutGeneration else { return false }
       displayLayerAPI.enqueue(pending.layer, pending.sample)
       return true
     }
@@ -348,11 +394,23 @@ extension PixelBufferRenderer {
     -> PixelBufferSampleDisposition {
     // Re-checked because the flush above released the state lock: a
     // replacement or teardown in that window must not resurrect this frame.
-    guard canEnqueueFrame(generation: pending.generation, on: pending.layer) else {
+    guard
+      canEnqueueFrame(
+        generation: pending.generation,
+        on: pending.layer,
+        playbackGeneration: pending.playbackGeneration,
+        voutGeneration: pending.voutGeneration
+      )
+    else {
       return endFlushRecovery()
     }
 
     return enqueueState.withLock { state in
+      guard state.latestVoutGeneration == pending.voutGeneration else {
+        state.flushRecoveryRetryCount = 0
+        state.flushRecoveryGeneration = nil
+        return .handled
+      }
       // A newer frame already claimed the slot. It supersedes this one, and
       // the drain loop picks it up on the next iteration.
       guard state.pending == nil else {

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer+Enqueue.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer+Enqueue.swift
@@ -10,6 +10,8 @@ struct EnqueuedSampleBuffer: @unchecked Sendable {
   let layer: AVSampleBufferDisplayLayer
   let sample: CMSampleBuffer
   let generation: UInt64
+  let playbackGeneration: UInt64
+  let voutGeneration: UInt64
 }
 
 struct PixelBufferEnqueueState: @unchecked Sendable {
@@ -29,6 +31,44 @@ struct PixelBufferEnqueueState: @unchecked Sendable {
   /// non-zero value is the explicit terminal failure the display never
   /// repainted from.
   var flushRecoveryFailureCount: UInt64 = 0
+  var flushRecoveryTotalRetryCount: UInt64 = 0
+  var enqueuedFrameCount: UInt64 = 0
+  var presentedFrameCount: UInt64 = 0
+  var flushCount: UInt64 = 0
+  var backpressureDropCount: UInt64 = 0
+  var lastEnqueuedAt: ContinuousClock.Instant?
+  var lastPresentedAt: ContinuousClock.Instant?
+  var latestPlaybackGeneration: UInt64?
+  var latestVoutGeneration: UInt64?
+  var voutTransitionCount: UInt64 = 0
+  var status: PixelBufferRendererTelemetryStatus = .idle
+}
+
+enum PixelBufferRendererTelemetryStatus: Sendable, Equatable {
+  case idle
+  case rendering
+  case backpressured
+  case recovering
+  case failed
+}
+
+struct PixelBufferRendererTelemetrySnapshot: Sendable, Equatable {
+  let playbackGeneration: UInt64?
+  let voutGeneration: UInt64?
+  let decodedFrameCount: UInt64
+  let enqueuedFrameCount: UInt64
+  let presentedFrameCount: UInt64
+  let droppedFrameCount: UInt64
+  let voutTransitionCount: UInt64
+  let flushCount: UInt64
+  let backpressureDropCount: UInt64
+  let replacementCount: UInt64
+  let flushRecoveryRetryCount: UInt64
+  let flushRecoveryFailureCount: UInt64
+  let lastDecodedAt: ContinuousClock.Instant?
+  let lastEnqueuedAt: ContinuousClock.Instant?
+  let lastPresentedAt: ContinuousClock.Instant?
+  let status: PixelBufferRendererTelemetryStatus
 }
 
 struct PixelBufferEnqueueSnapshot: Equatable {
@@ -103,14 +143,25 @@ extension PixelBufferRenderer {
   func enqueue(
     _ sample: CMSampleBuffer,
     generation: UInt64,
-    on layer: AVSampleBufferDisplayLayer
+    on layer: AVSampleBufferDisplayLayer,
+    playbackGeneration: UInt64 = 0,
+    voutGeneration: UInt64 = 0
   ) {
     let pending = EnqueuedSampleBuffer(
       layer: layer,
       sample: sample,
-      generation: generation
+      generation: generation,
+      playbackGeneration: playbackGeneration,
+      voutGeneration: voutGeneration
     )
     let shouldSchedule = enqueueState.withLock { state -> Bool in
+      state.enqueuedFrameCount &+= 1
+      state.lastEnqueuedAt = .now
+      state.latestPlaybackGeneration = playbackGeneration
+      if state.latestVoutGeneration != voutGeneration {
+        state.voutTransitionCount &+= 1
+        state.latestVoutGeneration = voutGeneration
+      }
       if state.pending != nil {
         state.replacementCount &+= 1
       }
@@ -137,6 +188,32 @@ extension PixelBufferRenderer {
         replacementCount: $0.replacementCount,
         flushRecoveryRetryCount: $0.flushRecoveryRetryCount,
         flushRecoveryFailureCount: $0.flushRecoveryFailureCount
+      )
+    }
+  }
+
+  var telemetrySnapshot: PixelBufferRendererTelemetrySnapshot {
+    let decoded = state.withLock {
+      ($0.decodedFrameCount, $0.lastDecodedAt)
+    }
+    return enqueueState.withLock {
+      PixelBufferRendererTelemetrySnapshot(
+        playbackGeneration: $0.latestPlaybackGeneration,
+        voutGeneration: $0.latestVoutGeneration,
+        decodedFrameCount: decoded.0,
+        enqueuedFrameCount: $0.enqueuedFrameCount,
+        presentedFrameCount: $0.presentedFrameCount,
+        droppedFrameCount: $0.replacementCount &+ $0.backpressureDropCount,
+        voutTransitionCount: $0.voutTransitionCount,
+        flushCount: $0.flushCount,
+        backpressureDropCount: $0.backpressureDropCount,
+        replacementCount: $0.replacementCount,
+        flushRecoveryRetryCount: $0.flushRecoveryTotalRetryCount,
+        flushRecoveryFailureCount: $0.flushRecoveryFailureCount,
+        lastDecodedAt: decoded.1,
+        lastEnqueuedAt: $0.lastEnqueuedAt,
+        lastPresentedAt: $0.lastPresentedAt,
+        status: $0.status
       )
     }
   }
@@ -195,6 +272,10 @@ extension PixelBufferRenderer {
         return endFlushRecovery()
       }
       displayLayerAPI.flush(pending.layer)
+      enqueueState.withLock {
+        $0.flushCount &+= 1
+        $0.status = .recovering
+      }
     }
 
     guard displayLayerAPI.isReadyForMoreMediaData(pending.layer) else {
@@ -208,7 +289,13 @@ extension PixelBufferRenderer {
       }
       // Plain backpressure keeps dropping: the decoder is still producing, so
       // a successor frame is already on its way and the newest one wins.
-      guard shouldFlush || isRecovering else { return .handled }
+      guard shouldFlush || isRecovering else {
+        enqueueState.withLock {
+          $0.backpressureDropCount &+= 1
+          $0.status = .backpressured
+        }
+        return .handled
+      }
       // Flush recovery has no such guarantee. A paused seek, a final frame or
       // a foreground repaint may have no successor at all, so the frame that
       // triggered the flush is the only thing that can repaint the display —
@@ -231,6 +318,9 @@ extension PixelBufferRenderer {
       enqueueState.withLock {
         $0.flushRecoveryRetryCount = 0
         $0.flushRecoveryGeneration = nil
+        $0.presentedFrameCount &+= 1
+        $0.lastPresentedAt = .now
+        $0.status = .rendering
       }
     }
     return .handled
@@ -282,9 +372,12 @@ extension PixelBufferRenderer {
         state.flushRecoveryRetryCount = 0
         state.flushRecoveryGeneration = nil
         state.flushRecoveryFailureCount &+= 1
+        state.status = .failed
         return .handled
       }
       state.flushRecoveryRetryCount &+= 1
+      state.flushRecoveryTotalRetryCount &+= 1
+      state.status = .recovering
       state.pending = pending
       return .deferred
     }

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer.swift
@@ -97,9 +97,8 @@ final class PixelBufferRenderer: Sendable {
     state.withLock { $0.displayLayer.layer = layer }
   }
 
-  /// Starts a new media generation and makes every frame captured before the
-  /// boundary stale. Counters stay cumulative so the low-rate health sampler
-  /// can derive a generation-local delta without resetting the frame hot path.
+  /// Starts a new media generation and makes every frame captured before the boundary stale.
+  /// Counters stay cumulative for generation-local health deltas without resetting the hot path.
   func beginPlaybackGeneration(_ generation: UInt64) {
     let changed = state.withLock { state -> Bool in
       guard state.playbackGeneration != generation else { return false }
@@ -113,6 +112,7 @@ final class PixelBufferRenderer: Sendable {
       $0.flushRecoveryRetryCount = 0
       $0.flushRecoveryGeneration = nil
       $0.latestPlaybackGeneration = generation
+      $0.latestVoutGeneration = nil
       $0.status = .idle
     }
     flushDisplayLayer()

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer.swift
@@ -55,6 +55,9 @@ final class PixelBufferRenderer: Sendable {
     /// the cadence is not known. Never a fabricated default: see
     /// ``PixelBufferRenderer/setFrameDuration(_:)``.
     var frameDuration: CMTime = .invalid
+    var decodedFrameCount: UInt64 = 0
+    var lastDecodedAt: ContinuousClock.Instant?
+    var playbackGeneration: UInt64?
 
     init(displayLayer: AVSampleBufferDisplayLayer?) {
       self.displayLayer = DisplayLayerBox(displayLayer)
@@ -92,6 +95,27 @@ final class PixelBufferRenderer: Sendable {
 
   func setDisplayLayer(_ layer: AVSampleBufferDisplayLayer?) {
     state.withLock { $0.displayLayer.layer = layer }
+  }
+
+  /// Starts a new media generation and makes every frame captured before the
+  /// boundary stale. Counters stay cumulative so the low-rate health sampler
+  /// can derive a generation-local delta without resetting the frame hot path.
+  func beginPlaybackGeneration(_ generation: UInt64) {
+    let changed = state.withLock { state -> Bool in
+      guard state.playbackGeneration != generation else { return false }
+      state.playbackGeneration = generation
+      state.advanceRenderGeneration()
+      return true
+    }
+    guard changed else { return }
+    enqueueState.withLock {
+      $0.pending = nil
+      $0.flushRecoveryRetryCount = 0
+      $0.flushRecoveryGeneration = nil
+      $0.latestPlaybackGeneration = generation
+      $0.status = .idle
+    }
+    flushDisplayLayer()
   }
 
   func setTimebase(_ tb: CMTimebase?) {
@@ -337,12 +361,18 @@ final class DirectPiPVideoCallbackSlot {
   init(
     lifetime: NativePlayerHandleLifetime,
     decodeRenderer: PixelBufferRenderer,
+    playbackGeneration: UInt64 = 0,
+    voutGenerationCounter: PixelBufferVoutGenerationCounter = PixelBufferVoutGenerationCounter(),
     api: DirectPiPVideoCallbackAPI
   ) {
     precondition(!lifetime.isReleased)
     self.lifetime = lifetime
     self.api = api
-    let context = PixelBufferRendererCallbackContext(renderer: decodeRenderer)
+    let context = PixelBufferRendererCallbackContext(
+      renderer: decodeRenderer,
+      playbackGeneration: playbackGeneration,
+      voutGenerationCounter: voutGenerationCounter
+    )
     self.context = context
     let retained = Unmanaged.passRetained(context)
     let opaque = retained.toOpaque()
@@ -407,13 +437,16 @@ final class DirectPiPVideoCallbackRegistration {
 
   private let renderer: PixelBufferRenderer
   private let api: DirectPiPVideoCallbackAPI
+  private let playbackGeneration: @Sendable () -> UInt64
   private var current: Binding?
 
   init(
     renderer: PixelBufferRenderer,
+    playbackGeneration: @escaping @Sendable () -> UInt64 = { 0 },
     api: DirectPiPVideoCallbackAPI = .live
   ) {
     self.renderer = renderer
+    self.playbackGeneration = playbackGeneration
     self.api = api
   }
 
@@ -421,11 +454,17 @@ final class DirectPiPVideoCallbackRegistration {
     DirectPiPVideoCallbackSlot(
       lifetime: lifetime,
       decodeRenderer: renderer,
+      playbackGeneration: playbackGeneration(),
+      voutGenerationCounter: current?.slot.context.voutGenerationSequence
+        ?? PixelBufferVoutGenerationCounter(),
       api: api
     )
   }
 
   func bind(to slot: DirectPiPVideoCallbackSlot, generation: UInt64) {
+    let playbackGeneration = playbackGeneration()
+    slot.context.beginPlaybackGeneration(playbackGeneration)
+    renderer.beginPlaybackGeneration(playbackGeneration)
     slot.activate(renderer: renderer)
     current = Binding(slot: slot, generation: generation)
   }
@@ -454,6 +493,15 @@ final class DirectPiPVideoCallbackRegistration {
   var currentOpaqueForTesting: UnsafeMutableRawPointer? {
     current?.slot.opaque
   }
+
+  var telemetrySnapshot: PixelBufferRendererTelemetrySnapshot {
+    renderer.telemetrySnapshot
+  }
+
+  func beginPlaybackGeneration(_ generation: UInt64) {
+    current?.slot.context.beginPlaybackGeneration(generation)
+    renderer.beginPlaybackGeneration(generation)
+  }
 }
 
 /// Stable object passed to libVLC's vmem callbacks.
@@ -479,13 +527,32 @@ final class PixelBufferRendererCallbackContext: Sendable {
   }
 
   private let state: Mutex<State>
+  private let playbackGeneration: Mutex<UInt64>
+  private let voutGenerationCounter: PixelBufferVoutGenerationCounter
 
-  init(renderer: PixelBufferRenderer) {
+  init(
+    renderer: PixelBufferRenderer,
+    playbackGeneration: UInt64 = 0,
+    voutGenerationCounter: PixelBufferVoutGenerationCounter = PixelBufferVoutGenerationCounter()
+  ) {
     state = Mutex(State(displayRenderer: renderer))
+    self.playbackGeneration = Mutex(playbackGeneration)
+    self.voutGenerationCounter = voutGenerationCounter
+  }
+
+  /// Advances the generation captured by subsequently negotiated vouts.
+  /// Already-open vouts retain their original value and are therefore rejected
+  /// by the display renderer after a media boundary.
+  func beginPlaybackGeneration(_ generation: UInt64) {
+    playbackGeneration.withLock { $0 = generation }
   }
 
   var hasOpenVoutForTesting: Bool {
     state.withLock { $0.openVoutCount > 0 }
+  }
+
+  var voutGenerationSequence: PixelBufferVoutGenerationCounter {
+    voutGenerationCounter
   }
 
   var retirementRequestedForTesting: Bool {
@@ -543,7 +610,9 @@ final class PixelBufferRendererCallbackContext: Sendable {
       handleContext: self,
       handleOpaque: handleOpaque,
       decodeRenderer: decodeRenderer,
-      sourceGeometry: sourceGeometry
+      sourceGeometry: sourceGeometry,
+      playbackGeneration: playbackGeneration.withLock { $0 },
+      voutGeneration: voutGenerationCounter.next()
     )
   }
 
@@ -621,6 +690,7 @@ final class PixelBufferRendererVoutCallbackContext: @unchecked Sendable {
     let buffer: CVPixelBuffer
     let opaque: UnsafeMutableRawPointer
     var isLocked: Bool
+    let playbackGeneration: UInt64
   }
 
   private struct LifecycleState: @unchecked Sendable {
@@ -630,20 +700,26 @@ final class PixelBufferRendererVoutCallbackContext: @unchecked Sendable {
 
   let decodeRenderer: PixelBufferRenderer
   let sourceGeometry: PixelBufferSourceGeometry
+  let voutGeneration: UInt64
   private let handleContext: PixelBufferRendererCallbackContext
   private let handleOpaque: UnsafeMutableRawPointer
   private let lifecycleState = Mutex(LifecycleState())
+  private let playbackGeneration: UInt64
 
   init(
     handleContext: PixelBufferRendererCallbackContext,
     handleOpaque: UnsafeMutableRawPointer,
     decodeRenderer: PixelBufferRenderer,
-    sourceGeometry: PixelBufferSourceGeometry
+    sourceGeometry: PixelBufferSourceGeometry,
+    playbackGeneration: UInt64,
+    voutGeneration: UInt64
   ) {
     self.handleContext = handleContext
     self.handleOpaque = handleOpaque
     self.decodeRenderer = decodeRenderer
     self.sourceGeometry = sourceGeometry
+    self.playbackGeneration = playbackGeneration
+    self.voutGeneration = voutGeneration
   }
 
   func withDisplayRenderer<T>(
@@ -669,7 +745,8 @@ final class PixelBufferRendererVoutCallbackContext: @unchecked Sendable {
       state.pendingPicture = PendingPicture(
         buffer: buffer,
         opaque: opaque,
-        isLocked: isLocked
+        isLocked: isLocked,
+        playbackGeneration: playbackGeneration
       )
       return true
     }
@@ -695,15 +772,15 @@ final class PixelBufferRendererVoutCallbackContext: @unchecked Sendable {
   /// dereference an already-drained picture.
   func consumePendingPicture(
     matching opaque: UnsafeMutableRawPointer
-  ) -> CVPixelBuffer? {
-    lifecycleState.withLock { state -> CVPixelBuffer? in
+  ) -> (buffer: CVPixelBuffer, playbackGeneration: UInt64)? {
+    lifecycleState.withLock { state -> (CVPixelBuffer, UInt64)? in
       guard state.pendingPicture?.opaque == opaque else { return nil }
       if state.pendingPicture?.isLocked == true {
         CVPixelBufferUnlockBaseAddress(state.pendingPicture!.buffer, [])
       }
-      let buffer = state.pendingPicture?.buffer
+      guard let pending = state.pendingPicture else { return nil }
       state.pendingPicture = nil
-      return buffer
+      return (pending.buffer, pending.playbackGeneration)
     }
   }
 
@@ -826,10 +903,21 @@ func pixelBufferDisplayCallback(
   guard
     let picture,
     let context = pixelBufferVoutCallbackContext(from: opaque),
-    let pb = context.consumePendingPicture(matching: picture)
+    let consumed = context.consumePendingPicture(matching: picture)
   else { return }
 
+  let pb = consumed.buffer
+  let playbackGeneration = consumed.playbackGeneration
+
   _ = context.withDisplayRenderer { renderer in
+    let acceptsPlaybackGeneration = renderer.state.withLock {
+      $0.playbackGeneration == playbackGeneration
+    }
+    guard acceptsPlaybackGeneration else { return }
+    renderer.state.withLock {
+      $0.decodedFrameCount &+= 1
+      $0.lastDecodedAt = .now
+    }
     guard let output = renderer.outputPixelBuffer(from: pb) else { return }
     let outputBuffer = output.buffer
     let renderGeneration = output.generation
@@ -887,7 +975,13 @@ func pixelBufferDisplayCallback(
     }
     // CMSampleBuffer is a CF type that lacks Sendable conformance but is thread-safe for read access
     nonisolated(unsafe) let sample = sb
-    renderer.enqueue(sample, generation: renderGeneration, on: layer)
+    renderer.enqueue(
+      sample,
+      generation: renderGeneration,
+      on: layer,
+      playbackGeneration: playbackGeneration,
+      voutGeneration: context.voutGeneration
+    )
   }
 }
 

--- a/Sources/SwiftVLC/PiP/PixelBufferVoutGenerationCounter.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferVoutGenerationCounter.swift
@@ -1,0 +1,15 @@
+import Synchronization
+
+/// Supplies one vout identity sequence across same-controller native-handle
+/// replacements. It is deliberately independent of renderer ownership so a
+/// retired handle can finish callbacks without keeping the old renderer alive.
+final class PixelBufferVoutGenerationCounter: Sendable {
+  private let value = Mutex<UInt64>(0)
+
+  func next() -> UInt64 {
+    value.withLock {
+      $0 &+= 1
+      return $0
+    }
+  }
+}

--- a/Sources/SwiftVLC/Player/PlaybackHealth.swift
+++ b/Sources/SwiftVLC/Player/PlaybackHealth.swift
@@ -1,0 +1,234 @@
+/// The kind of media currently making forward playback progress.
+public enum PlaybackContentKind: Sendable, Hashable {
+  /// Audio is progressing and the session has no observed video output.
+  case audioOnly
+  /// Video is progressing and no audio progress has been observed.
+  case videoOnly
+  /// Audio and video are both progressing.
+  case audiovisual
+}
+
+/// A non-terminal reason playback has not yet produced its next presentation.
+public enum PlaybackWaitingReason: Sendable, Hashable {
+  /// The input is still opening.
+  case opening
+  /// libVLC is filling its input buffer.
+  case buffering
+  /// Playback has started but the first video frame has not been presented.
+  case firstFrame
+  /// An accepted seek is waiting for presentation on the new timeline.
+  case seeking
+  /// A track/representation change is waiting for its first new presentation.
+  case adaptiveSwitch
+}
+
+/// The pipeline stage that has stopped making progress.
+public enum PlaybackStallReason: Sendable, Hashable {
+  /// No source or demux bytes are arriving.
+  case source
+  /// Source bytes are arriving but neither decoder is advancing.
+  case decoder
+  /// Video is decoding but no frame reaches presentation.
+  case display
+  /// Audio is decoding but no audio buffer reaches the output.
+  case audioOutput
+  /// The sample-buffer renderer is applying bounded flush recovery.
+  case rendererRecovery
+}
+
+/// Terminal playback-health failures.
+public enum PlaybackHealthFailure: Sendable, Hashable {
+  /// libVLC emitted an unrecoverable player error.
+  case player
+  /// The display renderer exhausted ten 16-millisecond flush retries.
+  ///
+  /// The failure is observed on the next health sample, so under normal
+  /// scheduling the typed terminal event arrives within about 410 milliseconds
+  /// of recovery beginning. System-level queue starvation can delay delivery.
+  case renderer
+}
+
+/// Current semantic playback-health classification.
+public enum PlaybackHealthState: Sendable, Hashable {
+  /// No media is actively progressing.
+  case idle
+  /// Playback is paused intentionally; lack of progress is not a stall.
+  case paused
+  /// Playback is waiting for an expected pipeline transition.
+  case waiting(PlaybackWaitingReason)
+  /// The observed media pipeline is making forward progress.
+  case healthy(PlaybackContentKind)
+  /// The identified pipeline stage has not progressed for the stall threshold.
+  case stalled(PlaybackStallReason)
+  /// Playback cannot recover without a new command or media session.
+  case failed(PlaybackHealthFailure)
+}
+
+/// Coarse status of the direct sample-buffer renderer.
+public enum PlaybackRendererStatus: Sendable, Hashable {
+  /// The current playback route does not expose renderer telemetry.
+  case unavailable
+  /// A renderer exists but has not accepted a frame yet.
+  case idle
+  /// Frames are reaching the display layer.
+  case rendering
+  /// The newest frame is replacing older work while the layer is saturated.
+  case backpressured
+  /// A flushed frame is being re-offered within the bounded retry budget.
+  case recovering
+  /// Bounded renderer recovery was exhausted.
+  case failed
+}
+
+/// Bounded cumulative counters for one playback generation.
+public struct PlaybackHealthCounters: Sendable, Hashable {
+  /// Bytes read from the current input.
+  public let sourceReadBytes: UInt64
+  /// Bytes delivered by the demuxer for the current media.
+  public let demuxReadBytes: UInt64
+  /// Video frames decoded in this playback generation.
+  public let decodedVideoFrames: UInt64
+  /// Audio buffers decoded in this playback generation.
+  public let decodedAudioFrames: UInt64
+  /// Video frames offered to the direct sample-buffer renderer.
+  public let enqueuedVideoFrames: UInt64
+  /// Video frames accepted by the native or direct presentation path.
+  public let presentedVideoFrames: UInt64
+  /// Audio buffers accepted by the audio output.
+  public let playedAudioBuffers: UInt64
+  /// Video frames lost by libVLC or the direct renderer.
+  public let droppedVideoFrames: UInt64
+  /// Video frames reported late by libVLC.
+  public let lateVideoFrames: UInt64
+  /// Direct-renderer video-output generations created during playback.
+  public let rendererRebuilds: UInt64
+  /// Direct-renderer flushes used to resume presentation.
+  public let rendererFlushes: UInt64
+  /// Direct-renderer frames dropped because its queue was saturated.
+  public let rendererBackpressureDrops: UInt64
+  /// Pending direct-renderer frames superseded by a newer frame.
+  public let rendererFrameReplacements: UInt64
+  /// Attempts to re-offer a frame after a direct-renderer flush.
+  public let rendererRecoveryRetries: UInt64
+  /// Direct-renderer frames that exhausted bounded flush recovery.
+  public let rendererRecoveryFailures: UInt64
+
+  init(
+    sourceReadBytes: UInt64 = 0,
+    demuxReadBytes: UInt64 = 0,
+    decodedVideoFrames: UInt64 = 0,
+    decodedAudioFrames: UInt64 = 0,
+    enqueuedVideoFrames: UInt64 = 0,
+    presentedVideoFrames: UInt64 = 0,
+    playedAudioBuffers: UInt64 = 0,
+    droppedVideoFrames: UInt64 = 0,
+    lateVideoFrames: UInt64 = 0,
+    rendererRebuilds: UInt64 = 0,
+    rendererFlushes: UInt64 = 0,
+    rendererBackpressureDrops: UInt64 = 0,
+    rendererFrameReplacements: UInt64 = 0,
+    rendererRecoveryRetries: UInt64 = 0,
+    rendererRecoveryFailures: UInt64 = 0
+  ) {
+    self.sourceReadBytes = sourceReadBytes
+    self.demuxReadBytes = demuxReadBytes
+    self.decodedVideoFrames = decodedVideoFrames
+    self.decodedAudioFrames = decodedAudioFrames
+    self.enqueuedVideoFrames = enqueuedVideoFrames
+    self.presentedVideoFrames = presentedVideoFrames
+    self.playedAudioBuffers = playedAudioBuffers
+    self.droppedVideoFrames = droppedVideoFrames
+    self.lateVideoFrames = lateVideoFrames
+    self.rendererRebuilds = rendererRebuilds
+    self.rendererFlushes = rendererFlushes
+    self.rendererBackpressureDrops = rendererBackpressureDrops
+    self.rendererFrameReplacements = rendererFrameReplacements
+    self.rendererRecoveryRetries = rendererRecoveryRetries
+    self.rendererRecoveryFailures = rendererRecoveryFailures
+  }
+}
+
+/// Low-rate, generation-scoped playback-health state.
+///
+/// Frame timestamps are monotonic durations since this media generation began,
+/// not wall-clock dates. Direct rendering is sampled at most four times per
+/// second; no public event is emitted on every decoded frame.
+public struct PlaybackHealthSnapshot: Sendable, Hashable {
+  /// Media generation to which every value in the snapshot belongs.
+  public let generation: PlaybackGeneration
+  /// Current semantic classification of the playback pipeline.
+  public let state: PlaybackHealthState
+  /// Monotonic snapshot revision within this player instance.
+  public let revision: UInt64
+  /// Elapsed generation time of the latest decoded video frame.
+  public let lastDecodedAt: Duration?
+  /// Elapsed generation time of the latest direct-renderer enqueue.
+  public let lastEnqueuedAt: Duration?
+  /// Elapsed generation time of the latest presented video frame.
+  public let lastPresentedAt: Duration?
+  /// Current state of the direct sample-buffer renderer.
+  public let rendererStatus: PlaybackRendererStatus
+  /// Monotonic direct-renderer vout identity, or `nil` on native routes.
+  public let voutGeneration: UInt64?
+  /// Cumulative pipeline counters for this media generation.
+  public let counters: PlaybackHealthCounters
+  /// Most recent stall in this generation, retained after recovery so a late
+  /// subscriber can reconstruct the paired stall/recovery transition.
+  public let lastStallReason: PlaybackStallReason?
+  /// Elapsed generation time when the most recent stall began.
+  public let lastStalledAt: Duration?
+  /// Elapsed generation time when the most recent stall recovered.
+  public let lastRecoveredAt: Duration?
+
+  init(
+    generation: PlaybackGeneration,
+    state: PlaybackHealthState,
+    revision: UInt64,
+    lastDecodedAt: Duration? = nil,
+    lastEnqueuedAt: Duration? = nil,
+    lastPresentedAt: Duration? = nil,
+    rendererStatus: PlaybackRendererStatus = .unavailable,
+    voutGeneration: UInt64? = nil,
+    counters: PlaybackHealthCounters = PlaybackHealthCounters(),
+    lastStallReason: PlaybackStallReason? = nil,
+    lastStalledAt: Duration? = nil,
+    lastRecoveredAt: Duration? = nil
+  ) {
+    self.generation = generation
+    self.state = state
+    self.revision = revision
+    self.lastDecodedAt = lastDecodedAt
+    self.lastEnqueuedAt = lastEnqueuedAt
+    self.lastPresentedAt = lastPresentedAt
+    self.rendererStatus = rendererStatus
+    self.voutGeneration = voutGeneration
+    self.counters = counters
+    self.lastStallReason = lastStallReason
+    self.lastStalledAt = lastStalledAt
+    self.lastRecoveredAt = lastRecoveredAt
+  }
+}
+
+/// A semantic transition on the playback-health timeline.
+public enum PlaybackHealthEventKind: Sendable, Hashable {
+  /// The first video frame was decoded for this media generation.
+  case firstDecodedFrame
+  /// The first video frame was presented for this media generation.
+  case firstPresentedFrame
+  /// Playback entered an expected non-terminal wait.
+  case waiting(PlaybackWaitingReason)
+  /// A pipeline stage exceeded the stall threshold.
+  case stalled(PlaybackStallReason)
+  /// Forward progress resumed after the identified stall.
+  case recovered(from: PlaybackStallReason)
+  /// Playback reached a typed failure that requires external action.
+  case terminalFailure(PlaybackHealthFailure)
+}
+
+/// A playback-health transition together with the state it produced.
+public struct PlaybackHealthEvent: Sendable, Hashable {
+  /// Semantic transition represented by this event.
+  public let kind: PlaybackHealthEventKind
+  /// Snapshot produced by the transition.
+  public let snapshot: PlaybackHealthSnapshot
+}

--- a/Sources/SwiftVLC/Player/Player+EventStreams.swift
+++ b/Sources/SwiftVLC/Player/Player+EventStreams.swift
@@ -1,0 +1,78 @@
+/// Public and internal streams sourced from the player's native event bridge.
+extension Player {
+  /// Raw event stream for custom processing, with the default buffering
+  /// policy (`.newest(64)`) and no filter.
+  /// Most consumers should use `@Observable` properties instead.
+  /// See ``events(policy:filter:)`` for the delivery guarantees and their
+  /// limits.
+  public nonisolated var events: AsyncStream<PlayerEvent> {
+    eventBridge.makeStream(policy: .newest(64), filter: nil)
+  }
+
+  /// Raw event stream with an explicit buffering policy and an optional
+  /// per-subscription filter.
+  ///
+  /// The default `.newest(64)` policy bounds memory but is lossy: a
+  /// consumer stalled past 64 undelivered events silently loses the
+  /// oldest ones, which can include one-shot terminal transitions such as
+  /// `.stateChanged(.stopped)` or ``PlayerEvent/endReached-enum.case``. Consumers
+  /// that must not miss those should pass `.unbounded`, ideally with a
+  /// `filter` that keeps the `timeChanged`/`positionChanged` firehose out
+  /// of the buffer.
+  ///
+  /// `filter` runs on libVLC's event thread for every event, outside any
+  /// SwiftVLC lock — keep it fast and never block in it. Don't touch
+  /// main-actor state from it: beyond the usual isolation rules, native
+  /// teardown (handle replacement, player deinit) joins the event thread
+  /// while detaching callbacks, so a filter blocked on the main actor
+  /// can deadlock teardown against the very thread it is stalling.
+  ///
+  /// A delivery limit that no policy removes: when the player replaces
+  /// its native handle (stopping drawable-hosted playback does this
+  /// lazily, and ``recast(to:)``-style renderer changes do it
+  /// mid-session), the bridge reattaches to the replacement handle before
+  /// the old one finishes stopping on a background queue. Terminal events
+  /// of the *swapped-out* handle are never delivered to any stream; state
+  /// derived from them is reset by the swap itself.
+  public nonisolated func events(
+    policy: EventBufferingPolicy = .newest(64),
+    filter: (@Sendable (PlayerEvent) -> Bool)? = nil
+  ) -> AsyncStream<PlayerEvent> {
+    eventBridge.makeStream(policy: policy, filter: filter)
+  }
+
+  /// Lossless stream of lifecycle state transitions — no firehose.
+  ///
+  /// Carries every change of ``state``, so a lagging consumer can never lose
+  /// a one-shot terminal transition. Memory is bounded in practice by the low
+  /// rate of state changes.
+  ///
+  /// Driven by the state itself rather than by the raw `.stateChanged` event,
+  /// which is what makes it *complete*. libVLC reports a native failure as
+  /// `.encounteredError` and buffering as `.bufferingProgress`, so neither
+  /// ever produced a `.stateChanged` to forward: a stream built by filtering
+  /// raw events silently omitted every transition to ``PlayerState/error``
+  /// and ``PlayerState/buffering``. Anything waiting on `.error` here waited
+  /// for something that could not arrive.
+  ///
+  /// Buffering is published at most once per entry into it — repeated
+  /// progress reports do not re-announce the state — so completeness does not
+  /// cost the no-firehose guarantee.
+  ///
+  /// Not de-duplicated: the same state published twice is delivered twice.
+  /// Same-player media replacement currently restarts a session on a repeated
+  /// `.playing`, so suppressing repeats would break it until events carry a
+  /// media generation to distinguish sessions by. Treat a value as "the
+  /// current state", not as "a value that differs from the last one".
+  public nonisolated var stateTransitions: AsyncStream<PlayerState> {
+    // Explicitly unbounded. `subscribe()` defaults to newest-64, which would
+    // make a stream documented as lossless silently drop the oldest pending
+    // transitions under a stalled consumer — losing exactly the one-shot
+    // terminal states this exists to protect.
+    stateTransitionBridge.subscribe(policy: .unbounded)
+  }
+
+  nonisolated var playbackIntentEvents: AsyncStream<Bool> {
+    playbackIntentBridge.subscribe()
+  }
+}

--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -179,7 +179,7 @@ extension Player {
     case .tracksChanged:
       let previousVideoTracks = videoTracks
       refreshTracks()
-      if videoTracks != previousVideoTracks {
+      if Self.playbackHealthVideoTracksDiffer(previousVideoTracks, videoTracks) {
         markPlaybackHealthAdaptiveSwitch()
       }
       // Adaptive streams can switch resolution mid-stream without any
@@ -322,6 +322,9 @@ extension Player {
   // MARK: - Playback state + intent publication
 
   func publishPlaybackState(_ newState: PlayerState) {
+    if newState == .playing, state != .playing {
+      rearmPlaybackHealthAfterEnteringPlaying()
+    }
     state = newState
     withMutation(keyPath: \.isActive) {}
     // The single funnel for `state`, and therefore the only place that can
@@ -463,9 +466,6 @@ extension Player {
     // New media, new timeline: clock samples still queued from the previous
     // one describe a media that is no longer loaded and must not be applied.
     acceptedTimelineRevision = eventBridge.advanceTimelineRevision()
-    #if os(iOS) || os(macOS)
-    directPiPVideoCallbackRegistration?.beginPlaybackGeneration(sessionGeneration)
-    #endif
     // `duration` and `isSeekable` publish the capability snapshot from their
     // own `didSet`, so clearing them one at a time would briefly expose
     // "duration cleared, seekability still the previous media's". Suppress

--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -177,7 +177,11 @@ extension Player {
       performDeferredPauseCommandIfNeeded()
 
     case .tracksChanged:
+      let previousVideoTracks = videoTracks
       refreshTracks()
+      if videoTracks != previousVideoTracks {
+        markPlaybackHealthAdaptiveSwitch()
+      }
       // Adaptive streams can switch resolution mid-stream without any
       // dedicated size event; libVLC reports the change through the
       // track list (ES selection/update), so re-signal the decoded
@@ -328,6 +332,8 @@ extension Player {
     // produced a `.stateChanged` to forward.
     stateTransitionBridge.broadcast(newState)
     publishPlaybackStatus()
+    samplePlaybackHealth()
+    reconcilePlaybackHealthSamplingTask()
   }
 
   /// Republishes the current state paired with the session it belongs to.
@@ -457,6 +463,9 @@ extension Player {
     // New media, new timeline: clock samples still queued from the previous
     // one describe a media that is no longer loaded and must not be applied.
     acceptedTimelineRevision = eventBridge.advanceTimelineRevision()
+    #if os(iOS) || os(macOS)
+    directPiPVideoCallbackRegistration?.beginPlaybackGeneration(sessionGeneration)
+    #endif
     // `duration` and `isSeekable` publish the capability snapshot from their
     // own `didSet`, so clearing them one at a time would briefly expose
     // "duration cleared, seekability still the previous media's". Suppress
@@ -510,6 +519,7 @@ extension Player {
     // generation carrying the outgoing media's capability — which would make
     // it distrust the poll for the rest of that media's lifetime.
     advanceCapabilityGeneration()
+    resetPlaybackHealth()
   }
 
   /// Re-applies the latest user intent to a media generation advanced by the

--- a/Sources/SwiftVLC/Player/Player+PlaybackHealth.swift
+++ b/Sources/SwiftVLC/Player/Player+PlaybackHealth.swift
@@ -26,8 +26,10 @@ struct PlaybackHealthMonitoringState {
   var previousCounters = PlaybackHealthCounters()
   var lastSourceProgressAt = ContinuousClock.now
   var lastDecodedProgressAt = ContinuousClock.now
+  var lastAudioDecodedProgressAt = ContinuousClock.now
   var lastPresentedProgressAt = ContinuousClock.now
   var lastAudioProgressAt = ContinuousClock.now
+  var activePlaybackBeganAt = ContinuousClock.now
   var firstDecodedEmitted = false
   var firstPresentedEmitted = false
   var pendingWaitingReason: PlaybackWaitingReason?
@@ -35,6 +37,7 @@ struct PlaybackHealthMonitoringState {
   var pendingPresentedBaseline: UInt64 = 0
   var pendingAudioBaseline: UInt64 = 0
   var lastStallReason: PlaybackStallReason?
+  var activeStallReason: PlaybackStallReason?
   var lastStalledAt: Duration?
   var lastRecoveredAt: Duration?
   var observedRendererFlushes: UInt64 = 0
@@ -50,8 +53,10 @@ struct PlaybackHealthMonitoringState {
     previousCounters = PlaybackHealthCounters()
     lastSourceProgressAt = now
     lastDecodedProgressAt = now
+    lastAudioDecodedProgressAt = now
     lastPresentedProgressAt = now
     lastAudioProgressAt = now
+    activePlaybackBeganAt = now
     firstDecodedEmitted = false
     firstPresentedEmitted = false
     pendingWaitingReason = nil
@@ -59,6 +64,7 @@ struct PlaybackHealthMonitoringState {
     pendingPresentedBaseline = 0
     pendingAudioBaseline = 0
     lastStallReason = nil
+    activeStallReason = nil
     lastStalledAt = nil
     lastRecoveredAt = nil
     observedRendererFlushes = 0
@@ -101,6 +107,9 @@ extension Player {
 
   func resetPlaybackHealth() {
     playbackHealthEventBridge.clearReplay()
+    #if os(iOS) || os(macOS)
+    directPiPVideoCallbackRegistration?.beginPlaybackGeneration(sessionGeneration)
+    #endif
     let renderer = capturePlaybackRendererHealth()
     playbackHealthMonitoringState.reset(
       generation: sessionGeneration,
@@ -127,12 +136,47 @@ extension Player {
 
   private func markPlaybackHealthWaiting(_ reason: PlaybackWaitingReason) {
     let now = ContinuousClock.now
+    let renderer = capturePlaybackRendererHealth()
+    let counters = makePlaybackHealthCounters(renderer: renderer)
+    updatePlaybackHealthProgress(counters: counters, renderer: renderer, now: now)
+    guard counters.rendererRecoveryFailures == 0 else {
+      clearPlaybackHealthWaiting()
+      publishPlaybackHealth(
+        state: .failed(.renderer),
+        counters: counters,
+        renderer: renderer,
+        now: now
+      )
+      reconcilePlaybackHealthSamplingTask()
+      return
+    }
     playbackHealthMonitoringState.pendingWaitingReason = reason
     playbackHealthMonitoringState.pendingWaitingBeganAt = now
-    playbackHealthMonitoringState.pendingPresentedBaseline = playbackHealth.counters.presentedVideoFrames
-    playbackHealthMonitoringState.pendingAudioBaseline = playbackHealth.counters.playedAudioBuffers
-    samplePlaybackHealth()
+    playbackHealthMonitoringState.pendingPresentedBaseline = counters.presentedVideoFrames
+    playbackHealthMonitoringState.pendingAudioBaseline = counters.playedAudioBuffers
+    // Publish from the exact counters used as the baseline. Sampling again
+    // here would let progress that predates the command clear the wait before
+    // any subscriber can observe it.
+    publishPlaybackHealth(
+      state: .waiting(reason),
+      counters: counters,
+      renderer: renderer,
+      now: now
+    )
     reconcilePlaybackHealthSamplingTask()
+  }
+
+  /// Grants a fresh progress window when intentional inactivity ends.
+  /// Generation clocks remain generation-relative for event timestamps; only
+  /// the stall clocks are rearmed.
+  func rearmPlaybackHealthAfterEnteringPlaying() {
+    let now = ContinuousClock.now
+    playbackHealthMonitoringState.lastSourceProgressAt = now
+    playbackHealthMonitoringState.lastDecodedProgressAt = now
+    playbackHealthMonitoringState.lastAudioDecodedProgressAt = now
+    playbackHealthMonitoringState.lastPresentedProgressAt = now
+    playbackHealthMonitoringState.lastAudioProgressAt = now
+    playbackHealthMonitoringState.activePlaybackBeganAt = now
   }
 
   func reconcilePlaybackHealthSamplingTask() {
@@ -165,10 +209,10 @@ extension Player {
 
   func samplePlaybackHealth() {
     if playbackHealthMonitoringState.generation != sessionGeneration {
-      playbackHealthMonitoringState.reset(
-        generation: sessionGeneration,
-        rendererBaseline: capturePlaybackRendererHealth()
-      )
+      // Recast and externally adopted generations can advance without a media
+      // reset. Use the full boundary operation so replay and direct-renderer
+      // telemetry cannot remain stamped with the predecessor generation.
+      resetPlaybackHealth()
     }
 
     let now = ContinuousClock.now
@@ -189,7 +233,7 @@ extension Player {
       clearPlaybackHealthWaiting()
       return .idle
     case .paused:
-      if renderer?.recoveryFailures ?? 0 > 0, renderer?.status == .failed {
+      if counters.rendererRecoveryFailures > 0 {
         clearPlaybackHealthWaiting()
         return .failed(.renderer)
       }
@@ -209,7 +253,7 @@ extension Player {
       break
     }
 
-    if renderer?.recoveryFailures ?? 0 > 0, renderer?.status == .failed {
+    if counters.rendererRecoveryFailures > 0 {
       return .failed(.renderer)
     }
     if renderer?.status == .recovering {
@@ -217,10 +261,10 @@ extension Player {
     }
 
     let hasVideo = activeVideoOutputs > 0
-      || !videoTracks.isEmpty
+      || videoTracks.contains(where: \.isSelected)
       || counters.decodedVideoFrames > 0
       || counters.presentedVideoFrames > 0
-    let hasAudio = !audioTracks.isEmpty
+    let hasAudio = audioTracks.contains(where: \.isSelected)
       || counters.decodedAudioFrames > 0
       || counters.playedAudioBuffers > 0
 
@@ -243,14 +287,33 @@ extension Player {
     if hasVideo {
       if
         counters.presentedVideoFrames == 0,
-        playbackHealthMonitoringState.startedAt.duration(to: now)
+        playbackHealthMonitoringState.activePlaybackBeganAt.duration(to: now)
         < Self.playbackHealthStallThreshold {
         return .waiting(.firstFrame)
       }
+      let videoIsProgressing = playbackHealthMonitoringState.lastPresentedProgressAt
+        .duration(to: now) < Self.playbackHealthStallThreshold
+      let audioIsProgressing = playbackHealthMonitoringState.lastAudioProgressAt
+        .duration(to: now) < Self.playbackHealthStallThreshold
       if
-        playbackHealthMonitoringState.lastPresentedProgressAt.duration(to: now)
+        hasAudio,
+        counters.playedAudioBuffers == 0,
+        playbackHealthMonitoringState.activePlaybackBeganAt.duration(to: now)
         < Self.playbackHealthStallThreshold {
+        return .waiting(.firstFrame)
+      }
+      if videoIsProgressing, !hasAudio || audioIsProgressing {
         return .healthy(contentKind(hasVideo: true, hasAudio: hasAudio))
+      }
+      if videoIsProgressing, hasAudio {
+        if
+          playbackHealthMonitoringState.lastAudioDecodedProgressAt.duration(to: now)
+          < Self.playbackHealthStallThreshold {
+          return .stalled(.audioOutput)
+        }
+        // Video presentation proves the shared source is still progressing;
+        // the missing audio progress is therefore downstream of the source.
+        return .stalled(.decoder)
       }
       if
         playbackHealthMonitoringState.lastDecodedProgressAt.duration(to: now)
@@ -267,12 +330,18 @@ extension Player {
 
     if hasAudio {
       if
+        counters.playedAudioBuffers == 0,
+        playbackHealthMonitoringState.activePlaybackBeganAt.duration(to: now)
+        < Self.playbackHealthStallThreshold {
+        return .waiting(.firstFrame)
+      }
+      if
         playbackHealthMonitoringState.lastAudioProgressAt.duration(to: now)
         < Self.playbackHealthStallThreshold {
         return .healthy(.audioOnly)
       }
       if
-        playbackHealthMonitoringState.lastDecodedProgressAt.duration(to: now)
+        playbackHealthMonitoringState.lastAudioDecodedProgressAt.duration(to: now)
         < Self.playbackHealthStallThreshold {
         return .stalled(.audioOutput)
       }
@@ -285,7 +354,7 @@ extension Player {
     }
 
     if
-      playbackHealthMonitoringState.startedAt.duration(to: now)
+      playbackHealthMonitoringState.activePlaybackBeganAt.duration(to: now)
       < Self.playbackHealthStallThreshold {
       return .waiting(.firstFrame)
     }
@@ -318,10 +387,11 @@ extension Player {
       || counters.demuxReadBytes > previous.demuxReadBytes {
       playbackHealthMonitoringState.lastSourceProgressAt = now
     }
-    if
-      counters.decodedVideoFrames > previous.decodedVideoFrames
-      || counters.decodedAudioFrames > previous.decodedAudioFrames {
+    if counters.decodedVideoFrames > previous.decodedVideoFrames {
       playbackHealthMonitoringState.lastDecodedProgressAt = renderer?.lastDecodedAt ?? now
+    }
+    if counters.decodedAudioFrames > previous.decodedAudioFrames {
+      playbackHealthMonitoringState.lastAudioDecodedProgressAt = now
     }
     if counters.presentedVideoFrames > previous.presentedVideoFrames {
       playbackHealthMonitoringState.lastPresentedProgressAt = renderer?.lastPresentedAt ?? now
@@ -426,6 +496,7 @@ extension Player {
       case .stalled(let reason) = newState,
       previousState != newState {
       playbackHealthMonitoringState.lastStallReason = reason
+      playbackHealthMonitoringState.activeStallReason = reason
       playbackHealthMonitoringState.lastStalledAt = elapsed(to: now)
       eventKinds.append(.stalled(reason))
     } else if
@@ -435,9 +506,10 @@ extension Player {
     }
 
     if
-      case .stalled(let reason) = previousState,
+      let reason = playbackHealthMonitoringState.activeStallReason,
       case .healthy = newState {
       playbackHealthMonitoringState.lastRecoveredAt = elapsed(to: now)
+      playbackHealthMonitoringState.activeStallReason = nil
       eventKinds.append(.recovered(from: reason))
     } else if
       !completedUnobservedRendererRecovery,
@@ -445,6 +517,7 @@ extension Player {
       renderer?.status == .rendering {
       playbackHealthMonitoringState.lastRecoveredAt = elapsed(to: renderer?.lastPresentedAt)
         ?? elapsed(to: now)
+      playbackHealthMonitoringState.activeStallReason = nil
       eventKinds.append(.recovered(from: .rendererRecovery))
     }
     if
@@ -488,6 +561,29 @@ extension Player {
 
   private func subtractingWithoutUnderflow(_ lhs: UInt64, _ rhs: UInt64) -> UInt64 {
     lhs >= rhs ? lhs - rhs : 0
+  }
+
+  /// `Track` identity intentionally compares only IDs. Health needs to notice
+  /// adaptive metadata changes that retain an ES ID, so compare the complete
+  /// video description in a stable ID order instead.
+  static func playbackHealthVideoTracksDiffer(_ lhs: [Track], _ rhs: [Track]) -> Bool {
+    guard lhs.count == rhs.count else { return true }
+    let left = lhs.sorted { $0.id < $1.id }
+    let right = rhs.sorted { $0.id < $1.id }
+    return zip(left, right).contains { left, right in
+      left.id != right.id
+        || left.type != right.type
+        || left.name != right.name
+        || left.codec != right.codec
+        || left.language != right.language
+        || left.trackDescription != right.trackDescription
+        || left.isSelected != right.isSelected
+        || left.bitrate != right.bitrate
+        || left.width != right.width
+        || left.height != right.height
+        || left.frameRate != right.frameRate
+        || left.frameRateRatio != right.frameRateRatio
+    }
   }
 
   private func capturePlaybackRendererHealth() -> PlaybackRendererHealthSample? {

--- a/Sources/SwiftVLC/Player/Player+PlaybackHealth.swift
+++ b/Sources/SwiftVLC/Player/Player+PlaybackHealth.swift
@@ -1,0 +1,540 @@
+import Foundation
+
+struct PlaybackRendererHealthSample: Sendable, Equatable {
+  var playbackGeneration: UInt64?
+  var voutGeneration: UInt64?
+  var decodedFrames: UInt64 = 0
+  var enqueuedFrames: UInt64 = 0
+  var presentedFrames: UInt64 = 0
+  var droppedFrames: UInt64 = 0
+  var rebuilds: UInt64 = 0
+  var flushes: UInt64 = 0
+  var backpressureDrops: UInt64 = 0
+  var replacements: UInt64 = 0
+  var recoveryRetries: UInt64 = 0
+  var recoveryFailures: UInt64 = 0
+  var lastDecodedAt: ContinuousClock.Instant?
+  var lastEnqueuedAt: ContinuousClock.Instant?
+  var lastPresentedAt: ContinuousClock.Instant?
+  var status: PlaybackRendererStatus = .unavailable
+}
+
+struct PlaybackHealthMonitoringState {
+  var generation: UInt64 = 0
+  var startedAt = ContinuousClock.now
+  var rendererBaseline: PlaybackRendererHealthSample?
+  var previousCounters = PlaybackHealthCounters()
+  var lastSourceProgressAt = ContinuousClock.now
+  var lastDecodedProgressAt = ContinuousClock.now
+  var lastPresentedProgressAt = ContinuousClock.now
+  var lastAudioProgressAt = ContinuousClock.now
+  var firstDecodedEmitted = false
+  var firstPresentedEmitted = false
+  var pendingWaitingReason: PlaybackWaitingReason?
+  var pendingWaitingBeganAt: ContinuousClock.Instant?
+  var pendingPresentedBaseline: UInt64 = 0
+  var pendingAudioBaseline: UInt64 = 0
+  var lastStallReason: PlaybackStallReason?
+  var lastStalledAt: Duration?
+  var lastRecoveredAt: Duration?
+  var observedRendererFlushes: UInt64 = 0
+
+  mutating func reset(
+    generation: UInt64,
+    rendererBaseline: PlaybackRendererHealthSample?
+  ) {
+    let now = ContinuousClock.now
+    self.generation = generation
+    startedAt = now
+    self.rendererBaseline = rendererBaseline
+    previousCounters = PlaybackHealthCounters()
+    lastSourceProgressAt = now
+    lastDecodedProgressAt = now
+    lastPresentedProgressAt = now
+    lastAudioProgressAt = now
+    firstDecodedEmitted = false
+    firstPresentedEmitted = false
+    pendingWaitingReason = nil
+    pendingWaitingBeganAt = nil
+    pendingPresentedBaseline = 0
+    pendingAudioBaseline = 0
+    lastStallReason = nil
+    lastStalledAt = nil
+    lastRecoveredAt = nil
+    observedRendererFlushes = 0
+  }
+}
+
+/// Playback-health publication and the low-rate classifier that drives it.
+extension Player {
+  /// How often cumulative pipeline counters are sampled.
+  ///
+  /// This is deliberately independent of source cadence: 24, 60, and 120 fps
+  /// all cost four public samples per second.
+  public nonisolated static var playbackHealthSamplingInterval: Duration {
+    .milliseconds(250)
+  }
+
+  /// A pipeline stage becomes stalled only after this much time without the
+  /// progress expected from the stages before it.
+  public nonisolated static var playbackHealthStallThreshold: Duration {
+    .seconds(2)
+  }
+
+  /// Current playback-health snapshots, replaying the latest value to a late
+  /// subscriber. The stream is bounded because each value supersedes the prior
+  /// point-in-time sample.
+  public nonisolated var playbackHealthSnapshots: AsyncStream<PlaybackHealthSnapshot> {
+    playbackHealthSnapshotBridge.subscribeReplayingLatest(policy: .newest(1))
+  }
+
+  /// Semantic playback-health transitions.
+  ///
+  /// The latest transition is replayed. The attached snapshot retains the last
+  /// stall reason and both stall/recovery timestamps, so a subscriber arriving
+  /// after recovery can still reconstruct the pair. The live buffer is
+  /// unbounded because first-frame, stall, recovery, and terminal transitions
+  /// must never be evicted by consumer lag.
+  public nonisolated var playbackHealthEvents: AsyncStream<PlaybackHealthEvent> {
+    playbackHealthEventBridge.subscribeReplayingLatest(policy: .unbounded)
+  }
+
+  func resetPlaybackHealth() {
+    playbackHealthEventBridge.clearReplay()
+    let renderer = capturePlaybackRendererHealth()
+    playbackHealthMonitoringState.reset(
+      generation: sessionGeneration,
+      rendererBaseline: renderer
+    )
+    publishPlaybackHealth(
+      state: .idle,
+      counters: PlaybackHealthCounters(),
+      renderer: renderer,
+      now: ContinuousClock.now
+    )
+  }
+
+  func markPlaybackHealthSeek() {
+    markPlaybackHealthWaiting(.seeking)
+  }
+
+  func markPlaybackHealthAdaptiveSwitch() {
+    guard state == .playing, playbackHealthMonitoringState.firstPresentedEmitted else {
+      return
+    }
+    markPlaybackHealthWaiting(.adaptiveSwitch)
+  }
+
+  private func markPlaybackHealthWaiting(_ reason: PlaybackWaitingReason) {
+    let now = ContinuousClock.now
+    playbackHealthMonitoringState.pendingWaitingReason = reason
+    playbackHealthMonitoringState.pendingWaitingBeganAt = now
+    playbackHealthMonitoringState.pendingPresentedBaseline = playbackHealth.counters.presentedVideoFrames
+    playbackHealthMonitoringState.pendingAudioBaseline = playbackHealth.counters.playedAudioBuffers
+    samplePlaybackHealth()
+    reconcilePlaybackHealthSamplingTask()
+  }
+
+  func reconcilePlaybackHealthSamplingTask() {
+    let needsSampling = state.isActive
+      || playbackHealthMonitoringState.pendingWaitingReason != nil
+    if !needsSampling {
+      playbackHealthSamplingTask?.cancel()
+      playbackHealthSamplingTask = nil
+      return
+    }
+    guard playbackHealthSamplingTask == nil else { return }
+    playbackHealthSamplingTask = Task { @MainActor [weak self] in
+      while !Task.isCancelled {
+        do {
+          try await Task.sleep(for: Self.playbackHealthSamplingInterval)
+        } catch {
+          return
+        }
+        guard let self else { return }
+        samplePlaybackHealth()
+        let keepSampling = state.isActive
+          || playbackHealthMonitoringState.pendingWaitingReason != nil
+        guard keepSampling else {
+          playbackHealthSamplingTask = nil
+          return
+        }
+      }
+    }
+  }
+
+  func samplePlaybackHealth() {
+    if playbackHealthMonitoringState.generation != sessionGeneration {
+      playbackHealthMonitoringState.reset(
+        generation: sessionGeneration,
+        rendererBaseline: capturePlaybackRendererHealth()
+      )
+    }
+
+    let now = ContinuousClock.now
+    let renderer = capturePlaybackRendererHealth()
+    let counters = makePlaybackHealthCounters(renderer: renderer)
+    updatePlaybackHealthProgress(counters: counters, renderer: renderer, now: now)
+    let classified = classifyPlaybackHealth(counters: counters, renderer: renderer, now: now)
+    publishPlaybackHealth(state: classified, counters: counters, renderer: renderer, now: now)
+  }
+
+  private func classifyPlaybackHealth(
+    counters: PlaybackHealthCounters,
+    renderer: PlaybackRendererHealthSample?,
+    now: ContinuousClock.Instant
+  ) -> PlaybackHealthState {
+    switch state {
+    case .idle, .stopped, .stopping:
+      clearPlaybackHealthWaiting()
+      return .idle
+    case .paused:
+      if renderer?.recoveryFailures ?? 0 > 0, renderer?.status == .failed {
+        clearPlaybackHealthWaiting()
+        return .failed(.renderer)
+      }
+      if renderer?.status == .recovering {
+        return .stalled(.rendererRecovery)
+      }
+      clearPlaybackHealthWaiting()
+      return .paused
+    case .error:
+      clearPlaybackHealthWaiting()
+      return .failed(.player)
+    case .opening:
+      return .waiting(.opening)
+    case .buffering:
+      return .waiting(.buffering)
+    case .playing:
+      break
+    }
+
+    if renderer?.recoveryFailures ?? 0 > 0, renderer?.status == .failed {
+      return .failed(.renderer)
+    }
+    if renderer?.status == .recovering {
+      return .stalled(.rendererRecovery)
+    }
+
+    let hasVideo = activeVideoOutputs > 0
+      || !videoTracks.isEmpty
+      || counters.decodedVideoFrames > 0
+      || counters.presentedVideoFrames > 0
+    let hasAudio = !audioTracks.isEmpty
+      || counters.decodedAudioFrames > 0
+      || counters.playedAudioBuffers > 0
+
+    if let waiting = playbackHealthMonitoringState.pendingWaitingReason {
+      let progressed = if hasVideo {
+        counters.presentedVideoFrames
+          > playbackHealthMonitoringState.pendingPresentedBaseline
+      } else {
+        counters.playedAudioBuffers > playbackHealthMonitoringState.pendingAudioBaseline
+      }
+      if progressed {
+        clearPlaybackHealthWaiting()
+      } else if
+        let began = playbackHealthMonitoringState.pendingWaitingBeganAt,
+        began.duration(to: now) < Self.playbackHealthStallThreshold {
+        return .waiting(waiting)
+      }
+    }
+
+    if hasVideo {
+      if
+        counters.presentedVideoFrames == 0,
+        playbackHealthMonitoringState.startedAt.duration(to: now)
+        < Self.playbackHealthStallThreshold {
+        return .waiting(.firstFrame)
+      }
+      if
+        playbackHealthMonitoringState.lastPresentedProgressAt.duration(to: now)
+        < Self.playbackHealthStallThreshold {
+        return .healthy(contentKind(hasVideo: true, hasAudio: hasAudio))
+      }
+      if
+        playbackHealthMonitoringState.lastDecodedProgressAt.duration(to: now)
+        < Self.playbackHealthStallThreshold {
+        return .stalled(.display)
+      }
+      if
+        playbackHealthMonitoringState.lastSourceProgressAt.duration(to: now)
+        < Self.playbackHealthStallThreshold {
+        return .stalled(.decoder)
+      }
+      return .stalled(.source)
+    }
+
+    if hasAudio {
+      if
+        playbackHealthMonitoringState.lastAudioProgressAt.duration(to: now)
+        < Self.playbackHealthStallThreshold {
+        return .healthy(.audioOnly)
+      }
+      if
+        playbackHealthMonitoringState.lastDecodedProgressAt.duration(to: now)
+        < Self.playbackHealthStallThreshold {
+        return .stalled(.audioOutput)
+      }
+      if
+        playbackHealthMonitoringState.lastSourceProgressAt.duration(to: now)
+        < Self.playbackHealthStallThreshold {
+        return .stalled(.decoder)
+      }
+      return .stalled(.source)
+    }
+
+    if
+      playbackHealthMonitoringState.startedAt.duration(to: now)
+      < Self.playbackHealthStallThreshold {
+      return .waiting(.firstFrame)
+    }
+    return .stalled(.source)
+  }
+
+  private func clearPlaybackHealthWaiting() {
+    playbackHealthMonitoringState.pendingWaitingReason = nil
+    playbackHealthMonitoringState.pendingWaitingBeganAt = nil
+    playbackHealthMonitoringState.pendingPresentedBaseline = 0
+    playbackHealthMonitoringState.pendingAudioBaseline = 0
+  }
+
+  private func contentKind(hasVideo: Bool, hasAudio: Bool) -> PlaybackContentKind {
+    switch (hasVideo, hasAudio) {
+    case (true, true): .audiovisual
+    case (true, false): .videoOnly
+    case (false, true), (false, false): .audioOnly
+    }
+  }
+
+  private func updatePlaybackHealthProgress(
+    counters: PlaybackHealthCounters,
+    renderer: PlaybackRendererHealthSample?,
+    now: ContinuousClock.Instant
+  ) {
+    let previous = playbackHealthMonitoringState.previousCounters
+    if
+      counters.sourceReadBytes > previous.sourceReadBytes
+      || counters.demuxReadBytes > previous.demuxReadBytes {
+      playbackHealthMonitoringState.lastSourceProgressAt = now
+    }
+    if
+      counters.decodedVideoFrames > previous.decodedVideoFrames
+      || counters.decodedAudioFrames > previous.decodedAudioFrames {
+      playbackHealthMonitoringState.lastDecodedProgressAt = renderer?.lastDecodedAt ?? now
+    }
+    if counters.presentedVideoFrames > previous.presentedVideoFrames {
+      playbackHealthMonitoringState.lastPresentedProgressAt = renderer?.lastPresentedAt ?? now
+    }
+    if counters.playedAudioBuffers > previous.playedAudioBuffers {
+      playbackHealthMonitoringState.lastAudioProgressAt = now
+    }
+    playbackHealthMonitoringState.previousCounters = counters
+  }
+
+  private func makePlaybackHealthCounters(
+    renderer: PlaybackRendererHealthSample?
+  ) -> PlaybackHealthCounters {
+    let stats = statistics
+    let direct = renderer.map(rendererDelta) ?? PlaybackRendererHealthSample()
+    return PlaybackHealthCounters(
+      sourceReadBytes: stats?.readBytes ?? 0,
+      demuxReadBytes: stats?.demuxReadBytes ?? 0,
+      decodedVideoFrames: max(stats?.decodedVideo ?? 0, direct.decodedFrames),
+      decodedAudioFrames: stats?.decodedAudio ?? 0,
+      enqueuedVideoFrames: direct.enqueuedFrames,
+      presentedVideoFrames: max(stats?.displayedPictures ?? 0, direct.presentedFrames),
+      playedAudioBuffers: stats?.playedAudioBuffers ?? 0,
+      droppedVideoFrames: addingWithoutOverflow(stats?.lostPictures ?? 0, direct.droppedFrames),
+      lateVideoFrames: stats?.latePictures ?? 0,
+      rendererRebuilds: direct.rebuilds,
+      rendererFlushes: direct.flushes,
+      rendererBackpressureDrops: direct.backpressureDrops,
+      rendererFrameReplacements: direct.replacements,
+      rendererRecoveryRetries: direct.recoveryRetries,
+      rendererRecoveryFailures: direct.recoveryFailures
+    )
+  }
+
+  private func rendererDelta(
+    _ current: PlaybackRendererHealthSample
+  ) -> PlaybackRendererHealthSample {
+    guard let baseline = playbackHealthMonitoringState.rendererBaseline else {
+      return current
+    }
+    var delta = current
+    delta.decodedFrames = subtractingWithoutUnderflow(current.decodedFrames, baseline.decodedFrames)
+    delta.enqueuedFrames = subtractingWithoutUnderflow(current.enqueuedFrames, baseline.enqueuedFrames)
+    delta.presentedFrames = subtractingWithoutUnderflow(current.presentedFrames, baseline.presentedFrames)
+    delta.droppedFrames = subtractingWithoutUnderflow(current.droppedFrames, baseline.droppedFrames)
+    delta.rebuilds = subtractingWithoutUnderflow(current.rebuilds, baseline.rebuilds)
+    delta.flushes = subtractingWithoutUnderflow(current.flushes, baseline.flushes)
+    delta.backpressureDrops = subtractingWithoutUnderflow(
+      current.backpressureDrops,
+      baseline.backpressureDrops
+    )
+    delta.replacements = subtractingWithoutUnderflow(current.replacements, baseline.replacements)
+    delta.recoveryRetries = subtractingWithoutUnderflow(
+      current.recoveryRetries,
+      baseline.recoveryRetries
+    )
+    delta.recoveryFailures = subtractingWithoutUnderflow(
+      current.recoveryFailures,
+      baseline.recoveryFailures
+    )
+    return delta
+  }
+
+  private func publishPlaybackHealth(
+    state newState: PlaybackHealthState,
+    counters: PlaybackHealthCounters,
+    renderer: PlaybackRendererHealthSample?,
+    now: ContinuousClock.Instant
+  ) {
+    let previousState = playbackHealth.state
+    var eventKinds: [PlaybackHealthEventKind] = []
+
+    let completedUnobservedRendererRecovery = counters.rendererFlushes
+      > playbackHealthMonitoringState.observedRendererFlushes
+      && renderer?.status == .rendering
+      && counters.rendererRecoveryFailures == 0
+    if completedUnobservedRendererRecovery {
+      playbackHealthMonitoringState.lastStallReason = .rendererRecovery
+      playbackHealthMonitoringState.lastStalledAt = elapsed(to: renderer?.lastEnqueuedAt)
+        ?? elapsed(to: now)
+      playbackHealthMonitoringState.lastRecoveredAt = elapsed(to: renderer?.lastPresentedAt)
+        ?? elapsed(to: now)
+      eventKinds.append(.stalled(.rendererRecovery))
+      eventKinds.append(.recovered(from: .rendererRecovery))
+    }
+    playbackHealthMonitoringState.observedRendererFlushes = counters.rendererFlushes
+
+    if
+      !playbackHealthMonitoringState.firstDecodedEmitted,
+      counters.decodedVideoFrames > 0 {
+      playbackHealthMonitoringState.firstDecodedEmitted = true
+      eventKinds.append(.firstDecodedFrame)
+    }
+    if
+      !playbackHealthMonitoringState.firstPresentedEmitted,
+      counters.presentedVideoFrames > 0 {
+      playbackHealthMonitoringState.firstPresentedEmitted = true
+      eventKinds.append(.firstPresentedFrame)
+    }
+
+    if
+      case .stalled(let reason) = newState,
+      previousState != newState {
+      playbackHealthMonitoringState.lastStallReason = reason
+      playbackHealthMonitoringState.lastStalledAt = elapsed(to: now)
+      eventKinds.append(.stalled(reason))
+    } else if
+      case .waiting(let reason) = newState,
+      previousState != newState {
+      eventKinds.append(.waiting(reason))
+    }
+
+    if
+      case .stalled(let reason) = previousState,
+      case .healthy = newState {
+      playbackHealthMonitoringState.lastRecoveredAt = elapsed(to: now)
+      eventKinds.append(.recovered(from: reason))
+    } else if
+      !completedUnobservedRendererRecovery,
+      previousState == .stalled(.rendererRecovery),
+      renderer?.status == .rendering {
+      playbackHealthMonitoringState.lastRecoveredAt = elapsed(to: renderer?.lastPresentedAt)
+        ?? elapsed(to: now)
+      eventKinds.append(.recovered(from: .rendererRecovery))
+    }
+    if
+      case .failed(let failure) = newState,
+      previousState != newState {
+      eventKinds.append(.terminalFailure(failure))
+    }
+
+    let snapshot = PlaybackHealthSnapshot(
+      generation: PlaybackGeneration(sessionGeneration),
+      state: newState,
+      revision: playbackHealth.revision &+ 1,
+      lastDecodedAt: elapsed(to: renderer?.lastDecodedAt)
+        ?? (counters.decodedVideoFrames > 0 ? elapsed(to: playbackHealthMonitoringState.lastDecodedProgressAt) : nil),
+      lastEnqueuedAt: elapsed(to: renderer?.lastEnqueuedAt),
+      lastPresentedAt: elapsed(to: renderer?.lastPresentedAt)
+        ?? (counters.presentedVideoFrames > 0 ? elapsed(to: playbackHealthMonitoringState.lastPresentedProgressAt) : nil),
+      rendererStatus: renderer?.status ?? .unavailable,
+      voutGeneration: renderer?.voutGeneration,
+      counters: counters,
+      lastStallReason: playbackHealthMonitoringState.lastStallReason,
+      lastStalledAt: playbackHealthMonitoringState.lastStalledAt,
+      lastRecoveredAt: playbackHealthMonitoringState.lastRecoveredAt
+    )
+    playbackHealth = snapshot
+    playbackHealthSnapshotBridge.broadcast(snapshot)
+    for kind in eventKinds {
+      playbackHealthEventBridge.broadcast(PlaybackHealthEvent(kind: kind, snapshot: snapshot))
+    }
+  }
+
+  private func elapsed(to instant: ContinuousClock.Instant?) -> Duration? {
+    guard let instant, instant >= playbackHealthMonitoringState.startedAt else { return nil }
+    return playbackHealthMonitoringState.startedAt.duration(to: instant)
+  }
+
+  private func addingWithoutOverflow(_ lhs: UInt64, _ rhs: UInt64) -> UInt64 {
+    let result = lhs.addingReportingOverflow(rhs)
+    return result.overflow ? .max : result.partialValue
+  }
+
+  private func subtractingWithoutUnderflow(_ lhs: UInt64, _ rhs: UInt64) -> UInt64 {
+    lhs >= rhs ? lhs - rhs : 0
+  }
+
+  private func capturePlaybackRendererHealth() -> PlaybackRendererHealthSample? {
+    #if os(iOS) || os(macOS)
+    guard let telemetry = directPiPVideoCallbackRegistration?.telemetrySnapshot else {
+      return nil
+    }
+    guard telemetry.playbackGeneration == sessionGeneration else { return nil }
+    let rendererStatus: PlaybackRendererStatus = switch telemetry.status {
+    case .idle: .idle
+    case .rendering: .rendering
+    case .backpressured: .backpressured
+    case .recovering: .recovering
+    case .failed: .failed
+    }
+    return PlaybackRendererHealthSample(
+      playbackGeneration: telemetry.playbackGeneration,
+      voutGeneration: telemetry.voutGeneration,
+      decodedFrames: telemetry.decodedFrameCount,
+      enqueuedFrames: telemetry.enqueuedFrameCount,
+      presentedFrames: telemetry.presentedFrameCount,
+      droppedFrames: telemetry.droppedFrameCount,
+      rebuilds: telemetry.voutTransitionCount,
+      flushes: telemetry.flushCount,
+      backpressureDrops: telemetry.backpressureDropCount,
+      replacements: telemetry.replacementCount,
+      recoveryRetries: telemetry.flushRecoveryRetryCount,
+      recoveryFailures: telemetry.flushRecoveryFailureCount,
+      lastDecodedAt: telemetry.lastDecodedAt,
+      lastEnqueuedAt: telemetry.lastEnqueuedAt,
+      lastPresentedAt: telemetry.lastPresentedAt,
+      status: rendererStatus
+    )
+    #else
+    return nil
+    #endif
+  }
+
+  #if DEBUG
+  func _applyPlaybackHealthSampleForTesting(
+    counters: PlaybackHealthCounters,
+    renderer: PlaybackRendererHealthSample? = nil,
+    now: ContinuousClock.Instant = .now
+  ) {
+    updatePlaybackHealthProgress(counters: counters, renderer: renderer, now: now)
+    let classified = classifyPlaybackHealth(counters: counters, renderer: renderer, now: now)
+    publishPlaybackHealth(state: classified, counters: counters, renderer: renderer, now: now)
+  }
+  #endif
+}

--- a/Sources/SwiftVLC/Player/Player+Programs.swift
+++ b/Sources/SwiftVLC/Player/Player+Programs.swift
@@ -152,6 +152,7 @@ extension Player {
       media: currentMedia?.pointer,
       outgoingNativeHandleGeneration: priorNativeHandleGeneration
     )
+    resetPlaybackHealth()
     publishPlaybackStatus()
     let generation = sessionGeneration
 

--- a/Sources/SwiftVLC/Player/Player+Seek.swift
+++ b/Sources/SwiftVLC/Player/Player+Seek.swift
@@ -164,6 +164,7 @@ extension Player {
     currentTime = .milliseconds(milliseconds)
     let position = publishPosition(forTargetMilliseconds: milliseconds)
     recordAuthoritativeTimeline(position: position)
+    markPlaybackHealthSeek()
   }
 
   // MARK: - Lenient Seeking
@@ -205,6 +206,7 @@ extension Player {
       currentTime = .milliseconds(checkedMilliseconds(for: position, durationMs: durationMs))
     }
     recordAuthoritativeTimeline(position: position.rawValue)
+    markPlaybackHealthSeek()
     return true
   }
 
@@ -314,6 +316,7 @@ extension Player {
         recordAuthoritativeTimeline(position: position)
       }
     }
+    markPlaybackHealthSeek()
     return revision
   }
 

--- a/Sources/SwiftVLC/Player/Player+Teardown.swift
+++ b/Sources/SwiftVLC/Player/Player+Teardown.swift
@@ -67,7 +67,9 @@ extension Player {
       break
     }
     let nativeHandleGeneration = eventBridge.currentNativeHandleGeneration
+    let playbackGeneration = PlaybackGeneration(sessionGeneration)
     let stream = eventBridge.makeSourcedStream(policy: .unbounded)
+    let statuses = playbackStatus
     // A terminal event that fired between the check above and the
     // subscription is invisible to the stream — re-check before waiting
     // so an in-flight stop completing right here costs nothing instead
@@ -86,15 +88,57 @@ extension Player {
     )
     // The internal consumer mirrors the same terminal event onto
     // `state` on its own main-actor schedule and may still be draining
-    // its backlog when the dedicated wait resumes. Reconcile here so
-    // the documented post-condition — the player is terminal on
-    // return — holds for the observable mirror, not just the native
-    // handle. Idempotent with the consumer's later delivery.
+    // its backlog when the dedicated wait resumes. Wait for that exact
+    // generation's terminal publication before falling back to a direct
+    // reconciliation. Publishing immediately lets an older queued
+    // `.stopping` overwrite `.stopped` before the consumer reaches its own
+    // terminal event.
     let terminal = nativePlaybackState
-    if terminal == .stopped || terminal == .error, state != terminal {
-      handleEvent(.stateChanged(terminal))
+    if
+      terminal == .stopped || terminal == .error,
+      state != terminal,
+      generation == playbackGeneration {
+      _ = await Self.awaitPlaybackMirror(
+        terminal,
+        generation: playbackGeneration,
+        on: statuses
+      )
+      if state != terminal, generation == playbackGeneration {
+        handleEvent(.stateChanged(terminal))
+      }
     }
     return Self.resolveStopOutcome(waitOutcome: outcome, nativeState: terminal)
+  }
+
+  /// Waits for the ordinary event consumer to publish the native terminal
+  /// state so `stopAndWait()` cannot return between queued lifecycle events.
+  nonisolated static func awaitPlaybackMirror(
+    _ expectedState: PlayerState,
+    generation: PlaybackGeneration,
+    on statuses: AsyncStream<PlaybackStatus>,
+    timeout: Duration = .seconds(1)
+  )
+    async -> Bool {
+    await withTaskGroup(of: Bool?.self) { group in
+      group.addTask {
+        for await status in statuses {
+          if status.generation > generation {
+            return false
+          }
+          if status.generation == generation, status.state == expectedState {
+            return true
+          }
+        }
+        return false
+      }
+      group.addTask {
+        try? await Task.sleep(for: timeout)
+        return false
+      }
+      let mirrored = await group.next() ?? false
+      group.cancelAll()
+      return mirrored ?? false
+    }
   }
 
   /// Folds the native handle's resting state into the wait's verdict.

--- a/Sources/SwiftVLC/Player/Player+Teardown.swift
+++ b/Sources/SwiftVLC/Player/Player+Teardown.swift
@@ -237,6 +237,10 @@ extension Player {
     // than one that can never emit.
     stateTransitionBridge.terminate()
     playbackStatusBridge.terminate()
+    playbackHealthSamplingTask?.cancel()
+    playbackHealthSamplingTask = nil
+    playbackHealthSnapshotBridge.terminate()
+    playbackHealthEventBridge.terminate()
     libvlc_media_player_set_nsobject(pointer, nil)
 
     let bridge = eventBridge

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -64,6 +64,17 @@ public final class Player {
   /// selected and decoding.
   public internal(set) var activeVideoOutputs: Int = 0
 
+  /// Current low-rate, generation-scoped playback-health snapshot.
+  ///
+  /// This is sampled at most four times per second. It is suitable for UI and
+  /// diagnostics without turning a 4K60 decode path into 60 observable writes
+  /// per second. Use ``playbackHealthEvents`` for semantic transitions.
+  public internal(set) var playbackHealth = PlaybackHealthSnapshot(
+    generation: PlaybackGeneration(0),
+    state: .idle,
+    revision: 0
+  )
+
   /// The currently loaded media.
   public internal(set) var currentMedia: Media?
 
@@ -320,84 +331,6 @@ public final class Player {
     currentMedia?.statistics()
   }
 
-  // MARK: - Event Stream
-
-  /// Raw event stream for custom processing, with the default buffering
-  /// policy (`.newest(64)`) and no filter.
-  /// Most consumers should use `@Observable` properties instead.
-  /// See ``events(policy:filter:)`` for the delivery guarantees and their
-  /// limits.
-  public nonisolated var events: AsyncStream<PlayerEvent> {
-    eventBridge.makeStream(policy: .newest(64), filter: nil)
-  }
-
-  /// Raw event stream with an explicit buffering policy and an optional
-  /// per-subscription filter.
-  ///
-  /// The default `.newest(64)` policy bounds memory but is lossy: a
-  /// consumer stalled past 64 undelivered events silently loses the
-  /// oldest ones, which can include one-shot terminal transitions such as
-  /// `.stateChanged(.stopped)` or ``PlayerEvent/endReached-enum.case``. Consumers
-  /// that must not miss those should pass `.unbounded`, ideally with a
-  /// `filter` that keeps the `timeChanged`/`positionChanged` firehose out
-  /// of the buffer.
-  ///
-  /// `filter` runs on libVLC's event thread for every event, outside any
-  /// SwiftVLC lock — keep it fast and never block in it. Don't touch
-  /// main-actor state from it: beyond the usual isolation rules, native
-  /// teardown (handle replacement, player deinit) joins the event thread
-  /// while detaching callbacks, so a filter blocked on the main actor
-  /// can deadlock teardown against the very thread it is stalling.
-  ///
-  /// A delivery limit that no policy removes: when the player replaces
-  /// its native handle (stopping drawable-hosted playback does this
-  /// lazily, and ``recast(to:)``-style renderer changes do it
-  /// mid-session), the bridge reattaches to the replacement handle before
-  /// the old one finishes stopping on a background queue. Terminal events
-  /// of the *swapped-out* handle are never delivered to any stream; state
-  /// derived from them is reset by the swap itself.
-  public nonisolated func events(
-    policy: EventBufferingPolicy = .newest(64),
-    filter: (@Sendable (PlayerEvent) -> Bool)? = nil
-  ) -> AsyncStream<PlayerEvent> {
-    eventBridge.makeStream(policy: policy, filter: filter)
-  }
-
-  /// Lossless stream of lifecycle state transitions — no firehose.
-  ///
-  /// Carries every change of ``state``, so a lagging consumer can never lose
-  /// a one-shot terminal transition. Memory is bounded in practice by the low
-  /// rate of state changes.
-  ///
-  /// Driven by the state itself rather than by the raw `.stateChanged` event,
-  /// which is what makes it *complete*. libVLC reports a native failure as
-  /// `.encounteredError` and buffering as `.bufferingProgress`, so neither
-  /// ever produced a `.stateChanged` to forward: a stream built by filtering
-  /// raw events silently omitted every transition to ``PlayerState/error``
-  /// and ``PlayerState/buffering``. Anything waiting on `.error` here waited
-  /// for something that could not arrive.
-  ///
-  /// Buffering is published at most once per entry into it — repeated
-  /// progress reports do not re-announce the state — so completeness does not
-  /// cost the no-firehose guarantee.
-  ///
-  /// Not de-duplicated: the same state published twice is delivered twice.
-  /// Same-player media replacement currently restarts a session on a repeated
-  /// `.playing`, so suppressing repeats would break it until events carry a
-  /// media generation to distinguish sessions by. Treat a value as "the
-  /// current state", not as "a value that differs from the last one".
-  public nonisolated var stateTransitions: AsyncStream<PlayerState> {
-    // Explicitly unbounded. `subscribe()` defaults to newest-64, which would
-    // make a stream documented as lossless silently drop the oldest pending
-    // transitions under a stalled consumer — losing exactly the one-shot
-    // terminal states this exists to protect.
-    stateTransitionBridge.subscribe(policy: .unbounded)
-  }
-
-  nonisolated var playbackIntentEvents: AsyncStream<Bool> {
-    playbackIntentBridge.subscribe()
-  }
-
   // MARK: - Internal
 
   @ObservationIgnored
@@ -419,6 +352,12 @@ public final class Player {
   /// Carries normalized lifecycle transitions. See ``stateTransitions``.
   nonisolated let stateTransitionBridge = Broadcaster<PlayerState>(defaultBufferSize: 64)
   nonisolated let playbackStatusBridge = Broadcaster<PlaybackStatus>(defaultBufferSize: 64)
+  nonisolated let playbackHealthSnapshotBridge = Broadcaster<PlaybackHealthSnapshot>(
+    defaultBufferSize: 16
+  )
+  nonisolated let playbackHealthEventBridge = Broadcaster<PlaybackHealthEvent>(
+    defaultBufferSize: 16
+  )
   /// ``isPlaybackRequestedActive`` mirrored for readers that cannot touch the
   /// main actor.
   ///
@@ -443,6 +382,8 @@ public final class Player {
   /// outgoing and incoming media. See ``resetMediaDerivedState()``.
   @ObservationIgnored var isSuppressingCapabilityPublish = false
   var eventTask: Task<Void, Never>?
+  var playbackHealthSamplingTask: Task<Void, Never>?
+  var playbackHealthMonitoringState = PlaybackHealthMonitoringState()
   var _position: Double = 0
   var _equalizer: Equalizer?
   var _volume: Float = 1.0
@@ -640,6 +581,7 @@ public final class Player {
     // the player exists: a subscriber attaching before any state change would
     // otherwise replay nothing and wait, on an idle player forever.
     publishPlaybackStatus()
+    playbackHealthSnapshotBridge.broadcast(playbackHealth)
   }
 
   static func makeNativePlayer(instance: VLCInstance) -> OpaquePointer {
@@ -662,6 +604,9 @@ public final class Player {
     playbackIntentBridge.terminate()
     stateTransitionBridge.terminate()
     playbackStatusBridge.terminate()
+    playbackHealthSnapshotBridge.terminate()
+    playbackHealthEventBridge.terminate()
+    playbackHealthSamplingTask?.cancel()
     #if os(iOS) || os(macOS)
     retireDirectPiPVideoCallbacksForHandleEnd()
     // No successor to move to here, unlike replacement and shutdown: the
@@ -975,7 +920,7 @@ public final class Player {
   /// Refreshes all observable track lists from the native player.
   ///
   /// The track arrays are asynchronously mirrored snapshots. Receiving the payload-free
-  /// ``PlayerEvent/tracksChanged`` or ``PlayerEvent/mediaChanged`` event does not guarantee
+  /// ``PlayerEvent/tracksChanged-enum.case`` or ``PlayerEvent/mediaChanged-enum.case`` event does not guarantee
   /// they are updated; consumers requiring an immediate native read should call this
   /// method after either event. This also invalidates selected-track observations.
   public func refreshTracks() {

--- a/Sources/SwiftVLC/Player/PlayerEventLane.swift
+++ b/Sources/SwiftVLC/Player/PlayerEventLane.swift
@@ -110,7 +110,7 @@ extension Player {
   /// Because control events are not in this buffer, dropping from it can never
   /// cost a one-shot transition.
   ///
-  /// The buffer keeps the newest ``Player/timingLaneBufferSize`` events across
+  /// The buffer keeps the newest `timingLaneBufferSize` events across
   /// the lane as a whole — it is **not** one slot per event kind. A consumer
   /// stalled across a long enough burst of the fastest kind (`timeChanged`, at
   /// roughly 30 Hz) can therefore still lose the newest sample of a slower one

--- a/Sources/SwiftVLC/SwiftVLC.docc/PlaybackEssentials.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/PlaybackEssentials.md
@@ -34,6 +34,7 @@ binds to them directly, without a publisher or Combine adapter.
 | ``Player/isPlaying`` | `Bool` | User-facing playback signal for Play/Pause controls while libVLC state transitions settle |
 | ``Player/isPlaybackRequestedActive`` | `Bool` | Lower-level playback intent mirrored by PiP and external transport controls |
 | ``Player/bufferFill`` | `Float` | Continuously-updated cache level (`0.0…1.0`), independent of `state` |
+| ``Player/playbackHealth`` | ``PlaybackHealthSnapshot`` | Generation-scoped progress, renderer state, and typed wait/stall classification |
 | ``Player/currentTime`` | `Duration` | Wall-clock position, millisecond resolution |
 | ``Player/duration`` | `Duration?` | `nil` until the container reports length |
 | ``Player/isSeekable`` | `Bool` | Whether seek operations take effect |
@@ -167,6 +168,53 @@ for await event in player.events {
 Multiple consumers can subscribe at the same time. Each call to
 ``Player/events`` returns an independent ``PlayerEvent`` stream.
 
+## Playback health
+
+``PlayerState/playing`` means libVLC entered its playing lifecycle; it does
+not prove that a decoder or output is still advancing. Read
+``Player/playbackHealth`` when UI or diagnostics need that distinction. It
+separates expected waits such as opening, buffering, seeking, adaptive track
+switches, and the first frame from source, decoder, display, audio-output, and
+direct-renderer stalls.
+
+```swift
+for await event in player.playbackHealthEvents {
+    switch event.kind {
+    case .firstPresentedFrame:
+        hidePoster()
+    case .stalled(let reason):
+        showRecoveryUI(for: reason)
+    case .recovered:
+        hideRecoveryUI()
+    case .terminalFailure(let failure):
+        report(failure, snapshot: event.snapshot)
+    default:
+        break
+    }
+}
+```
+
+Snapshots are sampled every ``Player/playbackHealthSamplingInterval`` and a
+pipeline stage is not classified as stalled until
+``Player/playbackHealthStallThreshold`` elapses. This caps public observation
+writes at four per second regardless of source frame rate. The cumulative
+``PlaybackHealthCounters`` expose native progress and direct-renderer flush,
+rebuild, replacement, backpressure, retry, and failure counts without emitting
+one event per frame.
+
+Every snapshot and event carries the current ``PlaybackGeneration``. Direct
+frames captured before a media replacement are rejected at the renderer
+boundary, and first-decoded/first-presented events fire once for each
+generation. A late subscriber receives the latest value; snapshots retain the
+most recent stall reason and its stall/recovery timestamps so the pair remains
+reconstructible after recovery.
+
+Direct renderer recovery retries the triggering frame ten times at
+16-millisecond intervals. A terminal ``PlaybackHealthFailure/renderer`` is
+published on the next 250-millisecond health sample when that budget is
+exhausted—normally within about 410 milliseconds of recovery beginning,
+although system queue starvation can delay delivery.
+
 ## Main actor and `sending`
 
 ``Player`` is `@MainActor`; every method call must originate on the
@@ -187,6 +235,13 @@ See <doc:ConcurrencyModel> for the full isolation story.
 
 ### Reading state
 - ``Player/state``
+- ``Player/playbackHealth``
+- ``Player/playbackHealthSnapshots``
+- ``Player/playbackHealthEvents``
+- ``PlaybackHealthSnapshot``
+- ``PlaybackHealthState``
+- ``PlaybackHealthEvent``
+- ``PlaybackHealthCounters``
 - ``Player/currentTime``
 - ``Player/duration``
 - ``Player/isPlaying``

--- a/Sources/SwiftVLC/SwiftVLC.docc/SwiftVLC.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/SwiftVLC.md
@@ -83,6 +83,10 @@ audio and video overlay APIs.
 - ``Player``
 - ``PlayerState``
 - ``PlayerEvent``
+- ``PlaybackHealthSnapshot``
+- ``PlaybackHealthState``
+- ``PlaybackHealthEvent``
+- ``PlaybackHealthCounters``
 - ``PlayerRole``
 - ``SeekRequest``
 - ``SeekOutcome``

--- a/Tests/SwiftVLCTests/Core/BroadcasterReplayTests.swift
+++ b/Tests/SwiftVLCTests/Core/BroadcasterReplayTests.swift
@@ -105,6 +105,30 @@ extension Integration {
       #expect(received == [2])
     }
 
+    @Test
+    func `Clearing replay preserves live subscribers but not stale seeding`() async {
+      let broadcaster = Broadcaster<Int>()
+      broadcaster.broadcast(1)
+      let existing = broadcaster.subscribeReplayingLatest(policy: .unbounded)
+
+      broadcaster.clearReplay()
+      let afterBoundary = broadcaster.subscribeReplayingLatest(policy: .unbounded)
+      broadcaster.broadcast(2)
+      broadcaster.terminate()
+
+      var existingValues: [Int] = []
+      for await value in existing {
+        existingValues.append(value)
+      }
+      var boundaryValues: [Int] = []
+      for await value in afterBoundary {
+        boundaryValues.append(value)
+      }
+
+      #expect(existingValues == [1, 2])
+      #expect(boundaryValues == [2])
+    }
+
     /// Every subscriber converges on the same value without waiting for another
     /// transition, which is what makes this usable for shared state.
     @Test

--- a/Tests/SwiftVLCTests/PiP/PiPCallbackRegistrationTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPCallbackRegistrationTests.swift
@@ -261,17 +261,41 @@ extension Integration {
     func `Native handle replacement installs successor generation before clearing old handle`() async throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
       let recorder = DirectPiPCallbackRecorder()
+      let firstRegistration = DirectPiPVideoCallbackRegistration(
+        renderer: PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer()),
+        api: recorder.api
+      )
+      player.claimDirectPiPVideoCallbacks(firstRegistration)
+
+      let oldPointer = player.pointer
+      let oldLifetime = player.nativeHandleLifetime
+      let oldHandle = UInt(bitPattern: oldPointer)
+      weak let oldContext = firstRegistration.currentContextForTesting
+      let oldOpaque = try #require(firstRegistration.currentOpaqueForTesting)
+      let firstVoutGeneration = try {
+        let context = try #require(oldContext)
+        let vout = try #require(
+          context.makeVoutContext(
+            handleOpaque: oldOpaque,
+            decodeRenderer: PixelBufferRenderer(),
+            sourceGeometry: PixelBufferSourceGeometry(fullFrameWidth: 2, height: 2)
+          )
+        )
+        defer { context.noteVoutClosed() }
+        return vout.voutGeneration
+      }()
+
+      // A successor controller adopts the same handle-level context. Its
+      // later handle replacement must continue that context's vout sequence,
+      // not restart from a controller-local counter.
       let registration = DirectPiPVideoCallbackRegistration(
         renderer: PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer()),
         api: recorder.api
       )
       player.claimDirectPiPVideoCallbacks(registration)
-
-      let oldPointer = player.pointer
-      let oldLifetime = player.nativeHandleLifetime
-      let oldHandle = UInt(bitPattern: oldPointer)
       let oldGeneration = try #require(registration.currentGeneration)
-      weak let oldContext = registration.currentContextForTesting
+      #expect(registration.currentContextForTesting === oldContext)
+      #expect(registration.currentOpaqueForTesting == oldOpaque)
 
       player.setDrawable(NSObject())
       player.stop()
@@ -289,6 +313,20 @@ extension Integration {
         recorder.operations == [.install(oldHandle), .install(newHandle), .clear(oldHandle)]
       )
       #expect(registration.currentLifetime === player.nativeHandleLifetime)
+      let newContext = try #require(registration.currentContextForTesting)
+      let newOpaque = try #require(registration.currentOpaqueForTesting)
+      let secondVoutGeneration = try {
+        let vout = try #require(
+          newContext.makeVoutContext(
+            handleOpaque: newOpaque,
+            decodeRenderer: PixelBufferRenderer(),
+            sourceGeometry: PixelBufferSourceGeometry(fullFrameWidth: 2, height: 2)
+          )
+        )
+        defer { newContext.noteVoutClosed() }
+        return vout.voutGeneration
+      }()
+      #expect(secondVoutGeneration > firstVoutGeneration)
 
       player.relinquishDirectPiPVideoCallbacks(registration)
       #expect(recorder.clearedHandles == [oldHandle, newHandle])

--- a/Tests/SwiftVLCTests/PiP/PixelBufferRendererCallbackTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferRendererCallbackTests.swift
@@ -47,8 +47,14 @@ extension Integration {
       let handleOpaque: UnsafeMutableRawPointer
       private var openVoutOpaques: [UnsafeMutableRawPointer] = []
 
-      init(displayRenderer: PixelBufferRenderer) {
-        let handleContext = PixelBufferRendererCallbackContext(renderer: displayRenderer)
+      init(
+        displayRenderer: PixelBufferRenderer,
+        playbackGeneration: @escaping @Sendable () -> UInt64 = { 0 }
+      ) {
+        let handleContext = PixelBufferRendererCallbackContext(
+          renderer: displayRenderer,
+          playbackGeneration: playbackGeneration()
+        )
         self.handleContext = handleContext
         handleOpaque = Unmanaged.passRetained(handleContext).toOpaque()
       }
@@ -720,6 +726,50 @@ extension Integration {
 
       // Give the renderer's async enqueue queue a moment to settle.
       try? await Task.sleep(for: .milliseconds(20))
+    }
+
+    @MainActor
+    @Test
+    func `Display callback rejects a vout created before a media boundary`() throws {
+      let generation = Mutex<UInt64>(1)
+      let displayLayer = AVSampleBufferDisplayLayer()
+      let renderer = PixelBufferRenderer(displayLayer: displayLayer)
+      renderer.beginPlaybackGeneration(1)
+      let lease = CallbackLease(
+        displayRenderer: renderer,
+        playbackGeneration: { generation.withLock { $0 } }
+      )
+      let vout = try lease.negotiate(width: 2, height: 2)
+      defer { lease.close(vout) }
+
+      let staleBuffer = try makeBGRAImageBuffer(width: 2, height: 2)
+      let stalePicture = try installUnlockedPicture(staleBuffer, on: vout)
+
+      generation.withLock { $0 = 2 }
+      lease.handleContext.beginPlaybackGeneration(2)
+      renderer.beginPlaybackGeneration(2)
+      pixelBufferDisplayCallback(opaque: vout.opaque, picture: stalePicture)
+
+      let afterStaleFrame = renderer.telemetrySnapshot
+      #expect(afterStaleFrame.playbackGeneration == 2)
+      #expect(afterStaleFrame.decodedFrameCount == 0)
+      #expect(afterStaleFrame.enqueuedFrameCount == 0)
+
+      let stillStaleBuffer = try makeBGRAImageBuffer(width: 2, height: 2)
+      let stillStalePicture = try installUnlockedPicture(stillStaleBuffer, on: vout)
+      pixelBufferDisplayCallback(opaque: vout.opaque, picture: stillStalePicture)
+      #expect(renderer.telemetrySnapshot.decodedFrameCount == 0)
+
+      let currentVout = try lease.negotiate(width: 2, height: 2)
+      defer { lease.close(currentVout) }
+      let currentBuffer = try makeBGRAImageBuffer(width: 2, height: 2)
+      let currentPicture = try installUnlockedPicture(currentBuffer, on: currentVout)
+      pixelBufferDisplayCallback(opaque: currentVout.opaque, picture: currentPicture)
+
+      let afterCurrentFrame = renderer.telemetrySnapshot
+      #expect(afterCurrentFrame.playbackGeneration == 2)
+      #expect(afterCurrentFrame.decodedFrameCount == 1)
+      #expect(afterCurrentFrame.enqueuedFrameCount == 1)
     }
 
     @MainActor

--- a/Tests/SwiftVLCTests/PiP/PixelBufferRendererEnqueueTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferRendererEnqueueTests.swift
@@ -416,11 +416,109 @@ extension Integration {
       expectNoDifference(probe.snapshot.enqueuedPresentationValues, [])
     }
 
+    @Test
+    func `A stale playback generation cannot install or deliver a frame`() throws {
+      let queue = DispatchQueue(label: "org.swiftvlc.tests.enqueue-playback-generation")
+      let layer = AVSampleBufferDisplayLayer()
+      let probe = DisplayLayerProbe()
+      let renderer = PixelBufferRenderer(
+        displayLayer: layer,
+        enqueueQueue: queue,
+        displayLayerAPI: probe.api
+      )
+      renderer.beginPlaybackGeneration(2)
+      let generation = renderer.state.withLock { $0.renderGeneration }
+
+      _ = try submitFrame(
+        index: 1,
+        renderer: renderer,
+        generation: generation,
+        layer: layer,
+        playbackGeneration: 1
+      )
+      #expect(waitUntilIdle(queue) == .success)
+      expectNoDifference(probe.snapshot.enqueuedPresentationValues, [])
+      #expect(renderer.telemetrySnapshot.enqueuedFrameCount == 0)
+
+      _ = try submitFrame(
+        index: 2,
+        renderer: renderer,
+        generation: generation,
+        layer: layer,
+        playbackGeneration: 2
+      )
+      #expect(probe.waitForDelivery() == .success)
+      #expect(waitUntilIdle(queue) == .success)
+      expectNoDifference(probe.snapshot.enqueuedPresentationValues, [2])
+    }
+
+    @Test
+    func `Retired vout callbacks cannot regress identity or replace successor frames`() throws {
+      let queue = DispatchQueue(label: "org.swiftvlc.tests.enqueue-vout-generation")
+      let blocker = QueueBlocker(queue: queue)
+      defer { blocker.release() }
+      #expect(blocker.waitUntilStarted() == .success)
+
+      let layer = AVSampleBufferDisplayLayer()
+      let probe = DisplayLayerProbe()
+      let renderer = PixelBufferRenderer(
+        displayLayer: layer,
+        enqueueQueue: queue,
+        displayLayerAPI: probe.api
+      )
+      renderer.beginPlaybackGeneration(3)
+      let generation = renderer.state.withLock { $0.renderGeneration }
+
+      _ = try submitFrame(
+        index: 1,
+        renderer: renderer,
+        generation: generation,
+        layer: layer,
+        playbackGeneration: 3,
+        voutGeneration: 1
+      )
+      _ = try submitFrame(
+        index: 2,
+        renderer: renderer,
+        generation: generation,
+        layer: layer,
+        playbackGeneration: 3,
+        voutGeneration: 2
+      )
+      _ = try submitFrame(
+        index: 3,
+        renderer: renderer,
+        generation: generation,
+        layer: layer,
+        playbackGeneration: 3,
+        voutGeneration: 1
+      )
+      _ = try submitFrame(
+        index: 4,
+        renderer: renderer,
+        generation: generation,
+        layer: layer,
+        playbackGeneration: 3,
+        voutGeneration: 2
+      )
+
+      blocker.release()
+      #expect(probe.waitForDelivery() == .success)
+      #expect(waitUntilIdle(queue) == .success)
+      expectNoDifference(probe.snapshot.enqueuedPresentationValues, [4])
+      let telemetry = renderer.telemetrySnapshot
+      #expect(telemetry.voutGeneration == 2)
+      #expect(telemetry.voutTransitionCount == 2)
+      #expect(telemetry.enqueuedFrameCount == 3)
+    }
+
     private func submitFrame(
       index: Int,
       renderer: PixelBufferRenderer,
       generation: UInt64,
-      layer: AVSampleBufferDisplayLayer
+      layer: AVSampleBufferDisplayLayer,
+      playbackGeneration: UInt64 = 0,
+      voutGeneration: UInt64 = 0
     )
       throws -> WeakPixelBuffer {
       try autoreleasepool {
@@ -444,7 +542,9 @@ extension Integration {
         try renderer.enqueue(
           #require(sample),
           generation: generation,
-          on: layer
+          on: layer,
+          playbackGeneration: playbackGeneration,
+          voutGeneration: voutGeneration
         )
         return weakBuffer
       }

--- a/Tests/SwiftVLCTests/Player/PlaybackHealthTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlaybackHealthTests.swift
@@ -1,0 +1,306 @@
+@testable import SwiftVLC
+import Testing
+
+extension Integration {
+  @Suite(.tags(.mainActor), .serialized)
+  @MainActor struct PlaybackHealthTests {
+    @Test
+    func `First decoded and presented frame fire exactly once per generation`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      player.state = .playing
+      player.activeVideoOutputs = 1
+      let events = player.playbackHealthEvents
+      let now = ContinuousClock.now
+
+      player._applyPlaybackHealthSampleForTesting(
+        counters: PlaybackHealthCounters(decodedVideoFrames: 1),
+        now: now
+      )
+      player._applyPlaybackHealthSampleForTesting(
+        counters: PlaybackHealthCounters(
+          decodedVideoFrames: 2,
+          presentedVideoFrames: 1
+        ),
+        now: now.advanced(by: .milliseconds(10))
+      )
+      player._applyPlaybackHealthSampleForTesting(
+        counters: PlaybackHealthCounters(
+          decodedVideoFrames: 2,
+          presentedVideoFrames: 1
+        ),
+        now: now.advanced(by: .milliseconds(20))
+      )
+
+      let firstGeneration = player.generation
+      try player.load(Media(url: TestMedia.testMP4URL))
+      player.state = .playing
+      player.activeVideoOutputs = 1
+      let newGenerationEvents = player.playbackHealthEvents
+      player._applyPlaybackHealthSampleForTesting(
+        counters: PlaybackHealthCounters(
+          decodedVideoFrames: 1,
+          presentedVideoFrames: 1
+        ),
+        now: now.advanced(by: .milliseconds(30))
+      )
+      player.playbackHealthEventBridge.terminate()
+
+      var received: [PlaybackHealthEventKind] = []
+      for await event in events {
+        received.append(event.kind)
+      }
+      var receivedAfterBoundary: [PlaybackHealthEvent] = []
+      for await event in newGenerationEvents {
+        receivedAfterBoundary.append(event)
+      }
+      #expect(received.filter { $0 == .firstDecodedFrame }.count == 2)
+      #expect(received.filter { $0 == .firstPresentedFrame }.count == 2)
+      #expect(receivedAfterBoundary.count == 2)
+      #expect(receivedAfterBoundary.allSatisfy { $0.snapshot.generation == player.generation })
+      #expect(player.playbackHealth.state == .healthy(.videoOnly))
+      #expect(player.playbackHealth.generation == player.generation)
+      #expect(player.generation > firstGeneration)
+    }
+
+    @Test
+    func `A recovered stall remains paired for late subscribers`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      player.state = .playing
+      player.activeVideoOutputs = 1
+      let now = ContinuousClock.now
+      let initial = PlaybackHealthCounters(
+        sourceReadBytes: 100,
+        decodedVideoFrames: 10,
+        presentedVideoFrames: 5
+      )
+      player._applyPlaybackHealthSampleForTesting(counters: initial, now: now)
+
+      player.playbackHealthMonitoringState.previousCounters = initial
+      player.playbackHealthMonitoringState.lastSourceProgressAt = now
+      player.playbackHealthMonitoringState.lastDecodedProgressAt = now
+      player.playbackHealthMonitoringState.lastPresentedProgressAt = now.advanced(by: .seconds(-3))
+      player._applyPlaybackHealthSampleForTesting(
+        counters: initial,
+        now: now.advanced(by: .milliseconds(10))
+      )
+      #expect(player.playbackHealth.state == .stalled(.display))
+
+      player._applyPlaybackHealthSampleForTesting(
+        counters: PlaybackHealthCounters(
+          sourceReadBytes: 100,
+          decodedVideoFrames: 11,
+          presentedVideoFrames: 6
+        ),
+        now: now.advanced(by: .milliseconds(20))
+      )
+      #expect(player.playbackHealth.state == .healthy(.videoOnly))
+
+      let snapshots = player.playbackHealthSnapshots
+      let events = player.playbackHealthEvents
+      player.playbackHealthSnapshotBridge.terminate()
+      player.playbackHealthEventBridge.terminate()
+
+      var replayedSnapshot: PlaybackHealthSnapshot?
+      for await snapshot in snapshots {
+        replayedSnapshot = snapshot
+      }
+      var replayedEvent: PlaybackHealthEvent?
+      for await event in events {
+        replayedEvent = event
+      }
+      #expect(replayedSnapshot?.lastStallReason == .display)
+      #expect(replayedSnapshot?.lastStalledAt != nil)
+      #expect(replayedSnapshot?.lastRecoveredAt != nil)
+      #expect(replayedEvent?.kind == .recovered(from: .display))
+    }
+
+    @Test
+    func `Expected waits remain distinct from stalls`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+
+      player.state = .opening
+      player._applyPlaybackHealthSampleForTesting(counters: PlaybackHealthCounters())
+      #expect(player.playbackHealth.state == .waiting(.opening))
+
+      player.state = .buffering
+      player._applyPlaybackHealthSampleForTesting(counters: PlaybackHealthCounters())
+      #expect(player.playbackHealth.state == .waiting(.buffering))
+
+      player.state = .paused
+      player._applyPlaybackHealthSampleForTesting(counters: PlaybackHealthCounters())
+      #expect(player.playbackHealth.state == .paused)
+    }
+
+    @Test
+    func `Seek and adaptive switch waits clear when presentation advances`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      player.state = .playing
+      player.activeVideoOutputs = 1
+      let initial = PlaybackHealthCounters(
+        decodedVideoFrames: 1,
+        presentedVideoFrames: 1
+      )
+      player._applyPlaybackHealthSampleForTesting(counters: initial)
+
+      player.markPlaybackHealthSeek()
+      #expect(player.playbackHealth.state == .waiting(.seeking))
+      player._applyPlaybackHealthSampleForTesting(
+        counters: PlaybackHealthCounters(
+          decodedVideoFrames: 2,
+          presentedVideoFrames: 2
+        )
+      )
+      #expect(player.playbackHealth.state == .healthy(.videoOnly))
+
+      player.markPlaybackHealthAdaptiveSwitch()
+      #expect(player.playbackHealth.state == .waiting(.adaptiveSwitch))
+      player._applyPlaybackHealthSampleForTesting(
+        counters: PlaybackHealthCounters(
+          decodedVideoFrames: 3,
+          presentedVideoFrames: 3
+        )
+      )
+      #expect(player.playbackHealth.state == .healthy(.videoOnly))
+    }
+
+    @Test
+    func `Paused playback clears a pending wait and sampler`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      player.state = .playing
+      player.activeVideoOutputs = 1
+      player.markPlaybackHealthSeek()
+      #expect(player.playbackHealthMonitoringState.pendingWaitingReason == .seeking)
+
+      player.state = .paused
+      player._applyPlaybackHealthSampleForTesting(counters: PlaybackHealthCounters())
+      player.reconcilePlaybackHealthSamplingTask()
+
+      #expect(player.playbackHealth.state == .paused)
+      #expect(player.playbackHealthMonitoringState.pendingWaitingReason == nil)
+      #expect(player.playbackHealthSamplingTask == nil)
+    }
+
+    @Test
+    func `Paused renderer recovery remains observable and paired`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      player.state = .paused
+      let events = player.playbackHealthEvents
+      let now = ContinuousClock.now
+
+      player._applyPlaybackHealthSampleForTesting(
+        counters: PlaybackHealthCounters(rendererFlushes: 1),
+        renderer: PlaybackRendererHealthSample(
+          playbackGeneration: player.sessionGeneration,
+          flushes: 1,
+          status: .recovering
+        ),
+        now: now
+      )
+      #expect(player.playbackHealth.state == .stalled(.rendererRecovery))
+
+      player._applyPlaybackHealthSampleForTesting(
+        counters: PlaybackHealthCounters(
+          presentedVideoFrames: 1,
+          rendererFlushes: 1
+        ),
+        renderer: PlaybackRendererHealthSample(
+          playbackGeneration: player.sessionGeneration,
+          presentedFrames: 1,
+          flushes: 1,
+          lastPresentedAt: now.advanced(by: .milliseconds(20)),
+          status: .rendering
+        ),
+        now: now.advanced(by: .milliseconds(20))
+      )
+      player.playbackHealthEventBridge.terminate()
+
+      var received: [PlaybackHealthEventKind] = []
+      for await event in events {
+        received.append(event.kind)
+      }
+      #expect(received.filter { $0 == .stalled(.rendererRecovery) }.count == 1)
+      #expect(received.filter { $0 == .recovered(from: .rendererRecovery) }.count == 1)
+      #expect(player.playbackHealth.state == .paused)
+    }
+
+    @Test
+    func `Pipeline counters identify source decoder display and audio-output stalls`() throws {
+      let source = try makePlayerForStall()
+      let now = ContinuousClock.now
+      source.playbackHealthMonitoringState.startedAt = now.advanced(by: .seconds(-3))
+      source.playbackHealthMonitoringState.lastSourceProgressAt = now.advanced(by: .seconds(-3))
+      source.playbackHealthMonitoringState.lastDecodedProgressAt = now.advanced(by: .seconds(-3))
+      source.playbackHealthMonitoringState.lastPresentedProgressAt = now.advanced(by: .seconds(-3))
+      source._applyPlaybackHealthSampleForTesting(counters: PlaybackHealthCounters(), now: now)
+      #expect(source.playbackHealth.state == .stalled(.source))
+
+      let decoder = try makePlayerForStall()
+      let decoderCounters = PlaybackHealthCounters(sourceReadBytes: 100)
+      decoder.playbackHealthMonitoringState.startedAt = now.advanced(by: .seconds(-3))
+      decoder.playbackHealthMonitoringState.previousCounters = decoderCounters
+      decoder.playbackHealthMonitoringState.lastSourceProgressAt = now
+      decoder.playbackHealthMonitoringState.lastDecodedProgressAt = now.advanced(by: .seconds(-3))
+      decoder.playbackHealthMonitoringState.lastPresentedProgressAt = now.advanced(by: .seconds(-3))
+      decoder._applyPlaybackHealthSampleForTesting(counters: decoderCounters, now: now)
+      #expect(decoder.playbackHealth.state == .stalled(.decoder))
+
+      let display = try makePlayerForStall()
+      let displayCounters = PlaybackHealthCounters(
+        sourceReadBytes: 100,
+        decodedVideoFrames: 10,
+        presentedVideoFrames: 1
+      )
+      display.playbackHealthMonitoringState.startedAt = now.advanced(by: .seconds(-3))
+      display.playbackHealthMonitoringState.previousCounters = displayCounters
+      display.playbackHealthMonitoringState.lastSourceProgressAt = now
+      display.playbackHealthMonitoringState.lastDecodedProgressAt = now
+      display.playbackHealthMonitoringState.lastPresentedProgressAt = now.advanced(by: .seconds(-3))
+      display._applyPlaybackHealthSampleForTesting(counters: displayCounters, now: now)
+      #expect(display.playbackHealth.state == .stalled(.display))
+
+      let audio = Player(instance: TestInstance.makeAudioOnly())
+      try audio.load(Media(url: TestMedia.twosecURL))
+      audio.state = .playing
+      let audioCounters = PlaybackHealthCounters(
+        sourceReadBytes: 100,
+        decodedAudioFrames: 10
+      )
+      audio.playbackHealthMonitoringState.startedAt = now.advanced(by: .seconds(-3))
+      audio.playbackHealthMonitoringState.previousCounters = audioCounters
+      audio.playbackHealthMonitoringState.lastSourceProgressAt = now
+      audio.playbackHealthMonitoringState.lastDecodedProgressAt = now
+      audio.playbackHealthMonitoringState.lastAudioProgressAt = now.advanced(by: .seconds(-3))
+      audio._applyPlaybackHealthSampleForTesting(counters: audioCounters, now: now)
+      #expect(audio.playbackHealth.state == .stalled(.audioOutput))
+    }
+
+    @Test
+    func `Audio-only progress is healthy without a video presentation`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      player.state = .playing
+      player._applyPlaybackHealthSampleForTesting(
+        counters: PlaybackHealthCounters(
+          decodedAudioFrames: 2,
+          playedAudioBuffers: 1
+        )
+      )
+      #expect(player.playbackHealth.state == .healthy(.audioOnly))
+      #expect(player.playbackHealth.lastPresentedAt == nil)
+    }
+
+    private func makePlayerForStall() throws -> Player {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      player.state = .playing
+      player.activeVideoOutputs = 1
+      return player
+    }
+  }
+}

--- a/Tests/SwiftVLCTests/Player/PlaybackHealthTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlaybackHealthTests.swift
@@ -230,10 +230,153 @@ extension Integration {
     }
 
     @Test
+    func `Renderer recovery failure remains terminal after renderer status changes`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      player.state = .playing
+      let now = ContinuousClock.now
+      let failed = PlaybackHealthCounters(rendererRecoveryFailures: 1)
+
+      player._applyPlaybackHealthSampleForTesting(
+        counters: failed,
+        renderer: PlaybackRendererHealthSample(
+          playbackGeneration: player.sessionGeneration,
+          recoveryFailures: 1,
+          status: .failed
+        ),
+        now: now
+      )
+      #expect(player.playbackHealth.state == .failed(.renderer))
+
+      player._applyPlaybackHealthSampleForTesting(
+        counters: failed,
+        renderer: PlaybackRendererHealthSample(
+          playbackGeneration: player.sessionGeneration,
+          recoveryFailures: 1,
+          status: .rendering
+        ),
+        now: now.advanced(by: .seconds(1))
+      )
+      #expect(player.playbackHealth.state == .failed(.renderer))
+    }
+
+    @Test
+    func `Recovery remains paired when an expected wait intervenes`() async throws {
+      let player = try makePlayerForStall()
+      let events = player.playbackHealthEvents
+      let now = ContinuousClock.now
+      let stalled = PlaybackHealthCounters(
+        sourceReadBytes: 100,
+        decodedVideoFrames: 10,
+        presentedVideoFrames: 1
+      )
+      player.playbackHealthMonitoringState.previousCounters = stalled
+      player.playbackHealthMonitoringState.lastSourceProgressAt = now
+      player.playbackHealthMonitoringState.lastDecodedProgressAt = now
+      player.playbackHealthMonitoringState.lastPresentedProgressAt = now.advanced(by: .seconds(-3))
+      player._applyPlaybackHealthSampleForTesting(counters: stalled, now: now)
+      #expect(player.playbackHealth.state == .stalled(.display))
+
+      player.markPlaybackHealthAdaptiveSwitch()
+      #expect(player.playbackHealth.state == .waiting(.adaptiveSwitch))
+      player._applyPlaybackHealthSampleForTesting(
+        counters: PlaybackHealthCounters(
+          sourceReadBytes: 100,
+          decodedVideoFrames: 11,
+          presentedVideoFrames: 2
+        ),
+        now: now.advanced(by: .milliseconds(20))
+      )
+      #expect(player.playbackHealth.state == .healthy(.videoOnly))
+
+      player.playbackHealthEventBridge.terminate()
+      var received: [PlaybackHealthEventKind] = []
+      for await event in events {
+        received.append(event.kind)
+      }
+      #expect(received.contains(.stalled(.display)))
+      #expect(received.contains(.recovered(from: .display)))
+    }
+
+    @Test
+    func `Entering playing rearms progress clocks after intentional inactivity`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      player.state = .paused
+      let stale = ContinuousClock.now.advanced(by: .seconds(-30))
+      player.playbackHealthMonitoringState.lastSourceProgressAt = stale
+      player.playbackHealthMonitoringState.lastDecodedProgressAt = stale
+      player.playbackHealthMonitoringState.lastAudioDecodedProgressAt = stale
+      player.playbackHealthMonitoringState.lastPresentedProgressAt = stale
+      player.playbackHealthMonitoringState.lastAudioProgressAt = stale
+
+      player.publishPlaybackState(.playing)
+
+      let now = ContinuousClock.now
+      #expect(
+        player.playbackHealthMonitoringState.lastSourceProgressAt.duration(to: now)
+          < .seconds(1)
+      )
+      #expect(
+        player.playbackHealthMonitoringState.lastPresentedProgressAt.duration(to: now)
+          < .seconds(1)
+      )
+      #expect(player.playbackHealth.state != .stalled(.source))
+    }
+
+    @Test
+    func `Audiovisual health requires selected audio output progress`() throws {
+      let player = try makePlayerForStall()
+      player.audioTracks = [makeAudioTrack(isSelected: true)]
+      let now = ContinuousClock.now
+      let counters = PlaybackHealthCounters(
+        sourceReadBytes: 100,
+        decodedVideoFrames: 10,
+        decodedAudioFrames: 10,
+        presentedVideoFrames: 5,
+        playedAudioBuffers: 2
+      )
+      player.playbackHealthMonitoringState.previousCounters = counters
+      player.playbackHealthMonitoringState.lastSourceProgressAt = now
+      player.playbackHealthMonitoringState.lastDecodedProgressAt = now
+      player.playbackHealthMonitoringState.lastAudioDecodedProgressAt = now
+      player.playbackHealthMonitoringState.lastPresentedProgressAt = now
+      player.playbackHealthMonitoringState.lastAudioProgressAt = now.advanced(by: .seconds(-3))
+
+      player._applyPlaybackHealthSampleForTesting(counters: counters, now: now)
+
+      #expect(player.playbackHealth.state == .stalled(.audioOutput))
+    }
+
+    @Test
+    func `Unselected audio does not turn video-only playback audiovisual`() throws {
+      let player = try makePlayerForStall()
+      player.audioTracks = [makeAudioTrack(isSelected: false)]
+      player._applyPlaybackHealthSampleForTesting(
+        counters: PlaybackHealthCounters(
+          decodedVideoFrames: 2,
+          presentedVideoFrames: 1
+        )
+      )
+
+      #expect(player.playbackHealth.state == .healthy(.videoOnly))
+    }
+
+    @Test
+    func `Adaptive video comparison notices metadata changes with the same track ID`() {
+      let original = makeVideoTrack(width: 1280, frameRate: 24)
+      let identical = makeVideoTrack(width: 1280, frameRate: 24)
+      let adapted = makeVideoTrack(width: 1920, frameRate: 30)
+
+      #expect(!Player.playbackHealthVideoTracksDiffer([original], [identical]))
+      #expect(Player.playbackHealthVideoTracksDiffer([original], [adapted]))
+    }
+
+    @Test
     func `Pipeline counters identify source decoder display and audio-output stalls`() throws {
       let source = try makePlayerForStall()
       let now = ContinuousClock.now
-      source.playbackHealthMonitoringState.startedAt = now.advanced(by: .seconds(-3))
+      source.playbackHealthMonitoringState.activePlaybackBeganAt = now.advanced(by: .seconds(-3))
       source.playbackHealthMonitoringState.lastSourceProgressAt = now.advanced(by: .seconds(-3))
       source.playbackHealthMonitoringState.lastDecodedProgressAt = now.advanced(by: .seconds(-3))
       source.playbackHealthMonitoringState.lastPresentedProgressAt = now.advanced(by: .seconds(-3))
@@ -242,7 +385,7 @@ extension Integration {
 
       let decoder = try makePlayerForStall()
       let decoderCounters = PlaybackHealthCounters(sourceReadBytes: 100)
-      decoder.playbackHealthMonitoringState.startedAt = now.advanced(by: .seconds(-3))
+      decoder.playbackHealthMonitoringState.activePlaybackBeganAt = now.advanced(by: .seconds(-3))
       decoder.playbackHealthMonitoringState.previousCounters = decoderCounters
       decoder.playbackHealthMonitoringState.lastSourceProgressAt = now
       decoder.playbackHealthMonitoringState.lastDecodedProgressAt = now.advanced(by: .seconds(-3))
@@ -256,7 +399,7 @@ extension Integration {
         decodedVideoFrames: 10,
         presentedVideoFrames: 1
       )
-      display.playbackHealthMonitoringState.startedAt = now.advanced(by: .seconds(-3))
+      display.playbackHealthMonitoringState.activePlaybackBeganAt = now.advanced(by: .seconds(-3))
       display.playbackHealthMonitoringState.previousCounters = displayCounters
       display.playbackHealthMonitoringState.lastSourceProgressAt = now
       display.playbackHealthMonitoringState.lastDecodedProgressAt = now
@@ -271,10 +414,10 @@ extension Integration {
         sourceReadBytes: 100,
         decodedAudioFrames: 10
       )
-      audio.playbackHealthMonitoringState.startedAt = now.advanced(by: .seconds(-3))
+      audio.playbackHealthMonitoringState.activePlaybackBeganAt = now.advanced(by: .seconds(-3))
       audio.playbackHealthMonitoringState.previousCounters = audioCounters
       audio.playbackHealthMonitoringState.lastSourceProgressAt = now
-      audio.playbackHealthMonitoringState.lastDecodedProgressAt = now
+      audio.playbackHealthMonitoringState.lastAudioDecodedProgressAt = now
       audio.playbackHealthMonitoringState.lastAudioProgressAt = now.advanced(by: .seconds(-3))
       audio._applyPlaybackHealthSampleForTesting(counters: audioCounters, now: now)
       #expect(audio.playbackHealth.state == .stalled(.audioOutput))
@@ -301,6 +444,46 @@ extension Integration {
       player.state = .playing
       player.activeVideoOutputs = 1
       return player
+    }
+
+    private func makeAudioTrack(isSelected: Bool) -> Track {
+      Track(
+        id: "audio-0",
+        type: .audio,
+        name: "Audio",
+        codec: 0,
+        language: nil,
+        trackDescription: nil,
+        isSelected: isSelected,
+        bitrate: 0,
+        channels: 2,
+        sampleRate: 48000,
+        width: nil,
+        height: nil,
+        frameRate: nil,
+        frameRateRatio: nil,
+        encoding: nil
+      )
+    }
+
+    private func makeVideoTrack(width: Int, frameRate: Double) -> Track {
+      Track(
+        id: "video-0",
+        type: .video,
+        name: "Video",
+        codec: 0,
+        language: nil,
+        trackDescription: nil,
+        isSelected: true,
+        bitrate: 0,
+        channels: nil,
+        sampleRate: nil,
+        width: width,
+        height: 720,
+        frameRate: frameRate,
+        frameRateRatio: nil,
+        encoding: nil
+      )
     }
   }
 }

--- a/Tests/SwiftVLCTests/Player/PlayerEventLaneTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerEventLaneTests.swift
@@ -197,8 +197,14 @@ extension Integration {
         switch envelope.event {
         case .stateChanged(.stopped):
           predecessorEnvelope = envelope
-        case .mediaChanged:
+        case .mediaChanged where predecessorEnvelope != nil:
           break drain
+        case .mediaChanged:
+          // `load` can deliver its native MediaChanged echo before the two
+          // deterministic testing envelopes below reach this consumer. That
+          // echo is unrelated to the ordering under test, so keep draining
+          // until the injected predecessor has been observed.
+          continue
         default:
           break
         }

--- a/Tests/SwiftVLCTests/Player/PlayerRecastPlaybackTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerRecastPlaybackTests.swift
@@ -24,12 +24,15 @@ extension Integration {
       )
 
       let oldPointer = player.pointer
+      let oldGeneration = player.generation
       try await player.recast(to: nil)
 
       #expect(
         player.pointer != oldPointer,
         "recast did not replace the native handle of an active session"
       )
+      #expect(player.generation > oldGeneration)
+      #expect(player.playbackHealth.generation == player.generation)
       try #require(
         await poll(until: { player.state == .playing }),
         "playback did not resume on the new session after recast"

--- a/Tests/SwiftVLCTests/Player/PlayerShutdownInertnessTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerShutdownInertnessTests.swift
@@ -14,9 +14,9 @@ import Testing
 ///    caller a player whose native handle is still being released.
 /// 2. Commands issued after shutdown — including from tasks that were
 ///    already suspended when it began — must not create media or outputs.
-/// 3. `events` and `playbackIntentEvents` are computed properties that
-///    subscribe per access, so a stream requested after shutdown must arrive
-///    already finished rather than waiting forever on a dead source.
+/// 3. Every computed event/snapshot stream subscribes per access, so a stream
+///    requested after shutdown must arrive already finished rather than
+///    waiting forever on a dead source.
 extension Integration {
   @Suite(.tags(.mainActor, .async), .timeLimit(.minutes(1)))
   @MainActor struct PlayerShutdownInertnessTests {
@@ -138,6 +138,26 @@ extension Integration {
         received += 1
       }
       #expect(received == 0)
+    }
+
+    /// Playback-health streams are also permanent per-player subscriptions;
+    /// shutdown must finish both the low-rate snapshots and semantic events.
+    @Test
+    func `Playback health streams requested after shutdown finish immediately`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      await player.shutdown()
+
+      var snapshots = 0
+      for await _ in player.playbackHealthSnapshots {
+        snapshots += 1
+      }
+      var events = 0
+      for await _ in player.playbackHealthEvents {
+        events += 1
+      }
+
+      #expect(snapshots == 0)
+      #expect(events == 0)
     }
 
     /// A stream opened *before* shutdown must also finish, so consumers

--- a/Tests/SwiftVLCTests/Player/PlayerStopOutcomeTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerStopOutcomeTests.swift
@@ -307,6 +307,40 @@ extension Integration {
       )
     }
 
+    @Test
+    func `Observable stop wait drains an older stopping publication first`() async {
+      let statuses = Self.statusStream([
+        PlaybackStatus(state: .stopping, generation: PlaybackGeneration(4)),
+        PlaybackStatus(state: .stopped, generation: PlaybackGeneration(4))
+      ])
+
+      let mirrored = await Player.awaitPlaybackMirror(
+        .stopped,
+        generation: PlaybackGeneration(4),
+        on: statuses,
+        timeout: .seconds(1)
+      )
+
+      #expect(mirrored)
+    }
+
+    @Test
+    func `Observable stop wait rejects a successor generation`() async {
+      let statuses = Self.statusStream([
+        PlaybackStatus(state: .stopping, generation: PlaybackGeneration(4)),
+        PlaybackStatus(state: .playing, generation: PlaybackGeneration(5))
+      ])
+
+      let mirrored = await Player.awaitPlaybackMirror(
+        .stopped,
+        generation: PlaybackGeneration(4),
+        on: statuses,
+        timeout: .seconds(1)
+      )
+
+      #expect(!mirrored)
+    }
+
     /// Builds a finite stream of the given events. The stream finishes after
     /// the last one, which also exercises the "source ended without a stop"
     /// path.
@@ -317,6 +351,17 @@ extension Integration {
       AsyncStream { continuation in
         for event in events {
           continuation.yield(event)
+        }
+        continuation.finish()
+      }
+    }
+
+    private static func statusStream(
+      _ statuses: [PlaybackStatus]
+    ) -> AsyncStream<PlaybackStatus> {
+      AsyncStream { continuation in
+        for status in statuses {
+          continuation.yield(status)
         }
         continuation.finish()
       }


### PR DESCRIPTION
## Summary

- expose generation-scoped playback-health snapshots and semantic events for first decode/presentation, expected waits, stalls, recovery, and typed terminal failures
- add low-rate source, decoder, audio-output, and direct-renderer telemetry without observable writes on the frame hot path
- retain and reject video frames by media generation, and keep vout identities monotonic across controller and native-handle replacement
- terminate health sampling and streams during shutdown, clear stale replay at media boundaries, and document the public API and recovery bound
- make the same-handle event-attribution test deterministic when a native `MediaChanged` echo races its injected envelopes

## Why

`Player.state == .playing` and buffer progress did not prove that media was actually decoding or presenting. Direct-renderer recovery was also private, so clients could not distinguish expected buffering and seeks from source, decoder, display, or audio-output stalls.

During validation, the first generation guard incorrectly left an installed callback slot stamped with generation zero after loading media. That rejected every legitimate frame as stale. The slot now owns a synchronized generation source: future vouts capture the current media generation, while already-open vouts retain the predecessor generation and are rejected after a boundary.

## Validation

- CI-equivalent SwiftPM suite: 1,947 tests in 167 suites passed with code coverage enabled
- focused real decoded-frame harness: 4 tests passed
- playback-health, renderer callback, and callback-registration suites passed
- SwiftLint strict and SwiftFormat strict passed
- release-integrity checks passed
- DocC generation passed with zero warnings
- public documentation coverage: 872/872 symbols (100%)

Closes #80
Closes #81
