### PR TITLE
Automate PiP capability convergence qualification

### DIFF
--- a/Showcase/Shared/AccessibilityID.swift
+++ b/Showcase/Shared/AccessibilityID.swift
@@ -195,6 +195,24 @@ enum AccessibilityID {
     static let staleSuccessorMutationsLabel = "pipContinuity.staleSuccessorMutations"
   }
 
+  enum PiPCapabilityValidation {
+    static let videoView = "pipCapability.videoView"
+    static let loadVODButton = "pipCapability.loadVOD"
+    static let loadLiveButton = "pipCapability.loadLive"
+    static let stateLabel = "pipCapability.state"
+    static let generationLabel = "pipCapability.generation"
+    static let currentTimeLabel = "pipCapability.currentTime"
+    static let snapshotLabel = "pipCapability.snapshot"
+    static let suppressionLabel = "pipCapability.suppression"
+    static let possibleLabel = "pipCapability.possible"
+    static let activeLabel = "pipCapability.active"
+    static let lifecycleEventsLabel = "pipCapability.lifecycleEvents"
+    static let skipResultLabel = "pipCapability.skipResult"
+    static let toggleButton = "pipCapability.toggle"
+    static let skipForwardButton = "pipCapability.skipForward"
+    static let errorLabel = "pipCapability.error"
+  }
+
   enum MatrixHValidation {
     static let stateLabel = "validation.matrixH.state"
     static let currentTimeLabel = "validation.matrixH.currentTime"

--- a/Showcase/Shared/LaunchArguments.swift
+++ b/Showcase/Shared/LaunchArguments.swift
@@ -163,6 +163,7 @@ enum UITestRoute: String, CaseIterable {
   case multiConsumer = "MultiConsumer"
   case harnessHome = "HarnessHome"
   case pipLiveValidation = "PiPLiveValidation"
+  case pipCapabilityValidation = "PiPCapabilityValidation"
 
   static var current: UITestRoute? {
     LaunchArguments.routeValue.flatMap(UITestRoute.init(rawValue:))

--- a/Showcase/UITests/iOS/Tests/PiPCapabilityDeviceUITests.swift
+++ b/Showcase/UITests/iOS/Tests/PiPCapabilityDeviceUITests.swift
@@ -1,0 +1,227 @@
+import XCTest
+
+/// Candidate-bound proof that PiP capability policy converges through native
+/// polling even when raw length and seekability callbacks are suppressed.
+final class PiPCapabilityDeviceUITests: ShowcaseIOSTestCase {
+  private struct BackendEvidence {
+    let suppressedLengthEvents: Int
+    let suppressedSeekableEvents: Int
+  }
+
+  func test_capabilityConvergenceAcrossNativeAndDirectBackends() throws {
+    #if targetEnvironment(simulator)
+    throw XCTSkip("System Picture in Picture requires a physical iOS device")
+    #else
+    guard ProcessInfo.processInfo.environment["SWIFTVLC_PIP_CAPABILITY_DEVICE"] == "YES" else {
+      throw XCTSkip("Set SWIFTVLC_PIP_CAPABILITY_DEVICE=YES for candidate-bound hardware runs")
+    }
+
+    let native = try runCapabilityTransitions(renderingPath: "native")
+    let direct = try runCapabilityTransitions(renderingPath: "direct")
+    attachQualificationEvidence(
+      [
+        "formatVersion": 1,
+        "scenario": "capability-convergence",
+        "backendResults": [
+          "native": "pass",
+          "direct": "pass"
+        ],
+        "transitions": "pass",
+        "skipControls": "pass",
+        "faultInjection": [
+          "rawEventsSuppressed": true,
+          "nativeLengthEvents": native.suppressedLengthEvents,
+          "nativeSeekableEvents": native.suppressedSeekableEvents,
+          "directLengthEvents": direct.suppressedLengthEvents,
+          "directSeekableEvents": direct.suppressedSeekableEvents
+        ],
+        "systemPiPMotion": [
+          "native": "pass",
+          "direct": "pass"
+        ]
+      ],
+      scenario: "capability-convergence"
+    )
+    #endif
+  }
+
+  private func runCapabilityTransitions(renderingPath: String) throws -> BackendEvidence {
+    addUIInterruptionMonitor(withDescription: "Local network permission") { alert in
+      let allow = alert.buttons["Allow"]
+      guard allow.exists else { return false }
+      allow.tap()
+      return true
+    }
+
+    replaceLaunchArgument(LaunchArguments.pipRenderingPath, with: renderingPath)
+    launch(route: .pipCapabilityValidation)
+    app.tap()
+
+    let state = element(AccessibilityID.PiPCapabilityValidation.stateLabel)
+    let generation = element(AccessibilityID.PiPCapabilityValidation.generationLabel)
+    let policy = element(AccessibilityID.PiPCapabilityValidation.snapshotLabel)
+    let suppression = element(AccessibilityID.PiPCapabilityValidation.suppressionLabel)
+    let possible = element(AccessibilityID.PiPCapabilityValidation.possibleLabel)
+    let active = element(AccessibilityID.PiPCapabilityValidation.activeLabel)
+    let lifecycle = element(AccessibilityID.PiPCapabilityValidation.lifecycleEventsLabel)
+    let skipResult = element(AccessibilityID.PiPCapabilityValidation.skipResultLabel)
+    let playbackError = element(AccessibilityID.PiPCapabilityValidation.errorLabel)
+    let loadVOD = app.buttons[AccessibilityID.PiPCapabilityValidation.loadVODButton]
+    let loadLive = app.buttons[AccessibilityID.PiPCapabilityValidation.loadLiveButton]
+    let toggle = app.buttons[AccessibilityID.PiPCapabilityValidation.toggleButton]
+    let skipForward = app.buttons[AccessibilityID.PiPCapabilityValidation.skipForwardButton]
+
+    waitForPrefix(suppression, prefix: "enabled:", timeout: 5)
+    reveal(loadVOD)
+    loadVOD.tap()
+    waitForLabel(state, equals: "playing", timeout: 20)
+    waitForLabel(policy, equals: "finite:seekable:interactive", timeout: 15)
+    waitForLabel(possible, equals: "yes", timeout: 15)
+
+    reveal(toggle)
+    XCTAssertTrue(toggle.isEnabled)
+    toggle.tap()
+    waitForLabel(active, equals: "yes", timeout: 10)
+    waitForOccurrence("didStart", count: 1, in: lifecycle, timeout: 10)
+    try exerciseSkip(skipForward, result: skipResult)
+
+    let initialGeneration = generation.label
+    reveal(loadLive, swiping: .down)
+    loadLive.tap()
+    waitForLabelChange(generation, from: initialGeneration, timeout: 5)
+    waitForLabel(policy, equals: "unbounded:unseekable:linear", timeout: 15)
+    waitForLabel(active, equals: "yes", timeout: 10)
+
+    let liveGeneration = generation.label
+    reveal(loadVOD, swiping: .down)
+    loadVOD.tap()
+    waitForLabelChange(generation, from: liveGeneration, timeout: 5)
+    waitForLabel(policy, equals: "finite:seekable:interactive", timeout: 15)
+    waitForLabel(active, equals: "yes", timeout: 10)
+    try exerciseSkip(skipForward, result: skipResult)
+
+    XCUIDevice.shared.press(.home)
+    if let failure = captureSystemPictureInPictureMotion() {
+      XCTFail("\(renderingPath) capability PiP motion failed: \(failure)")
+    }
+    app.activate()
+    waitForLabel(active, equals: "yes", timeout: 10)
+
+    reveal(toggle)
+    toggle.tap()
+    waitForLabel(active, equals: "no", timeout: 10)
+    XCTAssertFalse(
+      playbackError.exists,
+      "Capability surface reported an asynchronous playback error: \(playbackError.label)"
+    )
+    assertNoLibraryErrors()
+
+    let counts = try parseSuppressionSnapshot(suppression.label)
+    XCTAssertTrue(counts.isEnabled, "Raw capability fault injection was not active")
+    return BackendEvidence(
+      suppressedLengthEvents: counts.length,
+      suppressedSeekableEvents: counts.seekable
+    )
+  }
+
+  private func exerciseSkip(
+    _ button: XCUIElement,
+    result: XCUIElement
+  )
+    throws {
+    reveal(button)
+    XCTAssertTrue(button.isEnabled)
+    button.tap()
+    waitForPrefix(result, prefix: "pass:", timeout: 15)
+    let components = result.label.split(separator: ":")
+    let before = try XCTUnwrap(components.count == 3 ? Int64(components[1]) : nil)
+    let after = try XCTUnwrap(components.count == 3 ? Int64(components[2]) : nil)
+    XCTAssertGreaterThan(after, before, "PiP skip reported success without advancing playback")
+  }
+
+  private func element(_ identifier: String) -> XCUIElement {
+    app.descendants(matching: .any)[identifier]
+  }
+
+  private func waitForPrefix(
+    _ element: XCUIElement,
+    prefix: String,
+    timeout: TimeInterval
+  ) {
+    let predicate = NSPredicate { _, _ in
+      element.exists && element.label.hasPrefix(prefix)
+    }
+    let expectation = expectation(for: predicate, evaluatedWith: NSObject())
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [expectation], timeout: timeout),
+      .completed,
+      "Expected \(prefix), got: \(element.label)"
+    )
+  }
+
+  private func waitForLabelChange(
+    _ element: XCUIElement,
+    from previous: String,
+    timeout: TimeInterval
+  ) {
+    let predicate = NSPredicate { _, _ in
+      element.exists && element.label != previous
+    }
+    let expectation = expectation(for: predicate, evaluatedWith: NSObject())
+    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: timeout), .completed)
+  }
+
+  private func waitForOccurrence(
+    _ value: String,
+    count: Int,
+    in element: XCUIElement,
+    timeout: TimeInterval
+  ) {
+    let predicate = NSPredicate { _, _ in
+      element.label.split(separator: "|").count(where: { $0 == Substring(value) }) >= count
+    }
+    let expectation = expectation(for: predicate, evaluatedWith: NSObject())
+    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: timeout), .completed)
+  }
+
+  private func parseSuppressionSnapshot(
+    _ value: String
+  )
+    throws -> (isEnabled: Bool, length: Int, seekable: Int) {
+    let components = value.split(separator: ":")
+    XCTAssertEqual(components.count, 3, "Malformed suppression snapshot: \(value)")
+    return try (
+      XCTUnwrap(components.first.map { $0 == "enabled" }),
+      XCTUnwrap(components.count == 3 ? Int(components[1]) : nil),
+      XCTUnwrap(components.count == 3 ? Int(components[2]) : nil)
+    )
+  }
+
+  private func replaceLaunchArgument(_ name: String, with value: String) {
+    while let index = app.launchArguments.firstIndex(of: name) {
+      app.launchArguments.remove(at: index)
+      if index < app.launchArguments.endIndex {
+        app.launchArguments.remove(at: index)
+      }
+    }
+    app.launchArguments += [name, value]
+  }
+
+  private enum ScrollDirection {
+    case up
+    case down
+  }
+
+  private func reveal(
+    _ element: XCUIElement,
+    swiping direction: ScrollDirection = .up
+  ) {
+    for _ in 0..<10 where !element.isHittable {
+      switch direction {
+      case .up: app.swipeUp()
+      case .down: app.swipeDown()
+      }
+    }
+    XCTAssertTrue(element.isHittable)
+  }
+}

