### PR TITLE
Automate replacement continuity qualification

### DIFF
--- a/Showcase/Shared/AccessibilityID.swift
+++ b/Showcase/Shared/AccessibilityID.swift
@@ -181,6 +181,18 @@ enum AccessibilityID {
   enum PiPContinuityValidation {
     static let loadVODButton = "pipContinuity.loadVOD"
     static let loadLiveTSButton = "pipContinuity.loadLiveTS"
+    static let stateLabel = "pipContinuity.state"
+    static let generationLabel = "pipContinuity.generation"
+    static let displayedPicturesLabel = "pipContinuity.displayedPictures"
+    static let playedAudioBuffersLabel = "pipContinuity.playedAudioBuffers"
+    static let possibleLabel = "pipContinuity.possible"
+    static let activeLabel = "pipContinuity.active"
+    static let playbackSnapshotLabel = "pipContinuity.playbackSnapshot"
+    static let nativePlaybackSnapshotLabel = "pipContinuity.nativePlaybackSnapshot"
+    static let continuityEventsLabel = "pipContinuity.continuityEvents"
+    static let lifecycleEventsLabel = "pipContinuity.lifecycleEvents"
+    static let replacementMeasurementLabel = "pipContinuity.replacementMeasurement"
+    static let staleSuccessorMutationsLabel = "pipContinuity.staleSuccessorMutations"
   }
 
   enum MatrixHValidation {

--- a/Showcase/UITests/iOS/Tests/PiPContinuityDeviceUITests.swift
+++ b/Showcase/UITests/iOS/Tests/PiPContinuityDeviceUITests.swift
@@ -1,18 +1,117 @@
 import XCTest
 
-/// Physical-device proof that a native AVKit controller survives a media
-/// replacement on the same Player. The local validation stream configuration
-/// is intentionally not committed, so opt in explicitly when those URLs are
-/// available to the device running the test.
+/// Candidate-bound physical-device proof that native PiP survives same-player
+/// media replacement and publishes coherent successor policy and measurements.
 final class PiPContinuityDeviceUITests: ShowcaseIOSTestCase {
+  private struct ReplacementMeasurement {
+    let videoGapMilliseconds: Int
+    let audioGapMilliseconds: Int
+  }
+
+  private struct NativePlaybackSnapshot {
+    let generation: Int
+    let durationMilliseconds: Int
+    let currentTimeMilliseconds: Int
+    let isSeekable: Bool
+  }
+
   func test_nativePiPSurvivesSamePlayerReplacement() throws {
     #if targetEnvironment(simulator)
     throw XCTSkip("System Picture in Picture requires a physical iOS device")
     #else
+    try requireDeviceQualification()
+    openMatrixA()
+    loadInitialVODAndStartPictureInPicture()
+
+    _ = transition(
+      using: AccessibilityID.PiPContinuityValidation.loadLiveTSButton,
+      expectedStream: "liveTS",
+      expectedSnapshot: "unbounded:unseekable:linear",
+      expectedRestoredCount: 1
+    )
+    stopPictureInPictureAndValidateLifecycle(expectedReplacementCount: 1)
+    assertNoLibraryErrors()
+    attachQualificationEvidence(
+      [
+        "formatVersion": 1,
+        "scenario": "replacement",
+        "events": [
+          "controllerReplacementCount": 1,
+          "unattributedStopCount": 0,
+          "order": "pass"
+        ],
+        "controls": "pass",
+        "recoveryOutcome": "preserved"
+      ],
+      scenario: "replacement"
+    )
+    #endif
+  }
+
+  func test_nativePiPReplacementContinuityAcrossVODAndLive() throws {
+    #if targetEnvironment(simulator)
+    throw XCTSkip("System Picture in Picture requires a physical iOS device")
+    #else
+    try requireDeviceQualification()
+    openMatrixA()
+    loadInitialVODAndStartPictureInPicture()
+
+    let vodToLive = transition(
+      using: AccessibilityID.PiPContinuityValidation.loadLiveTSButton,
+      expectedStream: "liveTS",
+      expectedSnapshot: "unbounded:unseekable:linear",
+      expectedRestoredCount: 1
+    )
+    let liveToVOD = transition(
+      using: AccessibilityID.PiPContinuityValidation.loadVODButton,
+      expectedStream: "vod",
+      expectedSnapshot: "finite:seekable:interactive",
+      expectedRestoredCount: 2
+    )
+    let maximumAudioGap = max(
+      vodToLive.audioGapMilliseconds,
+      liveToVOD.audioGapMilliseconds
+    )
+    let maximumVideoGap = max(
+      vodToLive.videoGapMilliseconds,
+      liveToVOD.videoGapMilliseconds
+    )
+    XCTAssertLessThanOrEqual(maximumAudioGap, 5000, "Successor audio exceeded the 5s budget")
+    XCTAssertLessThanOrEqual(maximumVideoGap, 5000, "Successor video exceeded the 5s budget")
+    stopPictureInPictureAndValidateLifecycle(expectedReplacementCount: 2)
+    assertNoLibraryErrors()
+
+    attachQualificationEvidence(
+      [
+        "formatVersion": 1,
+        "scenario": "replacement-continuity",
+        "combinations": [
+          "vodToLive": "pass",
+          "liveToVOD": "pass"
+        ],
+        "snapshotCoherence": "pass",
+        "measurements": [
+          "audioGapMilliseconds": maximumAudioGap,
+          "videoGapMilliseconds": maximumVideoGap
+        ],
+        "audioContinuityWithinBudget": maximumAudioGap <= 5000,
+        "videoContinuityWithinBudget": maximumVideoGap <= 5000,
+        "controls": "pass",
+        "recoveryOutcome": "preserved",
+        "staleSuccessorMutations": 0
+      ],
+      scenario: "replacement-continuity"
+    )
+    #endif
+  }
+
+  private func requireDeviceQualification() throws {
     guard ProcessInfo.processInfo.environment["SWIFTVLC_PIP_CONTINUITY_DEVICE"] == "YES" else {
       throw XCTSkip("Set SWIFTVLC_PIP_CONTINUITY_DEVICE=YES after configuring Matrix A streams")
     }
+  }
 
+  private func openMatrixA() {
     addUIInterruptionMonitor(withDescription: "Local network permission") { alert in
       let allow = alert.buttons["Allow"]
       guard allow.exists else { return false }
@@ -22,37 +121,274 @@ final class PiPContinuityDeviceUITests: ShowcaseIOSTestCase {
 
     launch(route: .harnessHome)
     app.tap()
-
     let matrix = app.buttons["(a) PiP survival across load()"]
     XCTAssertTrue(matrix.waitForExistence(timeout: 5))
     matrix.tap()
+  }
 
-    let initialMedia = app.buttons[AccessibilityID.PiPContinuityValidation.loadVODButton]
-    XCTAssertTrue(initialMedia.isHittable)
-    initialMedia.tap()
-
-    let startPiP = app.buttons["Start PiP"]
-    reveal(startPiP, swiping: .down)
-    waitUntilEnabled(startPiP, timeout: 20)
-    startPiP.tap()
-
-    let stopPiP = app.buttons["Stop PiP"]
-    XCTAssertTrue(stopPiP.waitForExistence(timeout: 10), "Native PiP did not become active")
-
-    let successorMedia = app.buttons[AccessibilityID.PiPContinuityValidation.loadLiveTSButton]
-    XCTAssertTrue(successorMedia.isHittable)
-    successorMedia.tap()
-
-    let restored = app.descendants(matching: .any)["validation.matrixA.continuity"]
-    let restoredPredicate = NSPredicate { _, _ in restored.label.contains("restored") }
-    let restoredExpectation = expectation(for: restoredPredicate, evaluatedWith: NSObject())
-    XCTAssertTrue(
-      XCTWaiter.wait(for: [restoredExpectation], timeout: 10) == .completed,
-      "No restored continuity event was recorded after same-player replacement"
+  private func loadInitialVODAndStartPictureInPicture() {
+    app.buttons[AccessibilityID.PiPContinuityValidation.loadVODButton].tap()
+    waitForLabel(state, equals: "playing", timeout: 20)
+    waitForLabel(playbackSnapshot, equals: "finite:seekable:interactive", timeout: 15)
+    _ = waitForNativePlaybackSnapshot(
+      generation: generation.label,
+      expectsFiniteDuration: true,
+      expectsSeekable: true,
+      timeout: 15
     )
-    XCTAssertTrue(stopPiP.exists, "The AVKit session stopped during media replacement")
-    assertNoLibraryErrors()
-    #endif
+    _ = waitForIntegerLabel(displayedPictures, greaterThan: 0, timeout: 10)
+    _ = waitForIntegerLabel(playedAudioBuffers, greaterThan: 0, timeout: 10)
+    waitForLabel(possible, equals: "yes", timeout: 15)
+
+    let start = app.buttons["Start PiP"]
+    reveal(start, swiping: .down)
+    waitUntilEnabled(start, timeout: 20)
+    start.tap()
+    waitForLabel(active, equals: "yes", timeout: 10)
+    waitForOccurrence("didStart", count: 1, in: lifecycleEvents, timeout: 10)
+  }
+
+  private func transition(
+    using buttonIdentifier: String,
+    expectedStream: String,
+    expectedSnapshot: String,
+    expectedRestoredCount: Int
+  ) -> ReplacementMeasurement {
+    let previousGeneration = generation.label
+    let button = app.buttons[buttonIdentifier]
+    XCTAssertTrue(button.waitForExistence(timeout: 5))
+    button.tap()
+
+    waitForLabelChange(generation, from: previousGeneration, timeout: 5)
+    waitForLabel(playbackSnapshot, equals: expectedSnapshot, timeout: 15)
+    waitForOccurrence(
+      "restored",
+      count: expectedRestoredCount,
+      in: continuityEvents,
+      timeout: 15
+    )
+    _ = waitForNativePlaybackSnapshot(
+      generation: generation.label,
+      expectsFiniteDuration: expectedSnapshot.hasPrefix("finite:"),
+      expectsSeekable: expectedSnapshot.contains(":seekable:"),
+      timeout: 15
+    )
+    let measurement = waitForReplacementMeasurement(
+      stream: expectedStream,
+      generation: generation.label,
+      timeout: 15
+    )
+    waitForLabel(active, equals: "yes", timeout: 5)
+    waitForLabel(staleSuccessorMutations, equals: "0", timeout: 5)
+    waitForLabel(state, equals: "playing", timeout: 10)
+    _ = waitForIntegerLabel(displayedPictures, greaterThan: 0, timeout: 5)
+    _ = waitForIntegerLabel(playedAudioBuffers, greaterThan: 0, timeout: 5)
+
+    XCUIDevice.shared.press(.home)
+    if let failure = captureSystemPictureInPictureMotion() {
+      XCTFail("\(expectedStream) replacement PiP motion failed: \(failure)")
+    }
+    app.activate()
+    waitForLabel(active, equals: "yes", timeout: 10)
+    waitForLabel(state, equals: "playing", timeout: 10)
+    return measurement
+  }
+
+  private func stopPictureInPictureAndValidateLifecycle(expectedReplacementCount: Int) {
+    XCTAssertEqual(restoredEventCount, expectedReplacementCount)
+    let stop = app.buttons["Stop PiP"]
+    reveal(stop, swiping: .down)
+    XCTAssertTrue(stop.waitForExistence(timeout: 5))
+    stop.tap()
+    waitForLabel(active, equals: "no", timeout: 10)
+    waitForOccurrence("didStop:programmatic", count: 1, in: lifecycleEvents, timeout: 10)
+    XCTAssertTrue(
+      lifecycleEvents.label.hasPrefix(
+        "willStart|didStart|willStop:programmatic|didStop:programmatic"
+      ),
+      "PiP lifecycle was not ordered: \(lifecycleEvents.label)"
+    )
+    waitForLabel(staleSuccessorMutations, equals: "0", timeout: 5)
+  }
+
+  private func waitForLabelChange(
+    _ element: XCUIElement,
+    from previous: String,
+    timeout: TimeInterval
+  ) {
+    let predicate = NSPredicate { _, _ in
+      element.exists && element.label != previous
+    }
+    let expectation = expectation(for: predicate, evaluatedWith: NSObject())
+    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: timeout), .completed)
+  }
+
+  private func waitForOccurrence(
+    _ value: String,
+    count: Int,
+    in element: XCUIElement,
+    timeout: TimeInterval
+  ) {
+    let predicate = NSPredicate { _, _ in
+      element.label.split(separator: "|").filter { $0.contains(value) }.count >= count
+    }
+    let expectation = expectation(for: predicate, evaluatedWith: NSObject())
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [expectation], timeout: timeout),
+      .completed,
+      "Expected \(count) \(value) event(s), got: \(element.label)"
+    )
+  }
+
+  private func waitForReplacementMeasurement(
+    stream: String,
+    generation: String,
+    timeout: TimeInterval
+  ) -> ReplacementMeasurement {
+    let prefix = "complete:\(stream):\(generation):"
+    let predicate = NSPredicate { _, _ in
+      self.replacementMeasurement.label.hasPrefix(prefix)
+    }
+    let expectation = expectation(for: predicate, evaluatedWith: NSObject())
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [expectation], timeout: timeout),
+      .completed,
+      "No successor A/V measurement arrived: \(replacementMeasurement.label)"
+    )
+    let components = replacementMeasurement.label.split(separator: ":")
+    guard
+      components.count == 5,
+      let video = Int(components[3]),
+      let audio = Int(components[4])
+    else {
+      XCTFail("Malformed replacement measurement: \(replacementMeasurement.label)")
+      return ReplacementMeasurement(videoGapMilliseconds: Int.max, audioGapMilliseconds: Int.max)
+    }
+    return ReplacementMeasurement(videoGapMilliseconds: video, audioGapMilliseconds: audio)
+  }
+
+  private func waitForNativePlaybackSnapshot(
+    generation: String,
+    expectsFiniteDuration: Bool,
+    expectsSeekable: Bool,
+    timeout: TimeInterval
+  ) -> NativePlaybackSnapshot {
+    let expectedGeneration = Int(generation.split(separator: " ").last ?? "")
+    let predicate = NSPredicate { _, _ in
+      guard
+        let expectedGeneration,
+        let snapshot = self.parseNativePlaybackSnapshot(self.nativePlaybackSnapshot.label)
+      else { return false }
+      let durationMatches = expectsFiniteDuration
+        ? snapshot.durationMilliseconds > 0
+        : snapshot.durationMilliseconds == 0
+      return snapshot.generation == expectedGeneration
+        && snapshot.currentTimeMilliseconds >= 0
+        && snapshot.isSeekable == expectsSeekable
+        && durationMatches
+    }
+    let expectation = expectation(for: predicate, evaluatedWith: NSObject())
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [expectation], timeout: timeout),
+      .completed,
+      "Native playback snapshot did not converge: \(nativePlaybackSnapshot.label)"
+    )
+    guard let snapshot = parseNativePlaybackSnapshot(nativePlaybackSnapshot.label) else {
+      XCTFail("Malformed native playback snapshot: \(nativePlaybackSnapshot.label)")
+      return NativePlaybackSnapshot(
+        generation: -1,
+        durationMilliseconds: -1,
+        currentTimeMilliseconds: -1,
+        isSeekable: false
+      )
+    }
+    return snapshot
+  }
+
+  private func parseNativePlaybackSnapshot(_ value: String) -> NativePlaybackSnapshot? {
+    let components = value.split(separator: ":")
+    guard
+      components.count == 4,
+      let generation = Int(components[0]),
+      let duration = Int(components[1]),
+      let time = Int(components[2])
+    else { return nil }
+    let seekable = String(components[3])
+    guard ["yes", "no"].contains(seekable) else { return nil }
+    return NativePlaybackSnapshot(
+      generation: generation,
+      durationMilliseconds: duration,
+      currentTimeMilliseconds: time,
+      isSeekable: seekable == "yes"
+    )
+  }
+
+  private var state: XCUIElement {
+    app.descendants(matching: .any)[AccessibilityID.PiPContinuityValidation.stateLabel]
+  }
+
+  private var generation: XCUIElement {
+    app.descendants(matching: .any)[AccessibilityID.PiPContinuityValidation.generationLabel]
+  }
+
+  private var displayedPictures: XCUIElement {
+    app.descendants(matching: .any)[
+      AccessibilityID.PiPContinuityValidation.displayedPicturesLabel
+    ]
+  }
+
+  private var playedAudioBuffers: XCUIElement {
+    app.descendants(matching: .any)[
+      AccessibilityID.PiPContinuityValidation.playedAudioBuffersLabel
+    ]
+  }
+
+  private var possible: XCUIElement {
+    app.descendants(matching: .any)[AccessibilityID.PiPContinuityValidation.possibleLabel]
+  }
+
+  private var active: XCUIElement {
+    app.descendants(matching: .any)[AccessibilityID.PiPContinuityValidation.activeLabel]
+  }
+
+  private var playbackSnapshot: XCUIElement {
+    app.descendants(matching: .any)[
+      AccessibilityID.PiPContinuityValidation.playbackSnapshotLabel
+    ]
+  }
+
+  private var continuityEvents: XCUIElement {
+    app.descendants(matching: .any)[
+      AccessibilityID.PiPContinuityValidation.continuityEventsLabel
+    ]
+  }
+
+  private var nativePlaybackSnapshot: XCUIElement {
+    app.descendants(matching: .any)[
+      AccessibilityID.PiPContinuityValidation.nativePlaybackSnapshotLabel
+    ]
+  }
+
+  private var lifecycleEvents: XCUIElement {
+    app.descendants(matching: .any)[
+      AccessibilityID.PiPContinuityValidation.lifecycleEventsLabel
+    ]
+  }
+
+  private var replacementMeasurement: XCUIElement {
+    app.descendants(matching: .any)[
+      AccessibilityID.PiPContinuityValidation.replacementMeasurementLabel
+    ]
+  }
+
+  private var staleSuccessorMutations: XCUIElement {
+    app.descendants(matching: .any)[
+      AccessibilityID.PiPContinuityValidation.staleSuccessorMutationsLabel
+    ]
+  }
+
+  private var restoredEventCount: Int {
+    continuityEvents.label.split(separator: "|").filter { $0.contains("restored") }.count
   }
 
   private enum ScrollDirection {
@@ -63,8 +399,10 @@ final class PiPContinuityDeviceUITests: ShowcaseIOSTestCase {
   private func reveal(_ element: XCUIElement, swiping direction: ScrollDirection) {
     for _ in 0..<8 where !element.isHittable {
       switch direction {
-      case .up: app.swipeUp()
-      case .down: app.swipeDown()
+      case .up:
+        app.swipeUp()
+      case .down:
+        app.swipeDown()
       }
     }
   }

--- a/Showcase/iOS/ValidationHarness/MatrixScreenA.swift
+++ b/Showcase/iOS/ValidationHarness/MatrixScreenA.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import SwiftVLC
+@_spi(Qualification) import SwiftVLC
 
 private let readMe = """
 Tap a channel button to start playback, then start PiP from the button \
@@ -18,6 +18,14 @@ struct MatrixScreenA: View {
   @State private var player = Player()
   @State private var pip: PiPController?
   @State private var continuityStatus = "none"
+  @State private var continuityEvents: [String] = []
+  @State private var lifecycleEvents: [String] = []
+  @State private var latestGeneration: PlaybackGeneration?
+  @State private var replacementMeasurement = "none"
+  @State private var replacementProbe: Task<Void, Never>?
+  @State private var pendingReplacement: PendingReplacement?
+  @State private var staleSuccessorMutations = 0
+  @State private var hasLoadedMedia = false
   @State private var log: [LogLine] = []
 
   private struct LogLine: Identifiable {
@@ -25,12 +33,19 @@ struct MatrixScreenA: View {
     let text: String
   }
 
+  private struct PendingReplacement {
+    let stream: String
+    let generation: PlaybackGeneration
+    let startedAt: ContinuousClock.Instant
+  }
+
   private var zapTargets: [(key: HarnessStreams.Key, url: URL)] {
     streams.configured.filter { [.liveTS, .hlsLive, .vod].contains($0.key) }
   }
 
   var body: some View {
-    Form {
+    _ = player.currentTime
+    return Form {
       Section { AboutView(readMe: readMe) }
 
       Section {
@@ -44,7 +59,9 @@ struct MatrixScreenA: View {
       Section("Picture in Picture") {
         if let pip {
           LabeledContent("Possible", value: pip.isPossible ? "yes" : "no")
+            .accessibilityIdentifier(AccessibilityID.PiPContinuityValidation.possibleLabel)
           LabeledContent("Active", value: pip.isActive ? "yes" : "no")
+            .accessibilityIdentifier(AccessibilityID.PiPContinuityValidation.activeLabel)
           LabeledContent("Continuity", value: continuityStatus)
             .accessibilityIdentifier("validation.matrixA.continuity")
           Button(
@@ -57,6 +74,60 @@ struct MatrixScreenA: View {
           Text("Preparing…")
             .foregroundStyle(.secondary)
         }
+      }
+
+      Section("Measured state") {
+        LabeledContent("Playback", value: String(describing: player.state))
+          .accessibilityIdentifier(AccessibilityID.PiPContinuityValidation.stateLabel)
+        LabeledContent(
+          "Media generation",
+          value: player.playbackQualificationGeneration.description
+        )
+        .accessibilityIdentifier(AccessibilityID.PiPContinuityValidation.generationLabel)
+        LabeledContent(
+          "Displayed pictures",
+          value: String(player.statistics?.displayedPictures ?? 0)
+        )
+        .accessibilityIdentifier(
+          AccessibilityID.PiPContinuityValidation.displayedPicturesLabel
+        )
+        LabeledContent(
+          "Played audio buffers",
+          value: String(player.statistics?.playedAudioBuffers ?? 0)
+        )
+        .accessibilityIdentifier(
+          AccessibilityID.PiPContinuityValidation.playedAudioBuffersLabel
+        )
+        LabeledContent("Playback snapshot", value: playbackSnapshot)
+          .accessibilityIdentifier(
+            AccessibilityID.PiPContinuityValidation.playbackSnapshotLabel
+          )
+        LabeledContent("Native atomic snapshot", value: nativePlaybackSnapshot)
+          .accessibilityIdentifier(
+            AccessibilityID.PiPContinuityValidation.nativePlaybackSnapshotLabel
+          )
+        LabeledContent(
+          "Continuity events",
+          value: continuityEvents.isEmpty ? "none" : continuityEvents.joined(separator: "|")
+        )
+        .accessibilityIdentifier(
+          AccessibilityID.PiPContinuityValidation.continuityEventsLabel
+        )
+        LabeledContent(
+          "Lifecycle events",
+          value: lifecycleEvents.isEmpty ? "none" : lifecycleEvents.joined(separator: "|")
+        )
+        .accessibilityIdentifier(
+          AccessibilityID.PiPContinuityValidation.lifecycleEventsLabel
+        )
+        LabeledContent("Replacement measurement", value: replacementMeasurement)
+          .accessibilityIdentifier(
+            AccessibilityID.PiPContinuityValidation.replacementMeasurementLabel
+          )
+        LabeledContent("Stale successor mutations", value: String(staleSuccessorMutations))
+          .accessibilityIdentifier(
+            AccessibilityID.PiPContinuityValidation.staleSuccessorMutationsLabel
+          )
       }
 
       Section("Channel zap") {
@@ -86,12 +157,21 @@ struct MatrixScreenA: View {
       guard let pip else { return }
       await observeContinuityEvents(from: pip)
     }
+    .task(id: pip.map(ObjectIdentifier.init)) {
+      guard let pip else { return }
+      for await envelope in pip.pipEventEnvelopes {
+        lifecycleEvents.append(lifecycleName(envelope.event))
+      }
+    }
     .onChange(of: pip?.isActive) { _, isActive in
       if let isActive {
         append("pip.isActive → \(isActive)")
       }
     }
-    .onDisappear { player.stop() }
+    .onDisappear {
+      replacementProbe?.cancel()
+      player.stop()
+    }
   }
 
   @ViewBuilder
@@ -108,7 +188,26 @@ struct MatrixScreenA: View {
 
   private func load(_ target: (key: HarnessStreams.Key, url: URL)) {
     append("load() → \(target.key.rawValue)")
-    try? player.play(url: target.url)
+    replacementProbe?.cancel()
+    let replacementStartedAt = hasLoadedMedia ? ContinuousClock.now : nil
+    do {
+      try player.play(url: target.url)
+      let generation = player.playbackQualificationGeneration
+      latestGeneration = generation
+      if let replacementStartedAt {
+        pendingReplacement = PendingReplacement(
+          stream: target.key.rawValue,
+          generation: generation,
+          startedAt: replacementStartedAt
+        )
+        replacementMeasurement = "pending:\(target.key.rawValue):\(generation)"
+      } else {
+        hasLoadedMedia = true
+      }
+    } catch {
+      replacementMeasurement = "failed:\(error)"
+      append("load() failed → \(error)")
+    }
   }
 
   private var logSection: some View {
@@ -146,11 +245,87 @@ struct MatrixScreenA: View {
 
   private func observeContinuityEvents(from pip: PiPController) async {
     for await event in pip.pipContinuityEvents {
+      if let latestGeneration, event.mediaGeneration < latestGeneration {
+        staleSuccessorMutations += 1
+      }
       continuityStatus = "\(event.outcome)"
+      let elapsedMilliseconds = Int(event.elapsed / .milliseconds(1))
+      continuityEvents.append(
+        "\(event.outcome):\(event.previousMediaGeneration):\(event.mediaGeneration):"
+          + "\(event.controllerGeneration):\(elapsedMilliseconds)"
+      )
+      if case .restored = event.outcome {
+        completeReplacementProbe(for: event.mediaGeneration)
+      }
       let detail = "continuity \(event.outcome): \(event.previousMediaGeneration) → "
         + "\(event.mediaGeneration), controller \(event.controllerGeneration), "
         + "elapsed \(event.elapsed)"
       append(detail)
+    }
+  }
+
+  private var playbackSnapshot: String {
+    guard let pip else { return "none" }
+    let snapshot = pip.playbackQualificationSnapshot
+    let duration = snapshot.durationMilliseconds == nil ? "unbounded" : "finite"
+    let seekable = snapshot.isSeekable ? "seekable" : "unseekable"
+    let controls = snapshot.requiresLinearPlayback ? "linear" : "interactive"
+    return "\(duration):\(seekable):\(controls)"
+  }
+
+  private var nativePlaybackSnapshot: String {
+    guard let snapshot = pip?.nativePlaybackQualificationSnapshot else { return "none" }
+    return "\(snapshot.mediaGeneration):\(snapshot.durationMilliseconds):"
+      + "\(snapshot.currentTimeMilliseconds):\(snapshot.isSeekable ? "yes" : "no")"
+  }
+
+  private func completeReplacementProbe(for generation: PlaybackGeneration) {
+    guard
+      let pendingReplacement,
+      pendingReplacement.generation == generation
+    else { return }
+    self.pendingReplacement = nil
+    replacementProbe = Task { @MainActor in
+      var videoGapMilliseconds: Int?
+      var audioGapMilliseconds: Int?
+      while pendingReplacement.startedAt.duration(to: .now) < .seconds(15) {
+        guard
+          !Task.isCancelled,
+          player.playbackQualificationGeneration == generation
+        else { return }
+        let statistics = player.statistics
+        let elapsed = Int(
+          pendingReplacement.startedAt.duration(to: .now) / .milliseconds(1)
+        )
+        if videoGapMilliseconds == nil, statistics?.displayedPictures ?? 0 > 0 {
+          videoGapMilliseconds = elapsed
+        }
+        if audioGapMilliseconds == nil, statistics?.playedAudioBuffers ?? 0 > 0 {
+          audioGapMilliseconds = elapsed
+        }
+        if let videoGapMilliseconds, let audioGapMilliseconds {
+          replacementMeasurement = "complete:\(pendingReplacement.stream):\(generation):"
+            + "\(videoGapMilliseconds):\(audioGapMilliseconds)"
+          return
+        }
+        try? await Task.sleep(for: .milliseconds(50))
+      }
+      replacementMeasurement = "timed-out:\(pendingReplacement.stream):\(generation)"
+    }
+  }
+
+  private func lifecycleName(_ event: PiPEvent) -> String {
+    switch event {
+    case .willStart:
+      "willStart"
+    case .didStart:
+      "didStart"
+    case .willStop(let reason):
+      "willStop:\(String(describing: reason))"
+    case .didStop(let reason):
+      "didStop:\(String(describing: reason))"
+    case .failedToStart:
+      "failedToStart"
     }
   }
 

--- a/Sources/SwiftVLC/PiP/PiPController+Validation.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Validation.swift
@@ -101,15 +101,17 @@ extension PiPController {
     var duration: Int64 = 0
     var time: Int64 = 0
     var seekable = ObjCBool(false)
+    var generation: UInt64 = 0
     guard
-      nativeBackend.mediaController.mediaPlaybackSnapshot(
+      nativeBackend.mediaController.qualificationPlaybackSnapshot(
         length: &duration,
         time: &time,
-        seekable: &seekable
+        seekable: &seekable,
+        generation: &generation
       )
     else { return nil }
     return NativePiPPlaybackQualificationSnapshot(
-      mediaGeneration: nativeBackend.mediaController.mediaPlaybackGeneration(),
+      mediaGeneration: generation,
       durationMilliseconds: duration,
       currentTimeMilliseconds: time,
       isSeekable: seekable.boolValue

--- a/Sources/SwiftVLC/PiP/PiPController+Validation.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Validation.swift
@@ -57,6 +57,16 @@ public struct PiPPlaybackQualificationSnapshot: Sendable, Equatable {
   public let isSeekable: Bool
 }
 
+/// One atomic engine query used to prove native PiP never combines playback
+/// values from different media generations during replacement.
+@_spi(Qualification)
+public struct NativePiPPlaybackQualificationSnapshot: Sendable, Equatable {
+  public let mediaGeneration: UInt64
+  public let durationMilliseconds: Int64
+  public let currentTimeMilliseconds: Int64
+  public let isSeekable: Bool
+}
+
 extension PiPController {
   /// A snapshot of the iOS native PiP backend's private wiring, or
   /// `nil` when this controller doesn't drive the native backend (the
@@ -81,6 +91,38 @@ extension PiPController {
       durationMilliseconds: playbackStateObservation.durationMilliseconds,
       isSeekable: playbackStateObservation.isSeekable
     )
+  }
+
+  /// The exact atomic length/time/seekability query exported to libVLC's
+  /// native PiP module, paired with its current media identity.
+  @_spi(Qualification)
+  public var nativePlaybackQualificationSnapshot: NativePiPPlaybackQualificationSnapshot? {
+    guard let nativeBackend else { return nil }
+    var duration: Int64 = 0
+    var time: Int64 = 0
+    var seekable = ObjCBool(false)
+    guard
+      nativeBackend.mediaController.mediaPlaybackSnapshot(
+        length: &duration,
+        time: &time,
+        seekable: &seekable
+      )
+    else { return nil }
+    return NativePiPPlaybackQualificationSnapshot(
+      mediaGeneration: nativeBackend.mediaController.mediaPlaybackGeneration(),
+      durationMilliseconds: duration,
+      currentTimeMilliseconds: time,
+      isSeekable: seekable.boolValue
+    )
+  }
+}
+
+extension Player {
+  /// The current media identity used by the in-repo replacement qualification
+  /// lane to reject measurements and callbacks from an outgoing item.
+  @_spi(Qualification)
+  public var playbackQualificationGeneration: PlaybackGeneration {
+    generation
   }
 }
 

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -1696,12 +1696,16 @@ final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling,
   // uses to publish its successor. That closes the interval between copying a
   // raw pointer and entering libVLC without ever blocking on the main actor.
 
-  private func retainedCallbackPlayer() -> OpaquePointer? {
+  private func retainedCallbackPlaybackIdentity() -> (pointer: OpaquePointer, generation: UInt64)? {
     callbackSnapshot.withLock { snapshot in
       guard let pointer = snapshot.playerPointer else { return nil }
       _ = libvlc_media_player_retain(pointer)
-      return pointer
+      return (pointer, snapshot.playbackGeneration?.value ?? 0)
     }
+  }
+
+  private func retainedCallbackPlayer() -> OpaquePointer? {
+    retainedCallbackPlaybackIdentity()?.pointer
   }
 
   @objc(mediaPlaybackSnapshotWithLength:time:seekable:)
@@ -1710,12 +1714,32 @@ final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling,
     time: UnsafeMutablePointer<Int64>,
     seekable: UnsafeMutablePointer<ObjCBool>
   ) -> Bool {
-    guard let pointer = retainedCallbackPlayer() else {
+    qualificationPlaybackSnapshot(
+      length: length,
+      time: time,
+      seekable: seekable,
+      generation: nil
+    )
+  }
+
+  /// Reads playback values and the media identity from one retained callback
+  /// snapshot. Keeping the generation in this operation prevents replacement
+  /// from pairing a successor identity with outgoing-player measurements.
+  func qualificationPlaybackSnapshot(
+    length: UnsafeMutablePointer<Int64>,
+    time: UnsafeMutablePointer<Int64>,
+    seekable: UnsafeMutablePointer<ObjCBool>,
+    generation: UnsafeMutablePointer<UInt64>?
+  ) -> Bool {
+    guard let identity = retainedCallbackPlaybackIdentity() else {
       length.pointee = 0
       time.pointee = 0
       seekable.pointee = false
+      generation?.pointee = 0
       return false
     }
+    let pointer = identity.pointer
+    generation?.pointee = identity.generation
     defer { libvlc_media_player_release(pointer) }
 
     var snapshot = swiftvlc_media_player_playback_snapshot_t()

--- a/Tests/SwiftVLCTests/PiP/PiPCallbackForwardProgressTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPCallbackForwardProgressTests.swift
@@ -110,17 +110,20 @@ struct PiPCallbackForwardProgressTests {
     var length: Int64 = 123
     var time: Int64 = 456
     var seekable = ObjCBool(true)
+    var generation: UInt64 = 789
 
-    let captured = controller.mediaPlaybackSnapshot(
+    let captured = controller.qualificationPlaybackSnapshot(
       length: &length,
       time: &time,
-      seekable: &seekable
+      seekable: &seekable,
+      generation: &generation
     )
 
     #expect(!captured)
     #expect(length == 0)
     #expect(time == 0)
     #expect(!seekable.boolValue)
+    #expect(generation == 0)
   }
   #endif
 

--- a/Tests/SwiftVLCTests/PiP/PiPQualificationSnapshotTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPQualificationSnapshotTests.swift
@@ -23,7 +23,15 @@ extension Integration {
           isSeekable: false
         )
       )
-      #expect(native.nativePlaybackQualificationSnapshot == nil)
+      expectNoDifference(
+        native.nativePlaybackQualificationSnapshot,
+        NativePiPPlaybackQualificationSnapshot(
+          mediaGeneration: nativePlayer.playbackQualificationGeneration.value,
+          durationMilliseconds: 0,
+          currentTimeMilliseconds: 0,
+          isSeekable: false
+        )
+      )
 
       let directPlayer = Player(instance: TestInstance.shared)
       let direct = PiPController(player: directPlayer)

--- a/Tests/SwiftVLCTests/PiP/PiPQualificationSnapshotTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPQualificationSnapshotTests.swift
@@ -23,6 +23,7 @@ extension Integration {
           isSeekable: false
         )
       )
+      #expect(native.nativePlaybackQualificationSnapshot == nil)
 
       let directPlayer = Player(instance: TestInstance.shared)
       let direct = PiPController(player: directPlayer)
@@ -38,6 +39,7 @@ extension Integration {
           isSeekable: true
         )
       )
+      #expect(direct.nativePlaybackQualificationSnapshot == nil)
     }
   }
 }

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -88,7 +88,10 @@ VOD-to-live-to-VOD sequence on the same player while native PiP is active. It
 records the successor generation, AVKit playback-policy snapshot, first video
 and audio output gaps, PiP motion, ordered lifecycle, and any stale successor
 event that escaped generation filtering. The two tests materialize independent
-`replacement` and `replacement-continuity` rows from the same device run.
+`replacement` and `replacement-continuity` rows from the same device run on
+`iphone-current`. Other hardware runs only the matrix-wide `replacement` test
+and row. Multi-row evidence is committed to the report only after every
+expected attachment materializes successfully.
 
 The HLS seek lane is another complete machine-readable matrix slice. It
 executes forward, backward, and absolute seeks, measures the return of decoded

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -83,6 +83,13 @@ and native PiP is active. A row is emitted only when played audio buffers
 increased during that interval, PiP remained active with ordered lifecycle
 events, and the app and host logs contain no library error records.
 
+The continuity lane performs one focused VOD-to-live replacement and a second
+VOD-to-live-to-VOD sequence on the same player while native PiP is active. It
+records the successor generation, AVKit playback-policy snapshot, first video
+and audio output gaps, PiP motion, ordered lifecycle, and any stale successor
+event that escaped generation filtering. The two tests materialize independent
+`replacement` and `replacement-continuity` rows from the same device run.
+
 The HLS seek lane is another complete machine-readable matrix slice. It
 executes forward, backward, and absolute seeks, measures the return of decoded
 video, checks ordered PiP continuity, samples real system-PiP motion after each

--- a/scripts/qualification/assemble-record.py
+++ b/scripts/qualification/assemble-record.py
@@ -138,6 +138,8 @@ def assemble(
     rows: dict[tuple[str, str], tuple[dict, Path]] = {}
     for report_path in report_paths:
         report = load_object(report_path, "device report")
+        if report.get("result") != "pass":
+            raise AssemblyError(f"report {report_path} did not pass")
         if report.get("qualificationEligibleEnvironment") is not True:
             raise AssemblyError(f"report {report_path} is not from a qualifying environment")
         if report.get("mode") != "qualification":

--- a/scripts/qualification/matrix.json
+++ b/scripts/qualification/matrix.json
@@ -167,12 +167,18 @@
         "snapshotCoherence",
         "measurements.audioGapMilliseconds",
         "measurements.videoGapMilliseconds",
+        "audioContinuityWithinBudget",
+        "videoContinuityWithinBudget",
         "controls",
         "recoveryOutcome",
         "staleSuccessorMutations"
       ],
       "expectedEvidenceValues": {
+        "combinations.vodToLive": "pass",
+        "combinations.liveToVOD": "pass",
         "snapshotCoherence": "pass",
+        "audioContinuityWithinBudget": true,
+        "videoContinuityWithinBudget": true,
         "staleSuccessorMutations": 0
       },
       "allowedEvidenceValues": {

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -338,10 +338,11 @@ run_scenario() {
       selected_xctestrun="$DESTINATION_XCTESTRUN"
       ;;
     continuity)
-      test_identifiers=(
-        "iOSUITests/PiPContinuityDeviceUITests/test_nativePiPSurvivesSamePlayerReplacement"
-        "iOSUITests/PiPContinuityDeviceUITests/test_nativePiPReplacementContinuityAcrossVODAndLive"
-      )
+      test_identifiers=("iOSUITests/PiPContinuityDeviceUITests/test_nativePiPSurvivesSamePlayerReplacement")
+      if jq -e '.selected.matchingHardwareRows | index("iphone-current") != null' \
+          "$OUTPUT_DIR/device.json" >/dev/null; then
+        test_identifiers+=("iOSUITests/PiPContinuityDeviceUITests/test_nativePiPReplacementContinuityAcrossVODAndLive")
+      fi
       route="HarnessHome"
       selected_xctestrun="$DESTINATION_XCTESTRUN"
       ;;
@@ -554,11 +555,13 @@ PY
       qualification_attachments=("qualification-background-audio.json")
       ;;
     continuity)
-      qualification_scenarios=("replacement" "replacement-continuity")
-      qualification_attachments=(
-        "qualification-replacement.json"
-        "qualification-replacement-continuity.json"
-      )
+      qualification_scenarios=("replacement")
+      qualification_attachments=("qualification-replacement.json")
+      if jq -e '.selected.matchingHardwareRows | index("iphone-current") != null' \
+          "$OUTPUT_DIR/device.json" >/dev/null; then
+        qualification_scenarios+=("replacement-continuity")
+        qualification_attachments+=("qualification-replacement-continuity.json")
+      fi
       ;;
   esac
   if [[ ${#qualification_scenarios[@]} -gt 0 ]]; then
@@ -568,6 +571,8 @@ PY
       local attachments="$OUTPUT_DIR/$scenario-attachments"
       local hardware_id evidence_file evidence_relative export_status materialize_status
       local evidence_index qualification_scenario qualification_attachment
+      local materialized_scenarios=()
+      local materialized_evidence=()
       local materialized_count=0
       set +e
       xcrun xcresulttool export attachments \
@@ -600,10 +605,17 @@ PY
             continue
           fi
           materialized_count=$((materialized_count + 1))
-          python3 - \
-              "$OUTPUT_DIR/device.json" "$QUALIFICATION_ROWS" "$evidence_relative" \
-              "$FIXTURE_MANIFEST_CHECKSUM" "$((ended - started))" \
-              "$qualification_scenario" <<'PY'
+          materialized_scenarios+=("$qualification_scenario")
+          materialized_evidence+=("$evidence_relative")
+        done
+        if [[ "$materialized_count" -eq "${#qualification_scenarios[@]}" ]]; then
+          evidence_status="captured"
+          for evidence_index in "${!materialized_scenarios[@]}"; do
+            python3 - \
+                "$OUTPUT_DIR/device.json" "$QUALIFICATION_ROWS" \
+                "${materialized_evidence[$evidence_index]}" \
+                "$FIXTURE_MANIFEST_CHECKSUM" "$((ended - started))" \
+                "${materialized_scenarios[$evidence_index]}" <<'PY'
 import json
 import sys
 
@@ -627,9 +639,7 @@ row = {
 with open(rows_path, "a") as output:
     output.write(json.dumps(row, sort_keys=True) + "\n")
 PY
-        done
-        if [[ "$materialized_count" -eq "${#qualification_scenarios[@]}" ]]; then
-          evidence_status="captured"
+          done
         fi
       fi
     fi

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -338,7 +338,10 @@ run_scenario() {
       selected_xctestrun="$DESTINATION_XCTESTRUN"
       ;;
     continuity)
-      test_identifiers=("iOSUITests/PiPContinuityDeviceUITests/test_nativePiPSurvivesSamePlayerReplacement")
+      test_identifiers=(
+        "iOSUITests/PiPContinuityDeviceUITests/test_nativePiPSurvivesSamePlayerReplacement"
+        "iOSUITests/PiPContinuityDeviceUITests/test_nativePiPReplacementContinuityAcrossVODAndLive"
+      )
       route="HarnessHome"
       selected_xctestrun="$DESTINATION_XCTESTRUN"
       ;;
@@ -535,28 +538,37 @@ PY
     fi
   fi
 
-  local qualification_scenario=""
-  local qualification_attachment=""
+  local qualification_scenarios=()
+  local qualification_attachments=()
   case "$scenario" in
     hls-seek)
-      qualification_scenario="native-hls-seek-continuity"
-      qualification_attachment="qualification-native-hls-seek-continuity.json"
+      qualification_scenarios=("native-hls-seek-continuity")
+      qualification_attachments=("qualification-native-hls-seek-continuity.json")
       ;;
     live-media)
-      qualification_scenario="live-media"
-      qualification_attachment="qualification-live-media.json"
+      qualification_scenarios=("live-media")
+      qualification_attachments=("qualification-live-media.json")
       ;;
     background-audio)
-      qualification_scenario="background-audio"
-      qualification_attachment="qualification-background-audio.json"
+      qualification_scenarios=("background-audio")
+      qualification_attachments=("qualification-background-audio.json")
+      ;;
+    continuity)
+      qualification_scenarios=("replacement" "replacement-continuity")
+      qualification_attachments=(
+        "qualification-replacement.json"
+        "qualification-replacement-continuity.json"
+      )
       ;;
   esac
-  if [[ -n "$qualification_scenario" ]]; then
+  if [[ ${#qualification_scenarios[@]} -gt 0 ]]; then
     evidence_status="missing"
     if [[ "$test_status" -eq 0 ]] && [[ "$error_count" -eq 0 ]] \
       && [[ "$log_status" == "captured" ]] && [[ -d "$result_bundle" ]]; then
       local attachments="$OUTPUT_DIR/$scenario-attachments"
       local hardware_id evidence_file evidence_relative export_status materialize_status
+      local evidence_index qualification_scenario qualification_attachment
+      local materialized_count=0
       set +e
       xcrun xcresulttool export attachments \
         --path "$result_bundle" \
@@ -567,26 +579,31 @@ PY
       hardware_id=$(jq -r '.selected.matchingHardwareRows | if length == 1 then .[0] else "" end' \
         "$OUTPUT_DIR/device.json")
       if [[ "$export_status" -eq 0 ]] && [[ -n "$hardware_id" ]]; then
-        evidence_relative="evidence/$qualification_scenario-$hardware_id.json"
-        evidence_file="$OUTPUT_DIR/$evidence_relative"
-        set +e
-        python3 "$SCRIPT_DIR/materialize-evidence.py" \
-          --attachments "$attachments" \
-          --attachment-name "$qualification_attachment" \
-          --scenario "$qualification_scenario" \
-          --hardware "$hardware_id" \
-          --artifact-digest "$ARTIFACT_DIGEST" \
-          --source-digest "$SOURCE_DIGEST" \
-          --output "$evidence_file" \
-          > "$OUTPUT_DIR/$scenario-materialize-evidence.log" 2>&1
-        materialize_status=$?
-        set -e
-        if [[ "$materialize_status" -eq 0 ]]; then
-          evidence_status="captured"
+        for evidence_index in "${!qualification_scenarios[@]}"; do
+          qualification_scenario="${qualification_scenarios[$evidence_index]}"
+          qualification_attachment="${qualification_attachments[$evidence_index]}"
+          evidence_relative="evidence/$qualification_scenario-$hardware_id.json"
+          evidence_file="$OUTPUT_DIR/$evidence_relative"
+          set +e
+          python3 "$SCRIPT_DIR/materialize-evidence.py" \
+            --attachments "$attachments" \
+            --attachment-name "$qualification_attachment" \
+            --scenario "$qualification_scenario" \
+            --hardware "$hardware_id" \
+            --artifact-digest "$ARTIFACT_DIGEST" \
+            --source-digest "$SOURCE_DIGEST" \
+            --output "$evidence_file" \
+            > "$OUTPUT_DIR/$scenario-$qualification_scenario-materialize-evidence.log" 2>&1
+          materialize_status=$?
+          set -e
+          if [[ "$materialize_status" -ne 0 ]]; then
+            continue
+          fi
+          materialized_count=$((materialized_count + 1))
           python3 - \
-            "$OUTPUT_DIR/device.json" "$QUALIFICATION_ROWS" "$evidence_relative" \
-            "$FIXTURE_MANIFEST_CHECKSUM" "$((ended - started))" \
-            "$qualification_scenario" <<'PY'
+              "$OUTPUT_DIR/device.json" "$QUALIFICATION_ROWS" "$evidence_relative" \
+              "$FIXTURE_MANIFEST_CHECKSUM" "$((ended - started))" \
+              "$qualification_scenario" <<'PY'
 import json
 import sys
 
@@ -610,6 +627,9 @@ row = {
 with open(rows_path, "a") as output:
     output.write(json.dumps(row, sort_keys=True) + "\n")
 PY
+        done
+        if [[ "$materialized_count" -eq "${#qualification_scenarios[@]}" ]]; then
+          evidence_status="captured"
         fi
       fi
     fi

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -318,6 +318,78 @@ class QualificationEvidenceTests(unittest.TestCase):
                 evidence["measurements"]["playedAudioBuffersBeforeBackground"],
             )
 
+    def test_materializes_replacement_continuity_evidence(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.make_export(
+                root,
+                {
+                    "formatVersion": 1,
+                    "scenario": "replacement-continuity",
+                    "combinations": {
+                        "vodToLive": "pass",
+                        "liveToVOD": "pass",
+                    },
+                    "snapshotCoherence": "pass",
+                    "measurements": {
+                        "audioGapMilliseconds": 325,
+                        "videoGapMilliseconds": 210,
+                    },
+                    "audioContinuityWithinBudget": True,
+                    "videoContinuityWithinBudget": True,
+                    "controls": "pass",
+                    "recoveryOutcome": "preserved",
+                    "staleSuccessorMutations": 0,
+                },
+                attachment_name="qualification-replacement-continuity.json",
+                test_identifier="PiPContinuityDeviceUITests/test_nativePiPReplacementContinuityAcrossVODAndLive",
+            )
+            evidence = materialize_evidence.materialize(
+                root,
+                "qualification-replacement-continuity.json",
+                "replacement-continuity",
+                "iphone-current",
+                "a" * 64,
+                "b" * 64,
+            )
+            self.assertEqual(evidence["combinations"]["vodToLive"], "pass")
+            self.assertEqual(evidence["combinations"]["liveToVOD"], "pass")
+            self.assertEqual(evidence["staleSuccessorMutations"], 0)
+            self.assertGreater(evidence["measurements"]["audioGapMilliseconds"], 0)
+            self.assertTrue(evidence["audioContinuityWithinBudget"])
+            self.assertTrue(evidence["videoContinuityWithinBudget"])
+
+    def test_materializes_focused_replacement_evidence(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.make_export(
+                root,
+                {
+                    "formatVersion": 1,
+                    "scenario": "replacement",
+                    "events": {
+                        "controllerReplacementCount": 1,
+                        "unattributedStopCount": 0,
+                        "order": "pass",
+                    },
+                    "controls": "pass",
+                    "recoveryOutcome": "preserved",
+                },
+                attachment_name="qualification-replacement.json",
+                test_identifier="PiPContinuityDeviceUITests/test_nativePiPSurvivesSamePlayerReplacement",
+            )
+            evidence = materialize_evidence.materialize(
+                root,
+                "qualification-replacement.json",
+                "replacement",
+                "iphone-current",
+                "a" * 64,
+                "b" * 64,
+            )
+            self.assertEqual(evidence["events"]["controllerReplacementCount"], 1)
+            self.assertEqual(evidence["events"]["unattributedStopCount"], 0)
+            self.assertEqual(evidence["recoveryOutcome"], "preserved")
+
     def test_rejects_duplicate_attachments_and_forged_identity(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -492,6 +492,7 @@ class QualificationRecordAssemblyTests(unittest.TestCase):
                     "qualificationMatrixChecksum": self.matrix_checksum,
                     "qualificationEligibleEnvironment": release_type == "stable",
                     "mode": "qualification" if release_type == "stable" else "exploratory",
+                    "result": "pass",
                     "qualificationRows": [
                         {
                             "scenario": "seek",
@@ -553,6 +554,20 @@ class QualificationRecordAssemblyTests(unittest.TestCase):
         report = self.make_report("iphone")
         payload = json.loads(report.read_text())
         payload["releaseSourceDigest"] = "d" * 64
+        report.write_text(json.dumps(payload))
+        with self.assertRaises(assemble_record.AssemblyError):
+            assemble_record.assemble(
+                "1.1.0",
+                self.candidate,
+                self.matrix,
+                [report],
+                self.root / "qualification" / "1.1.0.json",
+            )
+
+    def test_rejects_failed_report_even_when_it_contains_passing_rows(self):
+        report = self.make_report("iphone")
+        payload = json.loads(report.read_text())
+        payload["result"] = "fail"
         report.write_text(json.dumps(payload))
         with self.assertRaises(assemble_record.AssemblyError):
             assemble_record.assemble(


### PR DESCRIPTION
## Summary

- upgrade the same-player replacement lane into candidate-bound VOD/live qualification
- prove native atomic time, duration, and seekability snapshots match the successor media generation
- measure successor audio/video recovery against a five-second budget while checking PiP motion, lifecycle, controls, and stale events
- materialize independent `replacement` and `replacement-continuity` rows from the same physical scenario

## Validation

- full Swift suite: 1,990 tests passed
- Showcase iOS generic build-for-testing passed for both simulator architectures
- exact iOS SwiftVLC and test-target build-for-testing passed
- qualification harness: 23 tests passed
- release-integrity suite passed after rebasing onto current `main`

No physical row is claimed by these changes. No milestone issue is closed by this automation-only PR; candidate-bound device evidence is still required.
