### PR TITLE
Automate background audio device qualification

### DIFF
--- a/Showcase/Shared/AccessibilityID.swift
+++ b/Showcase/Shared/AccessibilityID.swift
@@ -166,6 +166,8 @@ enum AccessibilityID {
     static let stateLabel = "pipLive.state"
     static let durationLabel = "pipLive.duration"
     static let displayedPicturesLabel = "pipLive.displayedPictures"
+    static let playedAudioBuffersLabel = "pipLive.playedAudioBuffers"
+    static let backgroundAudioObservationLabel = "pipLive.backgroundAudioObservation"
     static let possibleLabel = "pipLive.possible"
     static let activeLabel = "pipLive.active"
     static let linearPlaybackLabel = "pipLive.linearPlayback"

--- a/Showcase/UITests/iOS/Tests/PiPLiveDeviceUITests.swift
+++ b/Showcase/UITests/iOS/Tests/PiPLiveDeviceUITests.swift
@@ -47,10 +47,48 @@ final class PiPLiveDeviceUITests: ShowcaseIOSTestCase {
     #endif
   }
 
+  func test_backgroundAudioQualificationWhileAppIsBackgrounded() throws {
+    #if targetEnvironment(simulator)
+    throw XCTSkip("Background audio qualification requires a physical iOS device")
+    #else
+    let evidence = try runLivePictureInPicture(renderingPath: "native")
+    XCTAssertGreaterThan(
+      evidence.playedAudioBuffersAfterBackground,
+      evidence.playedAudioBuffersBeforeBackground
+    )
+    attachQualificationEvidence(
+      [
+        "formatVersion": 1,
+        "scenario": "background-audio",
+        "events": [
+          "started": true,
+          "unexpectedStopCount": evidence.unexpectedStopCount,
+          "order": "pass"
+        ],
+        "audioContinuity": "pass",
+        "backgroundApplicationState": true,
+        "measurementMethod": "libvlc-played-audio-buffers",
+        "measurements": [
+          "playedAudioBuffersBeforeBackground": evidence.playedAudioBuffersBeforeBackground,
+          "playedAudioBuffersAfterBackground": evidence.playedAudioBuffersAfterBackground
+        ]
+      ],
+      scenario: "background-audio"
+    )
+    #endif
+  }
+
   private struct LiveRunEvidence {
     let playbackRange: String
     let linearPlayback: Bool
     let unexpectedStopCount: Int
+    let playedAudioBuffersBeforeBackground: Int
+    let playedAudioBuffersAfterBackground: Int
+  }
+
+  private struct BackgroundAudioObservation {
+    let before: Int
+    let after: Int
   }
 
   private func runLivePictureInPicture(renderingPath: String) throws -> LiveRunEvidence {
@@ -92,6 +130,12 @@ final class PiPLiveDeviceUITests: ShowcaseIOSTestCase {
     let displayedPictures = app.descendants(matching: .any)[
       AccessibilityID.PiPLiveValidation.displayedPicturesLabel
     ]
+    let playedAudioBuffers = app.descendants(matching: .any)[
+      AccessibilityID.PiPLiveValidation.playedAudioBuffersLabel
+    ]
+    let backgroundAudioObservation = app.descendants(matching: .any)[
+      AccessibilityID.PiPLiveValidation.backgroundAudioObservationLabel
+    ]
     let possible = app.descendants(matching: .any)[AccessibilityID.PiPLiveValidation.possibleLabel]
     let active = app.descendants(matching: .any)[AccessibilityID.PiPLiveValidation.activeLabel]
     let linearPlayback = app.descendants(matching: .any)[
@@ -118,6 +162,7 @@ final class PiPLiveDeviceUITests: ShowcaseIOSTestCase {
       greaterThan: 0,
       timeout: 10
     )
+    _ = waitForIntegerLabel(playedAudioBuffers, greaterThan: 0, timeout: 10)
     assertRendersNonBlackFrame(video, timeout: 10)
     if renderingPath == "direct" {
       attachDirectRendererDiagnostics(
@@ -190,6 +235,15 @@ final class PiPLiveDeviceUITests: ShowcaseIOSTestCase {
       greaterThan: displayedBeforePiP,
       timeout: 10
     )
+    let audioObservation = waitForBackgroundAudioObservation(
+      backgroundAudioObservation,
+      timeout: 10
+    )
+    XCTAssertGreaterThan(
+      audioObservation.after,
+      audioObservation.before,
+      "Native audio output did not play buffers during the background interval"
+    )
     if renderingPath == "direct" {
       attachDirectRendererDiagnostics(
         video,
@@ -220,7 +274,9 @@ final class PiPLiveDeviceUITests: ShowcaseIOSTestCase {
     return LiveRunEvidence(
       playbackRange: playbackRange.label,
       linearPlayback: linearPlayback.label == "yes",
-      unexpectedStopCount: unexpectedStops.count
+      unexpectedStopCount: unexpectedStops.count,
+      playedAudioBuffersBeforeBackground: audioObservation.before,
+      playedAudioBuffersAfterBackground: audioObservation.after
     )
     #endif
   }
@@ -236,6 +292,32 @@ final class PiPLiveDeviceUITests: ShowcaseIOSTestCase {
     }
     let expectation = expectation(for: predicate, evaluatedWith: NSObject())
     XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: timeout), .completed)
+  }
+
+  private func waitForBackgroundAudioObservation(
+    _ element: XCUIElement,
+    timeout: TimeInterval
+  ) -> BackgroundAudioObservation {
+    let predicate = NSPredicate { _, _ in
+      self.parseBackgroundAudioObservation(element.label).map { $0.after > $0.before } == true
+    }
+    let expectation = expectation(for: predicate, evaluatedWith: NSObject())
+    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: timeout), .completed)
+    guard let observation = parseBackgroundAudioObservation(element.label) else {
+      XCTFail("Background audio probe did not publish two counters: \(element.label)")
+      return BackgroundAudioObservation(before: Int.max, after: Int.min)
+    }
+    return observation
+  }
+
+  private func parseBackgroundAudioObservation(_ value: String) -> BackgroundAudioObservation? {
+    let components = value.split(separator: ":")
+    guard
+      components.count == 2,
+      let before = Int(components[0]),
+      let after = Int(components[1])
+    else { return nil }
+    return BackgroundAudioObservation(before: before, after: after)
   }
 
   private func reveal(_ element: XCUIElement) {

--- a/Showcase/iOS/ValidationHarness/PiPLiveValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/PiPLiveValidationCase.swift
@@ -13,6 +13,8 @@ struct PiPLiveValidationCase: View {
   @State private var capturedRendererDiagnostics = "not-captured"
   @State private var diagnosticCaptureOrdinal: UInt64 = 0
   @State private var lifecycleEvents: [String] = []
+  @State private var backgroundAudioObservation = "none"
+  @State private var backgroundAudioProbe: Task<Void, Never>?
 
   private var renderingPath: PiPValidationRenderingPath {
     PiPValidationRenderingPath(
@@ -51,6 +53,16 @@ struct PiPLiveValidationCase: View {
           "Displayed pictures",
           value: String(player.statistics?.displayedPictures ?? 0),
           identifier: AccessibilityID.PiPLiveValidation.displayedPicturesLabel
+        )
+        valueRow(
+          "Played audio buffers",
+          value: String(player.statistics?.playedAudioBuffers ?? 0),
+          identifier: AccessibilityID.PiPLiveValidation.playedAudioBuffersLabel
+        )
+        valueRow(
+          "Background audio probe",
+          value: backgroundAudioObservation,
+          identifier: AccessibilityID.PiPLiveValidation.backgroundAudioObservationLabel
         )
         valueRow(
           "PiP possible",
@@ -128,10 +140,19 @@ struct PiPLiveValidationCase: View {
       captureRendererDiagnostics()
     }
     .onChange(of: scenePhase) { _, newPhase in
-      guard newPhase == .active else { return }
-      captureRendererDiagnostics()
+      switch newPhase {
+      case .background:
+        startBackgroundAudioProbe()
+      case .active:
+        captureRendererDiagnostics()
+      default:
+        break
+      }
     }
-    .onDisappear { player.stop() }
+    .onDisappear {
+      backgroundAudioProbe?.cancel()
+      player.stop()
+    }
   }
 
   @ViewBuilder
@@ -206,6 +227,18 @@ struct PiPLiveValidationCase: View {
       "requiresFlush=\(snapshot.displayLayerRequiresFlush)",
       "layerError=\(snapshot.displayLayerError ?? "nil")"
     ].joined(separator: ";")
+  }
+
+  private func startBackgroundAudioProbe() {
+    backgroundAudioProbe?.cancel()
+    let before = player.statistics?.playedAudioBuffers ?? 0
+    backgroundAudioObservation = "sampling:\(before)"
+    backgroundAudioProbe = Task { @MainActor in
+      try? await Task.sleep(for: .seconds(3))
+      guard !Task.isCancelled, UIApplication.shared.applicationState == .background else { return }
+      let after = player.statistics?.playedAudioBuffers ?? 0
+      backgroundAudioObservation = "\(before):\(after)"
+    }
   }
 
   private func lifecycleName(_ event: PiPEvent) -> String {

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -77,6 +77,12 @@ system-PiP motion while backgrounded, foreground recovery, continued decoded
 pictures, and zero library errors. It emits one combined `live-media` row so a
 passing backend cannot hide a failure in the other.
 
+The background-audio lane samples libVLC's native audio-output counter twice
+inside a timed interval while the application state is actually backgrounded
+and native PiP is active. A row is emitted only when played audio buffers
+increased during that interval, PiP remained active with ordered lifecycle
+events, and the app and host logs contain no library error records.
+
 The HLS seek lane is another complete machine-readable matrix slice. It
 executes forward, backward, and absolute seeks, measures the return of decoded
 video, checks ordered PiP continuity, samples real system-PiP motion after each

--- a/scripts/qualification/matrix.json
+++ b/scripts/qualification/matrix.json
@@ -105,12 +105,21 @@
       "id": "background-audio",
       "issues": [87, 88],
       "summary": "Audio continues with the app backgrounded",
-      "requiredEvidenceFields": ["events", "audioContinuity"],
+      "requiredEvidenceFields": [
+        "events",
+        "audioContinuity",
+        "backgroundApplicationState",
+        "measurementMethod",
+        "measurements.playedAudioBuffersBeforeBackground",
+        "measurements.playedAudioBuffersAfterBackground"
+      ],
       "expectedEvidenceValues": {
         "events.started": true,
         "events.unexpectedStopCount": 0,
         "events.order": "pass",
-        "audioContinuity": "pass"
+        "audioContinuity": "pass",
+        "backgroundApplicationState": true,
+        "measurementMethod": "libvlc-played-audio-buffers"
       }
     },
     {

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -32,7 +32,8 @@ Options:
   --fixtures PATH         Generated fixture directory
   --output PATH           Evidence output root
   --only SCENARIO         Repeat to select: analyzer, ui-suite, native-live,
-                          direct-live, live-media, continuity, hls-seek,
+                          direct-live, live-media, background-audio,
+                          continuity, hls-seek,
                           harness-regressions, ui-failures, thumbnail-preview
   --require-stable        Refuse beta/unknown OS or a non-matching matrix row
   --skip-build            Reuse an existing signed runner in derived data
@@ -274,13 +275,13 @@ xcrun devicectl device copy to \
   --destination Documents/streams.local.json \
   > "$OUTPUT_DIR/stage-streams.log"
 
-DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media continuity hls-seek)
+DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity hls-seek)
 if [[ ${#ONLY_SCENARIOS[@]} -eq 0 ]]; then
   ONLY_SCENARIOS=("${DEFAULT_SCENARIOS[@]}")
 fi
 for scenario in "${ONLY_SCENARIOS[@]}"; do
   case "$scenario" in
-    analyzer|ui-suite|native-live|direct-live|live-media|continuity|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
+    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
     *) echo "Error: unknown scenario: $scenario" >&2; exit 2 ;;
   esac
 done
@@ -327,6 +328,13 @@ run_scenario() {
       test_identifiers=("iOSUITests/PiPLiveDeviceUITests/test_liveMediaQualificationAcrossNativeAndDirectBackends")
       route="PiPLiveValidation"
       pip_url="$BASE_URL/live/live.ts"
+      selected_xctestrun="$DESTINATION_XCTESTRUN"
+      ;;
+    background-audio)
+      test_identifiers=("iOSUITests/PiPLiveDeviceUITests/test_backgroundAudioQualificationWhileAppIsBackgrounded")
+      route="PiPLiveValidation"
+      pip_url="$BASE_URL/live/live.ts"
+      rendering_path="native"
       selected_xctestrun="$DESTINATION_XCTESTRUN"
       ;;
     continuity)
@@ -537,6 +545,10 @@ PY
     live-media)
       qualification_scenario="live-media"
       qualification_attachment="qualification-live-media.json"
+      ;;
+    background-audio)
+      qualification_scenario="background-audio"
+      qualification_attachment="qualification-background-audio.json"
       ;;
   esac
   if [[ -n "$qualification_scenario" ]]; then

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -275,6 +275,49 @@ class QualificationEvidenceTests(unittest.TestCase):
                 evidence["backendResults"], {"native": "pass", "direct": "pass"}
             )
 
+    def test_materializes_background_audio_counter_evidence(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.make_export(
+                root,
+                {
+                    "formatVersion": 1,
+                    "scenario": "background-audio",
+                    "events": {
+                        "started": True,
+                        "unexpectedStopCount": 0,
+                        "order": "pass",
+                    },
+                    "audioContinuity": "pass",
+                    "backgroundApplicationState": True,
+                    "measurementMethod": "libvlc-played-audio-buffers",
+                    "measurements": {
+                        "playedAudioBuffersBeforeBackground": 100,
+                        "playedAudioBuffersAfterBackground": 180,
+                    },
+                },
+                attachment_name="qualification-background-audio.json",
+                test_identifier="PiPLiveDeviceUITests/test_backgroundAudioQualificationWhileAppIsBackgrounded",
+            )
+            evidence = materialize_evidence.materialize(
+                root,
+                "qualification-background-audio.json",
+                "background-audio",
+                "iphone-minimum",
+                "a" * 64,
+                "b" * 64,
+            )
+            self.assertEqual(evidence["scenario"], "background-audio")
+            self.assertEqual(evidence["hardware"], "iphone-minimum")
+            self.assertTrue(evidence["backgroundApplicationState"])
+            self.assertEqual(
+                evidence["measurementMethod"], "libvlc-played-audio-buffers"
+            )
+            self.assertGreater(
+                evidence["measurements"]["playedAudioBuffersAfterBackground"],
+                evidence["measurements"]["playedAudioBuffersBeforeBackground"],
+            )
+
     def test_rejects_duplicate_attachments_and_forged_identity(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
## Summary

- add a physical-device background-audio qualification lane for native PiP
- sample libVLC played-audio-buffer counters entirely while the app is backgrounded
- require candidate-bound machine-readable evidence with background-state and measurement provenance
- include the lane in the default device matrix and cover materialization with host tests

## Validation

- strict SwiftFormat and SwiftLint checks pass
- Showcase iOS generic-device build-for-testing passes for both architectures
- 21 qualification harness tests pass
- release-integrity checks pass

No milestone issue is closed by this automation-only PR; closure still requires passing candidate-bound hardware evidence.
