### PR TITLE
Handle managed audio lifecycle disruptions

### DIFF
--- a/Sources/SwiftVLC/PiP/PiPController+AudioSession.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+AudioSession.swift
@@ -7,6 +7,10 @@ import UIKit
 // MARK: - Audio-session policy
 
 extension PiPController {
+  #if os(iOS)
+  private static let managedAudioSessionControllers = NSHashTable<PiPController>.weakObjects()
+  #endif
+
   /// Live operation for deferred managed-session activation. Kept separate
   /// from the one-shot state machine so native-route tests can inject a
   /// deterministic failure/success sequence.
@@ -41,9 +45,7 @@ extension PiPController {
   /// No-op when ``managesAudioSession`` is `false`, after the first
   /// activation, and on platforms without `AVAudioSession`.
   func activateAudioSessionIfNeeded() {
-    #if os(iOS)
     activateAudioSessionIfNeeded(using: audioSessionActivation)
-    #endif
   }
 
   /// Runs the platform activation operation at most once after it succeeds.
@@ -53,14 +55,32 @@ extension PiPController {
   /// uses this same state machine; accepting the operation as an argument keeps
   /// the failure and retry behavior deterministic in platform-neutral tests.
   func activateAudioSessionIfNeeded(using activate: () throws -> Void) {
-    guard managesAudioSession, !hasActivatedAudioSession else { return }
+    guard managesAudioSession else { return }
+    if hasActivatedAudioSession {
+      resumeManagedAudioSuspensionAfterActivationIfNeeded()
+      return
+    }
     do {
       try activate()
       hasActivatedAudioSession = true
+      resumeManagedAudioSuspensionAfterActivationIfNeeded()
     } catch {
       // Activation can fail transiently (for example during an audio-session
       // interruption). Leave the state unset so the next signal retries.
     }
+  }
+
+  private func resumeManagedAudioSuspensionAfterActivationIfNeeded() {
+    guard
+      isManagedAudioResumePendingActivation,
+      !isManagedAudioResumeDeniedByInterruption,
+      player.isPlaybackRequestedActive,
+      playbackDriver.resume(false)
+    else { return }
+    isPlaybackSuspendedForManagedAudioLifecycle = false
+    isPlaybackSuspendedForMediaServices = false
+    isManagedAudioResumePendingActivation = false
+    player.preservesPlaybackIntentForManagedAudioSuspension = false
   }
 
   // MARK: - Session disruption
@@ -95,6 +115,9 @@ extension PiPController {
     case deviceLocked(isPictureInPictureActive: Bool)
     /// UIKit is returning to the foreground.
     case enteringForeground
+    /// Automatic PiP became active after the background grace had already
+    /// issued a lifecycle suspension.
+    case pictureInPictureBecameActive
   }
 
   /// What a disruption implies for the managed session.
@@ -125,6 +148,10 @@ extension PiPController {
     var clearsLifecycleSuspension = false
     /// Clear the media-services cause after a reset.
     var clearsMediaServicesSuspension = false
+    /// Retain an interruption-end denial across later lifecycle recovery.
+    var deniesManagedResume = false
+    /// A positive system decision or a new user intent clears the denial.
+    var clearsManagedResumeDenial = false
   }
 
   /// Decides the response to a session disruption.
@@ -154,7 +181,8 @@ extension PiPController {
     isPlaybackIntentActive: Bool,
     managesAudioSession: Bool,
     wasPlaybackSuspendedForLifecycle: Bool = false,
-    wasPlaybackSuspendedForMediaServices: Bool = false
+    wasPlaybackSuspendedForMediaServices: Bool = false,
+    wasManagedResumeDenied: Bool = false
   )
     -> AudioSessionReaction {
     guard managesAudioSession else { return AudioSessionReaction() }
@@ -168,7 +196,12 @@ extension PiPController {
         && isPlaybackIntentActive
         && !wasPlaybackSuspendedForLifecycle
         && !wasPlaybackSuspendedForMediaServices
-      return AudioSessionReaction(clearsActivationLatch: !resumes, reactivates: resumes)
+      return AudioSessionReaction(
+        clearsActivationLatch: !resumes,
+        reactivates: resumes,
+        deniesManagedResume: !shouldResume,
+        clearsManagedResumeDenial: shouldResume
+      )
 
     case .routeLost:
       // The session itself is still valid, so the latch stands.
@@ -192,10 +225,13 @@ extension PiPController {
       let resumes = isPlaybackIntentActive
         && wasPlaybackSuspendedForMediaServices
         && !wasPlaybackSuspendedForLifecycle
+        && !wasManagedResumeDenied
       return AudioSessionReaction(
-        clearsActivationLatch: !isPlaybackIntentActive,
+        clearsActivationLatch: !isPlaybackIntentActive || wasManagedResumeDenied,
         reconfiguresCategory: true,
-        reactivates: isPlaybackIntentActive && !wasPlaybackSuspendedForLifecycle,
+        reactivates: isPlaybackIntentActive
+          && !wasPlaybackSuspendedForLifecycle
+          && !wasManagedResumeDenied,
         resumesManagedSuspendedPlayback: resumes,
         clearsMediaServicesSuspension: wasPlaybackSuspendedForMediaServices
       )
@@ -213,10 +249,11 @@ extension PiPController {
         deactivatesSession: true
       )
 
-    case .enteringForeground:
+    case .enteringForeground, .pictureInPictureBecameActive:
       let resumes = isPlaybackIntentActive
         && wasPlaybackSuspendedForLifecycle
         && !wasPlaybackSuspendedForMediaServices
+        && !wasManagedResumeDenied
       return AudioSessionReaction(
         reactivates: resumes,
         resumesManagedSuspendedPlayback: resumes,
@@ -245,12 +282,25 @@ extension PiPController {
       if reaction.marksMediaServicesSuspension {
         isPlaybackSuspendedForMediaServices = true
       }
+      if reaction.marksLifecycleSuspension || reaction.marksMediaServicesSuspension {
+        isManagedAudioResumePendingActivation = false
+      }
     }
-    if reaction.deactivatesSession {
+    if reaction.deniesManagedResume {
+      isManagedAudioResumeDeniedByInterruption = true
+      isManagedAudioResumePendingActivation = false
+    }
+    if reaction.clearsManagedResumeDenial {
+      isManagedAudioResumeDeniedByInterruption = false
+    }
+    if reaction.deactivatesSession, pauseAccepted || wasAlreadySuspended {
       deactivateAudioSessionIfNeeded()
     }
     if reaction.clearsActivationLatch {
       hasActivatedAudioSession = false
+      if !reaction.reactivates {
+        isManagedAudioResumePendingActivation = false
+      }
     }
     if reaction.reconfiguresCategory {
       configureAudioSession()
@@ -270,8 +320,11 @@ extension PiPController {
       isPlaybackSuspendedForManagedAudioLifecycle
       || isPlaybackSuspendedForMediaServices,
       player.isPlaybackRequestedActive,
-      playbackDriver.resume() {
+      playbackDriver.resume(false) {
       resumedManagedSuspension = true
+    }
+    if reaction.resumesManagedSuspendedPlayback, !resumedManagedSuspension {
+      isManagedAudioResumePendingActivation = true
     }
     if
       reaction.clearsLifecycleSuspension,
@@ -283,6 +336,15 @@ extension PiPController {
       !reaction.resumesManagedSuspendedPlayback || resumedManagedSuspension {
       isPlaybackSuspendedForMediaServices = false
     }
+    if resumedManagedSuspension {
+      isManagedAudioResumePendingActivation = false
+    }
+    if
+      !isPlaybackSuspendedForManagedAudioLifecycle,
+      !isPlaybackSuspendedForMediaServices,
+      !isManagedAudioResumePendingActivation {
+      player.preservesPlaybackIntentForManagedAudioSuspension = false
+    }
   }
 
   /// Returns audio focus to other apps after SwiftVLC has suspended hidden
@@ -292,12 +354,28 @@ extension PiPController {
   func deactivateAudioSessionIfNeeded() {
     #if os(iOS)
     guard managesAudioSession, hasActivatedAudioSession else { return }
+    guard !hasAnotherManagedAudioSessionUser() else { return }
     try? AVAudioSession.sharedInstance().setActive(
       false,
       options: .notifyOthersOnDeactivation
     )
     #endif
   }
+
+  #if os(iOS)
+  func hasAnotherManagedAudioSessionUser() -> Bool {
+    Self.managedAudioSessionControllers.allObjects.contains {
+      $0 !== self
+        && $0.managesAudioSession
+        && $0.hasActivatedAudioSession
+        && ($0.isActive || (
+          $0.player.isPlaybackRequestedActive
+            && !$0.isPlaybackSuspendedForManagedAudioLifecycle
+            && !$0.isPlaybackSuspendedForMediaServices
+        ))
+    }
+  }
+  #endif
 
   #if os(iOS)
   /// Subscribes to the session disruptions the managed path reacts to.
@@ -307,6 +385,7 @@ extension PiPController {
   /// session the host app owns.
   func startAudioSessionObservers() {
     guard managesAudioSession else { return }
+    Self.managedAudioSessionControllers.add(self)
     let center = NotificationCenter.default
     let session = AVAudioSession.sharedInstance()
 
@@ -394,6 +473,7 @@ extension PiPController {
       NotificationCenter.default.removeObserver(observer)
     }
     audioSessionObservers.removeAll()
+    Self.managedAudioSessionControllers.remove(self)
   }
 
   private func handleInterruption(rawType: UInt?, rawOptions: UInt?) {
@@ -442,6 +522,9 @@ extension PiPController {
     if isActive {
       audioSessionBackgroundPauseTask?.cancel()
       audioSessionBackgroundPauseTask = nil
+      if isPlaybackSuspendedForManagedAudioLifecycle {
+        react(to: .pictureInPictureBecameActive)
+      }
     } else if isApplicationInBackground {
       scheduleBackgroundPauseIfNeeded(after: .zero)
     }
@@ -491,7 +574,9 @@ extension PiPController {
         wasPlaybackSuspendedForLifecycle:
         isPlaybackSuspendedForManagedAudioLifecycle,
         wasPlaybackSuspendedForMediaServices:
-        isPlaybackSuspendedForMediaServices
+        isPlaybackSuspendedForMediaServices,
+        wasManagedResumeDenied:
+        isManagedAudioResumeDeniedByInterruption
       )
     )
   }

--- a/Sources/SwiftVLC/PiP/PiPController+AudioSession.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+AudioSession.swift
@@ -1,5 +1,8 @@
 #if os(iOS) || os(macOS)
 import AVFoundation
+#if os(iOS)
+import UIKit
+#endif
 
 // MARK: - Audio-session policy
 
@@ -81,6 +84,17 @@ extension PiPController {
     /// The media server restarted. Every session object is invalid and the
     /// category has to be set again from scratch.
     case mediaServicesReset
+    /// The media server became unavailable. Playback is suspended while
+    /// preserving intent until the subsequent reset notification.
+    case mediaServicesLost
+    /// UIKit completed backgrounding while no PiP window was active.
+    /// `isPictureInPictureActive` is captured after a bounded grace period so
+    /// an automatic PiP start is not mistaken for hidden background playback.
+    case enteredBackground(isPictureInPictureActive: Bool)
+    /// Protected data became unavailable, which is UIKit's device-lock signal.
+    case deviceLocked(isPictureInPictureActive: Bool)
+    /// UIKit is returning to the foreground.
+    case enteringForeground
   }
 
   /// What a disruption implies for the managed session.
@@ -95,6 +109,22 @@ extension PiPController {
     /// Pause playback, because continuing would be wrong rather than merely
     /// silent.
     var pausesPlayback = false
+    /// Issue a lifecycle pause without changing the user's active playback
+    /// intent, so only SwiftVLC's own pause can be recovered on foreground.
+    var preservesPlaybackIntentWhenPausing = false
+    /// Resume a pause previously issued by the managed lifecycle path.
+    var resumesManagedSuspendedPlayback = false
+    /// Record app/device lifecycle as one cause of the managed pause.
+    var marksLifecycleSuspension = false
+    /// Record lost media services as another independent pause cause.
+    var marksMediaServicesSuspension = false
+    /// Give up audio focus after hidden playback has been suspended.
+    var deactivatesSession = false
+    /// Forget a previous lifecycle suspension without resuming it, e.g. after
+    /// the user explicitly paused while the app was backgrounded.
+    var clearsLifecycleSuspension = false
+    /// Clear the media-services cause after a reset.
+    var clearsMediaServicesSuspension = false
   }
 
   /// Decides the response to a session disruption.
@@ -122,7 +152,9 @@ extension PiPController {
   nonisolated static func reaction(
     to disruption: AudioSessionDisruption,
     isPlaybackIntentActive: Bool,
-    managesAudioSession: Bool
+    managesAudioSession: Bool,
+    wasPlaybackSuspendedForLifecycle: Bool = false,
+    wasPlaybackSuspendedForMediaServices: Bool = false
   )
     -> AudioSessionReaction {
     guard managesAudioSession else { return AudioSessionReaction() }
@@ -132,18 +164,63 @@ extension PiPController {
       return AudioSessionReaction(clearsActivationLatch: true)
 
     case .interruptionEnded(let shouldResume):
-      let resumes = shouldResume && isPlaybackIntentActive
+      let resumes = shouldResume
+        && isPlaybackIntentActive
+        && !wasPlaybackSuspendedForLifecycle
+        && !wasPlaybackSuspendedForMediaServices
       return AudioSessionReaction(clearsActivationLatch: !resumes, reactivates: resumes)
 
     case .routeLost:
       // The session itself is still valid, so the latch stands.
-      return AudioSessionReaction(pausesPlayback: true)
+      return AudioSessionReaction(
+        pausesPlayback: true,
+        clearsLifecycleSuspension: wasPlaybackSuspendedForLifecycle,
+        clearsMediaServicesSuspension: wasPlaybackSuspendedForMediaServices
+      )
+
+    case .mediaServicesLost:
+      let isAlreadySuspended = wasPlaybackSuspendedForLifecycle
+        || wasPlaybackSuspendedForMediaServices
+      return AudioSessionReaction(
+        clearsActivationLatch: true,
+        pausesPlayback: isPlaybackIntentActive && !isAlreadySuspended,
+        preservesPlaybackIntentWhenPausing: true,
+        marksMediaServicesSuspension: isPlaybackIntentActive
+      )
 
     case .mediaServicesReset:
+      let resumes = isPlaybackIntentActive
+        && wasPlaybackSuspendedForMediaServices
+        && !wasPlaybackSuspendedForLifecycle
       return AudioSessionReaction(
         clearsActivationLatch: !isPlaybackIntentActive,
         reconfiguresCategory: true,
-        reactivates: isPlaybackIntentActive
+        reactivates: isPlaybackIntentActive && !wasPlaybackSuspendedForLifecycle,
+        resumesManagedSuspendedPlayback: resumes,
+        clearsMediaServicesSuspension: wasPlaybackSuspendedForMediaServices
+      )
+
+    case .enteredBackground(let isPictureInPictureActive),
+         .deviceLocked(let isPictureInPictureActive):
+      guard !isPictureInPictureActive else { return AudioSessionReaction() }
+      let isAlreadySuspended = wasPlaybackSuspendedForLifecycle
+        || wasPlaybackSuspendedForMediaServices
+      return AudioSessionReaction(
+        clearsActivationLatch: true,
+        pausesPlayback: isPlaybackIntentActive && !isAlreadySuspended,
+        preservesPlaybackIntentWhenPausing: true,
+        marksLifecycleSuspension: isPlaybackIntentActive,
+        deactivatesSession: true
+      )
+
+    case .enteringForeground:
+      let resumes = isPlaybackIntentActive
+        && wasPlaybackSuspendedForLifecycle
+        && !wasPlaybackSuspendedForMediaServices
+      return AudioSessionReaction(
+        reactivates: resumes,
+        resumesManagedSuspendedPlayback: resumes,
+        clearsLifecycleSuspension: wasPlaybackSuspendedForLifecycle
       )
     }
   }
@@ -151,6 +228,27 @@ extension PiPController {
   /// Applies a decided reaction. Split from ``reaction(to:isPlaybackIntentActive:managesAudioSession:)``
   /// so the rules stay testable and only the effects need a live session.
   func apply(_ reaction: AudioSessionReaction) {
+    var pauseAccepted = !reaction.pausesPlayback
+    if reaction.pausesPlayback {
+      let attempt = playbackDriver.pause(
+        nil,
+        !reaction.preservesPlaybackIntentWhenPausing
+      )
+      pauseAccepted = attempt.accepted
+    }
+    let wasAlreadySuspended = isPlaybackSuspendedForManagedAudioLifecycle
+      || isPlaybackSuspendedForMediaServices
+    if pauseAccepted || wasAlreadySuspended {
+      if reaction.marksLifecycleSuspension {
+        isPlaybackSuspendedForManagedAudioLifecycle = true
+      }
+      if reaction.marksMediaServicesSuspension {
+        isPlaybackSuspendedForMediaServices = true
+      }
+    }
+    if reaction.deactivatesSession {
+      deactivateAudioSessionIfNeeded()
+    }
     if reaction.clearsActivationLatch {
       hasActivatedAudioSession = false
     }
@@ -165,9 +263,40 @@ extension PiPController {
       hasActivatedAudioSession = false
       activateAudioSessionIfNeeded()
     }
-    if reaction.pausesPlayback {
-      _ = playbackDriver.pause(nil, true)
+    var resumedManagedSuspension = false
+    if
+      reaction.resumesManagedSuspendedPlayback,
+      hasActivatedAudioSession,
+      isPlaybackSuspendedForManagedAudioLifecycle
+      || isPlaybackSuspendedForMediaServices,
+      player.isPlaybackRequestedActive,
+      playbackDriver.resume() {
+      resumedManagedSuspension = true
     }
+    if
+      reaction.clearsLifecycleSuspension,
+      !reaction.resumesManagedSuspendedPlayback || resumedManagedSuspension {
+      isPlaybackSuspendedForManagedAudioLifecycle = false
+    }
+    if
+      reaction.clearsMediaServicesSuspension,
+      !reaction.resumesManagedSuspendedPlayback || resumedManagedSuspension {
+      isPlaybackSuspendedForMediaServices = false
+    }
+  }
+
+  /// Returns audio focus to other apps after SwiftVLC has suspended hidden
+  /// playback. Failures are intentionally non-terminal: the activation latch
+  /// is still cleared, and foreground recovery will perform a fresh category
+  /// setup and activation rather than trusting stale process state.
+  func deactivateAudioSessionIfNeeded() {
+    #if os(iOS)
+    guard managesAudioSession, hasActivatedAudioSession else { return }
+    try? AVAudioSession.sharedInstance().setActive(
+      false,
+      options: .notifyOthersOnDeactivation
+    )
+    #endif
   }
 
   #if os(iOS)
@@ -180,6 +309,14 @@ extension PiPController {
     guard managesAudioSession else { return }
     let center = NotificationCenter.default
     let session = AVAudioSession.sharedInstance()
+
+    // A controller can be constructed by a background task after UIKit has
+    // already posted didEnterBackground. Seed the current state so that path
+    // receives the same bounded hidden-playback policy as a live transition.
+    isApplicationInBackground = UIApplication.shared.applicationState == .background
+    if isApplicationInBackground {
+      scheduleBackgroundPauseIfNeeded(after: .seconds(1))
+    }
 
     audioSessionObservers = [
       center.addObserver(
@@ -204,12 +341,49 @@ extension PiPController {
         }
       },
       center.addObserver(
+        forName: AVAudioSession.mediaServicesWereLostNotification,
+        object: session,
+        queue: .main
+      ) { [weak self] _ in
+        MainActor.assumeIsolated {
+          self?.react(to: .mediaServicesLost)
+        }
+      },
+      center.addObserver(
         forName: AVAudioSession.mediaServicesWereResetNotification,
         object: session,
         queue: .main
       ) { [weak self] _ in
         MainActor.assumeIsolated {
           self?.react(to: .mediaServicesReset)
+        }
+      },
+      center.addObserver(
+        forName: UIApplication.didEnterBackgroundNotification,
+        object: nil,
+        queue: .main
+      ) { [weak self] _ in
+        MainActor.assumeIsolated {
+          self?.applicationDidEnterBackground()
+        }
+      },
+      center.addObserver(
+        forName: UIApplication.willEnterForegroundNotification,
+        object: nil,
+        queue: .main
+      ) { [weak self] _ in
+        MainActor.assumeIsolated {
+          self?.applicationWillEnterForeground()
+        }
+      },
+      center.addObserver(
+        forName: UIApplication.protectedDataWillBecomeUnavailableNotification,
+        object: nil,
+        queue: .main
+      ) { [weak self] _ in
+        MainActor.assumeIsolated {
+          guard let self else { return }
+          self.react(to: .deviceLocked(isPictureInPictureActive: self.isActive))
         }
       }
     ]
@@ -245,6 +419,53 @@ extension PiPController {
   }
   #endif
 
+  /// Gives automatic PiP a bounded interval to become active before treating
+  /// background playback as hidden audio. AVKit's start callbacks can arrive
+  /// after UIKit's background notification, so an immediate `isActive` check
+  /// races a valid automatic transition.
+  func applicationDidEnterBackground(
+    pauseGrace: Duration = .seconds(1)
+  ) {
+    isApplicationInBackground = true
+    scheduleBackgroundPauseIfNeeded(after: pauseGrace)
+  }
+
+  func applicationWillEnterForeground() {
+    isApplicationInBackground = false
+    audioSessionBackgroundPauseTask?.cancel()
+    audioSessionBackgroundPauseTask = nil
+    react(to: .enteringForeground)
+  }
+
+  func handlePiPActiveChangedForManagedAudioSession(_ isActive: Bool) {
+    guard managesAudioSession else { return }
+    if isActive {
+      audioSessionBackgroundPauseTask?.cancel()
+      audioSessionBackgroundPauseTask = nil
+    } else if isApplicationInBackground {
+      scheduleBackgroundPauseIfNeeded(after: .zero)
+    }
+  }
+
+  private func scheduleBackgroundPauseIfNeeded(after grace: Duration) {
+    guard managesAudioSession, isApplicationInBackground, !isActive else { return }
+    audioSessionBackgroundPauseTask?.cancel()
+    audioSessionBackgroundPauseTask = Task { @MainActor [weak self] in
+      do {
+        try await Task.sleep(for: grace)
+      } catch {
+        return
+      }
+      guard
+        let self,
+        isApplicationInBackground,
+        !self.isActive
+      else { return }
+      audioSessionBackgroundPauseTask = nil
+      react(to: .enteredBackground(isPictureInPictureActive: false))
+    }
+  }
+
   /// Platform-neutral entry points, so the shared initializers and `deinit`
   /// do not need their own `#if`. macOS has no `AVAudioSession` and nothing to
   /// observe.
@@ -266,7 +487,11 @@ extension PiPController {
       Self.reaction(
         to: disruption,
         isPlaybackIntentActive: player.isPlaybackRequestedActive,
-        managesAudioSession: managesAudioSession
+        managesAudioSession: managesAudioSession,
+        wasPlaybackSuspendedForLifecycle:
+        isPlaybackSuspendedForManagedAudioLifecycle,
+        wasPlaybackSuspendedForMediaServices:
+        isPlaybackSuspendedForMediaServices
       )
     )
   }

--- a/Sources/SwiftVLC/PiP/PiPController+DeferredPause.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+DeferredPause.swift
@@ -218,7 +218,7 @@ extension PiPController {
       deferredPause = .idle
     }
     guard shouldResume else { return (needed: false, accepted: false) }
-    return (needed: true, accepted: playbackDriver.resume())
+    return (needed: true, accepted: playbackDriver.resume(true))
   }
 }
 

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -217,8 +217,9 @@ public final class PiPController: NSObject {
   @ObservationIgnored
   let audioSessionActivation: @MainActor () throws -> Void
 
-  /// Whether the deferred `AVAudioSession.setActive(true)` has been
-  /// issued. One-shot per controller; see ``managesAudioSession``.
+  /// Whether the latest deferred `AVAudioSession.setActive(true)` succeeded.
+  /// The latch is cleared after interruptions, media-services loss, and
+  /// lifecycle suspension so recovery never trusts an invalid session.
   @ObservationIgnored
   var hasActivatedAudioSession = false
 
@@ -227,6 +228,31 @@ public final class PiPController: NSObject {
   /// because nothing may be changed. See `startAudioSessionObservers()`.
   @ObservationIgnored
   var audioSessionObservers: [any NSObjectProtocol] = []
+
+  /// Delays the background-without-PiP decision long enough for AVKit's
+  /// automatic PiP transition to settle. Cancelled when PiP becomes active or
+  /// the app returns to the foreground.
+  @ObservationIgnored
+  var audioSessionBackgroundPauseTask: Task<Void, Never>?
+
+  /// Tracks UIKit lifecycle independently of PiP activity. If PiP stops while
+  /// the app is still backgrounded, managed playback must not continue as
+  /// hidden audio indefinitely.
+  @ObservationIgnored
+  var isApplicationInBackground = false
+
+  /// True only when SwiftVLC paused native playback for device/app lifecycle
+  /// while deliberately preserving the user's active playback intent. This is
+  /// the gate that lets foreground/reset recovery resume that exact pause
+  /// without ever resuming a user-paused player.
+  @ObservationIgnored
+  var isPlaybackSuspendedForManagedAudioLifecycle = false
+
+  /// Independent from app/device lifecycle suspension: media services can be
+  /// lost while the app is also backgrounded. Each recovery signal clears only
+  /// its own cause, and playback resumes after the final cause is gone.
+  @ObservationIgnored
+  var isPlaybackSuspendedForMediaServices = false
 
   /// Broadcasts ``PiPEvent``s to every ``pipEvents`` subscriber.
   /// Terminated in deinit so subscribers' streams finish with the
@@ -616,6 +642,7 @@ public final class PiPController: NSObject {
     timingObserverTask?.cancel()
     playbackIntentObserverTask?.cancel()
     cadenceObserverTask?.cancel()
+    audioSessionBackgroundPauseTask?.cancel()
     possibleObservation = nil
     activeObservation = nil
     stopAudioSessionObserversIfManaged()
@@ -844,6 +871,7 @@ public final class PiPController: NSObject {
   func updatePiPActive(_ isActive: Bool) {
     guard self.isActive != isActive else { return }
     self.isActive = isActive
+    handlePiPActiveChangedForManagedAudioSession(isActive)
     publishPiPSnapshot()
   }
 

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -72,7 +72,7 @@ public final class PiPController: NSObject {
       _ playbackGeneration: UInt64?,
       _ recordsPlaybackControlIntent: Bool
     ) -> PauseAttempt
-    let resume: @MainActor () -> Bool
+    let resume: @MainActor (_ recordsPlaybackControlIntent: Bool) -> Bool
     let cancelPendingPause: @MainActor (
       _ playbackGeneration: UInt64?,
       _ playbackControlRevision: UInt64?,
@@ -88,16 +88,24 @@ public final class PiPController: NSObject {
       Self(
         pause: {
           let revisionBeforePause = player.playbackControlIntentRevision
-          let accepted = player.issuePause(
-            playbackGeneration: $0,
-            recordsPlaybackControlIntent: $1
-          )
+          let accepted = if $1 {
+            player.issuePause(
+              playbackGeneration: $0,
+              recordsPlaybackControlIntent: true
+            )
+          } else {
+            player.issueManagedAudioPause(playbackGeneration: $0)
+          }
           return PauseAttempt(
             accepted: accepted,
             playbackControlRevision: $1 ? revisionBeforePause &+ 1 : nil
           )
         },
-        resume: { player.issueResume() },
+        resume: {
+          $0
+            ? player.issueResume()
+            : player.issueManagedAudioResume()
+        },
         cancelPendingPause: {
           player.cancelPendingPause(
             playbackGeneration: $0,
@@ -245,14 +253,28 @@ public final class PiPController: NSObject {
   /// while deliberately preserving the user's active playback intent. This is
   /// the gate that lets foreground/reset recovery resume that exact pause
   /// without ever resuming a user-paused player.
-  @ObservationIgnored
-  var isPlaybackSuspendedForManagedAudioLifecycle = false
+  var isPlaybackSuspendedForManagedAudioLifecycle: Bool {
+    get { player.isManagedAudioLifecycleSuspended }
+    set { player.isManagedAudioLifecycleSuspended = newValue }
+  }
 
   /// Independent from app/device lifecycle suspension: media services can be
   /// lost while the app is also backgrounded. Each recovery signal clears only
   /// its own cause, and playback resumes after the final cause is gone.
-  @ObservationIgnored
-  var isPlaybackSuspendedForMediaServices = false
+  var isPlaybackSuspendedForMediaServices: Bool {
+    get { player.isManagedAudioMediaServicesSuspended }
+    set { player.isManagedAudioMediaServicesSuspended = newValue }
+  }
+
+  var isManagedAudioResumeDeniedByInterruption: Bool {
+    get { player.isManagedAudioResumeDeniedByInterruption }
+    set { player.isManagedAudioResumeDeniedByInterruption = newValue }
+  }
+
+  var isManagedAudioResumePendingActivation: Bool {
+    get { player.isManagedAudioResumePendingActivation }
+    set { player.isManagedAudioResumePendingActivation = newValue }
+  }
 
   /// Broadcasts ``PiPEvent``s to every ``pipEvents`` subscriber.
   /// Terminated in deinit so subscribers' streams finish with the
@@ -985,6 +1007,7 @@ public final class PiPController: NSObject {
 
   private func handlePlaybackIntentChanged(_ active: Bool) {
     if active {
+      isManagedAudioResumeDeniedByInterruption = false
       activateAudioSessionIfNeeded()
     }
     if let pendingPiPPlaybackState, pendingPiPPlaybackState != active {

--- a/Sources/SwiftVLC/PiP/PiPVideoView.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView.swift
@@ -44,7 +44,12 @@ public struct PiPVideoView: UIViewRepresentable {
   ///     then never touches the session. Constructing a view for an inactive
   ///     Player does not activate the session. Recreating the native view for
   ///     a Player whose playback intent is already active does activate it so
-  ///     automatic PiP cannot outrun the managed audio-session setup.
+  ///     automatic PiP cannot outrun the managed audio-session setup. Managed
+  ///     playback also observes interruptions, route loss, media-services
+  ///     restart, device lock, and app foreground/background transitions.
+  ///     Background playback without active PiP is paused after a one-second
+  ///     auto-PiP grace period and resumes on foreground only when SwiftVLC
+  ///     issued that pause and the user's playback intent remains active.
   public init(
     _ player: Player,
     controller: Binding<PiPController?>? = nil,

--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -382,10 +382,15 @@ extension Player {
 
     case .paused:
       guard pauseTransition != .resuming, deferredPauseCommand != .resume else { return }
+      guard !preservesPlaybackIntentForManagedAudioSuspension else {
+        publishPlaybackIntent(true)
+        return
+      }
       publishPlaybackIntent(false)
 
     case .idle, .stopped, .stopping, .error:
       guard !hasPauseControl(after: sessionGeneration) else { return }
+      clearManagedAudioSuspensionForExplicitControl()
       publishPlaybackIntent(false)
     }
   }

--- a/Sources/SwiftVLC/Player/Player+Pause.swift
+++ b/Sources/SwiftVLC/Player/Player+Pause.swift
@@ -84,11 +84,48 @@ extension Player {
     _ = issueResume()
   }
 
+  /// Issues a native pause owned by managed audio lifecycle while keeping the
+  /// user's active playback intent published. Deferred pauses count as owned:
+  /// foreground recovery must be able to cancel them before they settle.
+  @discardableResult
+  func issueManagedAudioPause(
+    playbackGeneration requestedGeneration: UInt64? = nil
+  ) -> Bool {
+    guard isPlaybackRequestedActive else { return false }
+    preservesPlaybackIntentForManagedAudioSuspension = true
+    let issued = issuePause(
+      playbackGeneration: requestedGeneration,
+      recordsPlaybackControlIntent: false
+    )
+    publishPlaybackIntent(true)
+    let ownsPause = issued
+      || pauseTransition == .pausing
+      || deferredPauseCommand == .pause
+      || state == .paused
+      || nativePlaybackState == .paused
+    if !ownsPause {
+      preservesPlaybackIntentForManagedAudioSuspension = false
+    }
+    return ownsPause
+  }
+
+  @discardableResult
+  func issueManagedAudioResume() -> Bool {
+    let accepted = issueResume(recordsPlaybackControlIntent: false)
+    if accepted {
+      preservesPlaybackIntentForManagedAudioSuspension = false
+    }
+    return accepted
+  }
+
   @discardableResult
   func issuePause(
     playbackGeneration requestedGeneration: UInt64? = nil,
     recordsPlaybackControlIntent: Bool = true
   ) -> Bool {
+    if recordsPlaybackControlIntent {
+      clearManagedAudioSuspensionForExplicitControl()
+    }
     let followsCurrentGeneration = requestedGeneration == nil
     let previousPlaybackControlIntent = playbackControlIntent
     if recordsPlaybackControlIntent {
@@ -189,7 +226,7 @@ extension Player {
           deferredPauseCommandPlaybackGeneration == playbackGeneration {
           deferredPauseCommand = nil
         }
-        publishPlaybackIntent(false)
+        publishPauseIntent()
         return false
       default:
         if recordsPlaybackControlIntent {
@@ -268,7 +305,7 @@ extension Player {
       if deferredPauseCommandPlaybackGeneration == playbackGeneration {
         deferredPauseCommand = nil
       }
-      publishPlaybackIntent(false)
+      publishPauseIntent()
       let issuedPlaybackControlRevision = playbackControlIntentRevision
       libvlc_media_player_set_pause(pointer, 1)
       #if DEBUG
@@ -298,7 +335,7 @@ extension Player {
         }
         if playbackControlIntent == .pause {
           setDeferredPauseCommand(.pause, playbackGeneration: generationAfterPause)
-          publishPlaybackIntent(false)
+          publishPauseIntent()
         } else {
           publishPlaybackIntent(
             playbackControlIntent == .resume || state.isActive
@@ -323,7 +360,7 @@ extension Player {
       ? eventBridge.currentPlaybackGeneration
       : playbackGeneration
     setDeferredPauseCommand(.pause, playbackGeneration: generation)
-    publishPlaybackIntent(false)
+    publishPauseIntent()
   }
 
   /// A fresh command can be generation-bound (PiP debounce) without following
@@ -345,7 +382,13 @@ extension Player {
   }
 
   @discardableResult
-  func issueResume(playbackGeneration requestedGeneration: UInt64? = nil) -> Bool {
+  func issueResume(
+    playbackGeneration requestedGeneration: UInt64? = nil,
+    recordsPlaybackControlIntent: Bool = true
+  ) -> Bool {
+    if recordsPlaybackControlIntent {
+      clearManagedAudioSuspensionForExplicitControl()
+    }
     let followsCurrentGeneration = requestedGeneration == nil
     let previousPlaybackControlIntent = playbackControlIntent
     if followsCurrentGeneration {
@@ -558,6 +601,19 @@ extension Player {
     pauseTransition = nil
     deferredPauseCommand = nil
     playbackControlIntent = nil
+    clearManagedAudioSuspensionForExplicitControl()
     publishPlaybackIntent(false)
+  }
+
+  private func publishPauseIntent() {
+    publishPlaybackIntent(preservesPlaybackIntentForManagedAudioSuspension)
+  }
+
+  func clearManagedAudioSuspensionForExplicitControl() {
+    preservesPlaybackIntentForManagedAudioSuspension = false
+    isManagedAudioLifecycleSuspended = false
+    isManagedAudioMediaServicesSuspended = false
+    isManagedAudioResumeDeniedByInterruption = false
+    isManagedAudioResumePendingActivation = false
   }
 }

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -473,6 +473,16 @@ public final class Player {
   /// a MediaListPlayer is opening its next item.
   var deferredPauseCommandPlaybackGeneration: UInt64?
 
+  /// Managed audio lifecycle can pause the native player without changing the
+  /// user's active playback intent. This ownership lives on `Player`, not on a
+  /// transient PiP controller, so a same-player SwiftUI reconstruction can
+  /// still recover the exact library-issued pause.
+  var preservesPlaybackIntentForManagedAudioSuspension = false
+  var isManagedAudioLifecycleSuspended = false
+  var isManagedAudioMediaServicesSuspended = false
+  var isManagedAudioResumeDeniedByInterruption = false
+  var isManagedAudioResumePendingActivation = false
+
   /// Shadow of the string last passed to `Marquee.setText`. libVLC's text
   /// renderer keys its glyph-bitmap cache on the text string, so a style-
   /// only write (color/opacity/fontSize) hits the cached entry and draws
@@ -755,6 +765,7 @@ public final class Player {
     guard !isShutdown else {
       throw .invalidState("play() called on a player that has been shut down")
     }
+    clearManagedAudioSuspensionForExplicitControl()
     try prepareDrawableForPlayback()
     didReachEnd = false
     if libvlc_media_player_play(pointer) == -1 {

--- a/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
@@ -88,6 +88,17 @@ without SwiftVLC receiving a will-start callback. The direct route retries at
 will-start, and the native route retries when it observes did-start. If
 activation fails transiently, SwiftVLC leaves it pending for either fallback.
 
+The managed path observes audio interruptions, output-route loss,
+media-services loss/reset, device lock, and app lifecycle. A route loss pauses
+and changes playback intent so audio cannot jump unexpectedly to the speaker.
+Device lock or backgrounding without an active PiP window instead pauses native
+playback while preserving the user's intent, releases audio focus, and resumes
+only that exact library-issued pause after a successful foreground activation.
+Background handling waits one second for automatic PiP to become active; if PiP
+stops while the app remains backgrounded, playback is suspended immediately.
+Overlapping lifecycle and media-services suspensions are tracked separately, so
+neither recovery signal can resume playback while the other disruption remains.
+
 Pass `managesAudioSession: false` to ``PiPVideoView`` when your app owns
 audio-session policy. In that mode SwiftVLC neither changes the category
 nor activates the shared session.

--- a/Tests/SwiftVLCTests/PiP/PiPAudioSessionDisruptionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPAudioSessionDisruptionTests.swift
@@ -18,13 +18,17 @@ struct PiPAudioSessionDisruptionTests {
   private func reaction(
     _ disruption: PiPController.AudioSessionDisruption,
     playing: Bool = true,
-    managed: Bool = true
+    managed: Bool = true,
+    lifecycleSuspended: Bool = false,
+    mediaServicesSuspended: Bool = false
   )
     -> PiPController.AudioSessionReaction {
     PiPController.reaction(
       to: disruption,
       isPlaybackIntentActive: playing,
-      managesAudioSession: managed
+      managesAudioSession: managed,
+      wasPlaybackSuspendedForLifecycle: lifecycleSuspended,
+      wasPlaybackSuspendedForMediaServices: mediaServicesSuspended
     )
   }
 
@@ -92,13 +96,134 @@ struct PiPAudioSessionDisruptionTests {
     #expect(result.clearsActivationLatch)
   }
 
+  @Test
+  func `Losing media services suspends playback without changing intent`() {
+    let result = reaction(.mediaServicesLost)
+    #expect(result.clearsActivationLatch)
+    #expect(result.pausesPlayback)
+    #expect(result.preservesPlaybackIntentWhenPausing)
+    #expect(!result.reactivates)
+  }
+
+  @Test
+  func `A media services reset resumes only its own suspension`() {
+    let result = reaction(.mediaServicesReset, lifecycleSuspended: true)
+    #expect(result.reconfiguresCategory)
+    #expect(!result.reactivates)
+    #expect(!result.resumesManagedSuspendedPlayback)
+
+    let mediaServicesPause = reaction(
+      .mediaServicesReset,
+      mediaServicesSuspended: true
+    )
+    #expect(mediaServicesPause.reactivates)
+    #expect(mediaServicesPause.resumesManagedSuspendedPlayback)
+
+    let userPaused = reaction(
+      .mediaServicesReset,
+      playing: false,
+      mediaServicesSuspended: true
+    )
+    #expect(!userPaused.reactivates)
+    #expect(!userPaused.resumesManagedSuspendedPlayback)
+    #expect(userPaused.clearsMediaServicesSuspension)
+  }
+
+  @Test
+  func `Background without PiP suspends hidden playback and releases focus`() {
+    let result = reaction(.enteredBackground(isPictureInPictureActive: false))
+    #expect(result.clearsActivationLatch)
+    #expect(result.pausesPlayback)
+    #expect(result.preservesPlaybackIntentWhenPausing)
+    #expect(result.deactivatesSession)
+  }
+
+  @Test
+  func `Background with active PiP preserves playback and audio focus`() {
+    #expect(
+      reaction(.enteredBackground(isPictureInPictureActive: true))
+        == PiPController.AudioSessionReaction()
+    )
+  }
+
+  @Test
+  func `Device lock has the same deterministic suspension policy`() {
+    let result = reaction(.deviceLocked(isPictureInPictureActive: false))
+    #expect(result.pausesPlayback)
+    #expect(result.preservesPlaybackIntentWhenPausing)
+    #expect(result.deactivatesSession)
+
+    #expect(
+      reaction(.deviceLocked(isPictureInPictureActive: true))
+        == PiPController.AudioSessionReaction()
+    )
+  }
+
+  @Test
+  func `Duplicate lifecycle signals do not issue duplicate pauses`() {
+    let result = reaction(
+      .deviceLocked(isPictureInPictureActive: false),
+      lifecycleSuspended: true
+    )
+    #expect(!result.pausesPlayback)
+    #expect(result.deactivatesSession)
+    #expect(result.clearsActivationLatch)
+  }
+
+  @Test
+  func `Foreground resumes only playback suspended by lifecycle`() {
+    let result = reaction(.enteringForeground, lifecycleSuspended: true)
+    #expect(result.reactivates)
+    #expect(result.resumesManagedSuspendedPlayback)
+
+    let ordinaryPlayback = reaction(.enteringForeground)
+    #expect(!ordinaryPlayback.reactivates)
+    #expect(!ordinaryPlayback.resumesManagedSuspendedPlayback)
+
+    let userPaused = reaction(
+      .enteringForeground,
+      playing: false,
+      lifecycleSuspended: true
+    )
+    #expect(!userPaused.reactivates)
+    #expect(!userPaused.resumesManagedSuspendedPlayback)
+    #expect(userPaused.clearsLifecycleSuspension)
+  }
+
+  @Test
+  func `Overlapping background and media outage wait for both recoveries`() {
+    let resetWhileBackgrounded = reaction(
+      .mediaServicesReset,
+      lifecycleSuspended: true,
+      mediaServicesSuspended: true
+    )
+    #expect(!resetWhileBackgrounded.reactivates)
+    #expect(!resetWhileBackgrounded.resumesManagedSuspendedPlayback)
+    #expect(resetWhileBackgrounded.clearsMediaServicesSuspension)
+    #expect(!resetWhileBackgrounded.clearsLifecycleSuspension)
+
+    let foregroundWhileServicesAreLost = reaction(
+      .enteringForeground,
+      lifecycleSuspended: true,
+      mediaServicesSuspended: true
+    )
+    #expect(!foregroundWhileServicesAreLost.reactivates)
+    #expect(!foregroundWhileServicesAreLost.resumesManagedSuspendedPlayback)
+    #expect(foregroundWhileServicesAreLost.clearsLifecycleSuspension)
+    #expect(!foregroundWhileServicesAreLost.clearsMediaServicesSuspension)
+  }
+
   /// A library told not to manage the session must not manage it on the way
   /// out either — including not pausing the host app's playback.
   @Test(arguments: [
     PiPController.AudioSessionDisruption.interruptionBegan,
     .interruptionEnded(shouldResume: true),
     .routeLost,
-    .mediaServicesReset
+    .mediaServicesLost,
+    .mediaServicesReset,
+    .enteredBackground(isPictureInPictureActive: false),
+    .deviceLocked(isPictureInPictureActive: false),
+    .enteringForeground
   ])
   func `An unmanaged session is never touched`(disruption: PiPController.AudioSessionDisruption) {
     #expect(
@@ -117,14 +242,21 @@ extension Integration {
     @MainActor
     final class PauseRecorder {
       var pauseCount = 0
+      var pauseRecordsPlaybackIntent: [Bool] = []
+      var resumeCount = 0
+      var acceptsResume = true
 
       var driver: PiPController.PlaybackDriver {
         .init(
-          pause: { _, _ in
+          pause: { _, recordsPlaybackIntent in
             self.pauseCount += 1
+            self.pauseRecordsPlaybackIntent.append(recordsPlaybackIntent)
             return .init(accepted: true, playbackControlRevision: nil)
           },
-          resume: { true },
+          resume: {
+            self.resumeCount += 1
+            return self.acceptsResume
+          },
           cancelPendingPause: { _, _, _ in },
           shouldResume: { false },
           skip: { _ in .init(resolved: .settled) }
@@ -191,6 +323,77 @@ extension Integration {
 
       #expect(recorder.pauseCount == 0, "an unmanaged controller paused the host app's playback")
       #expect(controller.hasActivatedAudioSession)
+      await player.shutdown()
+    }
+
+    @Test
+    func `Background grace is cancelled when automatic PiP becomes active`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = PauseRecorder()
+      let controller = makeController(player: player, recorder: recorder)
+      player.setPlaybackIntentFromExternalControl(true)
+
+      controller.applicationDidEnterBackground(pauseGrace: .milliseconds(50))
+      controller.handlePiPActiveChangedForManagedAudioSession(true)
+      try? await Task.sleep(for: .milliseconds(100))
+
+      #expect(recorder.pauseCount == 0)
+      #expect(!controller.isPlaybackSuspendedForManagedAudioLifecycle)
+      controller.applicationWillEnterForeground()
+      await player.shutdown()
+    }
+
+    @Test
+    func `Stopping PiP in background suspends playback immediately`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = PauseRecorder()
+      let controller = makeController(player: player, recorder: recorder)
+      player.setPlaybackIntentFromExternalControl(true)
+      controller.hasActivatedAudioSession = true
+      controller.isApplicationInBackground = true
+      controller.handlePiPActiveChangedForManagedAudioSession(false)
+      for _ in 0..<20 where recorder.pauseCount == 0 {
+        await Task.yield()
+      }
+
+      #expect(recorder.pauseCount == 1)
+      #expect(recorder.pauseRecordsPlaybackIntent == [false])
+      #expect(controller.isPlaybackSuspendedForManagedAudioLifecycle)
+      #expect(!controller.hasActivatedAudioSession)
+      controller.applicationWillEnterForeground()
+      await player.shutdown()
+    }
+
+    @Test
+    func `A lifecycle pause resumes only after activation and accepted resume`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = PauseRecorder()
+      let controller = makeController(player: player, recorder: recorder)
+      player.setPlaybackIntentFromExternalControl(true)
+      controller.isPlaybackSuspendedForManagedAudioLifecycle = true
+      controller.hasActivatedAudioSession = true
+
+      controller.apply(
+        .init(
+          resumesManagedSuspendedPlayback: true,
+          clearsLifecycleSuspension: true
+        )
+      )
+
+      #expect(recorder.resumeCount == 1)
+      #expect(!controller.isPlaybackSuspendedForManagedAudioLifecycle)
+
+      controller.isPlaybackSuspendedForManagedAudioLifecycle = true
+      recorder.acceptsResume = false
+      controller.apply(
+        .init(
+          resumesManagedSuspendedPlayback: true,
+          clearsLifecycleSuspension: true
+        )
+      )
+
+      #expect(recorder.resumeCount == 2)
+      #expect(controller.isPlaybackSuspendedForManagedAudioLifecycle)
       await player.shutdown()
     }
   }

--- a/Tests/SwiftVLCTests/PiP/PiPAudioSessionDisruptionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPAudioSessionDisruptionTests.swift
@@ -20,7 +20,8 @@ struct PiPAudioSessionDisruptionTests {
     playing: Bool = true,
     managed: Bool = true,
     lifecycleSuspended: Bool = false,
-    mediaServicesSuspended: Bool = false
+    mediaServicesSuspended: Bool = false,
+    resumeDenied: Bool = false
   )
     -> PiPController.AudioSessionReaction {
     PiPController.reaction(
@@ -28,7 +29,8 @@ struct PiPAudioSessionDisruptionTests {
       isPlaybackIntentActive: playing,
       managesAudioSession: managed,
       wasPlaybackSuspendedForLifecycle: lifecycleSuspended,
-      wasPlaybackSuspendedForMediaServices: mediaServicesSuspended
+      wasPlaybackSuspendedForMediaServices: mediaServicesSuspended,
+      wasManagedResumeDenied: resumeDenied
     )
   }
 
@@ -191,6 +193,21 @@ struct PiPAudioSessionDisruptionTests {
   }
 
   @Test
+  func `Interruption denial blocks delayed lifecycle recovery`() {
+    let denied = reaction(
+      .enteringForeground,
+      lifecycleSuspended: true,
+      resumeDenied: true
+    )
+    #expect(!denied.reactivates)
+    #expect(!denied.resumesManagedSuspendedPlayback)
+
+    let systemDenied = reaction(.interruptionEnded(shouldResume: false))
+    #expect(systemDenied.deniesManagedResume)
+    #expect(!systemDenied.reactivates)
+  }
+
+  @Test
   func `Overlapping background and media outage wait for both recoveries`() {
     let resetWhileBackgrounded = reaction(
       .mediaServicesReset,
@@ -223,7 +240,8 @@ struct PiPAudioSessionDisruptionTests {
     .mediaServicesReset,
     .enteredBackground(isPictureInPictureActive: false),
     .deviceLocked(isPictureInPictureActive: false),
-    .enteringForeground
+    .enteringForeground,
+    .pictureInPictureBecameActive
   ])
   func `An unmanaged session is never touched`(disruption: PiPController.AudioSessionDisruption) {
     #expect(
@@ -253,7 +271,7 @@ extension Integration {
             self.pauseRecordsPlaybackIntent.append(recordsPlaybackIntent)
             return .init(accepted: true, playbackControlRevision: nil)
           },
-          resume: {
+          resume: { _ in
             self.resumeCount += 1
             return self.acceptsResume
           },
@@ -396,6 +414,125 @@ extension Integration {
       #expect(controller.isPlaybackSuspendedForManagedAudioLifecycle)
       await player.shutdown()
     }
+
+    @Test
+    func `A deferred managed pause preserves intent and can be cancelled`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(state: .opening, isPlaybackRequestedActive: true)
+      player._nativePlaybackStateOverrideForTesting = .opening
+
+      #expect(player.issueManagedAudioPause())
+      #expect(player.isPlaybackRequestedActive)
+      #expect(player.deferredPauseCommand == .pause)
+      #expect(player.preservesPlaybackIntentForManagedAudioSuspension)
+
+      player._handleEventForTesting(.stateChanged(.paused))
+      #expect(player.isPlaybackRequestedActive)
+      #expect(player.preservesPlaybackIntentForManagedAudioSuspension)
+
+      #expect(player.issueManagedAudioResume())
+      #expect(player.isPlaybackRequestedActive)
+      #expect(player.deferredPauseCommand != .pause)
+      #expect(!player.preservesPlaybackIntentForManagedAudioSuspension)
+      await player.shutdown()
+    }
+
+    @Test
+    func `Managed suspension ownership follows the player across controllers`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let firstRecorder = PauseRecorder()
+      let first = makeController(player: player, recorder: firstRecorder)
+      first.isPlaybackSuspendedForManagedAudioLifecycle = true
+      first.isPlaybackSuspendedForMediaServices = true
+
+      let successor = makeController(player: player, recorder: PauseRecorder())
+      #expect(successor.isPlaybackSuspendedForManagedAudioLifecycle)
+      #expect(successor.isPlaybackSuspendedForMediaServices)
+      withExtendedLifetime(first) {}
+      await player.shutdown()
+    }
+
+    @Test
+    func `Explicit playback control abandons managed suspension ownership`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      player._nativePlaybackStateOverrideForTesting = .playing
+      player.preservesPlaybackIntentForManagedAudioSuspension = true
+      player.isManagedAudioLifecycleSuspended = true
+      player.isManagedAudioMediaServicesSuspended = true
+      player.isManagedAudioResumeDeniedByInterruption = true
+      player.isManagedAudioResumePendingActivation = true
+
+      _ = player.issuePause()
+
+      #expect(!player.preservesPlaybackIntentForManagedAudioSuspension)
+      #expect(!player.isManagedAudioLifecycleSuspended)
+      #expect(!player.isManagedAudioMediaServicesSuspended)
+      #expect(!player.isManagedAudioResumeDeniedByInterruption)
+      #expect(!player.isManagedAudioResumePendingActivation)
+      await player.shutdown()
+    }
+
+    @Test
+    func `Late automatic PiP activation recovers a lifecycle-only pause`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = PauseRecorder()
+      let controller = makeController(player: player, recorder: recorder)
+      player.setPlaybackIntentFromExternalControl(true)
+      controller.hasActivatedAudioSession = true
+      controller.isPlaybackSuspendedForManagedAudioLifecycle = true
+
+      controller.handlePiPActiveChangedForManagedAudioSession(true)
+
+      #expect(recorder.resumeCount == 1)
+      #expect(!controller.isPlaybackSuspendedForManagedAudioLifecycle)
+      await player.shutdown()
+    }
+
+    @Test
+    func `A later activation retry completes the pending managed resume`() async {
+      enum ActivationFailure: Error { case transient }
+
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = PauseRecorder()
+      let controller = makeController(player: player, recorder: recorder)
+      player.setPlaybackIntentFromExternalControl(true)
+      controller.isPlaybackSuspendedForManagedAudioLifecycle = true
+      controller.isManagedAudioResumePendingActivation = true
+      var attempts = 0
+
+      controller.activateAudioSessionIfNeeded(using: {
+        attempts += 1
+        throw ActivationFailure.transient
+      })
+      #expect(recorder.resumeCount == 0)
+      #expect(controller.isPlaybackSuspendedForManagedAudioLifecycle)
+
+      controller.activateAudioSessionIfNeeded(using: { attempts += 1 })
+      #expect(attempts == 2)
+      #expect(recorder.resumeCount == 1)
+      #expect(!controller.isPlaybackSuspendedForManagedAudioLifecycle)
+      #expect(!controller.isManagedAudioResumePendingActivation)
+      await player.shutdown()
+    }
+
+    #if os(iOS)
+    @Test
+    func `An inactive controller cannot deactivate another active PiP user`() async {
+      let firstPlayer = Player(instance: TestInstance.makeAudioOnly())
+      let secondPlayer = Player(instance: TestInstance.makeAudioOnly())
+      let first = makeController(player: firstPlayer, recorder: PauseRecorder())
+      let second = makeController(player: secondPlayer, recorder: PauseRecorder())
+      first.hasActivatedAudioSession = true
+      second.hasActivatedAudioSession = true
+      second.updatePiPActive(true)
+
+      #expect(first.hasAnotherManagedAudioSessionUser())
+
+      await firstPlayer.shutdown()
+      await secondPlayer.shutdown()
+    }
+    #endif
   }
 }
 #endif

--- a/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerInteractionTests.swift
@@ -33,7 +33,7 @@ extension Integration {
             self.pauseCount += 1
             return .init(accepted: self.pauseResult, playbackControlRevision: nil)
           },
-          resume: {
+          resume: { _ in
             self.resumeCount += 1
             return self.resumeResult
           },

--- a/Tests/SwiftVLCTests/PiP/PiPControllerSkipTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerSkipTests.swift
@@ -20,7 +20,7 @@ extension Integration {
       var driver: PiPController.PlaybackDriver {
         .init(
           pause: { _, _ in .init(accepted: true, playbackControlRevision: nil) },
-          resume: { true },
+          resume: { _ in true },
           cancelPendingPause: { _, _, _ in },
           shouldResume: { false },
           skip: { interval in

--- a/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
@@ -33,7 +33,7 @@ extension Integration {
               playbackControlRevision: nil
             )
           },
-          resume: {
+          resume: { _ in
             self.resumeCount += 1
             return true
           },


### PR DESCRIPTION
Closes #87.

## Summary

- observe media-services loss/reset, device lock, and app foreground/background transitions when SwiftVLC manages the audio session
- allow automatic PiP one second to activate before pausing hidden background playback and releasing audio focus
- resume only the exact library-issued lifecycle pause, preserving user pause intent and tracking overlapping lifecycle/media-service disruptions independently
- document the managed-session policy and add focused policy/integration coverage

## Validation

- `xcrun --toolchain org.swift.633202607241a swift test --no-parallel --enable-code-coverage` — 1,968 tests / 167 suites passed
- `xcodebuild build-for-testing -scheme SwiftVLC -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/SwiftVLC-87-derived -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO` — succeeded
- `swiftformat Sources Tests Showcase --lint --strict`
- `swiftlint lint --strict --quiet Sources Tests Showcase`
- `./scripts/doc-coverage.sh` — 872/872 public symbols documented
- `git diff --check`
