### PR TITLE
Enforce v1.1.0 device qualification evidence

### DIFF
--- a/scripts/check-qualification.sh
+++ b/scripts/check-qualification.sh
@@ -75,6 +75,7 @@ fi
 
 python3 - "$MATRIX" "$RECORD" "$DIGEST" "$VERSION" <<'PY'
 import json
+import math
 import sys
 from pathlib import Path
 
@@ -264,6 +265,10 @@ for key in sorted(executed):
         problems.append(
             f"row {key[0]} on {key[1]} durationSeconds must be a number"
         )
+    elif not math.isfinite(duration_seconds):
+        problems.append(
+            f"row {key[0]} on {key[1]} durationSeconds must be finite"
+        )
     elif duration_seconds <= 0:
         problems.append(
             f"row {key[0]} on {key[1]} durationSeconds must be positive"
@@ -324,6 +329,43 @@ for key in sorted(executed):
                     value = value[component]
                 return value
 
+            def same_json_value(actual, expected):
+                # Python's bool subclasses int, but JSON booleans and numbers
+                # are different types. Compare recursively using JSON's type
+                # model so false cannot satisfy 0, including inside arrays or
+                # objects. Integers and floats remain one JSON number type.
+                if isinstance(expected, bool):
+                    return isinstance(actual, bool) and actual == expected
+                if isinstance(expected, (int, float)):
+                    return (
+                        isinstance(actual, (int, float))
+                        and not isinstance(actual, bool)
+                        and actual == expected
+                    )
+                if expected is None:
+                    return actual is None
+                if isinstance(expected, str):
+                    return isinstance(actual, str) and actual == expected
+                if isinstance(expected, list):
+                    return (
+                        isinstance(actual, list)
+                        and len(actual) == len(expected)
+                        and all(
+                            same_json_value(a, e)
+                            for a, e in zip(actual, expected)
+                        )
+                    )
+                if isinstance(expected, dict):
+                    return (
+                        isinstance(actual, dict)
+                        and actual.keys() == expected.keys()
+                        and all(
+                            same_json_value(actual[field], expected[field])
+                            for field in expected
+                        )
+                    )
+                return type(actual) is type(expected) and actual == expected
+
             required_evidence = scenario_by_id[key[0]].get(
                 "requiredEvidenceFields", []
             )
@@ -346,7 +388,7 @@ for key in sorted(executed):
             )
             for field, expected in expected_evidence.items():
                 value = nested_value(evidence_document, field)
-                if value is missing_marker or value != expected:
+                if value is missing_marker or not same_json_value(value, expected):
                     rendered = None if value is missing_marker else value
                     problems.append(
                         f"row {key[0]} on {key[1]} evidence field {field!r} "
@@ -359,7 +401,9 @@ for key in sorted(executed):
             )
             for field, allowed in allowed_evidence.items():
                 value = nested_value(evidence_document, field)
-                if value is missing_marker or value not in allowed:
+                if value is missing_marker or not any(
+                    same_json_value(value, candidate) for candidate in allowed
+                ):
                     rendered = None if value is missing_marker else value
                     problems.append(
                         f"row {key[0]} on {key[1]} evidence field {field!r} "

--- a/scripts/check-qualification.sh
+++ b/scripts/check-qualification.sh
@@ -109,11 +109,70 @@ if record.get("artifactDigestAlgorithm") != "swiftvlc-tree-v1":
         "'swiftvlc-tree-v1'"
     )
 
-required = {
-    (s["id"], h["id"])
-    for s in matrix["scenarios"]
-    for h in matrix["hardware"]
-}
+scenarios = matrix.get("scenarios")
+hardware_rows = matrix.get("hardware")
+if not isinstance(scenarios, list) or not isinstance(hardware_rows, list):
+    sys.exit("Error: qualification matrix needs 'scenarios' and 'hardware' arrays.")
+
+if any(
+    not isinstance(scenario, dict) or not isinstance(scenario.get("id"), str)
+    for scenario in scenarios
+):
+    sys.exit("Error: every qualification scenario needs a string 'id'.")
+if any(
+    not isinstance(hardware, dict) or not isinstance(hardware.get("id"), str)
+    for hardware in hardware_rows
+):
+    sys.exit("Error: every qualification hardware row needs a string 'id'.")
+
+scenario_by_id = {scenario["id"]: scenario for scenario in scenarios}
+hardware_by_id = {hardware["id"]: hardware for hardware in hardware_rows}
+if len(scenario_by_id) != len(scenarios):
+    sys.exit("Error: qualification matrix contains duplicate scenario ids.")
+if len(hardware_by_id) != len(hardware_rows):
+    sys.exit("Error: qualification matrix contains duplicate hardware ids.")
+
+required = set()
+for scenario in scenarios:
+    required_evidence = scenario.get("requiredEvidenceFields", [])
+    if (
+        not isinstance(required_evidence, list)
+        or any(not isinstance(field, str) or not field for field in required_evidence)
+    ):
+        sys.exit(
+            f"Error: scenario {scenario['id']!r} has invalid required evidence fields."
+        )
+    expected_evidence = scenario.get("expectedEvidenceValues", {})
+    if not isinstance(expected_evidence, dict):
+        sys.exit(
+            f"Error: scenario {scenario['id']!r} has invalid expected evidence values."
+        )
+    allowed_evidence = scenario.get("allowedEvidenceValues", {})
+    if (
+        not isinstance(allowed_evidence, dict)
+        or any(
+            not isinstance(field, str)
+            or not field
+            or not isinstance(allowed, list)
+            or not allowed
+            for field, allowed in allowed_evidence.items()
+        )
+    ):
+        sys.exit(
+            f"Error: scenario {scenario['id']!r} has invalid allowed evidence values."
+        )
+    selected_hardware = scenario.get("hardware", list(hardware_by_id))
+    if not isinstance(selected_hardware, list) or not selected_hardware:
+        sys.exit(
+            f"Error: scenario {scenario['id']!r} has an empty or invalid hardware list."
+        )
+    unknown = sorted(set(selected_hardware) - set(hardware_by_id))
+    if unknown:
+        sys.exit(
+            f"Error: scenario {scenario['id']!r} names unknown hardware: "
+            + ", ".join(unknown)
+        )
+    required.update((scenario["id"], hardware_id) for hardware_id in selected_hardware)
 
 rows = record.get("rows")
 if not isinstance(rows, list):
