### PR TITLE
Bind device qualification to exact release source

### DIFF
--- a/scripts/check-qualification.sh
+++ b/scripts/check-qualification.sh
@@ -61,11 +61,18 @@ if [[ "$SLICE_COUNT" -eq 0 ]]; then
 fi
 
 DIGEST="$(artifact_digest)"
+SOURCE_DIGEST=$("$SCRIPT_DIR/release-source-digest.py" "$VERSION")
+MATRIX_CHECKSUM=$(shasum -a 256 "$MATRIX" | cut -d' ' -f1)
+CANDIDATE_SOURCE_COMMIT="${SWIFTVLC_CANDIDATE_SOURCE_COMMIT:-}"
+CANDIDATE_SOURCE_DIGEST="${SWIFTVLC_CANDIDATE_SOURCE_DIGEST:-}"
+CANDIDATE_MATRIX_CHECKSUM="${SWIFTVLC_CANDIDATE_MATRIX_CHECKSUM:-}"
 
 if [[ ! -f "$RECORD" ]]; then
   echo "Error: no device qualification record for $VERSION." >&2
   echo "  Expected: $RECORD" >&2
   echo "  Artifact digest: $DIGEST" >&2
+  echo "  Release source digest: $SOURCE_DIGEST" >&2
+  echo "  Qualification matrix checksum: $MATRIX_CHECKSUM" >&2
   echo "" >&2
   echo "  The device matrix is the acceptance gate for system PiP; CI cannot" >&2
   echo "  stand in for it. Run the matrix on hardware and record the results," >&2
@@ -73,13 +80,26 @@ if [[ ! -f "$RECORD" ]]; then
   exit 1
 fi
 
-python3 - "$MATRIX" "$RECORD" "$DIGEST" "$VERSION" <<'PY'
+python3 - "$MATRIX" "$RECORD" "$DIGEST" "$VERSION" \
+  "$SOURCE_DIGEST" "$MATRIX_CHECKSUM" "$CANDIDATE_SOURCE_COMMIT" \
+  "$CANDIDATE_SOURCE_DIGEST" "$CANDIDATE_MATRIX_CHECKSUM" <<'PY'
 import json
 import math
+import re
 import sys
 from pathlib import Path
 
-matrix_path, record_path, digest, version = sys.argv[1:5]
+(
+    matrix_path,
+    record_path,
+    digest,
+    version,
+    source_digest,
+    matrix_checksum,
+    candidate_source_commit,
+    candidate_source_digest,
+    candidate_matrix_checksum,
+) = sys.argv[1:10]
 
 try:
     matrix = json.load(open(matrix_path))
@@ -108,6 +128,54 @@ if record.get("artifactDigestAlgorithm") != "swiftvlc-tree-v1":
     problems.append(
         "the record does not declare artifactDigestAlgorithm "
         "'swiftvlc-tree-v1'"
+    )
+
+if record.get("releaseSourceDigestAlgorithm") != "swiftvlc-git-tree-v1":
+    problems.append(
+        "the record does not declare releaseSourceDigestAlgorithm "
+        "'swiftvlc-git-tree-v1'"
+    )
+
+recorded_source_digest = record.get("releaseSourceDigest")
+if recorded_source_digest != source_digest:
+    problems.append(
+        "the record describes different Swift wrapper source\n"
+        f"    recorded:   {recorded_source_digest}\n"
+        f"    on disk:    {source_digest}\n"
+        "    Device evidence cannot carry across release-significant source changes."
+    )
+
+recorded_source_commit = record.get("sourceCommit")
+if not isinstance(recorded_source_commit, str) or not re.fullmatch(
+    r"[0-9a-f]{40}", recorded_source_commit
+):
+    problems.append("the record has no valid 40-character sourceCommit")
+elif candidate_source_commit and recorded_source_commit != candidate_source_commit:
+    problems.append(
+        "the record names a different candidate source commit\n"
+        f"    recorded:   {recorded_source_commit}\n"
+        f"    candidate:  {candidate_source_commit}"
+    )
+
+if candidate_source_digest and recorded_source_digest != candidate_source_digest:
+    problems.append(
+        "the record names a different candidate source digest\n"
+        f"    recorded:   {recorded_source_digest}\n"
+        f"    candidate:  {candidate_source_digest}"
+    )
+
+recorded_matrix_checksum = record.get("qualificationMatrixChecksum")
+if recorded_matrix_checksum != matrix_checksum:
+    problems.append(
+        "the qualification matrix changed after the device run\n"
+        f"    recorded:   {recorded_matrix_checksum}\n"
+        f"    on disk:    {matrix_checksum}"
+    )
+if candidate_matrix_checksum and recorded_matrix_checksum != candidate_matrix_checksum:
+    problems.append(
+        "the record names a different candidate qualification matrix\n"
+        f"    recorded:   {recorded_matrix_checksum}\n"
+        f"    candidate:  {candidate_matrix_checksum}"
     )
 
 scenarios = matrix.get("scenarios")
