### PR TITLE
Automate qualification record assembly

### DIFF
--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -187,6 +187,28 @@ the current identities itself and rejects stale source, a weakened or expanded
 matrix, a record from another candidate, or evidence captured against another
 wrapper revision.
 
+Candidate-bound rows from separate device runs can be accumulated without
+hand-editing JSON. Pass every retained `report.json` to the assembler, along
+with the candidate metadata used by the device runner:
+
+```bash
+python3 scripts/qualification/assemble-record.py \
+  --version 1.1.0 \
+  --candidate-metadata /absolute/path/to/candidate-metadata.json \
+  --matrix scripts/qualification/matrix.json \
+  --report /absolute/path/to/iphone-results/report.json \
+  --report /absolute/path/to/ipad-results/report.json \
+  --output scripts/qualification/1.1.0.json
+```
+
+The assembler rejects exploratory or beta-OS reports, identity mismatches,
+unknown or duplicate rows, failures, unsafe evidence paths, and evidence from a
+different artifact, source, scenario, or hardware row. It copies accepted
+attachments under `evidence/<version>/` and writes the record atomically. A
+partial record is allowed so multiple devices can be accumulated over time;
+only `check-qualification.sh` is the final gate, and it continues to reject the
+record until all required rows and scenario-specific evidence pass.
+
 ## Checking before release
 
 ```bash

--- a/scripts/qualification/assemble-record.py
+++ b/scripts/qualification/assemble-record.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Assemble candidate-bound device reports into one qualification record."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+
+class AssemblyError(ValueError):
+    pass
+
+
+SHA1 = re.compile(r"[0-9a-f]{40}")
+SHA256 = re.compile(r"[0-9a-f]{64}")
+ROW_ID = re.compile(r"[a-z0-9][a-z0-9-]*")
+
+
+def load_object(path: Path, description: str) -> dict:
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, ValueError) as error:
+        raise AssemblyError(f"cannot read {description} {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise AssemblyError(f"{description} {path} must be a JSON object")
+    return value
+
+
+def required_rows(matrix: dict) -> set[tuple[str, str]]:
+    scenarios = matrix.get("scenarios")
+    hardware = matrix.get("hardware")
+    if not isinstance(scenarios, list) or not isinstance(hardware, list):
+        raise AssemblyError("qualification matrix needs scenarios and hardware arrays")
+    if any(
+        not isinstance(row, dict)
+        or not ROW_ID.fullmatch(str(row.get("id", "")))
+        for row in hardware
+    ):
+        raise AssemblyError("qualification matrix has an invalid hardware id")
+    hardware_ids = {row["id"] for row in hardware}
+    if len(hardware_ids) != len(hardware):
+        raise AssemblyError("qualification matrix has invalid or duplicate hardware ids")
+
+    result: set[tuple[str, str]] = set()
+    scenario_ids: set[str] = set()
+    for scenario in scenarios:
+        if (
+            not isinstance(scenario, dict)
+            or not ROW_ID.fullmatch(str(scenario.get("id", "")))
+        ):
+            raise AssemblyError("qualification matrix has an invalid scenario id")
+        scenario_id = scenario["id"]
+        if scenario_id in scenario_ids:
+            raise AssemblyError("qualification matrix has duplicate scenario ids")
+        scenario_ids.add(scenario_id)
+        selected = scenario.get("hardware", sorted(hardware_ids))
+        if not isinstance(selected, list) or not selected:
+            raise AssemblyError(f"scenario {scenario_id!r} has no hardware rows")
+        unknown = set(selected) - hardware_ids
+        if unknown:
+            raise AssemblyError(
+                f"scenario {scenario_id!r} has unknown hardware rows: "
+                + ", ".join(sorted(unknown))
+            )
+        result.update((scenario_id, hardware_id) for hardware_id in selected)
+    return result
+
+
+def safe_evidence_path(report_path: Path, relative: object) -> Path:
+    if not isinstance(relative, str) or not relative:
+        raise AssemblyError(f"report {report_path} row has no evidence path")
+    candidate = Path(relative)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        raise AssemblyError(f"report {report_path} has unsafe evidence path {relative!r}")
+    resolved = (report_path.parent / candidate).resolve()
+    try:
+        resolved.relative_to(report_path.parent.resolve())
+    except ValueError as error:
+        raise AssemblyError(
+            f"report {report_path} evidence escapes its directory: {relative!r}"
+        ) from error
+    if not resolved.is_file():
+        raise AssemblyError(f"report {report_path} evidence is missing: {relative}")
+    return resolved
+
+
+def assemble(
+    version: str,
+    candidate_path: Path,
+    matrix_path: Path,
+    report_paths: list[Path],
+    output_path: Path,
+) -> dict:
+    if not report_paths:
+        raise AssemblyError("at least one device report is required")
+    candidate = load_object(candidate_path, "candidate metadata")
+    matrix = load_object(matrix_path, "qualification matrix")
+    matrix_checksum = hashlib.sha256(matrix_path.read_bytes()).hexdigest()
+    required = required_rows(matrix)
+
+    identity = {
+        "version": version,
+        "artifactDigestAlgorithm": "swiftvlc-tree-v1",
+        "artifactDigest": candidate.get("artifactDigest"),
+        "sourceCommit": candidate.get("sourceCommit"),
+        "releaseSourceDigestAlgorithm": "swiftvlc-git-tree-v1",
+        "releaseSourceDigest": candidate.get("releaseSourceDigest"),
+        "qualificationMatrixChecksum": matrix_checksum,
+    }
+    for field, pattern in (
+        ("artifactDigest", SHA256),
+        ("sourceCommit", SHA1),
+        ("releaseSourceDigest", SHA256),
+    ):
+        if not pattern.fullmatch(str(identity[field] or "")):
+            raise AssemblyError(f"candidate metadata has no valid {field}")
+    if candidate.get("version") != version:
+        raise AssemblyError(
+            f"candidate metadata version is {candidate.get('version')!r}, expected {version!r}"
+        )
+    for field, expected in (
+        ("artifactDigestAlgorithm", "swiftvlc-tree-v1"),
+        ("releaseSourceDigestAlgorithm", "swiftvlc-git-tree-v1"),
+    ):
+        if candidate.get(field) != expected:
+            raise AssemblyError(
+                f"candidate metadata {field} mismatch: "
+                f"{candidate.get(field)!r} != {expected!r}"
+            )
+
+    rows: dict[tuple[str, str], tuple[dict, Path]] = {}
+    for report_path in report_paths:
+        report = load_object(report_path, "device report")
+        if report.get("qualificationEligibleEnvironment") is not True:
+            raise AssemblyError(f"report {report_path} is not from a qualifying environment")
+        if report.get("mode") != "qualification":
+            raise AssemblyError(f"report {report_path} is not in qualification mode")
+        for field, expected in identity.items():
+            if report.get(field) != expected:
+                raise AssemblyError(
+                    f"report {report_path} {field} mismatch: "
+                    f"{report.get(field)!r} != {expected!r}"
+                )
+
+        report_rows = report.get("qualificationRows")
+        if not isinstance(report_rows, list) or not report_rows:
+            raise AssemblyError(f"report {report_path} has no qualification rows")
+        for row in report_rows:
+            if not isinstance(row, dict):
+                raise AssemblyError(f"report {report_path} contains a non-object row")
+            scenario = row.get("scenario")
+            hardware = row.get("hardware")
+            if not isinstance(scenario, str) or not isinstance(hardware, str):
+                raise AssemblyError(
+                    f"report {report_path} contains a row without string ids"
+                )
+            key = (scenario, hardware)
+            if key not in required:
+                raise AssemblyError(f"report {report_path} contains unknown row {key!r}")
+            if key in rows:
+                raise AssemblyError(
+                    f"duplicate qualification row {key[0]} on {key[1]}"
+                )
+            if row.get("result") != "pass":
+                raise AssemblyError(f"row {key[0]} on {key[1]} did not pass")
+            if row.get("osReleaseType") != "stable":
+                raise AssemblyError(f"row {key[0]} on {key[1]} is not from stable OS software")
+            evidence_path = safe_evidence_path(report_path, row.get("evidence"))
+            evidence = load_object(evidence_path, "evidence")
+            for field, expected in (
+                ("artifactDigest", identity["artifactDigest"]),
+                ("releaseSourceDigest", identity["releaseSourceDigest"]),
+                ("scenario", key[0]),
+                ("hardware", key[1]),
+            ):
+                if evidence.get(field) != expected:
+                    raise AssemblyError(
+                        f"evidence {evidence_path} {field} mismatch: "
+                        f"{evidence.get(field)!r} != {expected!r}"
+                    )
+            rows[key] = (row, evidence_path)
+
+    evidence_directory = output_path.parent / "evidence" / version
+    staged_rows = []
+    for key in sorted(rows):
+        row, source = rows[key]
+        filename = f"{key[0]}-{key[1]}.json"
+        relative = Path("evidence") / version / filename
+        staged = dict(row, evidence=str(relative))
+        staged_rows.append(staged)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    evidence_directory.mkdir(parents=True, exist_ok=True)
+    for key, (_, source) in sorted(rows.items()):
+        destination = evidence_directory / f"{key[0]}-{key[1]}.json"
+        with tempfile.NamedTemporaryFile(
+            dir=evidence_directory, prefix=f".{destination.name}.", delete=False
+        ) as temporary:
+            temporary_path = Path(temporary.name)
+        try:
+            shutil.copyfile(source, temporary_path)
+            os.replace(temporary_path, destination)
+        finally:
+            temporary_path.unlink(missing_ok=True)
+
+    record = {**identity, "rows": staged_rows}
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        dir=output_path.parent,
+        prefix=f".{output_path.name}.",
+        delete=False,
+    ) as temporary:
+        temporary_path = Path(temporary.name)
+        json.dump(record, temporary, indent=2, sort_keys=True)
+        temporary.write("\n")
+    try:
+        os.replace(temporary_path, output_path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+    return record
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--candidate-metadata", type=Path, required=True)
+    parser.add_argument("--matrix", type=Path, required=True)
+    parser.add_argument("--report", type=Path, action="append", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        record = assemble(
+            args.version,
+            args.candidate_metadata,
+            args.matrix,
+            args.report,
+            args.output,
+        )
+    except AssemblyError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+    print(f"Assembled {len(record['rows'])} candidate-bound qualification row(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -32,6 +32,7 @@ prepare_xctestrun = load_script("prepare-xctestrun.py")
 verify_fixtures = load_script("verify-fixtures.py")
 candidate_metadata = load_script("candidate-metadata.py")
 materialize_evidence = load_script("materialize-evidence.py")
+assemble_record = load_script("assemble-record.py")
 
 
 class DeviceInfoTests(unittest.TestCase):
@@ -270,6 +271,169 @@ class QualificationEvidenceTests(unittest.TestCase):
                     "a" * 64,
                     "b" * 64,
                 )
+
+
+class QualificationRecordAssemblyTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.matrix = self.root / "matrix.json"
+        self.matrix.write_text(
+            json.dumps(
+                {
+                    "scenarios": [{"id": "seek"}],
+                    "hardware": [
+                        {"id": "iphone", "deviceFamily": "iPhone", "osMajor": 26},
+                        {"id": "ipad", "deviceFamily": "iPad", "osMajor": 26},
+                    ],
+                }
+            )
+        )
+        self.matrix_checksum = hashlib.sha256(self.matrix.read_bytes()).hexdigest()
+        self.candidate = self.root / "candidate.json"
+        self.candidate.write_text(
+            json.dumps(
+                {
+                    "version": "1.1.0",
+                    "artifactDigestAlgorithm": "swiftvlc-tree-v1",
+                    "artifactDigest": "a" * 64,
+                    "sourceCommit": "b" * 40,
+                    "releaseSourceDigestAlgorithm": "swiftvlc-git-tree-v1",
+                    "releaseSourceDigest": "c" * 64,
+                }
+            )
+        )
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def make_report(self, hardware: str, release_type: str = "stable") -> Path:
+        directory = self.root / f"report-{hardware}"
+        evidence_directory = directory / "evidence"
+        evidence_directory.mkdir(parents=True)
+        evidence = evidence_directory / "seek.json"
+        evidence.write_text(
+            json.dumps(
+                {
+                    "artifactDigest": "a" * 64,
+                    "releaseSourceDigest": "c" * 64,
+                    "scenario": "seek",
+                    "hardware": hardware,
+                    "outcome": "pass",
+                }
+            )
+        )
+        report = directory / "report.json"
+        report.write_text(
+            json.dumps(
+                {
+                    "version": "1.1.0",
+                    "artifactDigestAlgorithm": "swiftvlc-tree-v1",
+                    "artifactDigest": "a" * 64,
+                    "sourceCommit": "b" * 40,
+                    "releaseSourceDigestAlgorithm": "swiftvlc-git-tree-v1",
+                    "releaseSourceDigest": "c" * 64,
+                    "qualificationMatrixChecksum": self.matrix_checksum,
+                    "qualificationEligibleEnvironment": release_type == "stable",
+                    "mode": "qualification" if release_type == "stable" else "exploratory",
+                    "qualificationRows": [
+                        {
+                            "scenario": "seek",
+                            "hardware": hardware,
+                            "device": f"Fixture {hardware}",
+                            "deviceFamily": "iPhone" if hardware == "iphone" else "iPad",
+                            "productType": "Fixture1,1",
+                            "osVersion": "26.0",
+                            "osBuild": "23A1",
+                            "osReleaseType": release_type,
+                            "fixture": "fixture:abc",
+                            "duration": "10s",
+                            "durationSeconds": 10,
+                            "evidence": "evidence/seek.json",
+                            "result": "pass",
+                        }
+                    ],
+                }
+            )
+        )
+        return report
+
+    def test_assembles_rows_and_copies_candidate_bound_evidence(self):
+        output = self.root / "qualification" / "1.1.0.json"
+        record = assemble_record.assemble(
+            "1.1.0",
+            self.candidate,
+            self.matrix,
+            [self.make_report("iphone"), self.make_report("ipad")],
+            output,
+        )
+        self.assertEqual(len(record["rows"]), 2)
+        self.assertEqual(record["artifactDigest"], "a" * 64)
+        for row in record["rows"]:
+            self.assertTrue((output.parent / row["evidence"]).is_file())
+
+    def test_rejects_exploratory_and_duplicate_rows(self):
+        output = self.root / "qualification" / "1.1.0.json"
+        with self.assertRaises(assemble_record.AssemblyError):
+            assemble_record.assemble(
+                "1.1.0",
+                self.candidate,
+                self.matrix,
+                [self.make_report("iphone", release_type="beta")],
+                output,
+            )
+
+        report = self.make_report("ipad")
+        with self.assertRaises(assemble_record.AssemblyError):
+            assemble_record.assemble(
+                "1.1.0",
+                self.candidate,
+                self.matrix,
+                [report, report],
+                output,
+            )
+
+    def test_rejects_report_identity_mismatch(self):
+        report = self.make_report("iphone")
+        payload = json.loads(report.read_text())
+        payload["releaseSourceDigest"] = "d" * 64
+        report.write_text(json.dumps(payload))
+        with self.assertRaises(assemble_record.AssemblyError):
+            assemble_record.assemble(
+                "1.1.0",
+                self.candidate,
+                self.matrix,
+                [report],
+                self.root / "qualification" / "1.1.0.json",
+            )
+
+    def test_rejects_candidate_algorithm_mismatch(self):
+        payload = json.loads(self.candidate.read_text())
+        payload["artifactDigestAlgorithm"] = "sha256-file-only"
+        self.candidate.write_text(json.dumps(payload))
+        with self.assertRaises(assemble_record.AssemblyError):
+            assemble_record.assemble(
+                "1.1.0",
+                self.candidate,
+                self.matrix,
+                [self.make_report("iphone")],
+                self.root / "qualification" / "1.1.0.json",
+            )
+
+    def test_rejects_evidence_that_escapes_report_directory(self):
+        report = self.make_report("iphone")
+        payload = json.loads(report.read_text())
+        payload["qualificationRows"][0]["evidence"] = "../outside.json"
+        report.write_text(json.dumps(payload))
+        (report.parent.parent / "outside.json").write_text("{}")
+        with self.assertRaises(assemble_record.AssemblyError):
+            assemble_record.assemble(
+                "1.1.0",
+                self.candidate,
+                self.matrix,
+                [report],
+                self.root / "qualification" / "1.1.0.json",
+            )
 
 
 class FixtureServerTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- assemble candidate-bound rows from multiple physical-device reports
- reject exploratory, mismatched, duplicate, failed, or path-unsafe evidence
- copy accepted evidence and atomically write the partial/final qualification record
- document the unattended accumulation workflow

## Validation
- `python3 -m unittest scripts/qualification/tests/test_qualification_harness.py` (19 tests)
- `./scripts/tests/release-integrity.sh`

A partial assembled record intentionally does not open the stable gate; `check-qualification.sh` remains the complete 53-row release gate. No manual Codex review was requested; the repository automatic review policy applies.