@@ -156,7 +215,6 @@ if failed:
 
 # Fields the criteria call for on every row. A row missing them is not a record
 # of anything reproducible.
-hardware_by_id = {hardware["id"]: hardware for hardware in matrix["hardware"]}
 for key in sorted(executed):
     if key not in required:
         continue
@@ -170,6 +228,7 @@ for key in sorted(executed):
         "osReleaseType",
         "fixture",
         "duration",
+        "durationSeconds",
         "evidence",
         "result",
     ):
@@ -196,6 +255,27 @@ for key in sorted(executed):
             f"row {key[0]} on {key[1]} uses {row.get('osReleaseType')!r} OS "
             "software; release qualification requires a stable OS build"
         )
+
+    duration_seconds = row.get("durationSeconds")
+    if (
+        not isinstance(duration_seconds, (int, float))
+        or isinstance(duration_seconds, bool)
+    ):
+        problems.append(
+            f"row {key[0]} on {key[1]} durationSeconds must be a number"
+        )
+    elif duration_seconds <= 0:
+        problems.append(
+            f"row {key[0]} on {key[1]} durationSeconds must be positive"
+        )
+    else:
+        minimum = scenario_by_id[key[0]].get("minimumDurationSeconds", 0)
+        if duration_seconds < minimum:
+            problems.append(
+                f"row {key[0]} on {key[1]} ran for {duration_seconds:g}s, "
+                f"below the required {minimum:g}s"
+            )
+
     evidence = row.get("evidence")
     if evidence:
         evidence_path = Path(evidence)
@@ -209,6 +289,83 @@ for key in sorted(executed):
                 f"row {key[0]} on {key[1]} evidence file does not exist: "
                 f"{evidence}"
             )
+        else:
+            resolved_evidence = Path(record_path).parent / evidence_path
+            try:
+                evidence_document = json.load(open(resolved_evidence))
+            except (OSError, ValueError) as error:
+                problems.append(
+                    f"row {key[0]} on {key[1]} evidence is not valid JSON: {error}"
+                )
+                continue
+            if not isinstance(evidence_document, dict):
+                problems.append(
+                    f"row {key[0]} on {key[1]} evidence must be a JSON object"
+                )
+                continue
+            for field, expected in (
+                ("artifactDigest", digest),
+                ("scenario", key[0]),
+                ("hardware", key[1]),
+            ):
+                if evidence_document.get(field) != expected:
+                    problems.append(
+                        f"row {key[0]} on {key[1]} evidence {field!r} is "
+                        f"{evidence_document.get(field)!r}, expected {expected!r}"
+                    )
+
+            missing_marker = object()
+
+            def nested_value(document, dotted_path):
+                value = document
+                for component in dotted_path.split("."):
+                    if not isinstance(value, dict) or component not in value:
+                        return missing_marker
+                    value = value[component]
+                return value
+
+            required_evidence = scenario_by_id[key[0]].get(
+                "requiredEvidenceFields", []
+            )
+            for field in required_evidence:
+                value = nested_value(evidence_document, field)
+                if (
+                    value is missing_marker
+                    or value is None
+                    or value == ""
+                    or value == []
+                    or value == {}
+                ):
+                    problems.append(
+                        f"row {key[0]} on {key[1]} evidence is missing "
+                        f"non-empty field {field!r}"
+                    )
+
+            expected_evidence = scenario_by_id[key[0]].get(
+                "expectedEvidenceValues", {}
+            )
+            for field, expected in expected_evidence.items():
+                value = nested_value(evidence_document, field)
+                if value is missing_marker or value != expected:
+                    rendered = None if value is missing_marker else value
+                    problems.append(
+                        f"row {key[0]} on {key[1]} evidence field {field!r} "
+                        f"is {rendered!r}, "
+                        f"expected {expected!r}"
+                    )
+
+            allowed_evidence = scenario_by_id[key[0]].get(
+                "allowedEvidenceValues", {}
+            )
+            for field, allowed in allowed_evidence.items():
+                value = nested_value(evidence_document, field)
+                if value is missing_marker or value not in allowed:
+                    rendered = None if value is missing_marker else value
+                    problems.append(
+                        f"row {key[0]} on {key[1]} evidence field {field!r} "
+                        f"is {rendered!r}, "
+                        f"expected one of {allowed!r}"
+                    )
 
 if problems:
     print(f"Error: {version} is not qualified for release.", file=sys.stderr)

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -8,10 +8,25 @@ acceptance gate, and `release.sh` refuses to package an artifact without one.
 
 ## Running the matrix
 
