### PR TITLE
Expose native terminal playback failure attribution

### DIFF
--- a/Sources/CLibVLC/include/vlc/libvlc_events.h
+++ b/Sources/CLibVLC/include/vlc/libvlc_events.h
@@ -63,6 +63,22 @@ typedef enum libvlc_stopping_reason_t {
     libvlc_stopping_reason_user,
 } libvlc_stopping_reason_t;
 
+/** Playback subsystem that reported a terminal error. */
+typedef enum libvlc_playback_failure_kind_t {
+    /** The engine could not attribute the error to one subsystem. */
+    libvlc_playback_failure_unknown,
+    /** Media access or transport failed. */
+    libvlc_playback_failure_source,
+    /** Container or stream demultiplexing failed. */
+    libvlc_playback_failure_demux,
+    /** Audio, video, or subtitle decoding failed. */
+    libvlc_playback_failure_decoder,
+    /** Video rendering failed. */
+    libvlc_playback_failure_renderer,
+    /** Audio or stream output failed. */
+    libvlc_playback_failure_output,
+} libvlc_playback_failure_kind_t;
+
 /**
  * \ingroup libvlc_event
  * @{
@@ -318,6 +334,10 @@ typedef struct libvlc_event_t
         {
             float new_cache;
         } media_player_buffering;
+        struct
+        {
+            libvlc_playback_failure_kind_t failure;
+        } media_player_encountered_error;
         struct
         {
             int new_chapter;

--- a/Tests/SwiftVLCTests/Core/VendoredHeaderParityTests.swift
+++ b/Tests/SwiftVLCTests/Core/VendoredHeaderParityTests.swift
@@ -41,4 +41,23 @@ struct VendoredHeaderParityTests {
     event.u.media_player_media_stopping.reason = libvlc_stopping_reason_user
     #expect(event.u.media_player_media_stopping.reason == libvlc_stopping_reason_user)
   }
+
+  /// Patch 0020 extends the existing encountered-error event rather than
+  /// creating a wrapper-only guess. Referencing every value and the union
+  /// field here keeps the shipped header aligned with that engine ABI.
+  @Test
+  func `The encountered-error event carries a playback failure kind`() {
+    #expect(libvlc_playback_failure_unknown.rawValue == 0)
+    #expect(libvlc_playback_failure_source.rawValue == 1)
+    #expect(libvlc_playback_failure_demux.rawValue == 2)
+    #expect(libvlc_playback_failure_decoder.rawValue == 3)
+    #expect(libvlc_playback_failure_renderer.rawValue == 4)
+    #expect(libvlc_playback_failure_output.rawValue == 5)
+
+    var event = libvlc_event_t()
+    event.u.media_player_encountered_error.failure = libvlc_playback_failure_renderer
+    #expect(
+      event.u.media_player_encountered_error.failure == libvlc_playback_failure_renderer
+    )
+  }
 }

--- a/scripts/build-libvlc.sh
+++ b/scripts/build-libvlc.sh
@@ -1506,6 +1506,17 @@ PYEOF
 info "Fixing duplicate symbols in static libraries..."
 "${SCRIPT_DIR}/fix-duplicate-symbols.sh" "${OUTPUT_DIR}/libvlc.xcframework"
 
+# Patch 0020 extends EncounteredError with subsystem attribution. Compile and
+# execute its source/demux/decoder fixtures against the exact archive and
+# vendored headers about to ship, rather than merely proving the engine source
+# compiled. iOS-only builds have no host-runnable slice and skip this gate.
+if grep -q 'libvlc_playback_failure_kind_t' \
+    "${REPO_ROOT}/Sources/CLibVLC/include/vlc/libvlc_events.h"; then
+    info "Validating terminal playback failure attribution..."
+    "${SCRIPT_DIR}/validate-playback-failure-kind.sh" \
+        "${OUTPUT_DIR}/libvlc.xcframework"
+fi
+
 # Remove the CLibVLC module.modulemap from xcframework headers to avoid
 # "redefinition of module" errors when building with xcodebuild. The CLibVLC
 # SPM target provides its own module map; the xcframework only needs the raw

--- a/scripts/patches/0020-expose-playback-failure-kind.patch
+++ b/scripts/patches/0020-expose-playback-failure-kind.patch
@@ -1,0 +1,401 @@
+# Attribute terminal playback errors to the engine subsystem that reported them.
+#
+# Patch 0015 preserved ERROR/EOS/USER at the libVLC boundary, but ERROR still
+# collapsed every pipeline failure to one value. SwiftVLC therefore had to
+# publish `.failure(.unknown)` even when the engine was at an authoritative
+# access, demux, decoder, renderer, or output failure site.
+#
+# This patch keeps the existing EncounteredError event and adds a failure-kind
+# payload. The first input failure wins, so secondary teardown errors cannot
+# relabel a generation. It is recorded even during input opening, but emitted
+# only when playback reaches ERROR_S or its final END_S transition; a
+# recoverable individual-stream failure therefore cannot end playback early,
+# while the eventual terminal result still records that degraded generation.
+# Input topology distinguishes combined access/demux
+# failures (network transports such as the HTTP access-demux) from failures in
+# a demux consuming a separate byte stream. Decoder critical errors and
+# unsupported codecs are decoder failures; video-output and audio-output
+# creation failures are reported before the decoder's subsequent critical
+# return can obscure their origin. Unknown remains the fallback for legacy or
+# otherwise unattributed ERROR_S transitions.
+#
+# This is a SwiftVLC-specific API extension, not a claimed upstream backport.
+# It has been compile-gated against the pinned engine with patches 0001-0020
+# applied. scripts/patches/validation/playback-failure-kind-probe.c provides
+# runtime validation of the public payload for source, demux, and decoder
+# failures; renderer and output failure injection remain part of the physical
+# device qualification matrix because those modules are platform-owned.
+--- a/include/vlc/libvlc_events.h
++++ b/include/vlc/libvlc_events.h
+@@ -62,6 +62,22 @@
+     /** media is stopping due to user request */
+     libvlc_stopping_reason_user,
+ } libvlc_stopping_reason_t;
++
++/** Playback subsystem that reported a terminal error. */
++typedef enum libvlc_playback_failure_kind_t {
++    /** The engine could not attribute the error to one subsystem. */
++    libvlc_playback_failure_unknown,
++    /** Media access or transport failed. */
++    libvlc_playback_failure_source,
++    /** Container or stream demultiplexing failed. */
++    libvlc_playback_failure_demux,
++    /** Audio, video, or subtitle decoding failed. */
++    libvlc_playback_failure_decoder,
++    /** Video rendering failed. */
++    libvlc_playback_failure_renderer,
++    /** Audio or stream output failed. */
++    libvlc_playback_failure_output,
++} libvlc_playback_failure_kind_t;
+
+ /**
+  * \ingroup libvlc_event
+@@ -320,6 +336,10 @@
+         } media_player_buffering;
+         struct
+         {
++            libvlc_playback_failure_kind_t failure;
++        } media_player_encountered_error;
++        struct
++        {
+             int new_chapter;
+         } media_player_chapter_changed;
+         struct
+--- a/include/vlc_player.h
++++ b/include/vlc_player.h
+@@ -256,6 +256,11 @@
+ {
+     VLC_PLAYER_ERROR_NONE,
+     VLC_PLAYER_ERROR_GENERIC,
++    VLC_PLAYER_ERROR_SOURCE,
++    VLC_PLAYER_ERROR_DEMUX,
++    VLC_PLAYER_ERROR_DECODER,
++    VLC_PLAYER_ERROR_RENDERER,
++    VLC_PLAYER_ERROR_OUTPUT,
+ };
+
+ /**
+--- a/lib/media_player.c
++++ b/lib/media_player.c
+@@ -166,17 +166,36 @@
+     libvlc_media_player_t *mp = data;
+
+     libvlc_event_t event;
++    libvlc_playback_failure_kind_t failure;
+     switch (error) {
+         case VLC_PLAYER_ERROR_NONE:
+             event.type = libvlc_MediaPlayerNothingSpecial;
+-            break;
++            libvlc_event_send(&mp->event_manager, &event);
++            return;
+         case VLC_PLAYER_ERROR_GENERIC:
+-            event.type = libvlc_MediaPlayerEncounteredError;
++            failure = libvlc_playback_failure_unknown;
+             break;
++        case VLC_PLAYER_ERROR_SOURCE:
++            failure = libvlc_playback_failure_source;
++            break;
++        case VLC_PLAYER_ERROR_DEMUX:
++            failure = libvlc_playback_failure_demux;
++            break;
++        case VLC_PLAYER_ERROR_DECODER:
++            failure = libvlc_playback_failure_decoder;
++            break;
++        case VLC_PLAYER_ERROR_RENDERER:
++            failure = libvlc_playback_failure_renderer;
++            break;
++        case VLC_PLAYER_ERROR_OUTPUT:
++            failure = libvlc_playback_failure_output;
++            break;
+         default:
+             vlc_assert_unreachable();
+     }
+
++    event.type = libvlc_MediaPlayerEncounteredError;
++    event.u.media_player_encountered_error.failure = failure;
+     libvlc_event_send(&mp->event_manager, &event);
+ }
+
+--- a/src/input/input_internal.h
++++ b/src/input/input_internal.h
+@@ -69,6 +69,17 @@
+     END_S,
+     ERROR_S,
+ } input_state_e;
++
++/** Subsystem that produced a terminal playback failure. */
++enum vlc_input_failure_kind
++{
++    VLC_INPUT_FAILURE_UNKNOWN,
++    VLC_INPUT_FAILURE_SOURCE,
++    VLC_INPUT_FAILURE_DEMUX,
++    VLC_INPUT_FAILURE_DECODER,
++    VLC_INPUT_FAILURE_RENDERER,
++    VLC_INPUT_FAILURE_OUTPUT,
++};
+
+ /**
+  * Input events
+@@ -86,6 +97,9 @@
+      * the input will be stopped normally at EOF */
+     INPUT_EVENT_EOF,
+
++    /* A playback subsystem reported a terminal failure */
++    INPUT_EVENT_FAILURE,
++
+     /* "rate" has changed */
+     INPUT_EVENT_RATE,
+
+@@ -310,6 +324,8 @@
+     union {
+         /* INPUT_EVENT_STATE */
+         struct vlc_input_event_state state;
++        /* INPUT_EVENT_FAILURE */
++        enum vlc_input_failure_kind failure;
+         /* INPUT_EVENT_RATE */
+         float rate;
+         /* INPUT_EVENT_CAPABILITIES */
+--- a/src/input/event.h
++++ b/src/input/event.h
+@@ -147,6 +147,15 @@
+     });
+ }
+
++static inline void input_SendEventFailure(input_thread_t *p_input,
++                                          enum vlc_input_failure_kind kind)
++{
++    input_SendEvent(p_input, &(struct vlc_input_event) {
++        .type = INPUT_EVENT_FAILURE,
++        .failure = kind,
++    });
++}
++
+ static inline void input_SendEventCache(input_thread_t *p_input, double f_level)
+ {
+     input_SendEvent(p_input, &(struct vlc_input_event) {
+--- a/src/input/decoder.h
++++ b/src/input/decoder.h
+@@ -35,6 +35,8 @@
+
+ struct vlc_input_decoder_callbacks {
+     /* notifications */
++    void (*on_failure)(vlc_input_decoder_t *decoder,
++                       enum vlc_input_failure_kind kind, void *userdata);
+     void (*on_vout_started)(vlc_input_decoder_t *decoder, vout_thread_t *vout,
+                             enum vlc_vout_order vout_order,
+                             void *userdata);
+--- a/src/input/decoder.c
++++ b/src/input/decoder.c
+@@ -709,6 +709,7 @@
+
+         if( p_aout == NULL )
+         {
++            decoder_Notify(p_owner, on_failure, VLC_INPUT_FAILURE_OUTPUT);
+             vlc_fifo_Unlock(p_owner->p_fifo);
+             return -1;
+         }
+@@ -833,6 +834,7 @@
+     }
+
+ error:
++    decoder_Notify(p_owner, on_failure, VLC_INPUT_FAILURE_RENDERER);
+     /* Clean fmt and vctx to trigger a new vout creation on the next update
+      * call */
+     vlc_fifo_Lock(p_owner->p_fifo);
+@@ -1801,6 +1803,7 @@
+         case VLCDEC_SUCCESS:
+             break;
+         case VLCDEC_ECRITICAL:
++            decoder_Notify(p_owner, on_failure, VLC_INPUT_FAILURE_DECODER);
+             p_owner->error = true;
+             break;
+         case VLCDEC_RELOAD:
+@@ -2440,6 +2443,7 @@
+     if( !p_dec->p_module )
+     {
+         DecoderUnsupportedCodec( p_dec, cfg->fmt, !cfg->sout );
++        decoder_Notify(p_owner, on_failure, VLC_INPUT_FAILURE_DECODER);
+
+         /* Don't use dec->fmt_in->i_cat since it may not be initialized here. */
+         DeleteDecoder( p_owner, cfg->fmt->i_cat );
+--- a/src/input/es_out.c
++++ b/src/input/es_out.c
+@@ -370,6 +370,20 @@
+ }
+
+ static void
++decoder_on_failure(vlc_input_decoder_t *decoder,
++                   enum vlc_input_failure_kind kind, void *userdata)
++{
++    (void) decoder;
++
++    es_out_id_t *id = userdata;
++    struct vlc_input_es_out *out = id->out;
++    es_out_sys_t *p_sys = PRIV(&out->out);
++
++    if (p_sys->p_input)
++        input_SendEventFailure(p_sys->p_input, kind);
++}
++
++static void
+ decoder_on_vout_started(vlc_input_decoder_t *decoder, vout_thread_t *vout,
+                       enum vlc_vout_order order, void *userdata)
+ {
+@@ -609,6 +623,7 @@
+ }
+
+ static const struct vlc_input_decoder_callbacks decoder_cbs = {
++    .on_failure = decoder_on_failure,
+     .on_vout_started = decoder_on_vout_started,
+     .on_vout_stopped = decoder_on_vout_stopped,
+     .on_output_paused = decoder_on_output_paused,
+--- a/src/input/input.c
++++ b/src/input/input.c
+@@ -550,6 +550,9 @@
+     }
+     else if( i_ret == VLC_DEMUXER_EGENERIC )
+     {
++        input_SendEventFailure(
++            p_input, p_demux->s == NULL ? VLC_INPUT_FAILURE_SOURCE
++                                        : VLC_INPUT_FAILURE_DEMUX);
+         input_ChangeState( p_input, ERROR_S, VLC_TICK_INVALID );
+     }
+     else if( p_priv->i_slave > 0 )
+@@ -794,6 +797,7 @@
+         priv->p_sout  = input_resource_RequestSout( priv->p_resource, psz );
+         if( priv->p_sout == NULL )
+         {
++            input_SendEventFailure(p_input, VLC_INPUT_FAILURE_OUTPUT);
+             input_ChangeState( p_input, ERROR_S, VLC_TICK_INVALID );
+             msg_Err( p_input, "cannot start stream output instance, " \
+                               "aborting" );
+@@ -1786,6 +1790,9 @@
+         if( demux_Control( p_demux, DEMUX_SET_PAUSE_STATE, false ) )
+         {
+             msg_Err( p_input, "cannot resume" );
++            input_SendEventFailure(
++                p_input, p_demux->s == NULL ? VLC_INPUT_FAILURE_SOURCE
++                                            : VLC_INPUT_FAILURE_DEMUX);
+             input_ChangeState( p_input, ERROR_S, i_control_date );
+             return;
+         }
+@@ -2745,7 +2752,10 @@
+     stream_t *p_stream = stream_AccessNew( obj, p_input, p_es_out,
+                                            preparsing, url );
+     if( p_stream == NULL )
++    {
++        input_SendEventFailure(p_input, VLC_INPUT_FAILURE_SOURCE);
+         return NULL;
++    }
+
+     p_stream = stream_FilterAutoNew( p_stream );
+
+@@ -2783,6 +2793,7 @@
+         return demux;
+
+ error:
++    input_SendEventFailure(p_input, VLC_INPUT_FAILURE_DEMUX);
+     vlc_stream_Delete( p_stream );
+     return NULL;
+ }
+@@ -2948,6 +2959,7 @@
+         if( in->p_demux == NULL )
+         {
+             msg_Err(p_input, "Failed to create demux filter");
++            input_SendEventFailure(p_input, VLC_INPUT_FAILURE_DEMUX);
+             if( in->p_slave_es_out )
+             {
+                 vlc_input_es_out_Delete(in->p_slave_es_out);
+--- a/src/player/input.c
++++ b/src/player/input.c
+@@ -350,18 +350,31 @@
+             break;
+         case END_S:
+             input->playing = false;
+-            input->stopping_reason = VLC_PLAYER_MEDIA_STOPPING_EOS;
++            if (input->error != VLC_PLAYER_ERROR_NONE)
++            {
++                input->stopping_reason = VLC_PLAYER_MEDIA_STOPPING_ERROR;
++                if (!input->error_reported)
++                {
++                    vlc_player_SendEvent(input->player, on_error_changed,
++                                         input->error);
++                    input->error_reported = true;
++                }
++            }
++            else
++                input->stopping_reason = VLC_PLAYER_MEDIA_STOPPING_EOS;
+             vlc_player_input_HandleState(input, VLC_PLAYER_STATE_STOPPING,
+                                          VLC_TICK_INVALID);
+             vlc_player_destructor_AddStoppingInput(input->player, input);
+             break;
+         case ERROR_S:
+             /* Don't send errors if the input is stopped by the user */
+-            if (input->started)
++            if (input->started && !input->error_reported)
+             {
+                 /* Contrary to the input_thead_t, an error is not a state */
+-                input->error = VLC_PLAYER_ERROR_GENERIC;
++                if (input->error == VLC_PLAYER_ERROR_NONE)
++                    input->error = VLC_PLAYER_ERROR_GENERIC;
+                 vlc_player_SendEvent(input->player, on_error_changed, input->error);
++                input->error_reported = true;
+             }
+             /* input->playing monitor the OPENING_S -> PLAYING_S transition.
+              * If input->playing is false, we have an error at the opening of
+@@ -993,6 +1006,37 @@
+         case INPUT_EVENT_STATE:
+             vlc_player_input_HandleStateEvent(input, event->state.value,
+                                               event->state.date);
++            break;
++        case INPUT_EVENT_FAILURE:
++            /* Preserve the first authoritative subsystem failure, including
++             * failures raised while the input is still opening. The terminal
++             * state transition owns the public notification so a recoverable
++             * stream failure cannot end playback early. */
++            if (input->error == VLC_PLAYER_ERROR_NONE)
++            {
++                switch (event->failure)
++                {
++                    case VLC_INPUT_FAILURE_SOURCE:
++                        input->error = VLC_PLAYER_ERROR_SOURCE;
++                        break;
++                    case VLC_INPUT_FAILURE_DEMUX:
++                        input->error = VLC_PLAYER_ERROR_DEMUX;
++                        break;
++                    case VLC_INPUT_FAILURE_DECODER:
++                        input->error = VLC_PLAYER_ERROR_DECODER;
++                        break;
++                    case VLC_INPUT_FAILURE_RENDERER:
++                        input->error = VLC_PLAYER_ERROR_RENDERER;
++                        break;
++                    case VLC_INPUT_FAILURE_OUTPUT:
++                        input->error = VLC_PLAYER_ERROR_OUTPUT;
++                        break;
++                    case VLC_INPUT_FAILURE_UNKNOWN:
++                    default:
++                        input->error = VLC_PLAYER_ERROR_GENERIC;
++                        break;
++                }
++            }
+             break;
+         case INPUT_EVENT_EOF:
+             handled = vlc_player_input_HandleAtoBLoop(input, true);
+@@ -1238,6 +1282,7 @@
+
+     input->state = VLC_PLAYER_STATE_STOPPED;
+     input->error = VLC_PLAYER_ERROR_NONE;
++    input->error_reported = false;
+     input->stopping_reason = VLC_PLAYER_MEDIA_STOPPING_ERROR;
+     input->rate = 1.f;
+     input->capabilities = 0;
+--- a/src/player/player.h
++++ b/src/player/player.h
+@@ -64,6 +64,7 @@
+
+     enum vlc_player_state state;
+     enum vlc_player_error error;
++    bool error_reported;
+     enum vlc_player_media_stopping_reason stopping_reason;
+     float rate;
+     int capabilities;

--- a/scripts/patches/manifest.sha256
+++ b/scripts/patches/manifest.sha256
@@ -17,3 +17,4 @@ ea85b92b4239f4812542b3f4d4efe0600b42b23a331d524a811de9ddeb8fde29  0016-skip-vlc-
 e41b501f77342eb6f5cbc6b8c84b4b2d29e375958ffcdc76a07fe3c597b2ba16  0017-native-pip-format-description-cache.patch
 00aa6608db4f668a20b4138f504045ea2ce87ed7066a7adae01def71f4015d8b  0018-media-list-player-observer-lock-order.patch
 bee0f53d544430719a74c9fba5d032dcf33e0cf3e659187f82ac2cc0484998b5  0019-darwin-sha512-stdin.patch
+5279e772e203583b689a7bc5c51e94c4b22c0b1fdc4b6ea45f46cff556d18e47  0020-expose-playback-failure-kind.patch

--- a/scripts/patches/validation/playback-failure-kind-probe.c
+++ b/scripts/patches/validation/playback-failure-kind-probe.c
@@ -1,0 +1,142 @@
+/* Runtime proof for patch 0020 (playback subsystem failure attribution).
+ *
+ * The engine compiles even if a failure site is accidentally left mapped to
+ * generic, so compile coverage alone is insufficient. This probe verifies the
+ * public EncounteredError payload for an unavailable access module, malformed
+ * local media, and a recognized container whose codec fourcc was replaced by
+ * an unsupported value.
+ *
+ * Prepare the two local fixtures and run against a patched native build:
+ *
+ *   printf 'not media' > /tmp/swiftvlc-malformed.mp4
+ *   cp Tests/SwiftVLCTests/Fixtures/test.mp4 /tmp/swiftvlc-unknown-codec.mp4
+ *   perl -pi -e 's/avc1/zzzz/g' /tmp/swiftvlc-unknown-codec.mp4
+ *   V=scripts/.build-libvlc/vlc
+ *   cp "$V/build-macosx-arm64/static-lib/libvlc-full-static.a" \
+ *     /tmp/libvlc-full-static-probe.a
+ *   ./scripts/fix-duplicate-symbols.sh /tmp/libvlc-full-static-probe.a
+ *   clang -o /tmp/playback-failure-kind-probe \
+ *     scripts/patches/validation/playback-failure-kind-probe.c \
+ *     -I Sources/CLibVLC/include /tmp/libvlc-full-static-probe.a \
+ *     -framework AppKit -framework AudioToolbox -framework AudioUnit \
+ *     -framework AVFoundation -framework AVKit -framework CoreAudio \
+ *     -framework CoreFoundation -framework CoreGraphics -framework CoreImage \
+ *     -framework CoreMedia -framework CoreServices -framework CoreText \
+ *     -framework CoreVideo -framework Foundation -framework IOKit \
+ *     -framework IOSurface -framework OpenGL -framework QuartzCore \
+ *     -framework Security -framework SystemConfiguration -framework VideoToolbox \
+ *     -lbz2 -lc++ -liconv -lresolv -lsqlite3 -lxml2 -lz
+ *   /tmp/playback-failure-kind-probe \
+ *     /tmp/swiftvlc-malformed.mp4 /tmp/swiftvlc-unknown-codec.mp4
+ */
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <vlc/vlc.h>
+
+static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t condition = PTHREAD_COND_INITIALIZER;
+static int seen;
+static libvlc_playback_failure_kind_t last_failure;
+
+static const char *failure_name(libvlc_playback_failure_kind_t failure)
+{
+    switch (failure) {
+    case libvlc_playback_failure_unknown: return "unknown";
+    case libvlc_playback_failure_source: return "source";
+    case libvlc_playback_failure_demux: return "demux";
+    case libvlc_playback_failure_decoder: return "decoder";
+    case libvlc_playback_failure_renderer: return "renderer";
+    case libvlc_playback_failure_output: return "output";
+    }
+    return "invalid";
+}
+
+static void on_event(const libvlc_event_t *event, void *data)
+{
+    (void)data;
+    if (event->type != libvlc_MediaPlayerEncounteredError)
+        return;
+
+    pthread_mutex_lock(&lock);
+    last_failure = event->u.media_player_encountered_error.failure;
+    seen = 1;
+    pthread_cond_signal(&condition);
+    pthread_mutex_unlock(&lock);
+}
+
+static int run(libvlc_instance_t *vlc, const char *mrl, int is_location,
+               libvlc_playback_failure_kind_t expected)
+{
+    libvlc_media_t *media = is_location ? libvlc_media_new_location(mrl)
+                                        : libvlc_media_new_path(mrl);
+    if (media == NULL)
+    {
+        fprintf(stderr, "cannot create media for %s\n", mrl);
+        return 1;
+    }
+
+    libvlc_media_player_t *player = libvlc_media_player_new_from_media(vlc, media);
+    if (player == NULL)
+    {
+        fprintf(stderr, "cannot create player for %s\n", mrl);
+        libvlc_media_release(media);
+        return 1;
+    }
+
+    libvlc_event_manager_t *events = libvlc_media_player_event_manager(player);
+    libvlc_event_attach(events, libvlc_MediaPlayerEncounteredError, on_event, NULL);
+
+    pthread_mutex_lock(&lock);
+    seen = 0;
+    last_failure = libvlc_playback_failure_unknown;
+    pthread_mutex_unlock(&lock);
+
+    libvlc_media_player_play(player);
+
+    struct timespec deadline;
+    clock_gettime(CLOCK_REALTIME, &deadline);
+    deadline.tv_sec += 15;
+    pthread_mutex_lock(&lock);
+    while (!seen && pthread_cond_timedwait(&condition, &lock, &deadline) == 0) {}
+    int got_event = seen;
+    libvlc_playback_failure_kind_t actual = last_failure;
+    pthread_mutex_unlock(&lock);
+
+    libvlc_media_player_stop_async(player);
+    libvlc_media_player_release(player);
+    libvlc_media_release(media);
+
+    int passed = got_event && actual == expected;
+    printf("%s expected=%-8s actual=%s\n", passed ? "PASS" : "FAIL",
+           failure_name(expected), got_event ? failure_name(actual) : "no event");
+    return passed ? 0 : 1;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc != 3)
+    {
+        fprintf(stderr, "usage: %s <malformed-media> <unsupported-codec-media>\n", argv[0]);
+        return 2;
+    }
+
+    const char *arguments[] = { "--no-audio", "--vout=dummy", "--aout=dummy" };
+    libvlc_instance_t *vlc = libvlc_new(3, arguments);
+    if (vlc == NULL)
+    {
+        fprintf(stderr, "libvlc_new failed\n");
+        return 2;
+    }
+
+    int result = 0;
+    result |= run(vlc, "swiftvlc-missing-source://unavailable", 1,
+                  libvlc_playback_failure_source);
+    result |= run(vlc, argv[1], 0, libvlc_playback_failure_demux);
+    result |= run(vlc, argv[2], 0, libvlc_playback_failure_decoder);
+
+    libvlc_release(vlc);
+    printf(result ? "RESULT: FAILED\n" : "RESULT: PASSED\n");
+    return result;
+}

--- a/scripts/validate-playback-failure-kind.sh
+++ b/scripts/validate-playback-failure-kind.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Runtime-check patch 0020 against the exact macOS archive and vendored headers
+# that the XCFramework will ship.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+XCFRAMEWORK="${1:-$REPO_ROOT/Vendor/libvlc.xcframework}"
+ARCHIVE="$XCFRAMEWORK/macos-arm64_x86_64/libvlc.a"
+
+if [[ ! -f "$ARCHIVE" ]]; then
+  echo "Playback failure-kind validation skipped (no macOS slice)."
+  exit 0
+fi
+
+WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/swiftvlc-failure-kind.XXXXXX")
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+printf 'not media' > "$WORK_DIR/malformed.mp4"
+cp "$REPO_ROOT/Tests/SwiftVLCTests/Fixtures/test.mp4" "$WORK_DIR/unknown-codec.mp4"
+perl -pi -e 's/avc1/zzzz/g' "$WORK_DIR/unknown-codec.mp4"
+
+clang -o "$WORK_DIR/probe" \
+  "$SCRIPT_DIR/patches/validation/playback-failure-kind-probe.c" \
+  -I "$REPO_ROOT/Sources/CLibVLC/include" "$ARCHIVE" \
+  -framework AppKit -framework AudioToolbox -framework AudioUnit \
+  -framework AVFoundation -framework AVKit -framework CoreAudio \
+  -framework CoreFoundation -framework CoreGraphics -framework CoreImage \
+  -framework CoreMedia -framework CoreServices -framework CoreText \
+  -framework CoreVideo -framework Foundation -framework IOKit \
+  -framework IOSurface -framework OpenGL -framework QuartzCore \
+  -framework Security -framework SystemConfiguration -framework VideoToolbox \
+  -lbz2 -lc++ -liconv -lresolv -lsqlite3 -lxml2 -lz
+
+"$WORK_DIR/probe" "$WORK_DIR/malformed.mp4" "$WORK_DIR/unknown-codec.mp4"


### PR DESCRIPTION
## Summary

- extend the patched libVLC `EncounteredError` event with source, demux, decoder, renderer, output, and unknown subsystem attribution
- preserve the first authoritative pipeline failure through opening and playback, then publish it only at the terminal transition
- add a host-runnable source/demux/decoder probe and make macOS engine builds run it against the exact XCFramework archive and vendored headers
- compile-gate vendored header parity for every new enum value and payload field

This is intentionally the engine half of #85. The Swift wrapper must not read the new payload until a beta artifact containing patch 0020 is published; doing so against beta.1 would read uninitialized union memory. After this merges, the next beta engine release can be built from `main`, then the wrapper half can safely land.

## Validation

- patched macOS arm64 engine build
- runtime failure probe: source, demux, decoder all passed
- `git apply --reverse --check` for patch 0020 against the patched engine tree
- `swift test --filter "VendoredHeaderParityTests|MapEventTests|PlaybackTerminalOutcomeTests"` (51 tests passed)
- `swiftlint lint --strict --quiet Sources Tests`
- `swiftformat Sources Tests --lint`
- `git diff --check`
- patch manifest verification

Advances #85.