--- a/Showcase/iOS/Internal/UITestSupport.swift
+++ b/Showcase/iOS/Internal/UITestSupport.swift
@@ -126,6 +126,7 @@ extension UITestRoute {
     case .multiConsumer: MultiConsumerEventsCase()
     case .harnessHome: HarnessHome()
     case .pipLiveValidation: PiPLiveValidationCase()
+    case .pipCapabilityValidation: PiPCapabilityValidationCase()
     }
   }
 }

--- a/Showcase/iOS/ValidationHarness/PiPCapabilityValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/PiPCapabilityValidationCase.swift
@@ -1,0 +1,218 @@
+import SwiftUI
+@_spi(Qualification) import SwiftVLC
+
+/// Physical-device fault-injection surface for PiP capability convergence.
+///
+/// Raw length and seekability callbacks are deliberately dropped. The only
+/// path left for the controller to discover finite/seekable VOD and
+/// unbounded/unseekable live media is Player's native-state polling.
+struct PiPCapabilityValidationCase: View {
+  @State private var player = Player()
+  @State private var controller: PiPController?
+  @State private var lifecycleEvents: [String] = []
+  @State private var skipResult = "none"
+  @State private var playbackError: String?
+
+  private let streams = HarnessStreams.load()?.streams
+
+  private var renderingPath: PiPCapabilityRenderingPath {
+    PiPCapabilityRenderingPath(
+      rawValue: LaunchArguments.pipRenderingPathValue ?? "native"
+    ) ?? .native
+  }
+
+  var body: some View {
+    _ = player.currentTime
+    return Form {
+      Section {
+        videoSurface
+          .frame(height: 240)
+          .listRowInsets(EdgeInsets())
+          .accessibilityIdentifier(AccessibilityID.PiPCapabilityValidation.videoView)
+      }
+
+      Section("Media") {
+        Button("Load finite VOD") { load(streams?.vod) }
+          .accessibilityIdentifier(AccessibilityID.PiPCapabilityValidation.loadVODButton)
+          .disabled(streams?.vod == nil)
+        Button("Load unbounded live stream") { load(streams?.liveTS) }
+          .accessibilityIdentifier(AccessibilityID.PiPCapabilityValidation.loadLiveButton)
+          .disabled(streams?.liveTS == nil)
+      }
+
+      Section("Measured state") {
+        valueRow(
+          "Playback",
+          value: String(describing: player.state),
+          identifier: AccessibilityID.PiPCapabilityValidation.stateLabel
+        )
+        valueRow(
+          "Media generation",
+          value: player.playbackQualificationGeneration.description,
+          identifier: AccessibilityID.PiPCapabilityValidation.generationLabel
+        )
+        valueRow(
+          "Current time",
+          value: String(player.currentTime.milliseconds),
+          identifier: AccessibilityID.PiPCapabilityValidation.currentTimeLabel
+        )
+        valueRow(
+          "Playback policy",
+          value: playbackSnapshot,
+          identifier: AccessibilityID.PiPCapabilityValidation.snapshotLabel
+        )
+        valueRow(
+          "Raw event suppression",
+          value: suppressionSnapshot,
+          identifier: AccessibilityID.PiPCapabilityValidation.suppressionLabel
+        )
+        valueRow(
+          "PiP possible",
+          value: controller?.isPossible == true ? "yes" : "no",
+          identifier: AccessibilityID.PiPCapabilityValidation.possibleLabel
+        )
+        valueRow(
+          "PiP active",
+          value: controller?.isActive == true ? "yes" : "no",
+          identifier: AccessibilityID.PiPCapabilityValidation.activeLabel
+        )
+        valueRow(
+          "Lifecycle",
+          value: lifecycleEvents.isEmpty ? "none" : lifecycleEvents.joined(separator: "|"),
+          identifier: AccessibilityID.PiPCapabilityValidation.lifecycleEventsLabel
+        )
+        valueRow(
+          "Skip result",
+          value: skipResult,
+          identifier: AccessibilityID.PiPCapabilityValidation.skipResultLabel
+        )
+      }
+
+      Section("Picture in Picture") {
+        Button(
+          controller?.isActive == true ? "Stop PiP" : "Start PiP",
+          systemImage: "pip",
+          action: { controller?.toggle() }
+        )
+        .accessibilityIdentifier(AccessibilityID.PiPCapabilityValidation.toggleButton)
+        .disabled(controller?.isPossible != true)
+
+        Button("Skip forward 10 seconds", systemImage: "goforward.10") {
+          performSkip()
+        }
+        .accessibilityIdentifier(AccessibilityID.PiPCapabilityValidation.skipForwardButton)
+        .disabled(controller == nil)
+
+        if let playbackError {
+          Text(playbackError)
+            .foregroundStyle(.red)
+            .accessibilityIdentifier(AccessibilityID.PiPCapabilityValidation.errorLabel)
+        }
+      }
+    }
+    .showcaseFormStyle()
+    .navigationTitle("PiP capability convergence")
+    .task {
+      player.suppressRawCapabilityEventsForQualification(true)
+    }
+    .task(id: controller.map(ObjectIdentifier.init)) {
+      lifecycleEvents.removeAll()
+      guard let controller else { return }
+      for await envelope in controller.pipEventEnvelopes {
+        lifecycleEvents.append(lifecycleName(envelope.event))
+      }
+    }
+    .onDisappear {
+      player.suppressRawCapabilityEventsForQualification(false)
+      player.stop()
+    }
+  }
+
+  @ViewBuilder
+  private var videoSurface: some View {
+    switch renderingPath {
+    case .native:
+      PiPVideoView(
+        player,
+        controller: $controller,
+        startsAutomaticallyFromInline: false
+      )
+    case .direct:
+      DirectPiPValidationSurface(player: player, controller: $controller)
+    }
+  }
+
+  private var playbackSnapshot: String {
+    guard let controller else { return "none" }
+    let snapshot = controller.playbackQualificationSnapshot
+    let duration = snapshot.durationMilliseconds == nil ? "unbounded" : "finite"
+    let seekable = snapshot.isSeekable ? "seekable" : "unseekable"
+    let controls = snapshot.requiresLinearPlayback ? "linear" : "interactive"
+    return "\(duration):\(seekable):\(controls)"
+  }
+
+  private var suppressionSnapshot: String {
+    let snapshot = player.rawCapabilityEventSuppressionSnapshot
+    return "\(snapshot.isEnabled ? "enabled" : "disabled"):"
+      + "\(snapshot.suppressedLengthEventCount):"
+      + "\(snapshot.suppressedSeekableEventCount)"
+  }
+
+  private func load(_ url: URL?) {
+    guard let url else {
+      playbackError = "Missing validation stream"
+      return
+    }
+    do {
+      skipResult = "none"
+      playbackError = nil
+      try player.play(url: url)
+    } catch {
+      playbackError = String(describing: error)
+    }
+  }
+
+  private func performSkip() {
+    guard let controller else {
+      skipResult = "failed:no-controller"
+      return
+    }
+    let before = player.currentTime.milliseconds
+    skipResult = "pending:\(before)"
+    Task { @MainActor in
+      let settled = await controller.performQualificationSkip(bySeconds: 10)
+      let after = player.currentTime.milliseconds
+      skipResult = "\(settled && after > before ? "pass" : "failed"):\(before):\(after)"
+    }
+  }
+
+  private func lifecycleName(_ event: PiPEvent) -> String {
+    switch event {
+    case .willStart:
+      "willStart"
+    case .didStart:
+      "didStart"
+    case .willStop(let reason):
+      "willStop:\(String(describing: reason))"
+    case .didStop(let reason):
+      "didStop:\(String(describing: reason))"
+    case .failedToStart:
+      "failedToStart"
+    }
+  }
+
+  private func valueRow(_ title: String, value: String, identifier: String) -> some View {
+    HStack {
+      Text(title)
+      Spacer()
+      Text(value)
+        .foregroundStyle(.secondary)
+        .accessibilityIdentifier(identifier)
+    }
+  }
+}
+
+private enum PiPCapabilityRenderingPath: String {
+  case native
+  case direct
+}