@@ -310,6 +378,7 @@ for key in sorted(executed):
                 continue
             for field, expected in (
                 ("artifactDigest", digest),
+                ("releaseSourceDigest", source_digest),
                 ("scenario", key[0]),
                 ("hardware", key[1]),
             ):
@@ -419,6 +488,6 @@ if problems:
 
 print(
     f"Device qualification verified: {len(required)} rows executed and passing "
-    f"for artifact {digest[:12]}…"
+    f"for artifact {digest[:12]}… and source {source_digest[:12]}…"
 )
 PY

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -31,6 +31,15 @@ The original cross-device PiP rows apply the same rule to each control,
 lifecycle order, recovery path, and stop reason; a top-level `result: "pass"`
 cannot mask a failed pause, missing restoration, or unsuccessful recovery.
 
+Qualification is bound to both halves of the shipped package. The
+XCFramework tree digest identifies the native engine and headers, while the
+release-source digest identifies every release-significant tracked file in the
+Swift wrapper checkout. The latter deliberately excludes only the record for
+the version being qualified and its `evidence/<version>/` attachments, so those
+results can be committed after candidate preparation without changing the
+candidate identity. Any source, test, release-script, or matrix change requires
+a new candidate and a new device run.
+
 Record the results as `scripts/qualification/<version>.json`:
 
 ```json
@@ -38,6 +47,10 @@ Record the results as `scripts/qualification/<version>.json`:
   "version": "1.1.0",
   "artifactDigestAlgorithm": "swiftvlc-tree-v1",
   "artifactDigest": "…",
+  "sourceCommit": "…",
+  "releaseSourceDigestAlgorithm": "swiftvlc-git-tree-v1",
+  "releaseSourceDigest": "…",
+  "qualificationMatrixChecksum": "…",
   "rows": [
     {
       "scenario": "vod-controls",
@@ -64,6 +77,7 @@ Every evidence file is a JSON object tied to the exact artifact and row:
 ```json
 {
   "artifactDigest": "…",
+  "releaseSourceDigest": "…",
   "scenario": "vod-controls",
   "hardware": "iphone-current",
   "events": {
@@ -101,6 +115,13 @@ Get it for the exact, already-stripped artifact you are about to qualify with:
 Do not strip, rewrite headers, or otherwise mutate the XCFramework after this
 digest is recorded. A header-only ABI mismatch can be just as unsafe as a
 library change.
+
+Candidate preparation records the source commit, release-source digest, and
+matrix checksum in `release-candidate.json`. Copy those values into the
+qualification record and each evidence file. `check-qualification.sh` computes
+the current identities itself and rejects stale source, a weakened or expanded
+matrix, a record from another candidate, or evidence captured against another
+wrapper revision.
 
 ## Checking before release
 

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -34,11 +34,14 @@ cannot mask a failed pause, missing restoration, or unsuccessful recovery.
 Qualification is bound to both halves of the shipped package. The
 XCFramework tree digest identifies the native engine and headers, while the
 release-source digest identifies every release-significant tracked file in the
-Swift wrapper checkout. The latter deliberately excludes only the record for
-the version being qualified and its `evidence/<version>/` attachments, so those
-results can be committed after candidate preparation without changing the
-candidate identity. Any source, test, release-script, or matrix change requires
-a new candidate and a new device run.
+Swift wrapper worktree. The latter deliberately excludes only the record for
+the version being qualified and its `evidence/<version>/` attachments. It also
+normalizes the narrowly validated Package.swift binary reference and Showcase
+package reference, because candidate testing uses repo-local wiring and the
+release commit deterministically replaces those fields with the final URL and
+version. Any other tracked or untracked source, test, release-script, or matrix
+change produces a different identity and requires a new candidate and device
+run.
 
 Record the results as `scripts/qualification/<version>.json`:
 

--- a/scripts/release-source-digest.py
+++ b/scripts/release-source-digest.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import os
+import re
+import stat
 import subprocess
 from pathlib import Path
 
@@ -39,10 +42,96 @@ def excluded(path: str, version: str) -> bool:
     )
 
 
+def normalized_package_manifest(payload: bytes) -> bytes:
+    try:
+        text = payload.decode()
+    except UnicodeDecodeError:
+        fail("Package.swift is not UTF-8")
+    release_pattern = re.compile(
+        r'\.binaryTarget\(\s*name:\s*"libvlc",\s*'
+        r'url:\s*"https://github\.com/harflabs/SwiftVLC/releases/download/'
+        r'v[^"/]+/libvlc\.xcframework\.zip",\s*'
+        r'checksum:\s*"[0-9a-f]{64}"\s*\)',
+        re.DOTALL,
+    )
+    local_pattern = re.compile(
+        r'\.binaryTarget\(\s*name:\s*"libvlc",\s*'
+        r'path:\s*"Vendor/libvlc\.xcframework"\s*\)',
+        re.DOTALL,
+    )
+    matches = len(release_pattern.findall(text)) + len(local_pattern.findall(text))
+    if matches != 1:
+        fail("Package.swift must contain exactly one known libvlc binary target")
+    text = release_pattern.sub("<SwiftVLC release-managed binary target>", text)
+    text = local_pattern.sub("<SwiftVLC release-managed binary target>", text)
+    return text.encode()
+
+
+def normalized_showcase_project(payload: bytes) -> bytes:
+    try:
+        text = payload.decode()
+    except UnicodeDecodeError:
+        fail("Showcase project is not UTF-8")
+    remote_pattern = re.compile(
+        r'/\* Begin XCRemoteSwiftPackageReference section \*/\n'
+        r'\t\tBA000001 /\* XCRemoteSwiftPackageReference "SwiftVLC" \*/ = \{\n'
+        r'\t\t\tisa = XCRemoteSwiftPackageReference;\n'
+        r'\t\t\trepositoryURL = "https://github\.com/harflabs/SwiftVLC";\n'
+        r'\t\t\trequirement = \{\n'
+        r'\t\t\t\tkind = (?:upToNextMajorVersion|exactVersion);\n'
+        r'\t\t\t\t(?:minimumVersion|version) = [0-9][0-9A-Za-z.\-]*;\n'
+        r'\t\t\t\};\n'
+        r'\t\t\};\n'
+        r'/\* End XCRemoteSwiftPackageReference section \*/'
+    )
+    local_pattern = re.compile(
+        r'/\* Begin XCLocalSwiftPackageReference section \*/\n'
+        r'\t\tBA000001 /\* XCLocalSwiftPackageReference "\.\." \*/ = \{\n'
+        r'\t\t\tisa = XCLocalSwiftPackageReference;\n'
+        r'\t\t\trelativePath = "?\.\."?;\n'
+        r'\t\t\};\n'
+        r'/\* End XCLocalSwiftPackageReference section \*/'
+    )
+    matches = len(remote_pattern.findall(text)) + len(local_pattern.findall(text))
+    if matches != 1:
+        fail("Showcase project must contain exactly one known SwiftVLC package reference")
+    marker = "<SwiftVLC release-managed package reference>"
+    text = remote_pattern.sub(marker, text)
+    text = local_pattern.sub(marker, text)
+    text = text.replace(
+        'BA000001 /* XCRemoteSwiftPackageReference "SwiftVLC" */',
+        "BA000001 /* SwiftVLC package reference */",
+    )
+    text = text.replace(
+        'BA000001 /* XCLocalSwiftPackageReference ".." */',
+        "BA000001 /* SwiftVLC package reference */",
+    )
+    return text.encode()
+
+
+def normalized_payload(path: str, payload: bytes) -> bytes:
+    if path == "Package.swift":
+        return normalized_package_manifest(payload)
+    if path == "Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj":
+        return normalized_showcase_project(payload)
+    return payload
+
+
 def source_digest(root: Path, version: str) -> str:
     entries = git_output(root, "ls-tree", "-rz", "--full-tree", "HEAD")
     digest = hashlib.sha256(ALGORITHM)
     included = 0
+
+    untracked = git_output(
+        root, "ls-files", "--others", "--exclude-standard", "-z"
+    ).split(b"\0")
+    unsafe_untracked = sorted(
+        raw_path.decode("utf-8")
+        for raw_path in untracked
+        if raw_path and not excluded(raw_path.decode("utf-8"), version)
+    )
+    if unsafe_untracked:
+        fail("untracked release source: " + ", ".join(unsafe_untracked))
 
     for raw_entry in entries.split(b"\0"):
         if not raw_entry:
@@ -55,7 +144,23 @@ def source_digest(root: Path, version: str) -> str:
             fail("git returned an invalid tree entry")
         if excluded(path, version):
             continue
-        for field in (mode, kind, object_id, raw_path):
+        candidate = root / path
+        if kind == b"commit":
+            actual_mode = mode
+            payload = object_id
+        elif mode == b"120000":
+            if not candidate.is_symlink():
+                fail(f"tracked symlink is missing or changed type: {path}")
+            actual_mode = b"120000"
+            payload = os.readlink(candidate).encode()
+        else:
+            if not candidate.is_file() or candidate.is_symlink():
+                fail(f"tracked file is missing or changed type: {path}")
+            actual_mode = (
+                b"100755" if candidate.stat().st_mode & stat.S_IXUSR else b"100644"
+            )
+            payload = normalized_payload(path, candidate.read_bytes())
+        for field in (actual_mode, kind, raw_path, payload):
             update_field(digest, field)
         included += 1
 

--- a/scripts/release-source-digest.py
+++ b/scripts/release-source-digest.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Hash release-significant tracked source for a qualification candidate."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+ALGORITHM = b"SwiftVLC release source git tree v1\0"
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"Error: {message}")
+
+
+def update_field(digest: object, value: bytes) -> None:
+    digest.update(len(value).to_bytes(8, "big"))
+    digest.update(value)
+
+
+def git_output(root: Path, *arguments: str) -> bytes:
+    try:
+        return subprocess.run(
+            ["git", "-C", str(root), *arguments],
+            check=True,
+            capture_output=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError) as error:
+        detail = getattr(error, "stderr", b"").decode(errors="replace").strip()
+        fail(detail or f"git {' '.join(arguments)} failed")
+
+
+def excluded(path: str, version: str) -> bool:
+    return path == f"scripts/qualification/{version}.json" or path.startswith(
+        f"scripts/qualification/evidence/{version}/"
+    )
+
+
+def source_digest(root: Path, version: str) -> str:
+    entries = git_output(root, "ls-tree", "-rz", "--full-tree", "HEAD")
+    digest = hashlib.sha256(ALGORITHM)
+    included = 0
+
+    for raw_entry in entries.split(b"\0"):
+        if not raw_entry:
+            continue
+        try:
+            metadata, raw_path = raw_entry.split(b"\t", 1)
+            mode, kind, object_id = metadata.split(b" ", 2)
+            path = raw_path.decode("utf-8")
+        except (ValueError, UnicodeDecodeError):
+            fail("git returned an invalid tree entry")
+        if excluded(path, version):
+            continue
+        for field in (mode, kind, object_id, raw_path):
+            update_field(digest, field)
+        included += 1
+
+    if included == 0:
+        fail("release source tree contains no tracked files")
+    return digest.hexdigest()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version")
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    arguments = parser.parse_args()
+    if not arguments.version:
+        fail("version must not be empty")
+    print(source_digest(arguments.root.resolve(), arguments.version))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -437,6 +437,11 @@ echo "Validating release manifest rewrites..."
 validate_release_rewrites
 echo "Release rewrite validation passed."
 
