### PR TITLE
Automate candidate-bound native HLS seek qualification

### DIFF
--- a/Showcase/Shared/AccessibilityID.swift
+++ b/Showcase/Shared/AccessibilityID.swift
@@ -178,6 +178,20 @@ enum AccessibilityID {
     static let loadLiveTSButton = "pipContinuity.loadLiveTS"
   }
 
+  enum MatrixHValidation {
+    static let stateLabel = "validation.matrixH.state"
+    static let currentTimeLabel = "validation.matrixH.currentTime"
+    static let displayedPicturesLabel = "validation.matrixH.displayedPictures"
+    static let activeLabel = "validation.matrixH.active"
+    static let unexpectedStopCountLabel = "validation.matrixH.unexpectedStops"
+    static let forwardResultLabel = "validation.matrixH.forwardResult"
+    static let backwardResultLabel = "validation.matrixH.backwardResult"
+    static let absoluteResultLabel = "validation.matrixH.absoluteResult"
+    static let seekBackwardButton = "validation.matrixH.seekBackward"
+    static let seekForwardButton = "validation.matrixH.seekForward"
+    static let seekAbsoluteButton = "validation.matrixH.seekAbsolute"
+  }
+
   enum AudioOutputs {
     static let videoView = "audioout.videoView"
     static let playPauseButton = "audioout.playPause"

--- a/Showcase/UITests/iOS/Support/ShowcaseIOSTestCase.swift
+++ b/Showcase/UITests/iOS/Support/ShowcaseIOSTestCase.swift
@@ -143,6 +143,41 @@ class ShowcaseIOSTestCase: XCTestCase {
     }
   }
 
+  /// Adds a machine-readable payload that the physical-device runner turns
+  /// into candidate-bound qualification evidence. Identity fields are added
+  /// by the host after exporting the xcresult attachment; a test process must
+  /// never guess which source tree or signed app bundle launched it.
+  func attachQualificationEvidence(
+    _ payload: [String: Any],
+    scenario: String,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    guard JSONSerialization.isValidJSONObject(payload) else {
+      XCTFail("Qualification evidence is not valid JSON", file: file, line: line)
+      return
+    }
+    do {
+      let data = try JSONSerialization.data(
+        withJSONObject: payload,
+        options: [.prettyPrinted, .sortedKeys]
+      )
+      let attachment = XCTAttachment(
+        data: data,
+        uniformTypeIdentifier: "public.json"
+      )
+      attachment.name = "qualification-\(scenario).json"
+      attachment.lifetime = .keepAlways
+      add(attachment)
+    } catch {
+      XCTFail(
+        "Could not encode qualification evidence: \(error)",
+        file: file,
+        line: line
+      )
+    }
+  }
+
   // MARK: - Wait helpers
 
   /// Spins until `element.label == expected`, or fails after `timeout`.

--- a/Showcase/UITests/iOS/Tests/PiPOverlayDeviceUITests.swift
+++ b/Showcase/UITests/iOS/Tests/PiPOverlayDeviceUITests.swift
@@ -48,18 +48,93 @@ final class PiPOverlayDeviceUITests: ShowcaseIOSTestCase {
     }
 
     openMatrixH()
-    let stopPiP = startPictureInPicture()
+    _ = startPictureInPicture()
 