--- a/Showcase/iOS/ValidationHarness/PiPCapabilityValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/PiPCapabilityValidationCase.swift
@@ -12,6 +12,7 @@ struct PiPCapabilityValidationCase: View {
   @State private var lifecycleEvents: [String] = []
   @State private var skipResult = "none"
   @State private var playbackError: String?
+  @State private var isSuppressionEnabled = false
 
   private let streams = HarnessStreams.load()?.streams
 
@@ -114,6 +115,7 @@ struct PiPCapabilityValidationCase: View {
     .navigationTitle("PiP capability convergence")
     .task {
       player.suppressRawCapabilityEventsForQualification(true)
+      isSuppressionEnabled = true
     }
     .task(id: controller.map(ObjectIdentifier.init)) {
       lifecycleEvents.removeAll()
@@ -124,6 +126,7 @@ struct PiPCapabilityValidationCase: View {
     }
     .onDisappear {
       player.suppressRawCapabilityEventsForQualification(false)
+      isSuppressionEnabled = false
       player.stop()
     }
   }
@@ -153,7 +156,7 @@ struct PiPCapabilityValidationCase: View {
 
   private var suppressionSnapshot: String {
     let snapshot = player.rawCapabilityEventSuppressionSnapshot
-    return "\(snapshot.isEnabled ? "enabled" : "disabled"):"
+    return "\(isSuppressionEnabled ? "enabled" : "disabled"):"
       + "\(snapshot.suppressedLengthEventCount):"
       + "\(snapshot.suppressedSeekableEventCount)"
   }

--- a/Showcase/macOS/Internal/MacShowcaseRootView.swift
+++ b/Showcase/macOS/Internal/MacShowcaseRootView.swift
@@ -405,7 +405,7 @@ extension MacShowcase {
     case .multiConsumer: self = .multiConsumerEvents
     case .statistics: self = .statistics
     case .logs: self = .logs
-    case .harnessHome, .pipLiveValidation: return nil
+    case .harnessHome, .pipLiveValidation, .pipCapabilityValidation: return nil
     }
   }
 }

--- a/Showcase/tvOS/Internal/TVShowcaseRootView.swift
+++ b/Showcase/tvOS/Internal/TVShowcaseRootView.swift
@@ -514,7 +514,8 @@ extension TVShowcase {
          .discoveryRenderers,
          .multiConsumer,
          .harnessHome,
-         .pipLiveValidation:
+         .pipLiveValidation,
+         .pipCapabilityValidation:
       return nil
     }
   }