+SOURCE_COMMIT=$(git rev-parse HEAD)
+RELEASE_SOURCE_DIGEST=$("$SCRIPT_DIR/release-source-digest.py" "$VERSION")
+QUALIFICATION_MATRIX_CHECKSUM=$(shasum -a 256 \
+  "$SCRIPT_DIR/qualification/matrix.json" | cut -d' ' -f1)
+
 # ── Artifact freshness ────────────────────────────────────────────────────────
 #
 # Everything below packages whatever xcframework is in Vendor/. Nothing so far
@@ -512,6 +517,7 @@ if [[ -n "$CANDIDATE_DIR" ]]; then
   echo "Verifying immutable release candidate..."
   CANDIDATE_VALUES=$(python3 - "$CANDIDATE_MANIFEST" "$VERSION" <<'PY'
 import json
+import re
 import sys
 
 path, version = sys.argv[1:3]
@@ -527,6 +533,10 @@ required = {
     "zipChecksum",
     "provenanceChecksum",
     "reproducibilityChecksum",
+    "sourceCommit",
+    "releaseSourceDigestAlgorithm",
+    "releaseSourceDigest",
+    "qualificationMatrixChecksum",
 }
 missing = sorted(required - candidate.keys())
 if missing:
@@ -537,16 +547,40 @@ if candidate["version"] != version:
     )
 if candidate["artifactDigestAlgorithm"] != "swiftvlc-tree-v1":
     sys.exit("Error: candidate uses an unsupported artifact digest algorithm")
