### PR TITLE
Prevent background audio session relatch

### DIFF
--- a/Sources/SwiftVLC/PiP/PiPController.swift
+++ b/Sources/SwiftVLC/PiP/PiPController.swift
@@ -994,10 +994,21 @@ public final class PiPController: NSObject {
     }
   }
 
-  private func handlePlaybackIntentChanged(_ active: Bool) {
+  func handlePlaybackIntentChanged(_ active: Bool) {
     if active {
-      isManagedAudioResumeDeniedByInterruption = false
-      activateAudioSessionIfNeeded()
+      // Lifecycle and media-services suspension preserve active playback
+      // intent on purpose. A queued copy of that intent is therefore not a
+      // recovery signal and must not retake audio focus after the suspension
+      // path released it. Foregrounding, PiP activation, or media-services
+      // reset owns the corresponding reactivation and resume. The one
+      // exception is an activation that those recovery paths already approved
+      // but could not complete transiently; a later signal must retry it.
+      if
+        isManagedAudioResumePendingActivation
+        || (!isPlaybackSuspendedForManagedAudioLifecycle
+          && !isPlaybackSuspendedForMediaServices) {
+        activateAudioSessionIfNeeded()
+      }
     }
     if let pendingPiPPlaybackState, pendingPiPPlaybackState != active {
       self.pendingPiPPlaybackState = active

--- a/Tests/SwiftVLCTests/PiP/PiPAudioSessionDisruptionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPAudioSessionDisruptionTests.swift
@@ -378,6 +378,13 @@ extension Integration {
       #expect(recorder.pauseRecordsPlaybackIntent == [false])
       #expect(controller.isPlaybackSuspendedForManagedAudioLifecycle)
       #expect(!controller.hasActivatedAudioSession)
+
+      // The active intent is deliberately preserved across this library-owned
+      // pause. A copy already queued in the observer must not reactivate audio
+      // before foreground or PiP recovery authorizes it.
+      controller.handlePlaybackIntentChanged(true)
+      #expect(!controller.hasActivatedAudioSession)
+
       controller.applicationWillEnterForeground()
       await player.shutdown()
     }
@@ -513,6 +520,39 @@ extension Integration {
       #expect(recorder.resumeCount == 1)
       #expect(!controller.isPlaybackSuspendedForManagedAudioLifecycle)
       #expect(!controller.isManagedAudioResumePendingActivation)
+      await player.shutdown()
+    }
+
+    @Test
+    func `A playback signal retries an approved pending activation`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let recorder = PauseRecorder()
+      let controller = makeController(player: player, recorder: recorder)
+      player.setPlaybackIntentFromExternalControl(true)
+      controller.isPlaybackSuspendedForManagedAudioLifecycle = true
+      controller.isManagedAudioResumePendingActivation = true
+
+      controller.handlePlaybackIntentChanged(true)
+
+      #expect(controller.hasActivatedAudioSession)
+      #expect(recorder.resumeCount == 1)
+      #expect(!controller.isPlaybackSuspendedForManagedAudioLifecycle)
+      #expect(!controller.isManagedAudioResumePendingActivation)
+      await player.shutdown()
+    }
+
+    @Test
+    func `A stale active intent preserves an interruption resume denial`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let controller = makeController(player: player, recorder: PauseRecorder())
+      controller.isPlaybackSuspendedForManagedAudioLifecycle = true
+      controller.isManagedAudioResumeDeniedByInterruption = true
+
+      controller.handlePlaybackIntentChanged(true)
+
+      #expect(controller.isManagedAudioResumeDeniedByInterruption)
+      #expect(!controller.hasActivatedAudioSession)
+      #expect(controller.isPlaybackSuspendedForManagedAudioLifecycle)
       await player.shutdown()
     }
 


### PR DESCRIPTION
## Summary

- prevent queued active playback-intent delivery from reactivating managed audio while lifecycle or media-services suspension is still in force
- keep foregrounding, successful PiP activation, and media-services reset as the only recovery authorities for those library-owned suspensions
- add a deterministic regression assertion for the late-delivery race found during v1.1.0 qualification work

Fixes #192.

## Validation

- SwiftFormat strict: 0 files require formatting
- SwiftLint strict: 0 violations
- focused `PiPAudioSessionEffectTests`: 100 consecutive runs passed (1,100 test executions)
- full Swift suite: 1,990 tests / 168 suites passed
- release-integrity tests passed
- `git diff --check` passed