-`matrix.json` lists the required scenarios and hardware. Every combination is
-required — 9 scenarios across 4 hardware rows. Simulator runs never satisfy a
-row: PiP is force-disabled there, and a simulator can report PiP active while
-its window stays black.
+`matrix.json` lists the required scenarios and hardware. A scenario without a
+`hardware` list runs on every hardware row; focused performance, soak, and
+failure scenarios name the exact hardware they require. The current matrix has
+49 required rows. Simulator runs never satisfy a row: PiP is force-disabled
+there, and a simulator can report PiP active while its window stays black.
+
+The matrix covers the device-only acceptance criteria of every open v1.1.0
+milestone issue, not only the original functional PiP matrix. Long-running
+scenarios declare `minimumDurationSeconds`, and performance/failure scenarios
+declare the non-empty fields their evidence JSON must contain. This makes the
+release gate reject a brief smoke run or an evidence attachment that omits the
+metric the issue asked us to qualify.
+
+The matrix can also constrain the meaning of evidence, not just its presence.
+`expectedEvidenceValues` requires an exact value (for example zero crashes),
+while `allowedEvidenceValues` accepts one of a documented set (for example a
+replacement session must be either preserved or boundedly re-engaged). This
+prevents a passing row from carrying evidence that actually records an
+unsupported feature, a regression, or a failed acceptance condition.
 
 Record the results as `scripts/qualification/<version>.json`:
 
@@ -32,6 +47,7 @@ Record the results as `scripts/qualification/<version>.json`:
       "osReleaseType": "stable",
       "fixture": "demo.mkv",
       "duration": "2m14s",
+      "durationSeconds": 134,
       "evidence": "evidence/v1.1.0/iphone-current-vod-controls.json",
       "result": "pass",
       "notes": "optional; put log excerpts or anomalies here"