+if candidate["releaseSourceDigestAlgorithm"] != "swiftvlc-git-tree-v1":
+    sys.exit("Error: candidate uses an unsupported release source digest algorithm")
+for field, length in (
+    ("sourceCommit", 40),
+    ("artifactDigest", 64),
+    ("zipChecksum", 64),
+    ("provenanceChecksum", 64),
+    ("reproducibilityChecksum", 64),
+    ("releaseSourceDigest", 64),
+    ("qualificationMatrixChecksum", 64),
+):
+    value = candidate[field]
+    if not isinstance(value, str) or not re.fullmatch(
+        rf"[0-9a-f]{{{length}}}", value
+    ):
+        sys.exit(f"Error: candidate has an invalid {field}")
 print(candidate["artifactDigest"])
 print(candidate["zipChecksum"])
 print(candidate["provenanceChecksum"])
 print(candidate["reproducibilityChecksum"])
+print(candidate["sourceCommit"])
+print(candidate["releaseSourceDigestAlgorithm"])
+print(candidate["releaseSourceDigest"])
+print(candidate["qualificationMatrixChecksum"])
 PY
 )
   CANDIDATE_TREE_DIGEST=$(printf '%s\n' "$CANDIDATE_VALUES" | sed -n '1p')
   EXPECTED_ZIP_CHECKSUM=$(printf '%s\n' "$CANDIDATE_VALUES" | sed -n '2p')
   EXPECTED_PROVENANCE_CHECKSUM=$(printf '%s\n' "$CANDIDATE_VALUES" | sed -n '3p')
   EXPECTED_REPRODUCIBILITY_CHECKSUM=$(printf '%s\n' "$CANDIDATE_VALUES" | sed -n '4p')
