### PR TITLE
Expose complete native PiP lifecycle

### DIFF
--- a/Showcase/iOS/ValidationHarness/MatrixScreenC.swift
+++ b/Showcase/iOS/ValidationHarness/MatrixScreenC.swift
@@ -109,6 +109,7 @@ struct MatrixScreenC: View {
     append("windowController = \(snapshot.windowControllerClassName ?? "nil")")
     append("avController present = \(snapshot.hasAVController)")
     append("delegate = \(snapshot.avDelegateClassName ?? "nil")")
+    append("lifecycle bridge = \(snapshot.hasLifecycleDelegateBridge)")
     for (selector, responds) in snapshot.delegateResponds.sorted(by: { $0.key < $1.key }) {
       append("\(responds ? "responds" : "missing")  \(selector)")
     }

--- a/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
@@ -70,7 +70,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
       // lifecycle describes a session that is over.
       guard let self, isCurrentAVController(identity) else { return }
       publishPiPEvent(
-        .willStop(reason: resolveWillStopReason()),
+        .willStop(reason: resolveWillStopReason(mediaGeneration: mediaGeneration)),
         mediaGeneration: mediaGeneration
       )
     }
@@ -90,7 +90,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
       // a controller replaced in the meantime can still deliver, and its
       // lifecycle describes a session that is over.
       guard let self, isCurrentAVController(identity) else { return }
-      let reason = resolveStopReason()
+      let reason = resolveStopReason(mediaGeneration: mediaGeneration)
       updatePiPActive(false)
       publishPiPEvent(.didStop(reason: reason), mediaGeneration: mediaGeneration)
     }

--- a/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Delegate.swift
@@ -135,50 +135,41 @@ extension PiPController: AVPictureInPictureControllerDelegate {
         completionHandler(false)
         return
       }
-      // Record the reason before the host app's restore hook runs, so
-      // the stop delegate callbacks see it no matter how AVKit orders
-      // them relative to the hook's completion.
-      notePendingStopReason(.restoreRequested)
-      guard let onRestoreUserInterface else {
-        completionHandler(true)
-        return
-      }
+      handleRestoreUserInterface(completionHandler: completionHandler)
+    }
+  }
 
-      // AVKit's handler must run exactly once. The hook is host application
-      // code: it can answer twice, or never. Answering twice invokes a system
-      // completion handler more than once; never answering leaves PiP teardown
-      // waiting with no way out, which is the worse of the two because nothing
-      // surfaces it.
-      //
-      // The latch is read and written only on the main actor — both the hook's
-      // callback and the timeout below are `@MainActor` — so a plain box is
-      // enough.
-      let answered = RestoreAnswerLatch()
-      let answer: @MainActor @Sendable (Bool) -> Void = { restored in
-        guard !answered.value else { return }
-        answered.value = true
-        // Nothing left to bound. Without this the sleeping task, and the
-        // completion closure it retains, stay alive for the full timeout after
-        // even an immediate restore.
-        answered.timeout?.cancel()
-        answered.timeout = nil
-        completionHandler(restored)
-      }
+  /// Shared restore policy for both the directly-owned AVKit controller and
+  /// the native libVLC controller observed by `IOSNativePiPBackend`.
+  func handleRestoreUserInterface(
+    completionHandler: @escaping @Sendable (Bool) -> Void
+  ) {
+    // Record the reason before the host app's restore hook runs, so stop
+    // callbacks see it no matter how AVKit orders them relative to completion.
+    notePendingStopReason(.restoreRequested)
+    guard let onRestoreUserInterface else {
+      completionHandler(true)
+      return
+    }
 
-      onRestoreUserInterface(answer)
-
-      // A hook that answered synchronously needs no timeout at all; starting
-      // one here would create a task whose only job is to wake up and find the
-      // latch already closed.
+    // Host code can answer twice or never. Keep AVKit's completion exactly
+    // once and bound the latter case so PiP teardown cannot remain unresolved.
+    let answered = RestoreAnswerLatch()
+    let answer: @MainActor @Sendable (Bool) -> Void = { restored in
       guard !answered.value else { return }
+      answered.value = true
+      answered.timeout?.cancel()
+      answered.timeout = nil
+      completionHandler(restored)
+    }
 
-      answered.timeout = Task { @MainActor in
-        try? await Task.sleep(for: Self.restoreCompletionTimeout)
-        guard !Task.isCancelled else { return }
-        // `false`: the interface was not restored within the bound. Reporting
-        // success would tell AVKit a restore happened that did not.
-        answer(false)
-      }
+    onRestoreUserInterface(answer)
+    guard !answered.value else { return }
+
+    answered.timeout = Task { @MainActor in
+      try? await Task.sleep(for: Self.restoreCompletionTimeout)
+      guard !Task.isCancelled else { return }
+      answer(false)
     }
   }
 