--- a/Sources/SwiftVLC/PiP/PiPController+PlaybackState.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+PlaybackState.swift
@@ -134,6 +134,24 @@ extension PiPController {
     }
   }
 
+  /// Qualification fault injection must drop raw capability callbacks from
+  /// this observer as well as from Player's observable mirror. The two own
+  /// independent subscriptions to the same event bridge; suppressing only the
+  /// Player consumer would let this controller converge from the callback and
+  /// produce a false-positive polling result.
+  static func shouldObservePlaybackStateEvent(
+    _ event: PlayerEvent,
+    suppressingRawCapabilityEvents: Bool
+  ) -> Bool {
+    guard suppressingRawCapabilityEvents else { return true }
+    switch event {
+    case .lengthChanged, .seekableChanged:
+      return false
+    default:
+      return true
+    }
+  }
+
   static func applyPlaybackStateUpdate(
     _ update: PlaybackStateUpdate,
     setRequiresLinearPlayback: (Bool) -> Void,

--- a/Sources/SwiftVLC/PiP/PiPController+StateObserver.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+StateObserver.swift
@@ -81,6 +81,11 @@ extension PiPController {
   /// The body both lane tasks run. Identical work either way: what differs
   /// between the lanes is delivery guarantees, not handling.
   private func handleStateObserverEvent(_ event: PlayerEvent) {
+    guard
+      Self.shouldObservePlaybackStateEvent(
+        event,
+        suppressingRawCapabilityEvents: player.isSuppressingRawCapabilityEvents
+      ) else { return }
     let active = player.isActive
     let rate = player.rate
     let playbackStateUpdate = playbackStateObservation.consume(

--- a/Sources/SwiftVLC/PiP/PiPController+Validation.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Validation.swift
@@ -1,6 +1,7 @@
 #if os(iOS)
 
 import AVKit
+import CoreMedia
 
 /// A snapshot of libVLC's private native PiP machinery on iOS.
 ///
@@ -67,6 +68,15 @@ public struct NativePiPPlaybackQualificationSnapshot: Sendable, Equatable {
   public let isSeekable: Bool
 }
 
+/// State from the qualification-only fault injector that drops raw libVLC
+/// length and seekability callbacks while preserving native polling.
+@_spi(Qualification)
+public struct RawCapabilityEventSuppressionSnapshot: Sendable, Equatable {
+  public let isEnabled: Bool
+  public let suppressedLengthEventCount: Int
+  public let suppressedSeekableEventCount: Int
+}
+
 extension PiPController {
   /// A snapshot of the iOS native PiP backend's private wiring, or
   /// `nil` when this controller doesn't drive the native backend (the
@@ -117,6 +127,18 @@ extension PiPController {
       isSeekable: seekable.boolValue
     )
   }
+
+  /// Exercises the exact relative-skip path AVKit uses and waits for its
+  /// terminal result. The device harness uses this instead of trying to tap a
+  /// locale-dependent system PiP control by its accessibility label.
+  @_spi(Qualification)
+  public func performQualificationSkip(bySeconds seconds: Double) async -> Bool {
+    let request = Self.performSkip(
+      on: player,
+      by: CMTime(seconds: seconds, preferredTimescale: 1000)
+    )
+    return await request.outcome == .settled
+  }
 }
 
 extension Player {
@@ -125,6 +147,26 @@ extension Player {
   @_spi(Qualification)
   public var playbackQualificationGeneration: PlaybackGeneration {
     generation
+  }
+
+  /// Enables deterministic suppression of the two raw callbacks whose
+  /// absence the capability-convergence lane must tolerate.
+  @_spi(Qualification)
+  public func suppressRawCapabilityEventsForQualification(_ suppressed: Bool) {
+    isSuppressingRawCapabilityEvents = suppressed
+    if suppressed {
+      suppressedRawLengthEventCount = 0
+      suppressedRawSeekableEventCount = 0
+    }
+  }
+
+  @_spi(Qualification)
+  public var rawCapabilityEventSuppressionSnapshot: RawCapabilityEventSuppressionSnapshot {
+    RawCapabilityEventSuppressionSnapshot(
+      isEnabled: isSuppressingRawCapabilityEvents,
+      suppressedLengthEventCount: suppressedRawLengthEventCount,
+      suppressedSeekableEventCount: suppressedRawSeekableEventCount
+    )
   }
 }
 

--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -172,10 +172,18 @@ extension Player {
       }
 
     case .lengthChanged(let length):
-      duration = length
+      if isSuppressingRawCapabilityEvents {
+        suppressedRawLengthEventCount += 1
+      } else {
+        duration = length
+      }
 
     case .seekableChanged(let seekable):
-      isSeekable = seekable
+      if isSuppressingRawCapabilityEvents {
+        suppressedRawSeekableEventCount += 1
+      } else {
+        isSeekable = seekable
+      }
 
     case .pausableChanged(let pausable):
       isPausable = pausable

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -386,6 +386,12 @@ public final class Player {
   /// per-property `didSet` publishes do not expose an intermediate mix of the
   /// outgoing and incoming media. See ``resetMediaDerivedState()``.
   @ObservationIgnored var isSuppressingCapabilityPublish = false
+  /// Qualification-only fault injection that drops raw length and seekability
+  /// events while leaving native polling active. This proves PiP capability
+  /// convergence does not depend on callbacks libVLC may omit in production.
+  @ObservationIgnored var isSuppressingRawCapabilityEvents = false
+  @ObservationIgnored var suppressedRawLengthEventCount = 0
+  @ObservationIgnored var suppressedRawSeekableEventCount = 0
   var eventTask: Task<Void, Never>?
   var playbackHealthSamplingTask: Task<Void, Never>?
   var playbackHealthMonitoringState = PlaybackHealthMonitoringState()

--- a/Tests/SwiftVLCTests/PiP/PiPPlaybackStateTransitionTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPPlaybackStateTransitionTests.swift
@@ -352,6 +352,60 @@ import Testing
     #expect(update == PiPController.PlaybackStateUpdate())
   }
 
+  /// A timeshift window can grow or slide without a new media generation.
+  /// Polling must republish the changed finite range without reverting the
+  /// already-interactive seek policy.
+  @Test
+  func `A sliding finite duration converges within one generation`() {
+    var state = PiPController.PlaybackStateObservationState(
+      duration: .seconds(120),
+      isSeekable: true
+    )
+
+    let update = state.consume(
+      .timeChanged(.seconds(30)),
+      capability: PlayerCapabilitySnapshot(
+        generation: 1,
+        durationMilliseconds: 180_000,
+        isSeekable: true
+      )
+    )
+
+    #expect(state.durationMilliseconds == 180_000)
+    #expect(state.isSeekable)
+    #expect(update.invalidatesPlaybackState)
+    #expect(update.requiresLinearPlayback == nil)
+    assertEffects(of: update, expectedLinearPlayback: nil)
+  }
+
+  @Test
+  func `Capability fault injection excludes raw callbacks from the PiP observer`() {
+    #expect(
+      !PiPController.shouldObservePlaybackStateEvent(
+        .lengthChanged(.seconds(30)),
+        suppressingRawCapabilityEvents: true
+      )
+    )
+    #expect(
+      !PiPController.shouldObservePlaybackStateEvent(
+        .seekableChanged(true),
+        suppressingRawCapabilityEvents: true
+      )
+    )
+    #expect(
+      PiPController.shouldObservePlaybackStateEvent(
+        .timeChanged(.seconds(1)),
+        suppressingRawCapabilityEvents: true
+      )
+    )
+    #expect(
+      PiPController.shouldObservePlaybackStateEvent(
+        .lengthChanged(.seconds(30)),
+        suppressingRawCapabilityEvents: false
+      )
+    )
+  }
+
   /// A poll that has not learned the length must not undo a length event that
   /// already arrived, or the two sources fight each other.
   @Test

