### PR TITLE
Expose PiP overlay support by backend

### DIFF
--- a/Sources/SwiftVLC/PiP/PiPOverlaySupport.swift
+++ b/Sources/SwiftVLC/PiP/PiPOverlaySupport.swift
@@ -1,0 +1,34 @@
+#if os(iOS) || os(macOS)
+/// Whether VLC subtitle, bitmap-subpicture, and on-screen-display regions are
+/// included in the video delivered to Picture in Picture.
+public enum PiPOverlaySupport: Hashable, Sendable {
+  /// VLC composites overlays into the video buffer before AVKit receives it.
+  case composited
+
+  /// The backend delivers the decoded video plane without VLC's overlay.
+  case unavailable
+}
+
+extension PiPController {
+  /// Whether the selected backend includes VLC subtitles, bitmap
+  /// subpictures, and OSD regions in the system PiP video.
+  ///
+  /// Direct ``PiPController`` rendering uses VLC's software-composited vmem
+  /// frames and reports ``PiPOverlaySupport/composited``. The native drawable
+  /// iOS native drawable backend currently sends AVKit the decoded video plane
+  /// separately from VLC's inline overlay view and reports
+  /// ``PiPOverlaySupport/unavailable``. The private macOS backend reparents the
+  /// complete VLC drawable and remains ``PiPOverlaySupport/composited``.
+  /// Check this value before offering overlay controls in a PiP-only UI.
+  public var overlaySupport: PiPOverlaySupport {
+    #if os(iOS)
+    nativeBackend == nil ? .composited : .unavailable
+    #else
+    // The private macOS backend reparents VLC's complete drawable instead of
+    // handing AVKit a video-only sample-buffer layer, so its sibling overlay
+    // remains part of the presented view.
+    .composited
+    #endif
+  }
+}
+#endif

--- a/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
@@ -66,6 +66,9 @@ video. VLC draws those regions into a sibling overlay view for inline playback,
 while AVKit receives only the video sample-buffer layer. Core Animation
 sublayers and sibling views are not composited into that content source.
 
+Check ``PiPController/overlaySupport`` to distinguish this native limitation
+from direct PiP, whose vmem buffers include VLC's software-composited overlay.
+
 Supporting subtitles without degrading the zero-copy and HDR paths requires a
 separate, same-format burn-in stage before sample enqueue. That compositor is
 not part of SwiftVLC today. Do not rely on an inline subtitle appearing in the

--- a/Tests/SwiftVLCTests/PiP/DecodedFrameHarnessTests.swift
+++ b/Tests/SwiftVLCTests/PiP/DecodedFrameHarnessTests.swift
@@ -66,6 +66,80 @@ extension Integration {
       }
     }
 
+    private final class CapturedFrame: @unchecked Sendable {
+      struct Snapshot: @unchecked Sendable {
+        var buffer: CVPixelBuffer?
+        var count: UInt64 = 0
+      }
+
+      let snapshot = Mutex(Snapshot())
+
+      func record(_ sample: CMSampleBuffer) {
+        guard let buffer = CMSampleBufferGetImageBuffer(sample) else { return }
+        snapshot.withLock {
+          $0.buffer = buffer
+          $0.count &+= 1
+        }
+      }
+    }
+
+    private final class CapturingHarness {
+      let layer: AVSampleBufferDisplayLayer
+      let renderer: PixelBufferRenderer
+      let registration: DirectPiPVideoCallbackRegistration
+      let capture: CapturedFrame
+
+      @MainActor
+      init(attachedTo player: Player) {
+        layer = AVSampleBufferDisplayLayer()
+        capture = CapturedFrame()
+        let capture = capture
+        renderer = PixelBufferRenderer(
+          displayLayer: layer,
+          displayLayerAPI: PixelBufferDisplayLayerAPI(
+            status: { _ in .rendering },
+            requiresFlush: { _ in false },
+            flush: { _ in },
+            isReadyForMoreMediaData: { _ in true },
+            enqueue: { _, sample in capture.record(sample) }
+          )
+        )
+        registration = DirectPiPVideoCallbackRegistration(renderer: renderer)
+        player.claimDirectPiPVideoCallbacks(registration)
+      }
+
+      var frameCount: UInt64 {
+        capture.snapshot.withLock { $0.count }
+      }
+
+      func rgbSum() -> UInt64? {
+        guard let buffer = capture.snapshot.withLock({ $0.buffer }) else { return nil }
+        guard CVPixelBufferGetPixelFormatType(buffer) == kCVPixelFormatType_32BGRA else {
+          return nil
+        }
+        CVPixelBufferLockBaseAddress(buffer, .readOnly)
+        defer { CVPixelBufferUnlockBaseAddress(buffer, .readOnly) }
+        guard let baseAddress = CVPixelBufferGetBaseAddress(buffer) else { return nil }
+
+        let width = CVPixelBufferGetWidth(buffer)
+        let height = CVPixelBufferGetHeight(buffer)
+        let bytesPerRow = CVPixelBufferGetBytesPerRow(buffer)
+        var sum: UInt64 = 0
+        for row in 0..<height {
+          let pixels = baseAddress
+            .advanced(by: row * bytesPerRow)
+            .assumingMemoryBound(to: UInt8.self)
+          for column in 0..<width {
+            let offset = column * 4
+            sum &+= UInt64(pixels[offset])
+            sum &+= UInt64(pixels[offset + 1])
+            sum &+= UInt64(pixels[offset + 2])
+          }
+        }
+        return sum
+      }
+    }
+
     /// The foundation: a real decode reaches the renderer and is converted.
     ///
     /// If this fails, the vmem path is not carrying pictures and nothing else