-    for title in ["Seek +10 seconds", "Seek −10 seconds", "Reload same media"] {
-      let transition = app.buttons[title]
+    let active = app.descendants(matching: .any)[AccessibilityID.MatrixHValidation.activeLabel]
+    let state = app.descendants(matching: .any)[AccessibilityID.MatrixHValidation.stateLabel]
+    let displayedPictures = app.descendants(matching: .any)[
+      AccessibilityID.MatrixHValidation.displayedPicturesLabel
+    ]
+    let unexpectedStops = app.descendants(matching: .any)[
+      AccessibilityID.MatrixHValidation.unexpectedStopCountLabel
+    ]
+    waitForLabel(active, equals: "yes", timeout: 10)
+    waitForLabel(state, equals: "playing", timeout: 20)
+    var displayed = waitForIntegerLabel(displayedPictures, greaterThan: 0, timeout: 10)
+    var maximumVideoGapMilliseconds = 0
+
+    let transitions = [
+      (
+        "forward",
+        AccessibilityID.MatrixHValidation.seekForwardButton,
+        AccessibilityID.MatrixHValidation.forwardResultLabel
+      ),
+      (
+        "backward",
+        AccessibilityID.MatrixHValidation.seekBackwardButton,
+        AccessibilityID.MatrixHValidation.backwardResultLabel
+      ),
+      (
+        "absolute",
+        AccessibilityID.MatrixHValidation.seekAbsoluteButton,
+        AccessibilityID.MatrixHValidation.absoluteResultLabel
+      )
+    ]
+    for (name, identifier, resultIdentifier) in transitions {
+      let transition = app.buttons[identifier]
       reveal(transition, swiping: .up)
       XCTAssertTrue(transition.isHittable)
+      let started = ContinuousClock.now
       transition.tap()
-      RunLoop.current.run(until: Date().addingTimeInterval(1))
-      XCTAssertTrue(stopPiP.exists, "Native PiP stopped after \(title)")
+      let seekResult = app.descendants(matching: .any)[resultIdentifier]
+      waitForLabel(seekResult, equals: "accepted", timeout: 3)
+      displayed = waitForIntegerLabel(
+        displayedPictures,
+        greaterThan: displayed,
+        timeout: 5
+      )
+      let elapsed = started.duration(to: .now)
+      let gapMilliseconds = Int(elapsed / .milliseconds(1))
+      maximumVideoGapMilliseconds = max(maximumVideoGapMilliseconds, gapMilliseconds)
+      waitForLabel(active, equals: "yes", timeout: 5)
+
+      XCUIDevice.shared.press(.home)
+      if let failure = captureSystemPictureInPictureMotion() {
+        XCTFail("\(name) seek PiP motion failed: \(failure)")
+      }
+      app.activate()
+      waitForLabel(state, equals: "playing", timeout: 10)
+      waitForLabel(active, equals: "yes", timeout: 10)
     }
 
+    XCTAssertEqual(Int(unexpectedStops.label), 0, "Native PiP stopped during a seek")
+    XCTAssertLessThanOrEqual(
+      maximumVideoGapMilliseconds,
+      5000,
+      "Video did not resume within the 5-second continuity budget"
+    )
     assertNoLibraryErrors()
+    attachQualificationEvidence(
+      [
+        "formatVersion": 1,
+        "scenario": "native-hls-seek-continuity",
+        "seekResults": [
+          "forward": "pass",
+          "backward": "pass",
+          "absolute": "pass"
+        ],
+        "events": ["unexpectedStopCount": 0],
+        "pipMotion": "pass",
+        "inlineRecovery": "pass",
+        "measurements": [
+          "maximumVideoGapMilliseconds": maximumVideoGapMilliseconds
+        ],
+        "videoContinuityWithinBudget": maximumVideoGapMilliseconds <= 5000,
+        "controls": "pass",
+        "libraryErrorCount": 0
+      ],
+      scenario: "native-hls-seek-continuity"
+    )
     #endif
   }
 

--- a/Showcase/iOS/Info.plist
+++ b/Showcase/iOS/Info.plist
@@ -25,5 +25,7 @@
 	<string>$(SWIFTVLC_SOURCE_COMMIT)</string>
 	<key>SwiftVLCReleaseSourceDigest</key>
 	<string>$(SWIFTVLC_RELEASE_SOURCE_DIGEST)</string>
+	<key>SwiftVLCArtifactDigest</key>
+	<string>$(SWIFTVLC_ARTIFACT_DIGEST)</string>
 </dict>
 </plist>