--- a/Tests/SwiftVLCTests/Player/PlayerCapabilitySnapshotTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerCapabilitySnapshotTests.swift
@@ -81,4 +81,19 @@ import Testing
     #expect(snapshot.durationMilliseconds == 90000)
     #expect(snapshot.isSeekable)
   }
+
+  @Test
+  func `Raw capability fault injection drops events without mutating the mirror`() {
+    let player = Player(instance: TestInstance.shared)
+    player._setStateForTesting(duration: .seconds(120), isSeekable: true)
+    player.isSuppressingRawCapabilityEvents = true
+
+    player._handleEventForTesting(.lengthChanged(.seconds(30)))
+    player._handleEventForTesting(.seekableChanged(false))
+
+    #expect(player.duration == .seconds(120))
+    #expect(player.isSeekable)
+    #expect(player.suppressedRawLengthEventCount == 1)
+    #expect(player.suppressedRawSeekableEventCount == 1)
+  }
 }

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -62,8 +62,9 @@ engine artifact.
 The command identifies the physical device and OS release type, generates and
 serves deterministic local media, installs the exact signed candidate and UI
 test runner, executes the analyzer, general UI stress suite, native/direct live
-PiP, same-player continuity, and HLS seek lanes, then pulls app logs and writes
-a machine-readable `report.json`. It retains every attempt log and xcresult,
+PiP, same-player continuity, capability convergence, and HLS seek lanes, then
+pulls app logs and writes a machine-readable `report.json`. It retains every
+attempt log and xcresult,
 records and verifies candidate metadata that binds the app tree digest to its
 source commit, release-source digest, and XCFramework digest, and retries only
 a small allowlist of Xcode/device-launch infrastructure failures. Every run