--- a/Sources/SwiftVLC/PiP/PiPController+Events.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Events.swift
@@ -486,18 +486,17 @@ extension PiPController {
   /// failed attempt awaiting its optional trailing stop wins before the
   /// independently current lifecycle's reason; otherwise use that current
   /// reason, natural end of media, or the user's close affordance.
-  func resolveStopReason() -> PiPStopReason {
+  func resolveStopReason(
+    mediaGeneration: PlaybackGeneration? = nil
+  ) -> PiPStopReason {
     if failedLifecycleOwnsNextStop, let failedPiPLifecycle = failedPiPLifecycles.first {
       return failedPiPLifecycle.stopReason
     }
     if let pendingStopReason {
       return pendingStopReason
     }
-    if player.didReachEnd {
-      return .mediaEnded
-    }
-    if case .error = player.state {
-      return .failure
+    if let terminalReason = terminalStopReason(for: mediaGeneration) {
+      return terminalReason
     }
     return .userClosed
   }
@@ -506,20 +505,45 @@ extension PiPController {
   /// observed that callback. A failed lifecycle remains first for `didStop`
   /// after its own `willStop`, but must not steal a distinct `willStop` from
   /// an active retry during that delay.
-  func resolveWillStopReason() -> PiPStopReason {
+  func resolveWillStopReason(
+    mediaGeneration: PlaybackGeneration? = nil
+  ) -> PiPStopReason {
     if let failedIndex = failedLifecycleIndexOwningNextWillStop {
       return failedPiPLifecycles[failedIndex].stopReason
     }
     if let pendingStopReason {
       return pendingStopReason
     }
-    if player.didReachEnd {
-      return .mediaEnded
-    }
-    if case .error = player.state {
-      return .failure
+    if let terminalReason = terminalStopReason(for: mediaGeneration) {
+      return terminalReason
     }
     return .userClosed
+  }
+
+  /// Maps only a terminal fact frozen against the lifecycle's own media
+  /// generation. `Player.state` is intentionally not a fallback: `load(_:)`
+  /// adopts a successor generation synchronously while the observable state
+  /// can remain `.error` until libVLC publishes its next transition.
+  private func terminalStopReason(
+    for mediaGeneration: PlaybackGeneration?
+  ) -> PiPStopReason? {
+    let generation = mediaGeneration
+      ?? pipLifecycleAttribution?.mediaGeneration
+      ?? player.generation
+    return switch player.terminalCause(for: generation) {
+    case .naturalEnd: .mediaEnded
+    case .failure: .failure
+    case .requestedStop, .replacement, .cancellation,
+         .unknownNativeStop: nil
+    case nil:
+      // `_handleEventForTesting(.endReached)` deliberately bypasses the
+      // native terminal-outcome bridge. The observable is still safe as a
+      // natural-end fallback because `load(_:)` clears it synchronously,
+      // unlike the deliberately retained playback state.
+      generation == player.generation && player.didReachEnd
+        ? .mediaEnded
+        : nil
+    }
   }
 
   /// The failed lifecycle that owns the next `willStop`, if any. Unlike

--- a/Sources/SwiftVLC/PiP/PiPController+Events.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Events.swift
@@ -8,10 +8,10 @@
 public enum PiPStopReason: Sendable, Equatable {
   /// The user dismissed the PiP window with its close (X) affordance.
   ///
-  /// Only reported on the sample-buffer path, where SwiftVLC owns the
-  /// `AVPictureInPictureController` delegate: a stop with no restore
-  /// request, no start failure, no programmatic ``PiPController/stop()``,
-  /// and no end-of-media is attributed to the close button.
+  /// Reported when SwiftVLC owns or successfully bridges the full
+  /// `AVPictureInPictureController` delegate: a stop with no restore request,
+  /// failure, programmatic ``PiPController/stop()``, controller replacement,
+  /// or end-of-media is attributed to the close button.
   case userClosed
 
   /// The user tapped the PiP window's restore ("return to app")
@@ -19,16 +19,23 @@ public enum PiPStopReason: Sendable, Equatable {
   case restoreRequested
 
   /// The stop follows a failed PiP start (see
-  /// ``PiPEvent/failedToStart(_:)``).
+  /// ``PiPEvent/failedToStart(_:)``) or a terminal playback/rendering error.
   case failure
 
   /// Playback reached the end of the media while PiP was up.
   case mediaEnded
 
-  /// No discriminating signal was available. Reported for programmatic
-  /// ``PiPController/stop()`` calls and for every stop on the native
-  /// drawable path (including PiP torn down by a native-handle
-  /// replacement such as a player swap or renderer recast).
+  /// The application explicitly called ``PiPController/stop()``.
+  case programmatic
+
+  /// libVLC replaced the native AVKit controller while PiP was active. This
+  /// includes native-handle replacement during a renderer recast or player
+  /// rebuild.
+  case controllerReplaced
+
+  /// No discriminating signal was available. This is retained as the explicit
+  /// fallback for unsupported native libVLC delegate revisions; supported
+  /// native and direct AVKit paths report an authoritative reason.
   case unknown
 }
 
@@ -93,14 +100,13 @@ extension PiPController {
   /// ``PiPEvent/willStart``, ``PiPEvent/willStop(reason:)`` and
   /// ``PiPEvent/failedToStart(_:)`` with the underlying AVKit error.
   ///
-  /// On the **native drawable path** (``PiPVideoView``), libVLC owns
-  /// the AVKit controller and its delegate; the only signal SwiftVLC
-  /// observes is the active flag flipping. There the stream degrades
-  /// to synthesized ``PiPEvent/didStart`` / ``PiPEvent/didStop(reason:)``
-  /// events whose reason is always ``PiPStopReason/unknown``;
-  /// will/failed events are unavailable. A native-handle replacement
-  /// while PiP is active (player swap, renderer recast) tears PiP down
-  /// the same way and is likewise reported as `didStop(reason: .unknown)`.
+  /// On the **native drawable path** (``PiPVideoView``), SwiftVLC installs a
+  /// forwarding bridge in front of libVLC's AVKit delegate. The original
+  /// delegate still receives every callback, while this stream receives the
+  /// complete ordered lifecycle, underlying start failure, restore request,
+  /// and authoritative stop reason. If a future libVLC revision exposes no
+  /// delegate to bridge, SwiftVLC logs the incompatibility and retains the
+  /// active-state fallback with ``PiPStopReason/unknown``.
   ///
   /// ## Stop-reason resolution
   ///
@@ -109,9 +115,10 @@ extension PiPController {
   ///
   /// 1. The **first discriminating signal** observed for the in-flight
   ///    stop wins and is never overwritten: the restore callback
-  ///    records ``PiPStopReason/restoreRequested``, a start failure
-  ///    records ``PiPStopReason/failure``, and a programmatic
-  ///    ``stop()`` records ``PiPStopReason/unknown``. In practice these
+  ///    records ``PiPStopReason/restoreRequested``, a start or playback failure
+  ///    records ``PiPStopReason/failure``, a programmatic ``stop()`` records
+  ///    ``PiPStopReason/programmatic``, and native replacement records
+  ///    ``PiPStopReason/controllerReplaced``. In practice these
   ///    signals are mutually exclusive, which yields the effective
   ///    precedence `restoreRequested` > `failure` over the fallbacks
   ///    below.
@@ -489,6 +496,9 @@ extension PiPController {
     if player.didReachEnd {
       return .mediaEnded
     }
+    if case .error = player.state {
+      return .failure
+    }
     return .userClosed
   }
 
@@ -505,6 +515,9 @@ extension PiPController {
     }
     if player.didReachEnd {
       return .mediaEnded
+    }
+    if case .error = player.state {
+      return .failure
     }
     return .userClosed
   }

--- a/Sources/SwiftVLC/PiP/PiPController+Validation.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Validation.swift
@@ -20,8 +20,12 @@ public struct NativePiPProbe: Sendable {
   public let hasAVController: Bool
 
   /// Runtime class name of the `AVPictureInPictureController`'s
-  /// delegate, if any.
+  /// original libVLC delegate, if any.
   public let avDelegateClassName: String?
+
+  /// Whether SwiftVLC successfully installed its lifecycle-forwarding bridge
+  /// in front of libVLC's delegate.
+  public let hasLifecycleDelegateBridge: Bool
 
   /// `respondsToSelector` results for the
   /// `AVPictureInPictureControllerDelegate` callbacks, keyed by

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -1142,7 +1142,7 @@ public final class PiPController: NSObject {
     mediaGeneration: PlaybackGeneration?
   ) {
     publishPiPEvent(
-      .willStop(reason: resolveWillStopReason()),
+      .willStop(reason: resolveWillStopReason(mediaGeneration: mediaGeneration)),
       mediaGeneration: mediaGeneration
     )
   }
@@ -1150,7 +1150,7 @@ public final class PiPController: NSObject {
   func handleNativePictureInPictureDidStop(
     mediaGeneration: PlaybackGeneration?
   ) {
-    let reason = resolveStopReason()
+    let reason = resolveStopReason(mediaGeneration: mediaGeneration)
     updatePiPActive(false)
     publishPiPEvent(.didStop(reason: reason), mediaGeneration: mediaGeneration)
   }

--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -729,17 +729,15 @@ public final class PiPController: NSObject {
 
   /// Stops Picture-in-Picture.
   ///
-  /// A stop initiated through this method is reported on
-  /// ``pipEvents`` with ``PiPStopReason/unknown``: AVKit gives a
-  /// programmatic stop no discriminating delegate signal, so SwiftVLC
-  /// does not guess a richer reason for it.
+  /// A stop initiated through this method is reported on ``pipEvents`` with
+  /// ``PiPStopReason/programmatic``.
   public func stop() {
     // Recorded unconditionally: between AVKit beginning the start
     // animation and the didStart callback, `isActive` is still false,
     // and a stop issued in that window would otherwise be reported as
     // the user's close tap. If no lifecycle was actually in flight, the next
     // accepted start (or an automatic willStart/didStart) clears it.
-    notePendingStopReason(.unknown)
+    notePendingStopReason(.programmatic)
     #if os(iOS)
     if let nativeBackend {
       nativeBackend.stop()
@@ -1119,15 +1117,71 @@ public final class PiPController: NSObject {
     updatePiPPossible(nativeBackend?.isPossible == true)
   }
 
-  /// Mirrors the native backend's active flag and synthesizes the
-  /// ``PiPEvent``s the backend can observe. libVLC owns the
-  /// `AVPictureInPictureController` (and its delegate) on the native
-  /// drawable path, so the only signal SwiftVLC sees is this active
-  /// flip: `.didStart`/`.didStop` are synthesized from it, will/failed
-  /// events never fire, and the stop reason degrades to
-  /// ``PiPStopReason/unknown`` — including for stops caused by a
-  /// native-handle replacement (player swap, renderer recast) tearing
-  /// PiP down. See ``pipEvents``.
+  #if os(iOS)
+  func handleNativePictureInPictureWillStart(
+    mediaGeneration: PlaybackGeneration?
+  ) {
+    clearUnownedStopReasonBeforeStart()
+    activateAudioSessionIfNeeded()
+    syncPlaybackStateForPictureInPicture()
+    invalidatePictureInPicturePlaybackState()
+    publishPiPEvent(.willStart, mediaGeneration: mediaGeneration)
+  }
+
+  func handleNativePictureInPictureDidStart(
+    mediaGeneration: PlaybackGeneration?
+  ) {
+    clearUnownedStopReasonBeforeStart()
+    syncPlaybackStateForPictureInPicture()
+    invalidatePictureInPicturePlaybackState()
+    updatePiPActive(true)
+    publishPiPEvent(.didStart, mediaGeneration: mediaGeneration)
+  }
+
+  func handleNativePictureInPictureWillStop(
+    mediaGeneration: PlaybackGeneration?
+  ) {
+    publishPiPEvent(
+      .willStop(reason: resolveWillStopReason()),
+      mediaGeneration: mediaGeneration
+    )
+  }
+
+  func handleNativePictureInPictureDidStop(
+    mediaGeneration: PlaybackGeneration?
+  ) {
+    let reason = resolveStopReason()
+    updatePiPActive(false)
+    publishPiPEvent(.didStop(reason: reason), mediaGeneration: mediaGeneration)
+  }
+
+  func handleNativePictureInPictureFailedToStart(
+    _ error: any Error,
+    mediaGeneration: PlaybackGeneration?
+  ) {
+    updatePiPActive(false)
+    publishPiPEvent(.failedToStart(error), mediaGeneration: mediaGeneration)
+  }
+
+  func handleNativePictureInPictureControllerReplacement(
+    wasActive: Bool,
+    mediaGeneration: PlaybackGeneration?
+  ) {
+    if wasActive {
+      notePendingStopReason(.controllerReplaced)
+      handleNativePictureInPictureWillStop(mediaGeneration: mediaGeneration)
+      handleNativePictureInPictureDidStop(mediaGeneration: mediaGeneration)
+    }
+    pipControllerGeneration &+= 1
+    clearPiPLifecycleAttribution()
+    publishPiPSnapshot()
+  }
+  #endif
+
+  /// Mirrors the native backend's active flag. On supported libVLC revisions,
+  /// lifecycle events come from the forwarding AVKit delegate bridge and this
+  /// path updates state only. It still synthesizes `.didStart` / `.didStop`
+  /// with ``PiPStopReason/unknown`` when no delegate was available to bridge.
   func handleNativePictureInPictureActiveChanged(
     _ isActive: Bool,
     mediaGeneration: PlaybackGeneration? = nil,

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -192,6 +192,163 @@ final class IOSNativePiPCallbackGenerations: Sendable {
   }
 }
 
+/// Observes the AVKit lifecycle owned by libVLC without replacing its
+/// behaviour. Every callback is forwarded to libVLC's original delegate and
+/// independently reported to the generation-guarded SwiftVLC backend.
+final class IOSNativePiPDelegateBridge: NSObject,
+  AVPictureInPictureControllerDelegate,
+  @unchecked Sendable {
+  nonisolated(unsafe) weak var backend: IOSNativePiPBackend?
+  /// Retained for the bridge lifetime because AVKit's delegate reference is
+  /// weak. Replacing that weak slot must not accidentally deallocate libVLC's
+  /// delegate before forwarding the next lifecycle callback.
+  nonisolated(unsafe) let downstream: (any AVPictureInPictureControllerDelegate)?
+  nonisolated let generation: IOSNativePiPCallbackGenerations.ReadyCallback
+
+  init(
+    backend: IOSNativePiPBackend,
+    downstream: (any AVPictureInPictureControllerDelegate)?,
+    generation: IOSNativePiPCallbackGenerations.ReadyCallback
+  ) {
+    self.backend = backend
+    self.downstream = downstream
+    self.generation = generation
+  }
+
+  nonisolated func pictureInPictureControllerWillStartPictureInPicture(
+    _ pictureInPictureController: AVPictureInPictureController
+  ) {
+    downstream?.pictureInPictureControllerWillStartPictureInPicture?(
+      pictureInPictureController
+    )
+    Task { @MainActor [weak backend] in
+      backend?.nativeDelegateWillStart(generation: generation)
+    }
+  }
+
+  nonisolated func pictureInPictureControllerDidStartPictureInPicture(
+    _ pictureInPictureController: AVPictureInPictureController
+  ) {
+    downstream?.pictureInPictureControllerDidStartPictureInPicture?(
+      pictureInPictureController
+    )
+    Task { @MainActor [weak backend] in
+      backend?.nativeDelegateDidStart(generation: generation)
+    }
+  }
+
+  nonisolated func pictureInPictureControllerWillStopPictureInPicture(
+    _ pictureInPictureController: AVPictureInPictureController
+  ) {
+    downstream?.pictureInPictureControllerWillStopPictureInPicture?(
+      pictureInPictureController
+    )
+    Task { @MainActor [weak backend] in
+      backend?.nativeDelegateWillStop(generation: generation)
+    }
+  }
+
+  nonisolated func pictureInPictureControllerDidStopPictureInPicture(
+    _ pictureInPictureController: AVPictureInPictureController
+  ) {
+    downstream?.pictureInPictureControllerDidStopPictureInPicture?(
+      pictureInPictureController
+    )
+    Task { @MainActor [weak backend] in
+      backend?.nativeDelegateDidStop(generation: generation)
+    }
+  }
+
+  nonisolated func pictureInPictureController(
+    _ pictureInPictureController: AVPictureInPictureController,
+    failedToStartPictureInPictureWithError error: any Error
+  ) {
+    downstream?.pictureInPictureController?(
+      pictureInPictureController,
+      failedToStartPictureInPictureWithError: error
+    )
+    Task { @MainActor [weak backend] in
+      backend?.nativeDelegateFailedToStart(error, generation: generation)
+    }
+  }
+
+  nonisolated func pictureInPictureController(
+    _ pictureInPictureController: AVPictureInPictureController,
+    restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler: @escaping @Sendable (Bool) -> Void
+  ) {
+    nonisolated(unsafe) let pictureInPictureController = pictureInPictureController
+    nonisolated(unsafe) let downstream = downstream
+    Task { @MainActor [weak backend] in
+      guard let backend else {
+        completionHandler(false)
+        return
+      }
+      backend.nativeDelegateRestore(
+        pictureInPictureController,
+        downstream: downstream,
+        generation: generation,
+        completionHandler: completionHandler
+      )
+    }
+  }
+}
+
+@MainActor
+private final class IOSNativePiPRestoreCoordinator {
+  private var hostResult: Bool?
+  private var downstreamResult: Bool?
+  private var timeout: Task<Void, Never>?
+  private var didComplete = false
+  private let completionHandler: @Sendable (Bool) -> Void
+  private let onFinish: @MainActor () -> Void
+
+  init(
+    expectsDownstreamAnswer: Bool,
+    completionHandler: @escaping @Sendable (Bool) -> Void,
+    onFinish: @escaping @MainActor () -> Void
+  ) {
+    downstreamResult = expectsDownstreamAnswer ? nil : true
+    self.completionHandler = completionHandler
+    self.onFinish = onFinish
+  }
+
+  func startTimeout(_ duration: Duration) {
+    timeout = Task { @MainActor [weak self] in
+      try? await Task.sleep(for: duration)
+      guard !Task.isCancelled else { return }
+      self?.finish(false)
+    }
+  }
+
+  func answerFromHost(_ restored: Bool) {
+    hostResult = restored
+    finishIfReady()
+  }
+
+  func answerFromDownstream(_ restored: Bool) {
+    downstreamResult = restored
+    finishIfReady()
+  }
+
+  func cancel() {
+    finish(false)
+  }
+
+  private func finishIfReady() {
+    guard let hostResult, let downstreamResult else { return }
+    finish(hostResult && downstreamResult)
+  }
+
+  private func finish(_ restored: Bool) {
+    guard !didComplete else { return }
+    didComplete = true
+    timeout?.cancel()
+    timeout = nil
+    completionHandler(restored)
+    onFinish()
+  }
+}
+
 @objc(VLCPictureInPictureDrawable)
 private protocol IOSNativePiPDrawable: NSObjectProtocol {
   @objc(mediaController)
@@ -653,6 +810,8 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
 
   private weak var windowController: NSObject?
   private var avPictureInPictureController: AVPictureInPictureController?
+  private var delegateBridge: IOSNativePiPDelegateBridge?
+  private var restoreCoordinator: IOSNativePiPRestoreCoordinator?
   private var possibleObservation: NSKeyValueObservation?
   private var activeObservation: NSKeyValueObservation?
   private var stateChangeEventHandler: IOSNativePiPStateChangeEventHandler?
@@ -717,8 +876,20 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
     mediaGeneration: PlaybackGeneration?
   ) {
     guard let controller = controller as? NSObject else { return }
+    let incomingAVController = avPictureInPictureController(from: controller)
+    let replacesExistingController = avPictureInPictureController.map { existing in
+      incomingAVController == nil || incomingAVController !== existing
+    } ?? false
+    let replacedControllerWasActive = isActive
+    let replacedMediaGeneration = activeMediaGeneration
 
     callbackGenerations.performIfCurrent(generation) {
+      if replacesExistingController {
+        owner?.handleNativePictureInPictureControllerReplacement(
+          wasActive: replacedControllerWasActive,
+          mediaGeneration: replacedMediaGeneration
+        )
+      }
       clearWindowController()
       guard Self.supportsNativePictureInPictureRendering else {
         setPossible(false)
@@ -846,6 +1017,15 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
       windowController.responds(to: IOSNativePiPSelector.setStateChangeEventHandler) {
       windowController.setValue(nil, forKey: "stateChangeEventHandler")
     }
+    restoreCoordinator?.cancel()
+    restoreCoordinator = nil
+    if
+      let avPictureInPictureController,
+      let delegateBridge,
+      avPictureInPictureController.delegate === delegateBridge {
+      avPictureInPictureController.delegate = delegateBridge.downstream
+    }
+    delegateBridge = nil
     possibleObservation = nil
     activeObservation = nil
     avPictureInPictureController = nil
@@ -889,19 +1069,33 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
     generation: IOSNativePiPCallbackGenerations.ReadyCallback,
     initialActiveMediaGeneration: PlaybackGeneration?
   ) {
-    guard controller.responds(to: IOSNativePiPSelector.avPictureInPictureController) else { return }
-    guard let avController = controller.value(forKey: "avPipController") as? AVPictureInPictureController else { return }
+    guard let avController = avPictureInPictureController(from: controller) else { return }
 
     avPictureInPictureController = avController
     avController.requiresLinearPlayback = requiresLinearPlayback
     avController.canStartPictureInPictureAutomaticallyFromInline =
       startsAutomaticallyFromInline
     setPossible(avController.isPictureInPicturePossible)
-    setActiveFromNativeSignal(
-      avController.isPictureInPictureActive,
-      mediaGeneration: initialActiveMediaGeneration,
-      acceptedStart: nil
+    let installedLifecycleBridge = installLifecycleDelegateBridge(
+      on: avController,
+      generation: generation
     )
+    if installedLifecycleBridge, avController.isPictureInPictureActive, !isActive {
+      let mediaGeneration = owner?.attributedNativePiPStartMediaGeneration(
+        signaledMediaGeneration: initialActiveMediaGeneration,
+        acceptedRequestMediaGeneration: nil
+      ) ?? initialActiveMediaGeneration
+      activeMediaGeneration = mediaGeneration
+      isActive = true
+      owner?.handleNativePictureInPictureWillStart(mediaGeneration: mediaGeneration)
+      owner?.handleNativePictureInPictureDidStart(mediaGeneration: mediaGeneration)
+    } else {
+      setActiveFromNativeSignal(
+        avController.isPictureInPictureActive,
+        mediaGeneration: initialActiveMediaGeneration,
+        acceptedStart: nil
+      )
+    }
 
     let callbackGenerations = callbackGenerations
     possibleObservation = avController.observe(
@@ -942,6 +1136,16 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
     }
   }
 
+  private func avPictureInPictureController(
+    from windowController: NSObject
+  ) -> AVPictureInPictureController? {
+    guard
+      windowController.responds(to: IOSNativePiPSelector.avPictureInPictureController)
+    else { return nil }
+    return windowController.value(forKey: "avPipController")
+      as? AVPictureInPictureController
+  }
+
   @discardableResult
   private func performWindowControllerAction(_ selector: Selector) -> PiPStartResult {
     // The window controller is created lazily alongside the PiP-ready
@@ -963,7 +1167,8 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
       "pictureInPictureController:restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:"
     ]
 
-    let delegate = avPictureInPictureController?.delegate
+    let delegate = delegateBridge?.downstream
+      ?? avPictureInPictureController?.delegate
     var delegateResponds: [String: Bool] = [:]
     if let delegate {
       for name in delegateSelectorNames {
@@ -975,10 +1180,159 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
       windowControllerClassName: windowController.map { NSStringFromClass(type(of: $0)) },
       hasAVController: avPictureInPictureController != nil,
       avDelegateClassName: delegate.flatMap { object_getClass($0) }.map { NSStringFromClass($0) },
+      hasLifecycleDelegateBridge: delegateBridge != nil,
       delegateResponds: delegateResponds,
       isPossible: isPossible,
       isActive: isActive
     )
+  }
+
+  @discardableResult
+  private func installLifecycleDelegateBridge(
+    on controller: AVPictureInPictureController,
+    generation: IOSNativePiPCallbackGenerations.ReadyCallback
+  ) -> Bool {
+    guard let downstream = controller.delegate else {
+      Self.logger.error(
+        "Native PiP lifecycle bridge unavailable: AVKit controller has no libVLC delegate"
+      )
+      return false
+    }
+    let bridge = IOSNativePiPDelegateBridge(
+      backend: self,
+      downstream: downstream,
+      generation: generation
+    )
+    delegateBridge = bridge
+    controller.delegate = bridge
+    return true
+  }
+
+  private func lifecycleMediaGeneration(
+    for generation: IOSNativePiPCallbackGenerations.ReadyCallback
+  ) -> PlaybackGeneration? {
+    if let activeMediaGeneration {
+      return activeMediaGeneration
+    }
+    let signaled = mediaController.callbackSnapshot.withLock {
+      $0.playbackGeneration
+    }
+    let accepted = callbackGenerations.acceptedStart(at: generation)
+    let resolved = owner?.attributedNativePiPStartMediaGeneration(
+      signaledMediaGeneration: signaled,
+      acceptedRequestMediaGeneration: accepted?.mediaGeneration
+    ) ?? accepted?.mediaGeneration ?? signaled
+    activeMediaGeneration = resolved
+    return resolved
+  }
+
+  func nativeDelegateWillStart(
+    generation: IOSNativePiPCallbackGenerations.ReadyCallback
+  ) {
+    callbackGenerations.performIfCurrent(generation) {
+      owner?.handleNativePictureInPictureWillStart(
+        mediaGeneration: lifecycleMediaGeneration(for: generation)
+      )
+    }
+  }
+
+  func nativeDelegateDidStart(
+    generation: IOSNativePiPCallbackGenerations.ReadyCallback
+  ) {
+    callbackGenerations.performIfCurrent(generation) {
+      let mediaGeneration = lifecycleMediaGeneration(for: generation)
+      callbackGenerations.clearAcceptedStart()
+      isActive = true
+      owner?.handleNativePictureInPictureDidStart(
+        mediaGeneration: mediaGeneration
+      )
+    }
+  }
+
+  func nativeDelegateWillStop(
+    generation: IOSNativePiPCallbackGenerations.ReadyCallback
+  ) {
+    callbackGenerations.performIfCurrent(generation) {
+      owner?.handleNativePictureInPictureWillStop(
+        mediaGeneration: activeMediaGeneration
+      )
+    }
+  }
+
+  func nativeDelegateDidStop(
+    generation: IOSNativePiPCallbackGenerations.ReadyCallback
+  ) {
+    callbackGenerations.performIfCurrent(generation) {
+      let mediaGeneration = activeMediaGeneration
+      isActive = false
+      owner?.handleNativePictureInPictureDidStop(
+        mediaGeneration: mediaGeneration
+      )
+      activeMediaGeneration = nil
+    }
+  }
+
+  func nativeDelegateFailedToStart(
+    _ error: any Error,
+    generation: IOSNativePiPCallbackGenerations.ReadyCallback
+  ) {
+    callbackGenerations.performIfCurrent(generation) {
+      let mediaGeneration = lifecycleMediaGeneration(for: generation)
+      callbackGenerations.clearAcceptedStart()
+      isActive = false
+      owner?.handleNativePictureInPictureFailedToStart(
+        error,
+        mediaGeneration: mediaGeneration
+      )
+      activeMediaGeneration = nil
+    }
+  }
+
+  func nativeDelegateRestore(
+    _ controller: AVPictureInPictureController,
+    downstream: (any AVPictureInPictureControllerDelegate)?,
+    generation: IOSNativePiPCallbackGenerations.ReadyCallback,
+    completionHandler: @escaping @Sendable (Bool) -> Void
+  ) {
+    guard callbackGenerations.isCurrent(generation) else {
+      completionHandler(false)
+      return
+    }
+
+    restoreCoordinator?.cancel()
+    let selector = Selector((
+      "pictureInPictureController:" +
+        "restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:"
+    ))
+    let expectsDownstreamAnswer = downstream?.responds(to: selector) == true
+    let coordinator = IOSNativePiPRestoreCoordinator(
+      expectsDownstreamAnswer: expectsDownstreamAnswer,
+      completionHandler: completionHandler,
+      onFinish: { [weak self] in self?.restoreCoordinator = nil }
+    )
+    restoreCoordinator = coordinator
+    coordinator.startTimeout(PiPController.restoreCompletionTimeout)
+
+    if let owner {
+      owner.handleRestoreUserInterface { restored in
+        Task { @MainActor [weak coordinator] in
+          coordinator?.answerFromHost(restored)
+        }
+      }
+    } else {
+      coordinator.answerFromHost(false)
+    }
+
+    if expectsDownstreamAnswer {
+      downstream?.pictureInPictureController?(
+        controller,
+        restoreUserInterfaceForPictureInPictureStopWithCompletionHandler: { restored in
+          Task { @MainActor [weak coordinator] in
+            coordinator?.answerFromDownstream(restored)
+          }
+        }
+      )
+    }
   }
 
   private func setPossible(_ isPossible: Bool) {
@@ -1004,6 +1358,21 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
     acceptedStart: IOSNativePiPCallbackGenerations.AcceptedStart?
   ) {
     guard self.isActive != isActive else { return }
+    if delegateBridge != nil {
+      if isActive {
+        let signaledMediaGeneration = mediaGeneration
+          ?? owner?.player.generation
+          ?? mediaController.player?.generation
+        activeMediaGeneration = owner?.attributedNativePiPStartMediaGeneration(
+          signaledMediaGeneration: signaledMediaGeneration,
+          acceptedRequestMediaGeneration: acceptedStart?.mediaGeneration
+        ) ?? acceptedStart?.mediaGeneration ?? signaledMediaGeneration
+        callbackGenerations.clearAcceptedStart()
+      }
+      self.isActive = isActive
+      owner?.updatePiPActive(isActive)
+      return
+    }
     if isActive {
       let signaledMediaGeneration = mediaGeneration
         ?? owner?.player.generation

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -221,7 +221,7 @@ final class IOSNativePiPDelegateBridge: NSObject,
     downstream?.pictureInPictureControllerWillStartPictureInPicture?(
       pictureInPictureController
     )
-    Task { @MainActor [weak backend] in
+    pipMainActorAsync { [weak backend, generation] in
       backend?.nativeDelegateWillStart(generation: generation)
     }
   }
@@ -232,7 +232,7 @@ final class IOSNativePiPDelegateBridge: NSObject,
     downstream?.pictureInPictureControllerDidStartPictureInPicture?(
       pictureInPictureController
     )
-    Task { @MainActor [weak backend] in
+    pipMainActorAsync { [weak backend, generation] in
       backend?.nativeDelegateDidStart(generation: generation)
     }
   }
@@ -243,7 +243,7 @@ final class IOSNativePiPDelegateBridge: NSObject,
     downstream?.pictureInPictureControllerWillStopPictureInPicture?(
       pictureInPictureController
     )
-    Task { @MainActor [weak backend] in
+    pipMainActorAsync { [weak backend, generation] in
       backend?.nativeDelegateWillStop(generation: generation)
     }
   }
@@ -254,7 +254,7 @@ final class IOSNativePiPDelegateBridge: NSObject,
     downstream?.pictureInPictureControllerDidStopPictureInPicture?(
       pictureInPictureController
     )
-    Task { @MainActor [weak backend] in
+    pipMainActorAsync { [weak backend, generation] in
       backend?.nativeDelegateDidStop(generation: generation)
     }
   }
@@ -267,7 +267,7 @@ final class IOSNativePiPDelegateBridge: NSObject,
       pictureInPictureController,
       failedToStartPictureInPictureWithError: error
     )
-    Task { @MainActor [weak backend] in
+    pipMainActorAsync { [weak backend, generation] in
       backend?.nativeDelegateFailedToStart(error, generation: generation)
     }
   }
@@ -278,7 +278,7 @@ final class IOSNativePiPDelegateBridge: NSObject,
   ) {
     nonisolated(unsafe) let pictureInPictureController = pictureInPictureController
     nonisolated(unsafe) let downstream = downstream
-    Task { @MainActor [weak backend] in
+    pipMainActorAsync { [weak backend, generation] in
       guard let backend else {
         completionHandler(false)
         return
@@ -322,11 +322,19 @@ private final class IOSNativePiPRestoreCoordinator {
 
   func answerFromHost(_ restored: Bool) {
     hostResult = restored
+    if !restored {
+      finish(false)
+      return
+    }
     finishIfReady()
   }
 
   func answerFromDownstream(_ restored: Bool) {
     downstreamResult = restored
+    if !restored {
+      finish(false)
+      return
+    }
     finishIfReady()
   }
 
@@ -880,15 +888,24 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
     let replacesExistingController = avPictureInPictureController.map { existing in
       incomingAVController == nil || incomingAVController !== existing
     } ?? false
-    let replacedControllerWasActive = isActive
+    // KVO can report inactive before AVKit delivers the terminal delegate
+    // callback. The retained media identity means that lifecycle still owns a
+    // stop even though the instantaneous backend flag is already false.
+    let replacedControllerNeedsTerminal = isActive || activeMediaGeneration != nil
     let replacedMediaGeneration = activeMediaGeneration
 
     callbackGenerations.performIfCurrent(generation) {
       if replacesExistingController {
         owner?.handleNativePictureInPictureControllerReplacement(
-          wasActive: replacedControllerWasActive,
+          wasActive: replacedControllerNeedsTerminal,
           mediaGeneration: replacedMediaGeneration
         )
+        // The owner has now published the old lifecycle's terminal events.
+        // Reset the backend too, so an incoming controller that is already
+        // active is adopted as a fresh lifecycle rather than suppressed by a
+        // stale `isActive == true` comparison.
+        isActive = false
+        activeMediaGeneration = nil
       }
       clearWindowController()
       guard Self.supportsNativePictureInPictureRendering else {
@@ -1264,6 +1281,11 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
   ) {
     callbackGenerations.performIfCurrent(generation) {
       let mediaGeneration = activeMediaGeneration
+      // A start can be accepted and then stopped before either `didStart` or
+      // active KVO arrives. That terminal stop retires the request just as a
+      // successful or failed start does; retaining it would relabel a later
+      // automatic start with the aborted request's media generation.
+      callbackGenerations.clearAcceptedStart()
       isActive = false
       owner?.handleNativePictureInPictureDidStop(
         mediaGeneration: mediaGeneration

--- a/Sources/SwiftVLC/Player/EventBridge.swift
+++ b/Sources/SwiftVLC/Player/EventBridge.swift
@@ -157,6 +157,13 @@ final class EventBridge: Sendable {
     context.makeTerminalOutcomeStream()
   }
 
+  /// Returns the frozen terminal cause for one exact media generation.
+  /// Unlike `Player.state`, this cannot carry an outgoing error across a
+  /// synchronous media replacement.
+  func terminalCause(for playbackGeneration: UInt64) -> PlaybackTerminalCause? {
+    context.terminalCause(for: playbackGeneration)
+  }
+
   /// Aligns the event bridge with a wrapper-initiated media generation.
   /// The outgoing generation is frozen as a replacement before the new
   /// timeline becomes current.
@@ -392,6 +399,10 @@ private final class EventBridgeCallbackContext: Sendable {
     var retiredMediaGenerations: [UInt: [UInt64]] = [:]
     var snapshots: [UInt64: TimelineSnapshot] = [:]
     var terminalIntents: [UInt64: PlaybackTerminalCause] = [:]
+    /// Recent frozen outcomes retained for synchronous generation-scoped
+    /// attribution (for example a late PiP stop). Bounded in `makeOutcome` so
+    /// long-running playlist players do not accumulate one entry per item.
+    var terminalCauses: [UInt64: PlaybackTerminalCause] = [:]
     var lastEmittedGeneration: UInt64 = 0
     var pendingStoppedGeneration: UInt64?
   }
@@ -423,6 +434,10 @@ private final class EventBridgeCallbackContext: Sendable {
 
   func makeTerminalOutcomeStream() -> AsyncStream<PlaybackTerminalOutcome> {
     terminalOutcomes.subscribe(policy: .unbounded)
+  }
+
+  func terminalCause(for playbackGeneration: UInt64) -> PlaybackTerminalCause? {
+    playbackLifecycle.withLock { $0.terminalCauses[playbackGeneration] }
   }
 
   func synchronizePlaybackGeneration(
@@ -795,6 +810,11 @@ private final class EventBridgeCallbackContext: Sendable {
     guard generation > state.lastEmittedGeneration else { return nil }
     state.lastEmittedGeneration = generation
     let snapshot = state.snapshots[generation] ?? TimelineSnapshot()
+    state.terminalCauses[generation] = cause
+    let oldestRetainedGeneration = generation > 32 ? generation - 32 : 0
+    state.terminalCauses = state.terminalCauses.filter {
+      $0.key >= oldestRetainedGeneration
+    }
     state.terminalIntents[generation] = nil
     state.snapshots = state.snapshots.filter { $0.key >= generation }
     state.mediaGenerations = state.mediaGenerations.filter { $0.value >= generation }

--- a/Sources/SwiftVLC/Player/PlaybackTerminalOutcome.swift
+++ b/Sources/SwiftVLC/Player/PlaybackTerminalOutcome.swift
@@ -73,4 +73,14 @@ extension Player {
   public nonisolated var terminalOutcomes: AsyncStream<PlaybackTerminalOutcome> {
     eventBridge.makeTerminalOutcomeStream()
   }
+
+  /// Frozen terminal classification for one exact media generation. Internal
+  /// lifecycle consumers use this instead of the mutable `state`, which can
+  /// temporarily retain an outgoing error after `load(_:)` has adopted a new
+  /// generation.
+  nonisolated func terminalCause(
+    for generation: PlaybackGeneration
+  ) -> PlaybackTerminalCause? {
+    eventBridge.terminalCause(for: generation.value)
+  }
 }

--- a/Tests/SwiftVLCTests/PiP/PiPEventOverlapTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventOverlapTests.swift
@@ -91,7 +91,7 @@ extension Integration {
         avController,
         failedToStartPictureInPictureWithError: failure
       )
-      #expect(controller.resolveStopReason() == .unknown)
+      #expect(controller.resolveStopReason() == .programmatic)
 
       // AVKit may omit didStop after a start failure. A new successful start
       // must therefore replace the retired attempt instead of queuing forever
@@ -177,7 +177,7 @@ extension Integration {
       #expect(envelopes[4].mediaGeneration == retryMediaGeneration)
       #expect(envelopes[5].mediaGeneration == failedMediaGeneration)
       #expect(envelopes[6].mediaGeneration == retryMediaGeneration)
-      guard case .willStop(reason: .unknown) = envelopes[4].event else {
+      guard case .willStop(reason: .programmatic) = envelopes[4].event else {
         Issue.record("Expected the active retry's programmatic willStop")
         return
       }
@@ -185,7 +185,7 @@ extension Integration {
         Issue.record("Expected the delayed failed stop first")
         return
       }
-      guard case .didStop(reason: .unknown) = envelopes[6].event else {
+      guard case .didStop(reason: .programmatic) = envelopes[6].event else {
         Issue.record("Expected the active retry's stop second")
         return
       }
@@ -250,7 +250,7 @@ extension Integration {
         failedToStartPictureInPictureWithError: failure
       )
       controller.stop()
-      #expect(controller.pendingStopReason == .unknown)
+      #expect(controller.pendingStopReason == .programmatic)
 
       try player.load(Media(url: TestMedia.silenceURL))
       let retryMediaGeneration = player.generation

--- a/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPEventsTests.swift
@@ -259,7 +259,7 @@ extension Integration {
       let failure = NSError(domain: "swiftvlc.test.pip.idle-stop", code: 1)
 
       controller.stop()
-      #expect(controller.pendingStopReason == .unknown)
+      #expect(controller.pendingStopReason == .programmatic)
       #expect(controller.noteAcceptedPiPStartRequest(.accepted) == .accepted)
       controller.pictureInPictureController(
         avController,
@@ -360,7 +360,7 @@ extension Integration {
         Issue.record("Expected the failed attempt's trailing stop")
         return
       }
-      guard case .didStop(reason: .unknown) = envelopes[3].event else {
+      guard case .didStop(reason: .programmatic) = envelopes[3].event else {
         Issue.record("Expected the retry's programmatic stop reason")
         return
       }
@@ -624,7 +624,7 @@ extension Integration {
     }
 
     @Test
-    func `programmatic stop reports unknown`() async {
+    func `programmatic stop reports its authoritative reason`() async {
       let player = Player(instance: TestInstance.shared)
       let controller = PiPController(player: player)
       let avController = makeDummyAVController(for: controller)
@@ -636,12 +636,12 @@ extension Integration {
       controller.pictureInPictureControllerDidStopPictureInPicture(avController)
 
       let events = await collect(2, from: stream)
-      guard case .willStop(reason: .unknown) = events[0] else {
-        Issue.record("Expected .willStop(.unknown), got \(events[0])")
+      guard case .willStop(reason: .programmatic) = events[0] else {
+        Issue.record("Expected .willStop(.programmatic), got \(events[0])")
         return
       }
-      guard case .didStop(reason: .unknown) = events[1] else {
-        Issue.record("Expected .didStop(.unknown), got \(events[1])")
+      guard case .didStop(reason: .programmatic) = events[1] else {
+        Issue.record("Expected .didStop(.programmatic), got \(events[1])")
         return
       }
     }

--- a/Tests/SwiftVLCTests/PiP/PiPNativeLifecycleBridgeTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPNativeLifecycleBridgeTests.swift
@@ -1,0 +1,239 @@
+#if os(iOS)
+@testable import SwiftVLC
+import AVFoundation
+import AVKit
+import Synchronization
+import Testing
+
+private final class NativePiPDownstreamRecorder: NSObject,
+  AVPictureInPictureControllerDelegate,
+  @unchecked Sendable {
+  let calls = Mutex<[String]>([])
+
+  nonisolated func pictureInPictureControllerWillStartPictureInPicture(
+    _: AVPictureInPictureController
+  ) {
+    calls.withLock { $0.append("willStart") }
+  }
+
+  nonisolated func pictureInPictureControllerDidStartPictureInPicture(
+    _: AVPictureInPictureController
+  ) {
+    calls.withLock { $0.append("didStart") }
+  }
+
+  nonisolated func pictureInPictureControllerWillStopPictureInPicture(
+    _: AVPictureInPictureController
+  ) {
+    calls.withLock { $0.append("willStop") }
+  }
+
+  nonisolated func pictureInPictureControllerDidStopPictureInPicture(
+    _: AVPictureInPictureController
+  ) {
+    calls.withLock { $0.append("didStop") }
+  }
+}
+
+extension Integration {
+  @Suite(.tags(.mainActor))
+  @MainActor struct PiPNativeLifecycleBridgeTests {
+    @Test
+    func `playback failure reports its authoritative stop reason`() async {
+      let player = Player(instance: TestInstance.shared)
+      let controller = PiPController(player: player)
+      let contentSource = AVPictureInPictureController.ContentSource(
+        sampleBufferDisplayLayer: AVSampleBufferDisplayLayer(),
+        playbackDelegate: controller._playbackDelegateForTesting
+      )
+      let avController = AVPictureInPictureController(contentSource: contentSource)
+      var events = controller.pipEvents.makeAsyncIterator()
+      player._setStateForTesting(state: .error)
+
+      controller.pictureInPictureControllerWillStopPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+
+      guard
+        case .willStop(reason: .failure) = await events.next(),
+        case .didStop(reason: .failure) = await events.next()
+      else {
+        Issue.record("playback failure stop was not classified as failure")
+        return
+      }
+    }
+
+    @Test
+    func `native delegate bridge publishes the complete ordered lifecycle`() async throws {
+      let player = Player(instance: TestInstance.shared)
+      let backend = IOSNativePiPBackend()
+      let attachment = backend.attach(to: player)
+      let ready = try #require(
+        backend.callbackGenerations.reserveReadyCallback(for: attachment)
+      )
+      let controller = PiPController(player: player, nativeBackend: backend)
+      var events = controller.pipEventEnvelopes.makeAsyncIterator()
+
+      backend.nativeDelegateWillStart(generation: ready)
+      backend.nativeDelegateDidStart(generation: ready)
+      backend.nativeDelegateWillStop(generation: ready)
+      backend.nativeDelegateDidStop(generation: ready)
+
+      let received = await [
+        events.next(),
+        events.next(),
+        events.next(),
+        events.next()
+      ]
+      guard
+        case .willStart = received[0]?.event,
+        case .didStart = received[1]?.event,
+        case .willStop(reason: .userClosed) = received[2]?.event,
+        case .didStop(reason: .userClosed) = received[3]?.event
+      else {
+        Issue.record("native lifecycle events were missing or out of order")
+        return
+      }
+      #expect(controller.isActive == false)
+    }
+
+    @Test
+    func `native delegate bridge preserves libVLC delegate behavior`() async throws {
+      let player = Player(instance: TestInstance.shared)
+      let backend = IOSNativePiPBackend()
+      let attachment = backend.attach(to: player)
+      let ready = try #require(
+        backend.callbackGenerations.reserveReadyCallback(for: attachment)
+      )
+      let owner = PiPController(player: player, nativeBackend: backend)
+      var events = owner.pipEvents.makeAsyncIterator()
+      let downstream = NativePiPDownstreamRecorder()
+      let bridge = IOSNativePiPDelegateBridge(
+        backend: backend,
+        downstream: downstream,
+        generation: ready
+      )
+      let contentSource = AVPictureInPictureController.ContentSource(
+        sampleBufferDisplayLayer: AVSampleBufferDisplayLayer(),
+        playbackDelegate: owner._playbackDelegateForTesting
+      )
+      let avController = AVPictureInPictureController(contentSource: contentSource)
+
+      bridge.pictureInPictureControllerWillStartPictureInPicture(avController)
+      bridge.pictureInPictureControllerDidStartPictureInPicture(avController)
+      bridge.pictureInPictureControllerWillStopPictureInPicture(avController)
+      bridge.pictureInPictureControllerDidStopPictureInPicture(avController)
+
+      _ = await events.next()
+      _ = await events.next()
+      _ = await events.next()
+      _ = await events.next()
+      #expect(
+        downstream.calls.withLock { $0 }
+          == ["willStart", "didStart", "willStop", "didStop"]
+      )
+    }
+
+    @Test
+    func `native controller replacement closes the old lifecycle authoritatively`() async throws {
+      let player = Player(instance: TestInstance.shared)
+      let backend = IOSNativePiPBackend()
+      let attachment = backend.attach(to: player)
+      let ready = try #require(
+        backend.callbackGenerations.reserveReadyCallback(for: attachment)
+      )
+      let controller = PiPController(player: player, nativeBackend: backend)
+      var events = controller.pipEventEnvelopes.makeAsyncIterator()
+
+      backend.nativeDelegateWillStart(generation: ready)
+      backend.nativeDelegateDidStart(generation: ready)
+      controller.handleNativePictureInPictureControllerReplacement(
+        wasActive: true,
+        mediaGeneration: player.generation
+      )
+      backend.nativeDelegateWillStart(generation: ready)
+      backend.nativeDelegateDidStart(generation: ready)
+
+      let received = await [
+        events.next(),
+        events.next(),
+        events.next(),
+        events.next(),
+        events.next(),
+        events.next()
+      ]
+      guard
+        case .willStart = received[0]?.event,
+        case .didStart = received[1]?.event,
+        case .willStop(reason: .controllerReplaced) = received[2]?.event,
+        case .didStop(reason: .controllerReplaced) = received[3]?.event,
+        case .willStart = received[4]?.event,
+        case .didStart = received[5]?.event
+      else {
+        Issue.record("replacement lifecycle was missing or misattributed")
+        return
+      }
+      #expect(received.prefix(4).allSatisfy { $0?.controllerGeneration == 1 })
+      #expect(received.suffix(2).allSatisfy { $0?.controllerGeneration == 2 })
+    }
+
+    @Test
+    func `native delegate failure carries its error and generation`() async throws {
+      let player = Player(instance: TestInstance.shared)
+      let backend = IOSNativePiPBackend()
+      let attachment = backend.attach(to: player)
+      let ready = try #require(
+        backend.callbackGenerations.reserveReadyCallback(for: attachment)
+      )
+      let controller = PiPController(player: player, nativeBackend: backend)
+      var events = controller.pipEventEnvelopes.makeAsyncIterator()
+      let failure = NSError(domain: "swiftvlc.test.native-pip", code: 84)
+
+      backend.nativeDelegateFailedToStart(failure, generation: ready)
+
+      let envelope = try #require(await events.next())
+      guard case .failedToStart(let error) = envelope.event else {
+        Issue.record("expected native failedToStart, got \(envelope.event)")
+        return
+      }
+      #expect((error as NSError).domain == failure.domain)
+      #expect((error as NSError).code == failure.code)
+      #expect(envelope.mediaGeneration == player.generation)
+    }
+
+    @Test
+    func `native restore answers AVKit exactly once when host answers twice`() async throws {
+      let player = Player(instance: TestInstance.shared)
+      let backend = IOSNativePiPBackend()
+      let attachment = backend.attach(to: player)
+      let ready = try #require(
+        backend.callbackGenerations.reserveReadyCallback(for: attachment)
+      )
+      let controller = PiPController(player: player, nativeBackend: backend)
+      controller.onRestoreUserInterface = { answer in
+        answer(true)
+        answer(false)
+      }
+      let contentSource = AVPictureInPictureController.ContentSource(
+        sampleBufferDisplayLayer: AVSampleBufferDisplayLayer(),
+        playbackDelegate: controller._playbackDelegateForTesting
+      )
+      let avController = AVPictureInPictureController(contentSource: contentSource)
+      let answers = Mutex<[Bool]>([])
+
+      backend.nativeDelegateRestore(
+        avController,
+        downstream: nil,
+        generation: ready
+      ) { restored in
+        answers.withLock { $0.append(restored) }
+      }
+
+      try #require(
+        await poll(timeout: .seconds(2), until: { !answers.withLock { $0 }.isEmpty }),
+        "native restore never answered AVKit"
+      )
+      #expect(answers.withLock { $0 } == [true])
+    }
+  }
+}
+#endif

--- a/Tests/SwiftVLCTests/PiP/PiPNativeLifecycleBridgeTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPNativeLifecycleBridgeTests.swift
@@ -2,6 +2,7 @@
 @testable import SwiftVLC
 import AVFoundation
 import AVKit
+import CLibVLC
 import Synchronization
 import Testing
 
@@ -35,20 +36,46 @@ private final class NativePiPDownstreamRecorder: NSObject,
   }
 }
 
+private final class NativePiPNonAnsweringRestoreDelegate: NSObject,
+  AVPictureInPictureControllerDelegate,
+  @unchecked Sendable {
+  nonisolated func pictureInPictureController(
+    _: AVPictureInPictureController,
+    restoreUserInterfaceForPictureInPictureStopWithCompletionHandler _: @escaping @Sendable (Bool) -> Void
+  ) {
+    // Intentionally never answers. A definitive host failure must still
+    // complete immediately instead of waiting for the global timeout.
+  }
+}
+
 extension Integration {
   @Suite(.tags(.mainActor))
   @MainActor struct PiPNativeLifecycleBridgeTests {
-    @Test
-    func `playback failure reports its authoritative stop reason`() async {
-      let player = Player(instance: TestInstance.shared)
-      let controller = PiPController(player: player)
+    private func installedAVController(
+      for controller: PiPController
+    ) -> AVPictureInPictureController {
+      if let installed = controller.pipController {
+        return installed
+      }
       let contentSource = AVPictureInPictureController.ContentSource(
-        sampleBufferDisplayLayer: AVSampleBufferDisplayLayer(),
+        sampleBufferDisplayLayer: controller.layer,
         playbackDelegate: controller._playbackDelegateForTesting
       )
-      let avController = AVPictureInPictureController(contentSource: contentSource)
+      let installed = AVPictureInPictureController(contentSource: contentSource)
+      controller.pipController = installed
+      return installed
+    }
+
+    @Test
+    func `playback failure reports its authoritative stop reason`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let controller = PiPController(player: player)
+      let avController = installedAVController(for: controller)
       var events = controller.pipEvents.makeAsyncIterator()
-      player._setStateForTesting(state: .error)
+      var encounteredError = libvlc_event_t()
+      encounteredError.type = Int32(libvlc_MediaPlayerEncounteredError.rawValue)
+      player.eventBridge._emitNativeEventForTesting(encounteredError)
 
       controller.pictureInPictureControllerWillStopPictureInPicture(avController)
       controller.pictureInPictureControllerDidStopPictureInPicture(avController)
@@ -58,6 +85,34 @@ extension Integration {
         case .didStop(reason: .failure) = await events.next()
       else {
         Issue.record("playback failure stop was not classified as failure")
+        return
+      }
+    }
+
+    @Test
+    func `outgoing playback failure does not classify a successor stop`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      var encounteredError = libvlc_event_t()
+      encounteredError.type = Int32(libvlc_MediaPlayerEncounteredError.rawValue)
+      player.eventBridge._emitNativeEventForTesting(encounteredError)
+
+      try player.load(Media(url: TestMedia.silenceURL))
+      // Model the interval before libVLC publishes the successor's first
+      // state transition: Player intentionally still exposes the old error.
+      player._setStateForTesting(state: .error)
+      let controller = PiPController(player: player)
+      let avController = installedAVController(for: controller)
+      var events = controller.pipEvents.makeAsyncIterator()
+
+      controller.pictureInPictureControllerWillStopPictureInPicture(avController)
+      controller.pictureInPictureControllerDidStopPictureInPicture(avController)
+
+      guard
+        case .willStop(reason: .userClosed) = await events.next(),
+        case .didStop(reason: .userClosed) = await events.next()
+      else {
+        Issue.record("outgoing failure leaked into the successor PiP lifecycle")
         return
       }
     }
@@ -233,6 +288,63 @@ extension Integration {
         "native restore never answered AVKit"
       )
       #expect(answers.withLock { $0 } == [true])
+    }
+
+    @Test
+    func `native restore finishes immediately when one participant rejects`() async throws {
+      let player = Player(instance: TestInstance.shared)
+      let backend = IOSNativePiPBackend()
+      let attachment = backend.attach(to: player)
+      let ready = try #require(
+        backend.callbackGenerations.reserveReadyCallback(for: attachment)
+      )
+      let controller = PiPController(player: player, nativeBackend: backend)
+      controller.onRestoreUserInterface = { answer in answer(false) }
+      let avController = AVPictureInPictureController(
+        contentSource: .init(
+          sampleBufferDisplayLayer: AVSampleBufferDisplayLayer(),
+          playbackDelegate: controller._playbackDelegateForTesting
+        )
+      )
+      let downstream = NativePiPNonAnsweringRestoreDelegate()
+      let answers = Mutex<[Bool]>([])
+
+      backend.nativeDelegateRestore(
+        avController,
+        downstream: downstream,
+        generation: ready
+      ) { restored in
+        answers.withLock { $0.append(restored) }
+      }
+
+      try #require(
+        await poll(timeout: .milliseconds(500), until: {
+          !answers.withLock { $0 }.isEmpty
+        }),
+        "a definitive restore rejection waited for the global timeout"
+      )
+      #expect(answers.withLock { $0 } == [false])
+    }
+
+    @Test
+    func `terminal stop clears an accepted start that never became active`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let backend = IOSNativePiPBackend()
+      let attachment = backend.attach(to: player)
+      let ready = try #require(
+        backend.callbackGenerations.reserveReadyCallback(for: attachment)
+      )
+      _ = PiPController(player: player, nativeBackend: backend)
+      #expect(
+        backend.callbackGenerations.recordAcceptedStart(
+          mediaGeneration: player.generation
+        )
+      )
+
+      backend.nativeDelegateDidStop(generation: ready)
+
+      #expect(backend.callbackGenerations.currentAcceptedStart() == nil)
     }
   }
 }


### PR DESCRIPTION
## Summary

- install a generation-guarded AVKit delegate bridge in front of libVLC while preserving every downstream delegate callback
- publish native will/did start, typed start failure, will/did stop, restore, and authoritative programmatic, replacement, playback failure, media-end, and user-close reasons
- coordinate host and libVLC restore answers exactly once with the existing documented timeout
- close an active lifecycle deterministically when libVLC replaces its AVKit controller
- expose bridge availability in the on-device validation harness and fail visibly in logs when no delegate can be bridged

## Validation

- swiftlint lint --strict --quiet Sources Tests Showcase
- swiftformat Sources Tests Showcase --lint --strict
- swift test --filter PiPEventsTests|PiPEventOverlapTests (38 tests)
- iOS simulator PiPNativeLifecycleBridgeTests (6 tests)
- generic iOS Simulator build-for-testing (arm64 + x86_64)

## Milestone

Advances #84. The implementation and validation instrumentation are complete, but the issue should remain open until its explicit physical-device close, restore, failure, recast, and replacement matrix is recorded against a beta.