@@ -81,6 +155,42 @@ extension Integration {
       try #require(
         await poll(timeout: .seconds(30), until: { harness.creations > 0 }),
         "no decoded frame reached the renderer, so the vmem path is not carrying pictures"
+      )
+    }
+
+    @Test(.timeLimit(.minutes(2)))
+    func `Direct PiP buffers include VLC subtitle blending`() async throws {
+      let baselinePlayer = Player(instance: TestInstance.makeVideoDecoding())
+      let baselineHarness = CapturingHarness(attachedTo: baselinePlayer)
+      try baselinePlayer.play(url: TestMedia.twosecURL)
+      defer { baselinePlayer.stop() }
+      try #require(
+        await poll(timeout: .seconds(30), until: { baselineHarness.frameCount > 2 }),
+        "no baseline video frames reached the direct PiP renderer"
+      )
+      let baseline = try #require(baselineHarness.rgbSum())
+      baselinePlayer.stop()
+
+      let subtitlePlayer = Player(instance: TestInstance.makeVideoDecoding())
+      let subtitleHarness = CapturingHarness(attachedTo: subtitlePlayer)
+      let media = try Media(url: TestMedia.twosecURL)
+      try media.addSlave(from: TestMedia.subtitleURL, type: .subtitle)
+      subtitlePlayer.load(media)
+      try subtitlePlayer.play()
+      defer { subtitlePlayer.stop() }
+      try #require(
+        await poll(timeout: .seconds(10), until: {
+          !subtitlePlayer.subtitleTracks.isEmpty
+        }),
+        "the sidecar subtitle track was not discovered"
+      )
+      subtitlePlayer.selectedSubtitleTrack = subtitlePlayer.subtitleTracks.first
+      try #require(
+        await poll(timeout: .seconds(30), until: {
+          subtitleHarness.frameCount > 2
+            && subtitleHarness.rgbSum().map { $0 > baseline + 10000 } == true
+        }),
+        "the selected VLC subtitle was not blended into direct PiP's video buffers"
       )
     }
 

--- a/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
@@ -563,6 +563,13 @@ extension Integration {
     }
 
     @Test
+    func `Direct PiP reports composited VLC overlays`() {
+      let player = Player(instance: TestInstance.shared)
+      let controller = PiPController(player: player)
+      #expect(controller.overlaySupport == .composited)
+    }
+
+    @Test
     func `layer returns a valid AVSampleBufferDisplayLayer`() {
       let player = Player(instance: TestInstance.shared)
       let controller = PiPController(player: player)

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewIOSNativeTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewIOSNativeTests.swift
@@ -14,6 +14,14 @@ extension Integration {
       libvlc_media_player_get_nsobject(player.pointer)
     }
 
+    @Test
+    func `iOS native PiP reports its video-only overlay limitation`() {
+      let player = Player(instance: TestInstance.shared)
+      let controller = PiPController(player: player, nativeBackend: IOSNativePiPBackend())
+
+      #expect(controller.overlaySupport == .unavailable)
+    }
+
     // Pinned libVLC copies `drawable-nsobject` into
     // `VLCVideoUIView._viewContainer` once, when the vout opens. Replacing
     // the player's variable cannot move that already-open vout. This probe

--- a/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPVideoViewTests.swift
@@ -443,6 +443,15 @@ extension Integration {
     }
 
     @Test
+    func `macOS native PiP reparents the composited VLC drawable`() {
+      let player = Player(instance: TestInstance.shared)
+      let host = MacNativePiPHostView()
+      let controller = PiPController(player: player, nativeBackend: host.nativePiPBackend)
+
+      #expect(controller.overlaySupport == .composited)
+    }
+
+    @Test
     func `macOS native PiP drawable does not expose VLC AVKit PiP callbacks`() {
       let view = MacNativePiPDrawableView()
 


### PR DESCRIPTION
## Summary

- prove with real decoded frames that direct PiP receives VLC software-composited subtitles
- expose typed overlay support for direct and native backends
- document the native sample-buffer limitation and the query apps can use

## Validation

- focused real-decode and direct/native support tests pass
- SwiftFormat strict lint across Sources and Tests
- SwiftLint strict across Sources and Tests
- git diff check

This advances issue 95 by completing the programmatic detection part of its third criterion. Native subtitle and OSD composition remains separate implementation work.