+  CANDIDATE_SOURCE_COMMIT=$(printf '%s\n' "$CANDIDATE_VALUES" | sed -n '5p')
+  CANDIDATE_SOURCE_DIGEST_ALGORITHM=$(printf '%s\n' "$CANDIDATE_VALUES" | sed -n '6p')
+  CANDIDATE_SOURCE_DIGEST=$(printf '%s\n' "$CANDIDATE_VALUES" | sed -n '7p')
+  CANDIDATE_MATRIX_CHECKSUM=$(printf '%s\n' "$CANDIDATE_VALUES" | sed -n '8p')
 
   ACTUAL_TREE_DIGEST=$("$SCRIPT_DIR/artifact-tree-digest.py" "$WORK_XCFW")
   CHECKSUM=$(swift package compute-checksum "$ZIP_PATH")
@@ -568,6 +602,21 @@ PY
   fi
   if [[ "$ACTUAL_REPRODUCIBILITY_CHECKSUM" != "$EXPECTED_REPRODUCIBILITY_CHECKSUM" ]]; then
     echo "Error: prepared reproducibility proof changed after candidate creation." >&2
+    exit 1
+  fi
+  if [[ "$RELEASE_SOURCE_DIGEST" != "$CANDIDATE_SOURCE_DIGEST" ]]; then
+    echo "Error: release-significant Swift source changed after candidate creation." >&2
+    echo "  candidate: $CANDIDATE_SOURCE_DIGEST" >&2
+    echo "  current:   $RELEASE_SOURCE_DIGEST" >&2
+    exit 1
+  fi
+  if [[ "$QUALIFICATION_MATRIX_CHECKSUM" != "$CANDIDATE_MATRIX_CHECKSUM" ]]; then
+    echo "Error: the qualification matrix changed after candidate creation." >&2
+    exit 1
+  fi
+  if ! git cat-file -e "${CANDIDATE_SOURCE_COMMIT}^{commit}" 2>/dev/null || \
+      ! git merge-base --is-ancestor "$CANDIDATE_SOURCE_COMMIT" HEAD; then
+    echo "Error: candidate source commit is not an ancestor of the release checkout." >&2
     exit 1
   fi
 
@@ -638,6 +687,9 @@ if [[ -n "$PREPARE_DIR" ]]; then
     CHECKSUM="$CHECKSUM" \
     PROVENANCE_CHECKSUM="$PROVENANCE_CHECKSUM" \
     REPRODUCIBILITY_CHECKSUM="$REPRODUCIBILITY_CHECKSUM" \
+    SOURCE_COMMIT="$SOURCE_COMMIT" \
+    RELEASE_SOURCE_DIGEST="$RELEASE_SOURCE_DIGEST" \
+    QUALIFICATION_MATRIX_CHECKSUM="$QUALIFICATION_MATRIX_CHECKSUM" \
     python3 - "$PREPARE_DIR/release-candidate.json" <<'PY'
 import json
 import os
@@ -650,6 +702,10 @@ candidate = {
     "zipChecksum": os.environ["CHECKSUM"],
     "provenanceChecksum": os.environ["PROVENANCE_CHECKSUM"],
     "reproducibilityChecksum": os.environ["REPRODUCIBILITY_CHECKSUM"],
+    "sourceCommit": os.environ["SOURCE_COMMIT"],
+    "releaseSourceDigestAlgorithm": "swiftvlc-git-tree-v1",
+    "releaseSourceDigest": os.environ["RELEASE_SOURCE_DIGEST"],
+    "qualificationMatrixChecksum": os.environ["QUALIFICATION_MATRIX_CHECKSUM"],
 }
 with open(sys.argv[1], "w") as output:
     json.dump(candidate, output, indent=2, sort_keys=True)
@@ -668,7 +724,10 @@ elif [[ "$UNQUALIFIED" == true ]]; then
   echo "  Publishing as a pre-release. It must not be described as qualified,"
   echo "  and the device matrix in scripts/qualification still owes a run."
 else
-  if ! "$SCRIPT_DIR/check-qualification.sh" "$VERSION" "$WORK_XCFW"; then
+  if ! SWIFTVLC_CANDIDATE_SOURCE_COMMIT="$CANDIDATE_SOURCE_COMMIT" \
+    SWIFTVLC_CANDIDATE_SOURCE_DIGEST="$CANDIDATE_SOURCE_DIGEST" \
+    SWIFTVLC_CANDIDATE_MATRIX_CHECKSUM="$CANDIDATE_MATRIX_CHECKSUM" \
+    "$SCRIPT_DIR/check-qualification.sh" "$VERSION" "$WORK_XCFW"; then
     echo "" >&2
     echo "  Qualify the prepared candidate before publishing stable." >&2
     exit 1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -41,6 +41,9 @@ DRY_RUN=false
 UNQUALIFIED=false
 PREPARE_DIR=""
 CANDIDATE_DIR=""
+CANDIDATE_SOURCE_COMMIT=""
+CANDIDATE_SOURCE_DIGEST=""
+CANDIDATE_MATRIX_CHECKSUM=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -438,6 +441,10 @@ validate_release_rewrites
 echo "Release rewrite validation passed."
 
 SOURCE_COMMIT=$(git rev-parse HEAD)