@@ -39,6 +55,30 @@ Record the results as `scripts/qualification/<version>.json`:
   ]
 }
 ```
+
+Every evidence file is a JSON object tied to the exact artifact and row:
+
+```json
+{
+  "artifactDigest": "…",
+  "scenario": "vod-controls",
+  "hardware": "iphone-current",
+  "events": ["willStart", "didStart", "willStop(userClosed)", "didStop(userClosed)"],
+  "controls": {
+    "pause": "pass",
+    "scrub": "pass",
+    "skipForward": "pass",
+    "skipBackward": "pass"
+  }
+}
+```
+
+Scenario-specific required fields use dotted paths such as `metrics.cpu` or
+`backendResults.native`. Zero is a valid recorded value (for example zero
+crashes or frame drops); missing, null, empty strings, and empty collections
+are not. Exact and allowed-value constraints use the same dotted-path syntax.
+Evidence may contain any additional raw samples, logs, Instruments exports,
+fixture hashes, or notes needed to make the result reproducible.
 
 `artifactDigest` is a path-independent SHA-256 over the complete XCFramework
 tree: libraries, headers, `Info.plist`, relative paths, symlinks, and modes.
@@ -61,9 +101,11 @@ library change.
 It fails when the record is absent, describes a different artifact, is for
 another version, omits a required row, contains a row that did not pass, or has
 a row missing device identity, stable OS build, fixture, duration, evidence, or
-result. Evidence paths are relative to the record and must exist. It also
-rejects an iPhone recorded for an iPad row, the wrong OS major, and beta OS
-software.
+result. Evidence paths are relative to the record; each file must exist, parse
+as JSON, name the same artifact/scenario/hardware, and contain the fields that
+scenario requires with the required semantic values. It also rejects an
+undersized soak, an iPhone recorded for an iPad row, the wrong OS major, and
+beta OS software.
 
 The digest is recomputed from the artifact on disk rather than trusted from the
 record — a record can claim any digest, and only a recomputed one can contradict

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -27,6 +27,9 @@ while `allowedEvidenceValues` accepts one of a documented set (for example a
 replacement session must be either preserved or boundedly re-engaged). This
 prevents a passing row from carrying evidence that actually records an
 unsupported feature, a regression, or a failed acceptance condition.
+The original cross-device PiP rows apply the same rule to each control,
+lifecycle order, recovery path, and stop reason; a top-level `result: "pass"`
+cannot mask a failed pause, missing restoration, or unsuccessful recovery.
 
 Record the results as `scripts/qualification/<version>.json`:
 
@@ -63,7 +66,11 @@ Every evidence file is a JSON object tied to the exact artifact and row:
   "artifactDigest": "…",
   "scenario": "vod-controls",
   "hardware": "iphone-current",
-  "events": ["willStart", "didStart", "willStop(userClosed)", "didStop(userClosed)"],
+  "events": {
+    "started": true,
+    "unexpectedStopCount": 0,
+    "order": "pass"
+  },
   "controls": {
     "pause": "pass",
     "scrub": "pass",
@@ -77,6 +84,9 @@ Scenario-specific required fields use dotted paths such as `metrics.cpu` or
 `backendResults.native`. Zero is a valid recorded value (for example zero
 crashes or frame drops); missing, null, empty strings, and empty collections
 are not. Exact and allowed-value constraints use the same dotted-path syntax.
+JSON types are strict: a boolean does not satisfy a numeric zero or one, even
+inside an array or object. Durations must also be finite positive numbers;
+`NaN` and infinity are rejected before minimum soak time is evaluated.
 Evidence may contain any additional raw samples, logs, Instruments exports,
 fixture hashes, or notes needed to make the result reproducible.
 

--- a/scripts/qualification/matrix.json
+++ b/scripts/qualification/matrix.json
@@ -1,20 +1,353 @@
 {
-  "description": "Physical-device rows that must be executed and passing before an xcframework can be released. Derived from the acceptance criteria of issue 88. Simulator runs never satisfy a row.",
+  "description": "Physical-device rows required before the v1.1.0 xcframework can be released. Simulator runs never satisfy a row.",
   "scenarios": [
-    { "id": "vod-controls",        "summary": "Finite VOD: play, pause, scrub, skip forward and back from the PiP controls" },
-    { "id": "live-media",          "summary": "Live stream with indefinite duration: PiP controls reflect an unbounded range" },
-    { "id": "restore",             "summary": "Restore from the PiP window back into the app" },
-    { "id": "close",               "summary": "Close the PiP window with the X control" },
-    { "id": "failed-start",        "summary": "PiP start refused or failing, surfaced rather than silent" },
-    { "id": "replacement",         "summary": "Same-player media replacement while PiP is active" },
-    { "id": "interruptions",       "summary": "Phone call or Siri interruption, and a route change such as Bluetooth disconnect" },
-    { "id": "background-audio",    "summary": "Audio continues with the app backgrounded" },
-    { "id": "long-stall",          "summary": "Sustained network stall and recovery while in PiP" }
+    {
+      "id": "vod-controls",
+      "issues": [88],
+      "summary": "Finite VOD: play, pause, scrub, skip forward and back from the PiP controls",
+      "requiredEvidenceFields": ["events", "controls"]
+    },
+    {
+      "id": "live-media",
+      "issues": [88],
+      "summary": "Live stream with indefinite duration: PiP controls reflect an unbounded range",
+      "requiredEvidenceFields": ["events", "playbackRange"]
+    },
+    {
+      "id": "restore",
+      "issues": [84, 88],
+      "summary": "Restore from the PiP window back into the app",
+      "requiredEvidenceFields": ["events"]
+    },
+    {
+      "id": "close",
+      "issues": [84, 88],
+      "summary": "Close the PiP window with the X control",
+      "requiredEvidenceFields": ["events"]
+    },
+    {
+      "id": "failed-start",
+      "issues": [84, 88, 104],
+      "summary": "PiP start refused or failing, surfaced rather than silent",
+      "requiredEvidenceFields": ["events"]
+    },
+    {
+      "id": "replacement",
+      "issues": [82, 84, 88],
+      "summary": "Same-player media replacement while PiP is active",
+      "requiredEvidenceFields": ["events", "recoveryOutcome"]
+    },
+    {
+      "id": "interruptions",
+      "issues": [87, 88],
+      "summary": "Phone call or Siri interruption, and a route change such as Bluetooth disconnect",
+      "requiredEvidenceFields": ["events"]
+    },
+    {
+      "id": "background-audio",
+      "issues": [87, 88],
+      "summary": "Audio continues with the app backgrounded",
+      "requiredEvidenceFields": ["events"]
+    },
+    {
+      "id": "long-stall",
+      "issues": [88],
+      "summary": "Sustained network stall and recovery while in PiP",
+      "requiredEvidenceFields": ["events", "recoveryOutcome"]
+    },
+    {
+      "id": "capability-convergence",
+      "issues": [75],
+      "hardware": ["iphone-current"],
+      "summary": "Suppressed seekable/length events and VOD/live/VOD transitions converge on direct and native PiP",
+      "requiredEvidenceFields": [
+        "backendResults.direct",
+        "backendResults.native",
+        "transitions",
+        "skipControls"
+      ],
+      "expectedEvidenceValues": {
+        "backendResults.direct": "pass",
+        "backendResults.native": "pass",
+        "transitions": "pass",
+        "skipControls": "pass"
+      }
+    },
+    {
+      "id": "replacement-continuity",
+      "issues": [82],
+      "hardware": ["iphone-current"],
+      "summary": "VOD/live and seekable/unseekable replacement combinations have coherent snapshots and deterministic recovery",
+      "requiredEvidenceFields": [
+        "combinations",
+        "snapshotCoherence",
+        "measurements.audioGapMilliseconds",
+        "measurements.videoGapMilliseconds",
+        "controls",
+        "recoveryOutcome",
+        "staleSuccessorMutations"
+      ],
+      "expectedEvidenceValues": {
+        "snapshotCoherence": "pass",
+        "staleSuccessorMutations": 0
+      },
+      "allowedEvidenceValues": {
+        "recoveryOutcome": ["preserved", "reengaged"]
+      }
+    },
+    {
+      "id": "native-lifecycle",
+      "issues": [84],
+      "hardware": ["iphone-current"],
+      "summary": "Native close, restore, start failure, programmatic stop, media end, failure, recast, and replacement publish ordered authoritative events",
+      "requiredEvidenceFields": ["bridgeProbe", "cases", "orderedEvents"],
+      "expectedEvidenceValues": {
+        "bridgeProbe": true,
+        "authoritativeStopReasons": true,
+        "restoreExactlyOnce": true,
+        "unsupportedBridgeVisible": true
+      }
+    },
+    {
+      "id": "terminal-outcomes",
+      "issues": [85],
+      "hardware": ["iphone-current"],
+      "summary": "EOF, stop, replacement, server close, malformed input, decode, renderer, and network failures produce one generation-scoped terminal outcome",
+      "requiredEvidenceFields": [
+        "cases",
+        "finalTimelines",
+        "generationIsolation",
+        "failureClassifications.source",
+        "failureClassifications.demux",
+        "failureClassifications.decoder",
+        "failureClassifications.renderer",
+        "failureClassifications.output",
+        "maximumTerminalOutcomesPerGeneration",
+        "unattributedStopNaturalEndCount"
+      ],
+      "expectedEvidenceValues": {
+        "generationIsolation": true,
+        "failureClassifications.source": "source",
+        "failureClassifications.demux": "demux",
+        "failureClassifications.decoder": "decoder",
+        "failureClassifications.renderer": "renderer",
+        "failureClassifications.output": "output",
+        "maximumTerminalOutcomesPerGeneration": 1,
+        "unattributedStopNaturalEndCount": 0
+      }
+    },
+    {
+      "id": "adaptive-hls-soak",
+      "issues": [91],
+      "hardware": ["iphone-current"],
+      "minimumDurationSeconds": 7200,
+      "summary": "Multi-hour live/VOD/event HLS soak across TS/fMP4, ABR, discontinuities, expired windows, retries, and cancellation",
+      "requiredEvidenceFields": [
+        "playlistCoverage",
+        "allocationProvenance",
+        "memorySeries",
+        "sanitizerFindings",
+        "crashes",
+        "unboundedRecoveries",
+        "monotonicGrowth",
+        "upstreamCrossLink"
+      ],
+      "expectedEvidenceValues": {
+        "sanitizerFindings": 0,
+        "crashes": 0,
+        "unboundedRecoveries": 0,
+        "monotonicGrowth": false
+      }
+    },
+    {
+      "id": "pip-render-performance-1080p60",
+      "issues": [93],
+      "hardware": ["iphone-current"],
+      "minimumDurationSeconds": 900,
+      "summary": "1080p60 direct PiP resize and replacement performance",
+      "requiredEvidenceFields": [
+        "metrics.cpu",
+        "metrics.gpu",
+        "metrics.rss",
+        "metrics.energy",
+        "metrics.thermal",
+        "metrics.conversionCost",
+        "metrics.frameDrops",
+        "metrics.presentationRate",
+        "resizeCycles",
+        "inlineQuality",
+        "effectiveWorkOutcome",
+        "boundedMemory",
+        "boundedWork"
+      ],
+      "expectedEvidenceValues": {
+        "inlineQuality": "preserved",
+        "effectiveWorkOutcome": "reduced",
+        "boundedMemory": true,
+        "boundedWork": true
+      }
+    },
+    {
+      "id": "pip-render-performance-4k60",
+      "issues": [93],
+      "hardware": ["iphone-current"],
+      "minimumDurationSeconds": 900,
+      "summary": "4K60 direct PiP resize and replacement performance",
+      "requiredEvidenceFields": [
+        "metrics.cpu",
+        "metrics.gpu",
+        "metrics.rss",
+        "metrics.energy",
+        "metrics.thermal",
+        "metrics.conversionCost",
+        "metrics.frameDrops",
+        "metrics.presentationRate",
+        "resizeCycles",
+        "inlineQuality",
+        "effectiveWorkOutcome",
+        "boundedMemory",
+        "boundedWork"
+      ],
+      "expectedEvidenceValues": {
+        "inlineQuality": "preserved",
+        "effectiveWorkOutcome": "reduced",
+        "boundedMemory": true,
+        "boundedWork": true
+      }
+    },
+    {
+      "id": "native-subtitle-matrix",
+      "issues": [95],
+      "hardware": ["iphone-current"],
+      "summary": "Text, styled, bitmap, forced, and live subtitles plus OSD remain correct through PiP transitions",
+      "requiredEvidenceFields": [
+        "supportMatrix",
+        "timingTransitions",
+        "metrics.cpu",
+        "metrics.gpu",
+        "metrics.colorHDRImpact"
+      ],
+      "expectedEvidenceValues": {
+        "supportMatrix.text": "supported",
+        "supportMatrix.styled": "supported",
+        "supportMatrix.bitmap": "supported",
+        "supportMatrix.forced": "supported",
+        "supportMatrix.live": "supported",
+        "supportMatrix.osd": "supported"
+      }
+    },
+    {
+      "id": "timebase-vod-soak",
+      "issues": [99],
+      "hardware": ["iphone-current"],
+      "minimumDurationSeconds": 7200,
+      "summary": "Multi-hour VOD direct PiP timebase and A/V drift at 0.5x, 1x, and 2x",
+      "requiredEvidenceFields": [
+        "rates",
+        "clockSeries",
+        "corrections",
+        "transitions",
+        "avPlayerBaseline",
+        "visibleSnapCount",
+        "monotonicityViolations"
+      ],
+      "expectedEvidenceValues": {
+        "rates": [0.5, 1, 2],
+        "visibleSnapCount": 0,
+        "monotonicityViolations": 0
+      }
+    },
+    {
+      "id": "timebase-live-soak",
+      "issues": [99],
+      "hardware": ["iphone-current"],
+      "minimumDurationSeconds": 7200,
+      "summary": "Multi-hour live direct PiP timebase and A/V drift at supported rates",
+      "requiredEvidenceFields": [
+        "rates",
+        "clockSeries",
+        "corrections",
+        "transitions",
+        "avPlayerBaseline",
+        "visibleSnapCount",
+        "monotonicityViolations"
+      ],
+      "expectedEvidenceValues": {
+        "rates": [0.5, 1, 2],
+        "visibleSnapCount": 0,
+        "monotonicityViolations": 0
+      }
+    },
+    {
+      "id": "cadence-matrix",
+      "issues": [102],
+      "hardware": ["iphone-current"],
+      "minimumDurationSeconds": 600,
+      "summary": "23.976/24/25/29.97/30/50/59.94/60 fps and VFR cadence through rate, pause, replacement, and resize transitions",
+      "requiredEvidenceFields": [
+        "rates",
+        "vfr",
+        "presentationMetrics",
+        "transitionResults",
+        "fabricatedDurationCount"
+      ],
+      "expectedEvidenceValues": {
+        "rates": [23.976, 24, 25, 29.97, 30, 50, 59.94, 60],
+        "vfr": true,
+        "fabricatedDurationCount": 0
+      }
+    },
+    {
+      "id": "deferred-pause-rejection",
+      "issues": [103],
+      "hardware": ["iphone-current"],
+      "summary": "Permanent and transient unpausable inputs settle with typed outcomes and truthful controls",
+      "requiredEvidenceFields": ["permanentCase", "transientCase", "cancellationCases"],
+      "expectedEvidenceValues": {
+        "permanentCase.outcome": "rejected",
+        "transientCase.outcome": "issued",
+        "cancellationCases": "pass",
+        "endlessTaskCount": 0,
+        "duplicatePauseCount": 0,
+        "truthfulControls": true
+      }
+    },
+    {
+      "id": "accepted-start-delayed-failure",
+      "issues": [104],
+      "hardware": ["iphone-current"],
+      "summary": "An accepted native start followed by delayed AVKit failure retains ordered controller/media attribution",
+      "requiredEvidenceFields": ["startResult", "orderedEvents", "controllerGeneration", "mediaGeneration"],
+      "expectedEvidenceValues": {
+        "startResult": "accepted",
+        "orderedAttribution": true
+      }
+    }
   ],
   "hardware": [
-    { "id": "iphone-minimum", "deviceFamily": "iPhone", "osMajor": 18, "summary": "iPhone on the minimum supported OS" },
-    { "id": "iphone-current", "deviceFamily": "iPhone", "osMajor": 26, "summary": "iPhone on the current stable OS" },
-    { "id": "ipad-minimum",   "deviceFamily": "iPad",   "osMajor": 18, "summary": "iPad on the minimum supported OS" },
-    { "id": "ipad-current",   "deviceFamily": "iPad",   "osMajor": 26, "summary": "iPad on the current stable OS" }
+    {
+      "id": "iphone-minimum",
+      "deviceFamily": "iPhone",
+      "osMajor": 18,
+      "summary": "iPhone on the minimum supported OS"
+    },
+    {
+      "id": "iphone-current",
+      "deviceFamily": "iPhone",
+      "osMajor": 26,
+      "summary": "iPhone on the current stable OS"
+    },
+    {
+      "id": "ipad-minimum",
+      "deviceFamily": "iPad",
+      "osMajor": 18,
+      "summary": "iPad on the minimum supported OS"
+    },
+    {
+      "id": "ipad-current",
+      "deviceFamily": "iPad",
+      "osMajor": 26,
+      "summary": "iPad on the current stable OS"
+    }
   ]
 }

--- a/scripts/qualification/matrix.json
+++ b/scripts/qualification/matrix.json
@@ -5,55 +5,130 @@
       "id": "vod-controls",
       "issues": [88],
       "summary": "Finite VOD: play, pause, scrub, skip forward and back from the PiP controls",
-      "requiredEvidenceFields": ["events", "controls"]
+      "requiredEvidenceFields": ["events", "controls"],
+      "expectedEvidenceValues": {
+        "events.started": true,
+        "events.unexpectedStopCount": 0,
+        "events.order": "pass",
+        "controls.play": "pass",
+        "controls.pause": "pass",
+        "controls.scrub": "pass",
+        "controls.skipForward": "pass",
+        "controls.skipBackward": "pass"
+      }
     },
     {
       "id": "live-media",
       "issues": [88],
       "summary": "Live stream with indefinite duration: PiP controls reflect an unbounded range",
-      "requiredEvidenceFields": ["events", "playbackRange"]
+      "requiredEvidenceFields": ["events", "playbackRange"],
+      "expectedEvidenceValues": {
+        "events.started": true,
+        "events.unexpectedStopCount": 0,
+        "events.order": "pass",
+        "playbackRange": "unbounded",
+        "linearPlayback": true
+      }
     },
     {
       "id": "restore",
       "issues": [84, 88],
       "summary": "Restore from the PiP window back into the app",
-      "requiredEvidenceFields": ["events"]
+      "requiredEvidenceFields": ["events", "restoreResult"],
+      "expectedEvidenceValues": {
+        "events.didStartCount": 1,
+        "events.willStopReason": "restoreRequested",
+        "events.didStopReason": "restoreRequested",
+        "events.order": "pass",
+        "restoreResult": "pass",
+        "completionCount": 1
+      }
     },
     {
       "id": "close",
       "issues": [84, 88],
       "summary": "Close the PiP window with the X control",
-      "requiredEvidenceFields": ["events"]
+      "requiredEvidenceFields": ["events", "stopReason"],
+      "expectedEvidenceValues": {
+        "events.didStartCount": 1,
+        "events.willStopReason": "userClosed",
+        "events.didStopReason": "userClosed",
+        "events.order": "pass",
+        "stopReason": "userClosed"
+      }
     },
     {
       "id": "failed-start",
       "issues": [84, 88, 104],
       "summary": "PiP start refused or failing, surfaced rather than silent",
-      "requiredEvidenceFields": ["events"]
+      "requiredEvidenceFields": ["events", "failureSurfaced"],
+      "expectedEvidenceValues": {
+        "events.failedToStartCount": 1,
+        "events.didStartCount": 0,
+        "events.order": "pass",
+        "failureSurfaced": true
+      }
     },
     {
       "id": "replacement",
       "issues": [82, 84, 88],
       "summary": "Same-player media replacement while PiP is active",
-      "requiredEvidenceFields": ["events", "recoveryOutcome"]
+      "requiredEvidenceFields": ["events", "controls", "recoveryOutcome"],
+      "expectedEvidenceValues": {
+        "events.controllerReplacementCount": 1,
+        "events.unattributedStopCount": 0,
+        "events.order": "pass",
+        "controls": "pass"
+      },
+      "allowedEvidenceValues": {
+        "recoveryOutcome": ["preserved", "reengaged"]
+      }
     },
     {
       "id": "interruptions",
       "issues": [87, 88],
       "summary": "Phone call or Siri interruption, and a route change such as Bluetooth disconnect",
-      "requiredEvidenceFields": ["events"]
+      "requiredEvidenceFields": [
+        "events",
+        "interruptionRecovery",
+        "routeChangeRecovery"
+      ],
+      "expectedEvidenceValues": {
+        "events.started": true,
+        "events.unexpectedStopCount": 0,
+        "events.order": "pass",
+        "interruptionRecovery": "pass",
+        "routeChangeRecovery": "pass"
+      }
     },
     {
       "id": "background-audio",
       "issues": [87, 88],
       "summary": "Audio continues with the app backgrounded",
-      "requiredEvidenceFields": ["events"]
+      "requiredEvidenceFields": ["events", "audioContinuity"],
+      "expectedEvidenceValues": {
+        "events.started": true,
+        "events.unexpectedStopCount": 0,
+        "events.order": "pass",
+        "audioContinuity": "pass"
+      }
     },
     {
       "id": "long-stall",
       "issues": [88],
       "summary": "Sustained network stall and recovery while in PiP",
-      "requiredEvidenceFields": ["events", "recoveryOutcome"]
+      "requiredEvidenceFields": [
+        "events",
+        "recoveryOutcome",
+        "boundedMemory"
+      ],
+      "expectedEvidenceValues": {
+        "events.started": true,
+        "events.unexpectedStopCount": 0,
+        "events.order": "pass",
+        "recoveryOutcome": "recovered",
+        "boundedMemory": true
+      }
     },
     {
       "id": "capability-convergence",

--- a/scripts/tests/release-integrity.sh
+++ b/scripts/tests/release-integrity.sh
@@ -217,13 +217,33 @@ import json
 import sys
 
 matrix_path, record_path, digest = sys.argv[1:4]
-open(str(record_path).rsplit("/", 1)[0] + "/evidence.json", "w").write("{}\n")
 matrix = {
-    "scenarios": [{"id": "vod"}],
+    "scenarios": [
+        {
+            "id": "vod",
+            "hardware": ["iphone-current"],
+            "minimumDurationSeconds": 60,
+            "requiredEvidenceFields": ["metrics.cpu", "outcome"],
+            "expectedEvidenceValues": {"metrics.errors": 0},
+            "allowedEvidenceValues": {"outcome": ["stable", "recovered"]},
+        }
+    ],
     "hardware": [
-        {"id": "iphone-current", "deviceFamily": "iPhone", "osMajor": 26}
+        {"id": "iphone-current", "deviceFamily": "iPhone", "osMajor": 26},
+        {"id": "ipad-current", "deviceFamily": "iPad", "osMajor": 26},
     ],
 }
+evidence = {
+    "artifactDigest": digest,
+    "scenario": "vod",
+    "hardware": "iphone-current",
+    "metrics": {"cpu": 0, "errors": 0},
+    "outcome": "stable",
+}
+json.dump(
+    evidence,
+    open(str(record_path).rsplit("/", 1)[0] + "/evidence.json", "w"),
+)
 record = {
     "version": "1.1.0",
     "artifactDigestAlgorithm": "swiftvlc-tree-v1",
@@ -240,6 +260,7 @@ record = {
             "osReleaseType": "stable",
             "fixture": "fixture.mp4",
             "duration": "2m",
+            "durationSeconds": 120,
             "evidence": "evidence.json",
             "result": "pass",
         }
@@ -247,6 +268,101 @@ record = {
 }
 json.dump(matrix, open(matrix_path, "w"))
 json.dump(record, open(record_path, "w"))
+PY
+
+SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
+  SWIFTVLC_QUALIFICATION_RECORD="$temp_dir/record.json" \
+  "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null
+
+# The scenario is scoped to iPhone, so the unrecorded iPad row must not be
+# invented by the checker. The successful call above is the regression test.
+
+python3 - "$temp_dir/record.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+record = json.load(open(path))
+record["rows"][0]["durationSeconds"] = 30
+json.dump(record, open(path, "w"))
+PY
+if SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
+  SWIFTVLC_QUALIFICATION_RECORD="$temp_dir/record.json" \
+  "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null 2>&1; then
+  fail "qualification accepted a run shorter than the scenario minimum"
+fi
+
+python3 - "$temp_dir/record.json" "$temp_dir/evidence.json" <<'PY'
+import json
+import sys
+
+record_path, evidence_path = sys.argv[1:3]
+record = json.load(open(record_path))
+record["rows"][0]["durationSeconds"] = 120
+json.dump(record, open(record_path, "w"))
+evidence = json.load(open(evidence_path))
+evidence["metrics"].pop("cpu")
+json.dump(evidence, open(evidence_path, "w"))
+PY
+if SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
+  SWIFTVLC_QUALIFICATION_RECORD="$temp_dir/record.json" \
+  "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null 2>&1; then
+  fail "qualification accepted evidence missing a required metric"
+fi
+
+python3 - "$temp_dir/evidence.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+evidence = json.load(open(path))
+evidence["metrics"]["cpu"] = 0
+json.dump(evidence, open(path, "w"))
+PY
+
+SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
+  SWIFTVLC_QUALIFICATION_RECORD="$temp_dir/record.json" \
+  "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null
+
+python3 - "$temp_dir/evidence.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+evidence = json.load(open(path))
+evidence["metrics"]["errors"] = 1
+json.dump(evidence, open(path, "w"))
+PY
+if SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
+  SWIFTVLC_QUALIFICATION_RECORD="$temp_dir/record.json" \
+  "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null 2>&1; then
+  fail "qualification accepted evidence with a wrong expected value"
+fi
+
+python3 - "$temp_dir/evidence.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+evidence = json.load(open(path))
+evidence["metrics"]["errors"] = 0
+evidence["outcome"] = "failed"
+json.dump(evidence, open(path, "w"))
+PY
+if SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
+  SWIFTVLC_QUALIFICATION_RECORD="$temp_dir/record.json" \
+  "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null 2>&1; then
+  fail "qualification accepted evidence outside the allowed values"
+fi
+
+python3 - "$temp_dir/evidence.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+evidence = json.load(open(path))
+evidence["outcome"] = "recovered"
+json.dump(evidence, open(path, "w"))
 PY
 
 SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \

--- a/scripts/tests/release-integrity.sh
+++ b/scripts/tests/release-integrity.sh
@@ -223,9 +223,15 @@ matrix = {
             "id": "vod",
             "hardware": ["iphone-current"],
             "minimumDurationSeconds": 60,
-            "requiredEvidenceFields": ["metrics.cpu", "outcome"],
-            "expectedEvidenceValues": {"metrics.errors": 0},
-            "allowedEvidenceValues": {"outcome": ["stable", "recovered"]},
+            "requiredEvidenceFields": ["metrics.cpu", "outcome", "retryCount"],
+            "expectedEvidenceValues": {
+                "metrics.errors": 0,
+                "rates": [1, 2],
+            },
+            "allowedEvidenceValues": {
+                "outcome": ["stable", "recovered"],
+                "retryCount": [0, 1],
+            },
         }
     ],
     "hardware": [
@@ -238,7 +244,9 @@ evidence = {
     "scenario": "vod",
     "hardware": "iphone-current",
     "metrics": {"cpu": 0, "errors": 0},
+    "rates": [1.0, 2],
     "outcome": "stable",
+    "retryCount": 0,
 }
 json.dump(
     evidence,
@@ -291,6 +299,25 @@ if SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
   "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null 2>&1; then
   fail "qualification accepted a run shorter than the scenario minimum"
 fi
+
+for non_finite in nan infinity; do
+  python3 - "$temp_dir/record.json" "$non_finite" <<'PY'
+import json
+import sys
+
+path, kind = sys.argv[1:3]
+record = json.load(open(path))
+record["rows"][0]["durationSeconds"] = (
+    float("nan") if kind == "nan" else float("inf")
+)
+json.dump(record, open(path, "w"))
+PY
+  if SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
+    SWIFTVLC_QUALIFICATION_RECORD="$temp_dir/record.json" \
+    "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null 2>&1; then
+    fail "qualification accepted a non-finite duration: $non_finite"
+  fi
+done
 
 python3 - "$temp_dir/record.json" "$temp_dir/evidence.json" <<'PY'
 import json
@@ -345,7 +372,54 @@ import sys
 
 path = sys.argv[1]
 evidence = json.load(open(path))
+evidence["metrics"]["errors"] = False
+json.dump(evidence, open(path, "w"))
+PY
+if SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
+  SWIFTVLC_QUALIFICATION_RECORD="$temp_dir/record.json" \
+  "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null 2>&1; then
+  fail "qualification treated a boolean as an expected number"
+fi
+
+python3 - "$temp_dir/evidence.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+evidence = json.load(open(path))
 evidence["metrics"]["errors"] = 0
+evidence["rates"] = [True, 2]
+json.dump(evidence, open(path, "w"))
+PY
+if SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
+  SWIFTVLC_QUALIFICATION_RECORD="$temp_dir/record.json" \
+  "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null 2>&1; then
+  fail "qualification treated a boolean as a number inside an expected array"
+fi
+
+python3 - "$temp_dir/evidence.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+evidence = json.load(open(path))
+evidence["rates"] = [1.0, 2]
+evidence["retryCount"] = False
+json.dump(evidence, open(path, "w"))
+PY
+if SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
+  SWIFTVLC_QUALIFICATION_RECORD="$temp_dir/record.json" \
+  "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null 2>&1; then
+  fail "qualification treated a boolean as an allowed number"
+fi
+
+python3 - "$temp_dir/evidence.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+evidence = json.load(open(path))
+evidence["retryCount"] = 0
 evidence["outcome"] = "failed"
 json.dump(evidence, open(path, "w"))
 PY
@@ -389,6 +463,30 @@ if SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
   "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null 2>&1; then
   fail "qualification accepted a beta OS row"
 fi
+
+python3 - "$ROOT_DIR/scripts/qualification/matrix.json" <<'PY'
+import json
+import sys
+
+matrix = json.load(open(sys.argv[1]))
+for scenario in matrix["scenarios"]:
+    if 88 not in scenario.get("issues", []):
+        continue
+    expected = scenario.get("expectedEvidenceValues", {})
+    if not any(field.startswith("events.") for field in expected):
+        raise SystemExit(
+            f"issue 88 scenario {scenario['id']} does not enforce lifecycle outcomes"
+        )
+    if "controls" in scenario.get("requiredEvidenceFields", []):
+        allowed = scenario.get("allowedEvidenceValues", {})
+        if not any(
+            field == "controls" or field.startswith("controls.")
+            for field in expected.keys() | allowed.keys()
+        ):
+            raise SystemExit(
+                f"issue 88 scenario {scenario['id']} does not enforce control outcomes"
+            )
+PY
 
 cd "$ROOT_DIR"
 bash -n \


### PR DESCRIPTION
## Summary

- expand the physical-device release matrix from 36 generic PiP rows to 49 rows covering every device-only acceptance condition still open in the v1.1.0 milestone
- tie every evidence attachment to the exact XCFramework digest, scenario, and hardware row
- enforce minimum soak durations, required metrics, exact acceptance values, and bounded allowed outcomes
- add release-integrity regressions for scoped hardware, duration, missing metrics, zero values, exact values, and allowed values

## Validation

- `python3 -m json.tool scripts/qualification/matrix.json`
- `bash -n scripts/check-qualification.sh scripts/tests/release-integrity.sh`
- `./scripts/tests/release-integrity.sh`

This does not close the milestone issues. It makes their remaining physical-device evidence an objective release gate rather than a checklist that can be declared complete without artifacts.