@@ -92,6 +93,19 @@ event that escaped generation filtering. The two tests materialize independent
 `iphone-current`. Other hardware runs only the matrix-wide `replacement` test
 and row. Multi-row evidence is committed to the report only after every
 expected attachment materializes successfully.
+
+The iPhone-current-only capability-convergence lane runs VOD-to-live-to-VOD
+transitions while PiP is active on both the native drawable and direct
+sample-buffer backends. A
+qualification-only fault injector drops raw length and seekability callbacks
+from both independent Player and PiP-controller event consumers, forcing
+Player's native polling to publish the capability. The test requires
+finite seekable VOD to become interactive, unbounded live media to remain
+linear, the successor VOD to become interactive again, the real AVKit skip
+path to settle and advance playback, sustained system-PiP motion, and zero
+library errors before emitting the combined `capability-convergence` row. The
+default run omits this lane on other hardware rows, and an explicit unsupported
+request fails before testing rather than producing evidence for an unknown row.
 
 The HLS seek lane is another complete machine-readable matrix slice. It
 executes forward, backward, and absolute seeks, measures the return of decoded

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -33,7 +33,7 @@ Options:
   --output PATH           Evidence output root
   --only SCENARIO         Repeat to select: analyzer, ui-suite, native-live,
                           direct-live, live-media, background-audio,