+# These two files contain narrowly validated release-managed references. The
+# digest normalizes only those fields, so local Showcase wiring and the final
+# URL/version rewrite describe the same runtime source while every other
+# tracked byte remains qualification-significant.
 RELEASE_SOURCE_DIGEST=$("$SCRIPT_DIR/release-source-digest.py" "$VERSION")
 QUALIFICATION_MATRIX_CHECKSUM=$(shasum -a 256 \
   "$SCRIPT_DIR/qualification/matrix.json" | cut -d' ' -f1)
@@ -723,6 +730,8 @@ elif [[ "$UNQUALIFIED" == true ]]; then
   echo "WARNING: releasing WITHOUT device qualification."
   echo "  Publishing as a pre-release. It must not be described as qualified,"
   echo "  and the device matrix in scripts/qualification still owes a run."
+elif [[ "$DRY_RUN" == true ]]; then
+  echo "Dry run only; no device qualification is claimed."
 else
   if ! SWIFTVLC_CANDIDATE_SOURCE_COMMIT="$CANDIDATE_SOURCE_COMMIT" \
     SWIFTVLC_CANDIDATE_SOURCE_DIGEST="$CANDIDATE_SOURCE_DIGEST" \

--- a/scripts/tests/release-integrity.sh
+++ b/scripts/tests/release-integrity.sh
@@ -210,7 +210,55 @@ if 'rm -f "${OUTPUT_DIR}/libvlc-provenance.json"' not in build:
     sys.exit("a failed rebuild can leave stale provenance beside its artifact")
 if "libvlc-provenance.py\" rebind" in release or "find \"$WORK_XCFW\" -name '*.a'" in release:
     sys.exit("release packaging still mutates or rebinds the proven artifact")
+for marker in (
+    '"releaseSourceDigestAlgorithm": "swiftvlc-git-tree-v1"',
+    '"releaseSourceDigest": os.environ["RELEASE_SOURCE_DIGEST"]',
+    '"qualificationMatrixChecksum": os.environ["QUALIFICATION_MATRIX_CHECKSUM"]',
+    'SWIFTVLC_CANDIDATE_SOURCE_DIGEST="$CANDIDATE_SOURCE_DIGEST"',
+):
+    if marker not in release:
+        sys.exit(f"release candidate is not bound to qualification input: {marker}")
 PY
+
+source_repo="$temp_dir/release-source-repo"
+mkdir -p "$source_repo/Sources" "$source_repo/scripts/qualification/evidence/1.1.0"
+git -C "$source_repo" init -q
+git -C "$source_repo" config user.name "SwiftVLC Test"
+git -C "$source_repo" config user.email "swiftvlc-test@example.invalid"
+printf 'public let value = 1\n' > "$source_repo/Sources/Value.swift"
+printf '{"scenarios":[],"hardware":[]}\n' > \
+  "$source_repo/scripts/qualification/matrix.json"
+git -C "$source_repo" add .
+git -C "$source_repo" commit -qm "source"
+source_digest_a=$("$SCRIPT_DIR/release-source-digest.py" 1.1.0 --root "$source_repo")
+
+printf '{"version":"1.1.0"}\n' > \
+  "$source_repo/scripts/qualification/1.1.0.json"
+printf '{"result":"pass"}\n' > \
+  "$source_repo/scripts/qualification/evidence/1.1.0/result.json"
+git -C "$source_repo" add .
+git -C "$source_repo" commit -qm "evidence"
+source_digest_b=$("$SCRIPT_DIR/release-source-digest.py" 1.1.0 --root "$source_repo")
+if [[ "$source_digest_a" != "$source_digest_b" ]]; then
+  fail "qualification records changed the release-source digest"
+fi
+
+printf 'public let value = 2\n' > "$source_repo/Sources/Value.swift"
+git -C "$source_repo" add Sources/Value.swift
+git -C "$source_repo" commit -qm "source change"
+source_digest_c=$("$SCRIPT_DIR/release-source-digest.py" 1.1.0 --root "$source_repo")
+if [[ "$source_digest_b" == "$source_digest_c" ]]; then
+  fail "a Swift source change did not change the release-source digest"
+fi
+
+printf '{"scenarios":[{"id":"new"}],"hardware":[]}\n' > \
+  "$source_repo/scripts/qualification/matrix.json"
+git -C "$source_repo" add scripts/qualification/matrix.json
+git -C "$source_repo" commit -qm "matrix change"
+source_digest_d=$("$SCRIPT_DIR/release-source-digest.py" 1.1.0 --root "$source_repo")
+if [[ "$source_digest_c" == "$source_digest_d" ]]; then
+  fail "a qualification matrix change did not change the release-source digest"
+fi
 
 python3 - "$temp_dir/matrix.json" "$temp_dir/record.json" "$digest_a" <<'PY'
 import json
@@ -278,12 +326,117 @@ json.dump(matrix, open(matrix_path, "w"))
 json.dump(record, open(record_path, "w"))
 PY
 