--- a/Showcase/iOS/ValidationHarness/MatrixScreenH.swift
+++ b/Showcase/iOS/ValidationHarness/MatrixScreenH.swift
@@ -21,6 +21,10 @@ struct MatrixScreenH: View {
   @State private var pip: PiPController?
   @State private var log: [LogLine] = []
   @State private var marqueeVisible = false
+  @State private var unexpectedStopCount = 0
+  @State private var forwardSeekAccepted: Bool?
+  @State private var backwardSeekAccepted: Bool?
+  @State private var absoluteSeekAccepted: Bool?
 
   private struct LogLine: Identifiable {
     let id = UUID()
@@ -43,6 +47,7 @@ struct MatrixScreenH: View {
         if let pip {
           LabeledContent("Possible", value: pip.isPossible ? "yes" : "no")
           LabeledContent("Active", value: pip.isActive ? "yes" : "no")
+            .accessibilityIdentifier(AccessibilityID.MatrixHValidation.activeLabel)
           LabeledContent("Overlay support", value: String(describing: pip.overlaySupport))
             .accessibilityIdentifier("validation.matrixH.overlaySupport")
           Button(
@@ -57,17 +62,47 @@ struct MatrixScreenH: View {
         }
       }
 
+      Section("Measured state") {
+        LabeledContent("Playback", value: String(describing: player.state))
+          .accessibilityIdentifier(AccessibilityID.MatrixHValidation.stateLabel)
+        LabeledContent("Current time", value: player.currentTime.formatted)
+          .accessibilityIdentifier(AccessibilityID.MatrixHValidation.currentTimeLabel)
+        LabeledContent(
+          "Displayed pictures",
+          value: String(player.statistics?.displayedPictures ?? 0)
+        )
+        .accessibilityIdentifier(AccessibilityID.MatrixHValidation.displayedPicturesLabel)
+        LabeledContent("Unexpected PiP stops", value: String(unexpectedStopCount))
+          .accessibilityIdentifier(AccessibilityID.MatrixHValidation.unexpectedStopCountLabel)
+        LabeledContent("Forward seek", value: resultDescription(forwardSeekAccepted))
+          .accessibilityIdentifier(AccessibilityID.MatrixHValidation.forwardResultLabel)
+        LabeledContent("Backward seek", value: resultDescription(backwardSeekAccepted))
+          .accessibilityIdentifier(AccessibilityID.MatrixHValidation.backwardResultLabel)
+        LabeledContent("Absolute seek", value: resultDescription(absoluteSeekAccepted))
+          .accessibilityIdentifier(AccessibilityID.MatrixHValidation.absoluteResultLabel)
+      }
+
       subtitleTrackSection
 
       Section("Transitions") {
         Button("Seek −10 seconds") {
           let accepted = player.jump(by: .seconds(-10))
+          backwardSeekAccepted = accepted
           append("jump(-10s) → \(accepted)")
         }
+        .accessibilityIdentifier(AccessibilityID.MatrixHValidation.seekBackwardButton)
         Button("Seek +10 seconds") {
           let accepted = player.jump(by: .seconds(10))
+          forwardSeekAccepted = accepted
           append("jump(+10s) → \(accepted)")
         }
+        .accessibilityIdentifier(AccessibilityID.MatrixHValidation.seekForwardButton)
+        Button("Seek to 50%") {
+          let accepted = player.seek(toPosition: 0.5)
+          absoluteSeekAccepted = accepted
+          append("seek(50%) → \(accepted)")
+        }
+        .accessibilityIdentifier(AccessibilityID.MatrixHValidation.seekAbsoluteButton)
         Button("Reload same media") {
           activate()
           append("reload() requested")
@@ -96,6 +131,14 @@ struct MatrixScreenH: View {
     .task {
       activate()
       await observeEvents()
+    }
+    .task(id: pip == nil) {
+      guard let pip else { return }
+      for await event in pip.pipEvents {
+        if case .didStop = event {
+          unexpectedStopCount += 1
+        }
+      }
     }
     .onChange(of: marqueeVisible) { _, visible in
       if visible {
@@ -200,6 +243,14 @@ struct MatrixScreenH: View {
     log.insert(LogLine(text: "\(timestamp)  \(text)"), at: 0)
     if log.count > 200 {
       log.removeLast()
+    }
+  }
+
+  private func resultDescription(_ accepted: Bool?) -> String {
+    switch accepted {
+    case true: "accepted"
+    case false: "rejected"
+    case nil: "pending"
     }
   }
 }

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -50,10 +50,14 @@ the exact local `Vendor/libvlc.xcframework`, so remote package resolution cannot
 silently substitute an older wrapper or engine. A reused `--candidate-app` or `--skip-build`
 requires `--candidate-metadata`; metadata creation succeeds only for an app
 that was built with the `SwiftVLCSourceCommit` and
-`SwiftVLCReleaseSourceDigest` Info.plist keys. Use
+`SwiftVLCReleaseSourceDigest` Info.plist keys. The signed app also embeds
+`SwiftVLCArtifactDigest`, and metadata creation rejects it unless that value
+matches the complete XCFramework tree supplied to the runner. Use
 `candidate-metadata.py source` before an external build to obtain those values,
 then `candidate-metadata.py create` after signing to bind them to the app-tree
-digest.
+digest. Candidate metadata also records and verifies the complete XCFramework
+tree digest; a signed app cannot be paired with evidence naming a different
+engine artifact.
 
 The command identifies the physical device and OS release type, generates and
 serves deterministic local media, installs the exact signed candidate and UI
@@ -61,10 +65,19 @@ test runner, executes the analyzer, general UI stress suite, native/direct live
 PiP, same-player continuity, and HLS seek lanes, then pulls app logs and writes
 a machine-readable `report.json`. It retains every attempt log and xcresult,
 records and verifies candidate metadata that binds the app tree digest to its
-source commit and release-source digest, and retries only a small allowlist of
-Xcode/device-launch infrastructure failures. Every run reinstalls both exact
-signed apps; an assertion, product failure, or provenance mismatch is never
-retried into a pass.
+source commit, release-source digest, and XCFramework digest, and retries only
+a small allowlist of Xcode/device-launch infrastructure failures. Every run
+reinstalls both exact signed apps; an assertion, product failure, or provenance
+mismatch is never retried into a pass.
+
+The HLS seek lane is the first complete machine-readable matrix slice. It
+executes forward, backward, and absolute seeks, measures the return of decoded
+video, checks ordered PiP continuity, samples real system-PiP motion after each
+seek, verifies inline recovery, and exports an XCTest JSON attachment. The host
+materializes that attachment under `evidence/`, adding artifact, source, and
+hardware identity fields that the test process is forbidden to provide. The
+matching row appears under `qualificationRows` in `report.json`; beta-OS rows
+remain exploratory and are rejected by `check-qualification.sh`.
 
 Use `--require-stable` for release evidence. It fails before testing if the
 device is a simulator, runs beta or unknown software, or does not match a

--- a/scripts/qualification/candidate-metadata.py
+++ b/scripts/qualification/candidate-metadata.py
@@ -32,13 +32,20 @@ def command_output(arguments: list[str]) -> str:
         raise CandidateMetadataError(detail) from error
 
 
-def validate(metadata: dict, version: str, app_digest: str) -> dict:
+def validate(
+    metadata: dict,
+    version: str,
+    app_digest: str,
+    artifact_digest: str,
+) -> dict:
     required = {
         "formatVersion": 1,
         "version": version,
         "releaseSourceDigestAlgorithm": "swiftvlc-git-tree-v1",
         "candidateAppDigestAlgorithm": "swiftvlc-tree-v1",
         "candidateAppDigest": app_digest,
+        "artifactDigestAlgorithm": "swiftvlc-tree-v1",
+        "artifactDigest": artifact_digest,
     }
     for key, expected in required.items():
         if metadata.get(key) != expected:
@@ -70,13 +77,22 @@ def source_identity(source_root: Path, version: str) -> dict:
     }
 
 
-def create(app: Path, version: str, digest_script: Path) -> dict:
+def create(app: Path, xcframework: Path, version: str, digest_script: Path) -> dict:
     try:
         with (app / "Info.plist").open("rb") as source:
             info = plistlib.load(source)
     except (OSError, plistlib.InvalidFileException) as error:
         raise CandidateMetadataError(f"cannot read candidate Info.plist: {error}") from error
     app_digest = command_output(["python3", str(digest_script), str(app)])
+    artifact_digest = command_output(
+        ["python3", str(digest_script), str(xcframework)]
+    )
+    embedded_artifact_digest = info.get("SwiftVLCArtifactDigest")
+    if embedded_artifact_digest != artifact_digest:
+        raise CandidateMetadataError(
+            "candidate embedded artifact digest mismatch: "
+            f"{embedded_artifact_digest!r} != {artifact_digest!r}"
+        )
     metadata = {
         "formatVersion": 1,
         "version": version,
@@ -85,8 +101,33 @@ def create(app: Path, version: str, digest_script: Path) -> dict:
         "releaseSourceDigest": info.get("SwiftVLCReleaseSourceDigest"),
         "candidateAppDigestAlgorithm": "swiftvlc-tree-v1",
         "candidateAppDigest": app_digest,
+        "artifactDigestAlgorithm": "swiftvlc-tree-v1",
+        "artifactDigest": embedded_artifact_digest,
     }
-    return validate(metadata, version, app_digest)
+    return validate(metadata, version, app_digest, artifact_digest)
+
+
+def verify(
+    metadata: dict,
+    app: Path,
+    xcframework: Path,
+    version: str,
+    digest_script: Path,
+) -> dict:
+    embedded = create(app, xcframework, version, digest_script)
+    validated = validate(
+        metadata,
+        version,
+        embedded["candidateAppDigest"],
+        embedded["artifactDigest"],
+    )
+    for field in ("sourceCommit", "releaseSourceDigest"):
+        if validated.get(field) != embedded[field]:
+            raise CandidateMetadataError(
+                f"candidate metadata {field} does not match the signed app: "
+                f"{validated.get(field)!r} != {embedded[field]!r}"
+            )
+    return validated
 
 
 def main() -> None:
@@ -95,6 +136,7 @@ def main() -> None:
 
     create_parser = subparsers.add_parser("create")
     create_parser.add_argument("--candidate-app", type=Path, required=True)
+    create_parser.add_argument("--xcframework", type=Path, required=True)
     create_parser.add_argument("--version", required=True)
     create_parser.add_argument("--digest-script", type=Path, required=True)
     create_parser.add_argument("--output", type=Path, required=True)
@@ -105,6 +147,7 @@ def main() -> None:
 
     verify_parser = subparsers.add_parser("verify")
     verify_parser.add_argument("--candidate-app", type=Path, required=True)
+    verify_parser.add_argument("--xcframework", type=Path, required=True)
     verify_parser.add_argument("--metadata", type=Path, required=True)
     verify_parser.add_argument("--version", required=True)
     verify_parser.add_argument("--digest-script", type=Path, required=True)
@@ -112,16 +155,24 @@ def main() -> None:
     args = parser.parse_args()
     try:
         if args.command == "create":
-            metadata = create(args.candidate_app, args.version, args.digest_script)
+            metadata = create(
+                args.candidate_app,
+                args.xcframework,
+                args.version,
+                args.digest_script,
+            )
             args.output.parent.mkdir(parents=True, exist_ok=True)
             args.output.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n")
         elif args.command == "source":
             metadata = source_identity(args.source_root.resolve(), args.version)
         else:
-            app_digest = command_output(
-                ["python3", str(args.digest_script), str(args.candidate_app)]
+            metadata = verify(
+                json.loads(args.metadata.read_text()),
+                args.candidate_app,
+                args.xcframework,
+                args.version,
+                args.digest_script,
             )
-            metadata = validate(json.loads(args.metadata.read_text()), args.version, app_digest)
     except (CandidateMetadataError, OSError, json.JSONDecodeError) as error:
         parser.error(str(error))
     print(json.dumps(metadata, sort_keys=True))

--- a/scripts/qualification/materialize-evidence.py
+++ b/scripts/qualification/materialize-evidence.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Bind an XCTest JSON attachment to an exact release candidate and device row."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+class EvidenceError(ValueError):
+    pass
+
+
+HOST_IDENTITY_FIELDS = {"artifactDigest", "releaseSourceDigest", "hardware"}
+
+
+def find_attachment(directory: Path, expected_name: str) -> Path:
+    manifest_path = directory / "manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, ValueError) as error:
+        raise EvidenceError(f"cannot read attachment manifest: {error}") from error
+
+    matches = []
+    if not isinstance(manifest, list):
+        raise EvidenceError("attachment manifest must be an array")
+    for test in manifest:
+        if not isinstance(test, dict):
+            continue
+        for attachment in test.get("attachments", []):
+            if (
+                isinstance(attachment, dict)
+                and attachment.get("suggestedHumanReadableName") == expected_name
+            ):
+                exported = attachment.get("exportedFileName")
+                if not isinstance(exported, str) or not exported:
+                    raise EvidenceError(f"attachment {expected_name!r} has no exported filename")
+                matches.append(directory / exported)
+
+    if len(matches) != 1:
+        raise EvidenceError(
+            f"expected exactly one {expected_name!r} attachment, found {len(matches)}"
+        )
+    if not matches[0].is_file():
+        raise EvidenceError(f"exported attachment is missing: {matches[0].name}")
+    return matches[0]
+
+
+def materialize(
+    attachments: Path,
+    attachment_name: str,
+    scenario: str,
+    hardware: str,
+    artifact_digest: str,
+    source_digest: str,
+) -> dict:
+    attachment_path = find_attachment(attachments, attachment_name)
+    try:
+        payload = json.loads(attachment_path.read_text())
+    except (OSError, ValueError) as error:
+        raise EvidenceError(f"cannot read evidence attachment: {error}") from error
+    if not isinstance(payload, dict):
+        raise EvidenceError("evidence attachment must be a JSON object")
+    if payload.get("scenario") != scenario:
+        raise EvidenceError(
+            f"attachment scenario is {payload.get('scenario')!r}, expected {scenario!r}"
+        )
+    forged = sorted(HOST_IDENTITY_FIELDS.intersection(payload))
+    if forged:
+        raise EvidenceError(
+            "test attachment may not supply host identity fields: " + ", ".join(forged)
+        )
+
+    return {
+        **payload,
+        "artifactDigest": artifact_digest,
+        "releaseSourceDigest": source_digest,
+        "hardware": hardware,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--attachments", type=Path, required=True)
+    parser.add_argument("--attachment-name", required=True)
+    parser.add_argument("--scenario", required=True)
+    parser.add_argument("--hardware", required=True)
+    parser.add_argument("--artifact-digest", required=True)
+    parser.add_argument("--source-digest", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    try:
+        evidence = materialize(
+            args.attachments,
+            args.attachment_name,
+            args.scenario,
+            args.hardware,
+            args.artifact_digest,
+            args.source_digest,
+        )
+    except EvidenceError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -113,6 +113,7 @@ if [[ ! -f "$FIXTURES/manifest.json" ]]; then
 fi
 python3 "$SCRIPT_DIR/verify-fixtures.py" "$FIXTURES" > /dev/null
 cp "$FIXTURES/manifest.json" "$OUTPUT_DIR/fixture-manifest.json"
+FIXTURE_MANIFEST_CHECKSUM=$(shasum -a 256 "$FIXTURES/manifest.json" | cut -d' ' -f1)
 
 READY_FILE="$WORK_DIR/server-ready.json"
 python3 "$SCRIPT_DIR/fixture-server.py" \
@@ -148,6 +149,8 @@ if [[ "$SKIP_BUILD" == false ]]; then
     --version "$VERSION")
   BUILD_SOURCE_COMMIT=$(jq -r '.sourceCommit' <<< "$BUILD_SOURCE_IDENTITY")
   BUILD_SOURCE_DIGEST=$(jq -r '.releaseSourceDigest' <<< "$BUILD_SOURCE_IDENTITY")
+  BUILD_ARTIFACT_DIGEST=$(python3 "$ROOT_DIR/scripts/artifact-tree-digest.py" \
+    "$ROOT_DIR/Vendor/libvlc.xcframework")
   BUILD_SOURCE_ROOT="$WORK_DIR/source"
   mkdir -p "$BUILD_SOURCE_ROOT"
   git -C "$ROOT_DIR" archive HEAD | tar -x -C "$BUILD_SOURCE_ROOT"
@@ -162,6 +165,7 @@ if [[ "$SKIP_BUILD" == false ]]; then
     -derivedDataPath "$DERIVED_DATA" \
     SWIFTVLC_SOURCE_COMMIT="$BUILD_SOURCE_COMMIT" \
     SWIFTVLC_RELEASE_SOURCE_DIGEST="$BUILD_SOURCE_DIGEST" \
+    SWIFTVLC_ARTIFACT_DIGEST="$BUILD_ARTIFACT_DIGEST" \
     CODE_SIGNING_ALLOWED=YES \
     > "$OUTPUT_DIR/build.log"
 fi
@@ -190,6 +194,7 @@ if [[ "$PREBUILT_CANDIDATE" == true ]]; then
   fi
   python3 "$SCRIPT_DIR/candidate-metadata.py" verify \
     --candidate-app "$CANDIDATE_APP" \
+    --xcframework "$ROOT_DIR/Vendor/libvlc.xcframework" \
     --metadata "$CANDIDATE_METADATA" \
     --version "$VERSION" \
     --digest-script "$ROOT_DIR/scripts/artifact-tree-digest.py" \
@@ -198,12 +203,14 @@ if [[ "$PREBUILT_CANDIDATE" == true ]]; then
 else
   python3 "$SCRIPT_DIR/candidate-metadata.py" create \
     --candidate-app "$CANDIDATE_APP" \
+    --xcframework "$ROOT_DIR/Vendor/libvlc.xcframework" \
     --version "$VERSION" \
     --digest-script "$ROOT_DIR/scripts/artifact-tree-digest.py" \
     --output "$CANDIDATE_IDENTITY" \
     > /dev/null
 fi
 CANDIDATE_APP_DIGEST=$(jq -r '.candidateAppDigest' "$CANDIDATE_IDENTITY")
+ARTIFACT_DIGEST=$(jq -r '.artifactDigest' "$CANDIDATE_IDENTITY")
 SOURCE_COMMIT=$(jq -r '.sourceCommit' "$CANDIDATE_IDENTITY")
 SOURCE_DIGEST=$(jq -r '.releaseSourceDigest' "$CANDIDATE_IDENTITY")
 
@@ -280,6 +287,8 @@ done
 
 RESULTS_TSV="$WORK_DIR/results.tsv"
 : > "$RESULTS_TSV"
+QUALIFICATION_ROWS="$WORK_DIR/qualification-rows.jsonl"
+: > "$QUALIFICATION_ROWS"
 
 run_scenario() {
   local scenario="$1"
@@ -370,7 +379,7 @@ run_scenario() {
     cp "$selected_xctestrun" "$OUTPUT_DIR/destination-$scenario.xctestrun"
   fi
 
-  local started ended test_status result error_count log_status
+  local started ended test_status result error_count log_status evidence_status
   local xcodebuild_log="$OUTPUT_DIR/$scenario-xcodebuild.log"
   local result_bundle="$OUTPUT_DIR/$scenario.xcresult"
   local test_selection_args=()
@@ -417,6 +426,7 @@ run_scenario() {
 
   error_count=0
   log_status="none"
+  evidence_status="not-applicable"
   if [[ "$scenario" == "ui-suite" || "$scenario" == "harness-regressions" || "$scenario" == "ui-failures" || "$scenario" == "thumbnail-preview" ]]; then
     local document_capture="$OUTPUT_DIR/$scenario-documents"
     set +e
@@ -511,12 +521,76 @@ PY
     fi
   fi
 
+  if [[ "$scenario" == "hls-seek" ]]; then
+    evidence_status="missing"
+    if [[ "$test_status" -eq 0 ]] && [[ "$error_count" -eq 0 ]] \
+      && [[ "$log_status" == "captured" ]] && [[ -d "$result_bundle" ]]; then
+      local attachments="$OUTPUT_DIR/$scenario-attachments"
+      local hardware_id evidence_file evidence_relative export_status materialize_status
+      set +e
+      xcrun xcresulttool export attachments \
+        --path "$result_bundle" \
+        --output-path "$attachments" \
+        > "$OUTPUT_DIR/$scenario-export-attachments.log" 2>&1
+      export_status=$?
+      set -e
+      hardware_id=$(jq -r '.selected.matchingHardwareRows | if length == 1 then .[0] else "" end' \
+        "$OUTPUT_DIR/device.json")
+      if [[ "$export_status" -eq 0 ]] && [[ -n "$hardware_id" ]]; then
+        evidence_relative="evidence/native-hls-seek-continuity-$hardware_id.json"
+        evidence_file="$OUTPUT_DIR/$evidence_relative"
+        set +e
+        python3 "$SCRIPT_DIR/materialize-evidence.py" \
+          --attachments "$attachments" \
+          --attachment-name qualification-native-hls-seek-continuity.json \
+          --scenario native-hls-seek-continuity \
+          --hardware "$hardware_id" \
+          --artifact-digest "$ARTIFACT_DIGEST" \
+          --source-digest "$SOURCE_DIGEST" \
+          --output "$evidence_file" \
+          > "$OUTPUT_DIR/$scenario-materialize-evidence.log" 2>&1
+        materialize_status=$?
+        set -e
+        if [[ "$materialize_status" -eq 0 ]]; then
+          evidence_status="captured"
+          python3 - \
+            "$OUTPUT_DIR/device.json" "$QUALIFICATION_ROWS" "$evidence_relative" \
+            "$FIXTURE_MANIFEST_CHECKSUM" "$((ended - started))" <<'PY'
+import json
+import sys
+
+device_path, rows_path, evidence, fixture_checksum, duration = sys.argv[1:]
+device = json.load(open(device_path))["selected"]
+row = {
+    "scenario": "native-hls-seek-continuity",
+    "hardware": device["matchingHardwareRows"][0],
+    "device": device["marketingName"],
+    "deviceFamily": device["deviceFamily"],
+    "productType": device["productType"],
+    "osVersion": device["osVersion"],
+    "osBuild": device["osBuild"],
+    "osReleaseType": device["osReleaseType"],
+    "fixture": f"qualification-fixtures:{fixture_checksum}",
+    "duration": f"{duration}s",
+    "durationSeconds": int(duration),
+    "evidence": evidence,
+    "result": "pass",
+}
+with open(rows_path, "a") as output:
+    output.write(json.dumps(row, sort_keys=True) + "\n")
+PY
+        fi
+      fi
+    fi
+  fi
+
   result="pass"
-  if [[ "$test_status" -ne 0 ]] || [[ "$error_count" -ne 0 ]] || [[ "$log_status" == "missing" ]]; then
+  if [[ "$test_status" -ne 0 ]] || [[ "$error_count" -ne 0 ]] || [[ "$log_status" == "missing" ]] \
+    || [[ "$evidence_status" == "missing" ]]; then
     result="fail"
   fi
-  printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
-    "$scenario" "$result" "$test_status" "$error_count" "$log_status" "$((ended - started))" \
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$scenario" "$result" "$test_status" "$error_count" "$log_status" "$evidence_status" "$((ended - started))" \
     >> "$RESULTS_TSV"
   echo "$scenario: $result"
 }
@@ -530,7 +604,7 @@ MATRIX_CHECKSUM=$(shasum -a 256 "$SCRIPT_DIR/matrix.json" | cut -d' ' -f1)
 python3 - \
   "$RESULTS_TSV" "$OUTPUT_DIR/report.json" "$OUTPUT_DIR/device.json" \
   "$VERSION" "$SOURCE_COMMIT" "$SOURCE_DIGEST" "$MATRIX_CHECKSUM" \
-  "$CANDIDATE_APP_DIGEST" "$RUN_MODE" <<'PY'
+  "$CANDIDATE_APP_DIGEST" "$ARTIFACT_DIGEST" "$RUN_MODE" "$QUALIFICATION_ROWS" <<'PY'
 import json
 import sys
 
@@ -543,13 +617,15 @@ import sys
     source_digest,
     matrix_checksum,
     app_digest,
+    artifact_digest,
     mode,
+    qualification_rows_path,
 ) = sys.argv[1:]
 
 scenarios = []
 with open(results_path) as source:
     for line in source:
-        scenario, result, exit_code, errors, log_status, duration = line.rstrip("\n").split("\t")
+        scenario, result, exit_code, errors, log_status, evidence_status, duration = line.rstrip("\n").split("\t")
         scenarios.append(
             {
                 "scenario": scenario,
@@ -557,11 +633,14 @@ with open(results_path) as source:
                 "xcodebuildExitCode": int(exit_code),
                 "libraryErrorCount": int(errors),
                 "appLog": log_status,
+                "qualificationEvidence": evidence_status,
                 "durationSeconds": int(duration),
             }
         )
 
 device = json.load(open(device_path))["selected"]
+with open(qualification_rows_path) as source:
+    qualification_rows = [json.loads(line) for line in source if line.strip()]
 report = {
     "formatVersion": 1,
     "version": version,
@@ -575,8 +654,11 @@ report = {
     "qualificationMatrixChecksum": matrix_checksum,
     "candidateAppDigestAlgorithm": "swiftvlc-tree-v1",
     "candidateAppDigest": app_digest,
+    "artifactDigestAlgorithm": "swiftvlc-tree-v1",
+    "artifactDigest": artifact_digest,
     "device": device,
     "scenarios": scenarios,
+    "qualificationRows": qualification_rows,
     "result": "pass" if scenarios and all(row["result"] == "pass" for row in scenarios) else "fail",
 }
 with open(output_path, "w") as output:

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -31,6 +31,7 @@ fixture_server = load_script("fixture-server.py")
 prepare_xctestrun = load_script("prepare-xctestrun.py")
 verify_fixtures = load_script("verify-fixtures.py")
 candidate_metadata = load_script("candidate-metadata.py")
+materialize_evidence = load_script("materialize-evidence.py")
 
 
 class DeviceInfoTests(unittest.TestCase):
@@ -125,33 +126,48 @@ class CandidateMetadataTests(unittest.TestCase):
             "releaseSourceDigest": "c" * 64,
             "candidateAppDigestAlgorithm": "swiftvlc-tree-v1",
             "candidateAppDigest": app_digest,
+            "artifactDigestAlgorithm": "swiftvlc-tree-v1",
+            "artifactDigest": "d" * 64,
         }
         self.assertEqual(
-            candidate_metadata.validate(metadata, "1.1.0", app_digest), metadata
+            candidate_metadata.validate(metadata, "1.1.0", app_digest, "d" * 64),
+            metadata,
         )
         with self.assertRaises(candidate_metadata.CandidateMetadataError):
-            candidate_metadata.validate(metadata, "1.1.0", "d" * 64)
+            candidate_metadata.validate(metadata, "1.1.0", "e" * 64, "d" * 64)
 
     def test_metadata_reads_source_identity_from_the_signed_app_payload(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             app = root / "iOS.app"
             app.mkdir()
+            xcframework = root / "libvlc.xcframework"
+            xcframework.mkdir()
             with (app / "Info.plist").open("wb") as output:
                 plistlib.dump(
                     {
                         "SwiftVLCSourceCommit": "b" * 40,
                         "SwiftVLCReleaseSourceDigest": "c" * 64,
+                        "SwiftVLCArtifactDigest": "a" * 64,
                     },
                     output,
                 )
             digest_script = root / "digest.py"
             digest_script.write_text(f'print("{"a" * 64}")\n')
 
-            metadata = candidate_metadata.create(app, "1.1.0", digest_script)
+            metadata = candidate_metadata.create(
+                app, xcframework, "1.1.0", digest_script
+            )
             self.assertEqual(metadata["sourceCommit"], "b" * 40)
             self.assertEqual(metadata["releaseSourceDigest"], "c" * 64)
             self.assertEqual(metadata["candidateAppDigest"], "a" * 64)
+            self.assertEqual(metadata["artifactDigest"], "a" * 64)
+
+            forged = dict(metadata, sourceCommit="d" * 40)
+            with self.assertRaises(candidate_metadata.CandidateMetadataError):
+                candidate_metadata.verify(
+                    forged, app, xcframework, "1.1.0", digest_script
+                )
 
 
 class FixtureManifestTests(unittest.TestCase):
@@ -175,6 +191,85 @@ class FixtureManifestTests(unittest.TestCase):
             sample.write_bytes(b"corrupted")
             with self.assertRaises(verify_fixtures.FixtureVerificationError):
                 verify_fixtures.verify(root)
+
+
+class QualificationEvidenceTests(unittest.TestCase):
+    def make_export(self, root: Path, payload: dict, attachment_count: int = 1):
+        exported = root / "attachment.json"
+        exported.write_text(json.dumps(payload))
+        attachment = {
+            "exportedFileName": exported.name,
+            "suggestedHumanReadableName": "qualification-native-hls-seek-continuity.json",
+        }
+        manifest = [
+            {
+                "testIdentifier": "PiPOverlayDeviceUITests/test_nativePiPHLSSeekAndReloadRemainActive",
+                "attachments": [attachment] * attachment_count,
+            }
+        ]
+        (root / "manifest.json").write_text(json.dumps(manifest))
+
+    def test_materializes_test_payload_with_host_owned_identity(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.make_export(
+                root,
+                {
+                    "formatVersion": 1,
+                    "scenario": "native-hls-seek-continuity",
+                    "seekResults": {"forward": "pass"},
+                },
+            )
+            evidence = materialize_evidence.materialize(
+                root,
+                "qualification-native-hls-seek-continuity.json",
+                "native-hls-seek-continuity",
+                "iphone-current",
+                "a" * 64,
+                "b" * 64,
+            )
+            self.assertEqual(evidence["artifactDigest"], "a" * 64)
+            self.assertEqual(evidence["releaseSourceDigest"], "b" * 64)
+            self.assertEqual(evidence["hardware"], "iphone-current")
+            self.assertEqual(evidence["seekResults"]["forward"], "pass")
+
+    def test_rejects_duplicate_attachments_and_forged_identity(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.make_export(
+                root,
+                {
+                    "scenario": "native-hls-seek-continuity",
+                    "artifactDigest": "forged",
+                },
+                attachment_count=2,
+            )
+            with self.assertRaises(materialize_evidence.EvidenceError):
+                materialize_evidence.materialize(
+                    root,
+                    "qualification-native-hls-seek-continuity.json",
+                    "native-hls-seek-continuity",
+                    "iphone-current",
+                    "a" * 64,
+                    "b" * 64,
+                )
+
+            self.make_export(
+                root,
+                {
+                    "scenario": "native-hls-seek-continuity",
+                    "artifactDigest": "forged",
+                },
+            )
+            with self.assertRaises(materialize_evidence.EvidenceError):
+                materialize_evidence.materialize(
+                    root,
+                    "qualification-native-hls-seek-continuity.json",
+                    "native-hls-seek-continuity",
+                    "iphone-current",
+                    "a" * 64,
+                    "b" * 64,
+                )
 
 
 class FixtureServerTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- turn the native HLS seek device lane into machine-readable qualification evidence
- verify forward, backward, and absolute seeks with bounded video recovery and real system-PiP motion
- bind XCTest evidence to the signed app, exact XCFramework, wrapper source, and hardware row
- keep the overall 53-row release gate fail-closed

## Validation
- `swift test` — 1,990 tests in 168 suites passed
- iOS `build-for-testing` — passed for both simulator architectures
- strict SwiftFormat and SwiftLint — passed
- qualification harness — 14 tests passed
- `scripts/tests/release-integrity.sh` — passed

Closes no milestone issue: physical stable-OS evidence still has to execute successfully on each required hardware row.