### PR TITLE
Map terminal failures to playback subsystems

### DIFF
--- a/Sources/SwiftVLC/Player/EventBridge+Mapping.swift
+++ b/Sources/SwiftVLC/Player/EventBridge+Mapping.swift
@@ -133,3 +133,17 @@ func mapEvent(_ event: libvlc_event_t) -> PlayerEvent? {
     return nil
   }
 }
+
+func mapPlaybackFailureKind(
+  _ failure: libvlc_playback_failure_kind_t
+) -> PlaybackFailureKind {
+  switch failure {
+  case libvlc_playback_failure_source: .source
+  case libvlc_playback_failure_demux: .demux
+  case libvlc_playback_failure_decoder: .decoder
+  case libvlc_playback_failure_renderer: .renderer
+  case libvlc_playback_failure_output: .output
+  case libvlc_playback_failure_unknown: .unknown
+  default: .unknown
+  }
+}

--- a/Sources/SwiftVLC/Player/EventBridge.swift
+++ b/Sources/SwiftVLC/Player/EventBridge.swift
@@ -709,14 +709,20 @@ private final class EventBridgeCallbackContext: Sendable {
     return result.0
   }
 
-  func noteEncounteredError(nativeHandleGeneration: UInt64) -> UInt64 {
+  func noteEncounteredError(
+    _ failure: PlaybackFailureKind,
+    nativeHandleGeneration: UInt64
+  ) -> UInt64 {
     let result = playbackLifecycle.withLock { state -> (UInt64, PlaybackTerminalOutcome?) in
       let generation = state.currentGeneration
-      state.terminalIntents[generation] = .failure(.unknown)
+      guard generation > state.lastEmittedGeneration else {
+        return (generation, nil)
+      }
+      state.terminalIntents[generation] = .failure(failure)
       let outcome = makeOutcome(
         in: &state,
         generation: generation,
-        cause: .failure(.unknown),
+        cause: .failure(failure),
         nativeHandleGeneration: nativeHandleGeneration
       )
       return (generation, outcome)
@@ -881,6 +887,9 @@ private func playerEventCallback(
 
   case .encounteredError:
     playbackGeneration = context.noteEncounteredError(
+      mapPlaybackFailureKind(
+        event.pointee.u.media_player_encountered_error.failure
+      ),
       nativeHandleGeneration: attachment.nativeHandleGeneration
     )
     shouldSynthesizeEnd = false

--- a/Sources/SwiftVLC/Player/PlaybackTerminalOutcome.swift
+++ b/Sources/SwiftVLC/Player/PlaybackTerminalOutcome.swift
@@ -16,10 +16,9 @@ public enum PlaybackTerminalCause: Hashable, Sendable {
 
 /// The playback subsystem that failed, when SwiftVLC can identify it.
 ///
-/// The bundled engine currently distinguishes a general playback error from
-/// clean EOF and user stop, but does not attribute every error to a subsystem.
-/// Such failures are reported as ``unknown`` instead of guessing from timing
-/// or log text.
+/// The bundled engine attributes failures at the access, demux, decoder,
+/// renderer, and output boundaries. Failures outside those authoritative
+/// paths are reported as ``unknown`` instead of guessing from timing or logs.
 public enum PlaybackFailureKind: Hashable, Sendable {
   /// Media source or transport failed.
   case source

--- a/Tests/SwiftVLCTests/Player/MapEventTests.swift
+++ b/Tests/SwiftVLCTests/Player/MapEventTests.swift
@@ -89,6 +89,19 @@ extension Logic {
     }
 
     @Test
+    func `Playback failure kinds preserve authoritative subsystem attribution`() {
+      #expect(mapPlaybackFailureKind(libvlc_playback_failure_source) == .source)
+      #expect(mapPlaybackFailureKind(libvlc_playback_failure_demux) == .demux)
+      #expect(mapPlaybackFailureKind(libvlc_playback_failure_decoder) == .decoder)
+      #expect(mapPlaybackFailureKind(libvlc_playback_failure_renderer) == .renderer)
+      #expect(mapPlaybackFailureKind(libvlc_playback_failure_output) == .output)
+      #expect(mapPlaybackFailureKind(libvlc_playback_failure_unknown) == .unknown)
+      #expect(
+        mapPlaybackFailureKind(libvlc_playback_failure_kind_t(rawValue: 999)) == .unknown
+      )
+    }
+
+    @Test
     func `MediaChanged maps to mediaChanged`() {
       let mapped = mapEvent(event(type: libvlc_MediaPlayerMediaChanged.rawValue))
       guard case .mediaChanged = mapped else {

--- a/Tests/SwiftVLCTests/Player/PlaybackTerminalOutcomeTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlaybackTerminalOutcomeTests.swift
@@ -148,6 +148,27 @@ extension Integration {
     }
 
     @Test
+    func `Encountered error freezes the engine failure kind for its generation`() async throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.twosecURL))
+      let expectedGeneration = player.generation
+      let outcome = firstOutcome(from: player.terminalOutcomes)
+
+      var error = libvlc_event_t()
+      error.type = Int32(libvlc_MediaPlayerEncounteredError.rawValue)
+      error.u.media_player_encountered_error.failure = libvlc_playback_failure_decoder
+      player.eventBridge._emitNativeEventForTesting(error)
+
+      let value = try #require(await outcome.value)
+      #expect(value.generation == expectedGeneration)
+      #expect(value.cause == .failure(.decoder))
+
+      error.u.media_player_encountered_error.failure = libvlc_playback_failure_output
+      player.eventBridge._emitNativeEventForTesting(error)
+      #expect(player.terminalCause(for: expectedGeneration) == .failure(.decoder))
+    }
+
+    @Test
     func `Unattributed stop reports unknown and never claims natural end`() async throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
       try player.load(Media(url: TestMedia.twosecURL))

--- a/scripts/tests/release-integrity.sh
+++ b/scripts/tests/release-integrity.sh
@@ -506,8 +506,12 @@ fi
 artifact_info=$(./scripts/resolve-release-artifact.sh)
 actual_tag=$(printf '%s' "$artifact_info" \
   | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag"])')
-[[ "$actual_tag" == "v1.1.0-beta.1" ]] \
-  || fail "checkout resolved $actual_tag instead of v1.1.0-beta.1"
+showcase_version=$(sed -n \
+  's/^[[:space:]]*version = \([^;]*\);$/\1/p' \
+  Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj)
+[[ -n "$showcase_version" ]] || fail "Showcase release version was not found"
+[[ "$actual_tag" == "v$showcase_version" ]] \
+  || fail "checkout resolves $actual_tag but Showcase resolves v$showcase_version"
 
 stable_info=$(SWIFTVLC_RELEASE_TAG=v1.0.0 ./scripts/resolve-release-artifact.sh)
 stable_tag=$(printf '%s' "$stable_info" \


### PR DESCRIPTION
## Summary
- map authoritative libVLC source, demux, decoder, renderer, and output failure kinds into generation-scoped terminal outcomes
- keep the first frozen terminal cause when a late duplicate error arrives
- keep release-integrity validation aligned with the Showcase exact release instead of hard-coding beta.1

## Validation
- `CI=true swift test --no-parallel` — 1,981 tests in 167 suites passed
- iOS Simulator `xcodebuild build-for-testing` for arm64 and x86_64 — passed
- `./scripts/tests/release-integrity.sh` — passed
- SwiftLint strict and SwiftFormat strict — passed
- validated against the published v1.1.0-beta.2 binary and headers

Advances issue 85. Physical failure-path qualification remains tracked by the milestone acceptance matrix.