+qualification_source_digest=$("$SCRIPT_DIR/release-source-digest.py" 1.1.0)
+qualification_source_commit=$(git rev-parse HEAD)
+qualification_matrix_checksum=$(shasum -a 256 \
+  "$temp_dir/matrix.json" | cut -d' ' -f1)
+python3 - "$temp_dir/record.json" "$temp_dir/evidence.json" \
+  "$qualification_source_commit" "$qualification_source_digest" \
+  "$qualification_matrix_checksum" <<'PY'
+import json
+import sys
+
+record_path, evidence_path, commit, source_digest, matrix_checksum = sys.argv[1:]
+record = json.load(open(record_path))
+record.update(
+    {
+        "sourceCommit": commit,
+        "releaseSourceDigestAlgorithm": "swiftvlc-git-tree-v1",
+        "releaseSourceDigest": source_digest,
+        "qualificationMatrixChecksum": matrix_checksum,
+    }
+)
+json.dump(record, open(record_path, "w"))
+evidence = json.load(open(evidence_path))
+evidence["releaseSourceDigest"] = source_digest
+json.dump(evidence, open(evidence_path, "w"))
+PY
+
 SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
+  SWIFTVLC_QUALIFICATION_RECORD="$temp_dir/record.json" \
+  "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null
+
+SWIFTVLC_CANDIDATE_SOURCE_COMMIT="$qualification_source_commit" \
+  SWIFTVLC_CANDIDATE_SOURCE_DIGEST="$qualification_source_digest" \
+  SWIFTVLC_CANDIDATE_MATRIX_CHECKSUM="$qualification_matrix_checksum" \
+  SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
   SWIFTVLC_QUALIFICATION_RECORD="$temp_dir/record.json" \
   "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null
 
 # The scenario is scoped to iPhone, so the unrecorded iPad row must not be
 # invented by the checker. The successful call above is the regression test.
+
+python3 - "$temp_dir/record.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+record = json.load(open(path))
+record["releaseSourceDigest"] = "0" * 64
+json.dump(record, open(path, "w"))
+PY
+if SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
+  SWIFTVLC_QUALIFICATION_RECORD="$temp_dir/record.json" \
+  "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null 2>&1; then
+  fail "qualification survived a Swift wrapper source change"
+fi
+
+python3 - "$temp_dir/record.json" "$qualification_source_digest" <<'PY'
+import json
+import sys
+
+path, source_digest = sys.argv[1:]
+record = json.load(open(path))
+record["releaseSourceDigest"] = source_digest
+json.dump(record, open(path, "w"))
+PY
+python3 - "$temp_dir/evidence.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+evidence = json.load(open(path))
+evidence["releaseSourceDigest"] = "0" * 64
+json.dump(evidence, open(path, "w"))
+PY
+if SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
+  SWIFTVLC_QUALIFICATION_RECORD="$temp_dir/record.json" \
+  "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null 2>&1; then
+  fail "qualification accepted evidence from another Swift wrapper source"
+fi
+
+python3 - "$temp_dir/evidence.json" "$qualification_source_digest" <<'PY'
+import json
+import sys
+
+path, source_digest = sys.argv[1:]
+evidence = json.load(open(path))
+evidence["releaseSourceDigest"] = source_digest
+json.dump(evidence, open(path, "w"))
+PY
+cp "$temp_dir/matrix.json" "$temp_dir/matrix-original.json"
+python3 - "$temp_dir/matrix.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+matrix = json.load(open(path))
+matrix["changedAfterQualification"] = True
+json.dump(matrix, open(path, "w"))
+PY
+if SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
+  SWIFTVLC_QUALIFICATION_RECORD="$temp_dir/record.json" \
+  "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null 2>&1; then
+  fail "qualification survived a matrix change"
+fi
+cp "$temp_dir/matrix-original.json" "$temp_dir/matrix.json"
+
+if SWIFTVLC_CANDIDATE_SOURCE_COMMIT=0000000000000000000000000000000000000000 \
+  SWIFTVLC_QUALIFICATION_MATRIX="$temp_dir/matrix.json" \
+  SWIFTVLC_QUALIFICATION_RECORD="$temp_dir/record.json" \
+  "$SCRIPT_DIR/check-qualification.sh" 1.1.0 "$temp_dir/tree-a" >/dev/null 2>&1; then
+  fail "qualification accepted a record from another candidate commit"
+fi
 
 python3 - "$temp_dir/record.json" <<'PY'
 import json

--- a/scripts/tests/release-integrity.sh
+++ b/scripts/tests/release-integrity.sh
@@ -215,22 +215,67 @@ for marker in (
     '"releaseSourceDigest": os.environ["RELEASE_SOURCE_DIGEST"]',
     '"qualificationMatrixChecksum": os.environ["QUALIFICATION_MATRIX_CHECKSUM"]',
     'SWIFTVLC_CANDIDATE_SOURCE_DIGEST="$CANDIDATE_SOURCE_DIGEST"',
+    'elif [[ "$DRY_RUN" == true ]]; then',
 ):
     if marker not in release:
         sys.exit(f"release candidate is not bound to qualification input: {marker}")
 PY
 
 source_repo="$temp_dir/release-source-repo"