-                          continuity, hls-seek,
+                          continuity, capability-convergence, hls-seek,
                           harness-regressions, ui-failures, thumbnail-preview
   --require-stable        Refuse beta/unknown OS or a non-matching matrix row
   --skip-build            Reuse an existing signed runner in derived data
@@ -224,6 +224,7 @@ DESTINATION_XCTESTRUN="$WORK_DIR/destination.xctestrun"
 python3 "$SCRIPT_DIR/prepare-xctestrun.py" "$XCTESTRUN" "$DESTINATION_XCTESTRUN" \
   --environment SWIFTVLC_PIP_LIVE_URL_BASE64="$PIP_LIVE_URL_BASE64" \
   --environment SWIFTVLC_PIP_CONTINUITY_DEVICE=YES \
+  --environment SWIFTVLC_PIP_CAPABILITY_DEVICE=YES \
   --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
   --environment SWIFTVLC_PIP_SEEK_DEVICE=YES
 cp "$DESTINATION_XCTESTRUN" "$OUTPUT_DIR/destination.xctestrun"
@@ -275,16 +276,46 @@ xcrun devicectl device copy to \
   --destination Documents/streams.local.json \
   > "$OUTPUT_DIR/stage-streams.log"
 
-DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity hls-seek)
+DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence hls-seek)
+SCENARIOS_WERE_EXPLICIT=false
 if [[ ${#ONLY_SCENARIOS[@]} -eq 0 ]]; then
   ONLY_SCENARIOS=("${DEFAULT_SCENARIOS[@]}")
+else
+  SCENARIOS_WERE_EXPLICIT=true
 fi
 for scenario in "${ONLY_SCENARIOS[@]}"; do
   case "$scenario" in
-    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
+    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
     *) echo "Error: unknown scenario: $scenario" >&2; exit 2 ;;
   esac
 done
+
+device_matches_hardware_row() {
+  local hardware_row="$1"
+  jq -e --arg hardware_row "$hardware_row" \
+    '.selected.matchingHardwareRows | index($hardware_row) != null' \
+    "$OUTPUT_DIR/device.json" > /dev/null
+}
+
+if ! device_matches_hardware_row "iphone-current"; then
+  if [[ "$SCENARIOS_WERE_EXPLICIT" == true ]]; then
+    for scenario in "${ONLY_SCENARIOS[@]}"; do
+      if [[ "$scenario" == "capability-convergence" ]]; then
+        echo "Error: capability-convergence requires the iphone-current hardware row." >&2
+        exit 2
+      fi
+    done
+  else
+    FILTERED_SCENARIOS=()
+    for scenario in "${ONLY_SCENARIOS[@]}"; do
+      if [[ "$scenario" != "capability-convergence" ]]; then
+        FILTERED_SCENARIOS+=("$scenario")
+      fi
+    done
+    ONLY_SCENARIOS=("${FILTERED_SCENARIOS[@]}")
+    echo "Skipping capability-convergence: selected device does not match iphone-current."
+  fi
+fi
 
 RESULTS_TSV="$WORK_DIR/results.tsv"
 : > "$RESULTS_TSV"
@@ -346,6 +377,13 @@ run_scenario() {
       route="HarnessHome"
       selected_xctestrun="$DESTINATION_XCTESTRUN"
       ;;
+    capability-convergence)
+      test_identifiers=(
+        "iOSUITests/PiPCapabilityDeviceUITests/test_capabilityConvergenceAcrossNativeAndDirectBackends"
+      )
+      route="PiPCapabilityValidation"
+      selected_xctestrun="$DESTINATION_XCTESTRUN"
+      ;;
     hls-seek)
       test_identifiers=("iOSUITests/PiPOverlayDeviceUITests/test_nativePiPHLSSeekAndReloadRemainActive")
       route="HarnessHome"
@@ -385,6 +423,7 @@ run_scenario() {
     python3 "$SCRIPT_DIR/prepare-xctestrun.py" "$XCTESTRUN" "$selected_xctestrun" \
       --environment SWIFTVLC_PIP_LIVE_URL_BASE64="$PIP_LIVE_URL_BASE64" \
       --environment SWIFTVLC_PIP_CONTINUITY_DEVICE=YES \
+      --environment SWIFTVLC_PIP_CAPABILITY_DEVICE=YES \
       --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
       --environment SWIFTVLC_PIP_SEEK_DEVICE=YES \
       --environment SWIFTVLC_DEVICE_LOG_PREFIX="$run_id-$scenario"
@@ -409,6 +448,7 @@ run_scenario() {
     test_selection_args+=(
       -skip-testing:iOSUITests/PiPLiveDeviceUITests
       -skip-testing:iOSUITests/PiPContinuityDeviceUITests
+      -skip-testing:iOSUITests/PiPCapabilityDeviceUITests
       -skip-testing:iOSUITests/PiPOverlayDeviceUITests
     )
   fi
@@ -562,6 +602,10 @@ PY
         qualification_scenarios+=("replacement-continuity")
         qualification_attachments+=("qualification-replacement-continuity.json")
       fi
+      ;;
+    capability-convergence)
+      qualification_scenarios=("capability-convergence")
+      qualification_attachments=("qualification-capability-convergence.json")
       ;;
   esac
   if [[ ${#qualification_scenarios[@]} -gt 0 ]]; then

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -359,6 +359,37 @@ class QualificationEvidenceTests(unittest.TestCase):
             self.assertTrue(evidence["audioContinuityWithinBudget"])
             self.assertTrue(evidence["videoContinuityWithinBudget"])
 
+    def test_materializes_capability_convergence_evidence(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.make_export(
+                root,
+                {
+                    "formatVersion": 1,
+                    "scenario": "capability-convergence",
+                    "backendResults": {"native": "pass", "direct": "pass"},
+                    "transitions": "pass",
+                    "skipControls": "pass",
+                    "faultInjection": {"rawEventsSuppressed": True},
+                },
+                attachment_name="qualification-capability-convergence.json",
+                test_identifier="PiPCapabilityDeviceUITests/test_capabilityConvergenceAcrossNativeAndDirectBackends",
+            )
+            evidence = materialize_evidence.materialize(
+                root,
+                "qualification-capability-convergence.json",
+                "capability-convergence",
+                "iphone-current",
+                "a" * 64,
+                "b" * 64,
+            )
+            self.assertEqual(
+                evidence["backendResults"], {"native": "pass", "direct": "pass"}
+            )
+            self.assertEqual(evidence["transitions"], "pass")
+            self.assertEqual(evidence["skipControls"], "pass")
+            self.assertTrue(evidence["faultInjection"]["rawEventsSuppressed"])
+
     def test_materializes_focused_replacement_evidence(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
## Summary
- add a candidate-bound Release lane for PiP capability convergence across VOD → live → VOD on the physical current iPhone row
- verify both native and direct PiP publish coherent duration/seekability policy, exact skip behavior, and real system PiP motion
- add qualification-only suppression of raw capability callbacks on both Player and PiP observer paths so convergence is proven from the fallback clock/state lanes
- reject explicitly requested unsupported hardware rows and omit this row by default elsewhere

## Validation
- SwiftFormat strict
- SwiftLint strict
- 25 qualification harness tests
- release-integrity suite
- full Swift suite: 1,995 tests in 168 suites

No physical-device pass is claimed by this PR and no milestone issue is closed; the lane records candidate-bound evidence when qualifying hardware is connected.