-mkdir -p "$source_repo/Sources" "$source_repo/scripts/qualification/evidence/1.1.0"
+mkdir -p "$source_repo/Sources" \
+  "$source_repo/scripts/qualification/evidence/1.1.0" \
+  "$source_repo/Showcase/SwiftVLCShowcase.xcodeproj"
 git -C "$source_repo" init -q
 git -C "$source_repo" config user.name "SwiftVLC Test"
 git -C "$source_repo" config user.email "swiftvlc-test@example.invalid"
 printf 'public let value = 1\n' > "$source_repo/Sources/Value.swift"
 printf '{"scenarios":[],"hardware":[]}\n' > \
   "$source_repo/scripts/qualification/matrix.json"
+cp "$ROOT_DIR/Package.swift" "$source_repo/Package.swift"
+cp "$ROOT_DIR/Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj" \
+  "$source_repo/Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj"
 git -C "$source_repo" add .
 git -C "$source_repo" commit -qm "source"
 source_digest_a=$("$SCRIPT_DIR/release-source-digest.py" 1.1.0 --root "$source_repo")
+
+cp "$source_repo/Package.swift" "$temp_dir/source-Package.swift"
+cp "$source_repo/Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj" \
+  "$temp_dir/source-project.pbxproj"
+python3 - "$source_repo/Package.swift" \
+  "$source_repo/Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj" <<'PY'
+import re
+import sys
+
+package_path, project_path = sys.argv[1:]
+package = open(package_path).read()
+package = re.sub(
+    r"v1\.1\.0-beta\.5/libvlc\.xcframework\.zip",
+    "v1.1.0/libvlc.xcframework.zip",
+    package,
+)
+package = re.sub(r'checksum: "[0-9a-f]{64}"', 'checksum: "' + "0" * 64 + '"', package)
+open(package_path, "w").write(package)
+project = open(project_path).read().replace(
+    "version = 1.1.0-beta.5;", "version = 1.1.0;"
+)
+open(project_path, "w").write(project)
+PY
+source_digest_rewritten=$(
+  "$SCRIPT_DIR/release-source-digest.py" 1.1.0 --root "$source_repo"
+)
+if [[ "$source_digest_a" != "$source_digest_rewritten" ]]; then
+  fail "deterministic release reference rewrites changed the source digest"
+fi
+cp "$temp_dir/source-Package.swift" "$source_repo/Package.swift"
+cp "$temp_dir/source-project.pbxproj" \
+  "$source_repo/Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj"
+
+printf 'public let untracked = true\n' > "$source_repo/Sources/Untracked.swift"
+if "$SCRIPT_DIR/release-source-digest.py" 1.1.0 \
+  --root "$source_repo" >/dev/null 2>&1; then
+  fail "untracked Swift source did not invalidate the release-source digest"
+fi
+rm "$source_repo/Sources/Untracked.swift"
 
 printf '{"version":"1.1.0"}\n' > \
   "$source_repo/scripts/qualification/1.1.0.json"
@@ -244,11 +289,17 @@ if [[ "$source_digest_a" != "$source_digest_b" ]]; then
 fi
 
 printf 'public let value = 2\n' > "$source_repo/Sources/Value.swift"
+source_digest_dirty=$(
+  "$SCRIPT_DIR/release-source-digest.py" 1.1.0 --root "$source_repo"
+)
+if [[ "$source_digest_b" == "$source_digest_dirty" ]]; then
+  fail "an uncommitted Swift source change did not change the source digest"
+fi
 git -C "$source_repo" add Sources/Value.swift
 git -C "$source_repo" commit -qm "source change"
 source_digest_c=$("$SCRIPT_DIR/release-source-digest.py" 1.1.0 --root "$source_repo")
-if [[ "$source_digest_b" == "$source_digest_c" ]]; then
-  fail "a Swift source change did not change the release-source digest"
+if [[ "$source_digest_dirty" != "$source_digest_c" ]]; then
+  fail "committing unchanged worktree source changed the release-source digest"
 fi
 
 printf '{"scenarios":[{"id":"new"}],"hardware":[]}\n' > \


### PR DESCRIPTION
## Summary

- add a deterministic digest over every release-significant tracked file
- bind prepared candidates to the source commit, source digest, and qualification-matrix checksum
- require the qualification record and every evidence attachment to name the same source digest
- allow only the versioned qualification record and its evidence directory to be committed after candidate preparation
- reject source changes, matrix changes, stale evidence, and records copied from another candidate

## Why

The existing stable-release gate identified the native XCFramework exactly, but not the Swift wrapper revision or the matrix used on hardware. A device record could therefore survive later Swift-source changes or a changed matrix as long as the engine bytes stayed unchanged.

## Impact

Stable v1.1.0 cannot inherit hardware evidence from another wrapper revision or acceptance matrix. The mechanical release commit may still rewrite the binary URL and Showcase exact version after qualification; all other tracked changes invalidate the candidate.

## Validation

- `scripts/tests/release-integrity.sh` — passed
- Python compile check — passed
- shell syntax checks — passed
- Git whitespace check — clean
- negative coverage: Swift source mutation, matrix mutation, stale per-row evidence, and mismatched candidate commit all rejected
