### PR TITLE
Automate deferred PiP pause qualification

### DIFF
--- a/Showcase/Shared/AccessibilityID.swift
+++ b/Showcase/Shared/AccessibilityID.swift
@@ -213,6 +213,18 @@ enum AccessibilityID {
     static let errorLabel = "pipCapability.error"
   }
 
+  enum PiPDeferredPauseValidation {
+    static let videoView = "pipDeferredPause.videoView"
+    static let stateLabel = "pipDeferredPause.state"
+    static let intentLabel = "pipDeferredPause.intent"
+    static let possibleLabel = "pipDeferredPause.possible"
+    static let activeLabel = "pipDeferredPause.active"
+    static let resultLabel = "pipDeferredPause.result"
+    static let toggleButton = "pipDeferredPause.toggle"
+    static let runButton = "pipDeferredPause.run"
+    static let errorLabel = "pipDeferredPause.error"
+  }
+
   enum MatrixHValidation {
     static let stateLabel = "validation.matrixH.state"
     static let currentTimeLabel = "validation.matrixH.currentTime"

--- a/Showcase/Shared/LaunchArguments.swift
+++ b/Showcase/Shared/LaunchArguments.swift
@@ -164,6 +164,7 @@ enum UITestRoute: String, CaseIterable {
   case harnessHome = "HarnessHome"
   case pipLiveValidation = "PiPLiveValidation"
   case pipCapabilityValidation = "PiPCapabilityValidation"
+  case pipDeferredPauseValidation = "PiPDeferredPauseValidation"
 
   static var current: UITestRoute? {
     LaunchArguments.routeValue.flatMap(UITestRoute.init(rawValue:))

--- a/Showcase/UITests/iOS/Support/ShowcaseIOSTestCase.swift
+++ b/Showcase/UITests/iOS/Support/ShowcaseIOSTestCase.swift
@@ -148,11 +148,24 @@ class ShowcaseIOSTestCase: XCTestCase {
   /// by the host after exporting the xcresult attachment; a test process must
   /// never guess which source tree or signed app bundle launched it.
   func attachQualificationEvidence(
-    _ payload: [String: Any],
+    _ suppliedPayload: [String: Any],
     scenario: String,
     file: StaticString = #filePath,
     line: UInt = #line
   ) {
+    if
+      let embeddedScenario = suppliedPayload["scenario"],
+      embeddedScenario as? String != scenario {
+      XCTFail(
+        "Qualification evidence scenario does not match \(scenario)",
+        file: file,
+        line: line
+      )
+      return
+    }
+    var payload = suppliedPayload
+    payload["formatVersion"] = payload["formatVersion"] ?? 1
+    payload["scenario"] = scenario
     guard JSONSerialization.isValidJSONObject(payload) else {
       XCTFail("Qualification evidence is not valid JSON", file: file, line: line)
       return

--- a/Showcase/UITests/iOS/Tests/PiPDeferredPauseDeviceUITests.swift
+++ b/Showcase/UITests/iOS/Tests/PiPDeferredPauseDeviceUITests.swift
@@ -1,0 +1,104 @@
+import XCTest
+
+/// Candidate-bound proof of the bounded deferred-pause state machine through
+/// the exact AVKit command entry point and a Release-build fault injector.
+final class PiPDeferredPauseDeviceUITests: ShowcaseIOSTestCase {
+  func test_deferredPauseRejectionAndCancellationStayTruthful() throws {
+    #if targetEnvironment(simulator)
+    throw XCTSkip("System Picture in Picture requires a physical iOS device")
+    #else
+    guard ProcessInfo.processInfo.environment["SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE"] == "YES" else {
+      throw XCTSkip("Set SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES for candidate-bound hardware runs")
+    }
+
+    addUIInterruptionMonitor(withDescription: "Local network permission") { alert in
+      let allow = alert.buttons["Allow"]
+      guard allow.exists else { return false }
+      allow.tap()
+      return true
+    }
+    launch(route: .pipDeferredPauseValidation)
+    app.tap()
+
+    let state = element(AccessibilityID.PiPDeferredPauseValidation.stateLabel)
+    let possible = element(AccessibilityID.PiPDeferredPauseValidation.possibleLabel)
+    let active = element(AccessibilityID.PiPDeferredPauseValidation.activeLabel)
+    let result = element(AccessibilityID.PiPDeferredPauseValidation.resultLabel)
+    let toggle = app.buttons[AccessibilityID.PiPDeferredPauseValidation.toggleButton]
+    let run = app.buttons[AccessibilityID.PiPDeferredPauseValidation.runButton]
+    let error = element(AccessibilityID.PiPDeferredPauseValidation.errorLabel)
+
+    waitForLabel(state, equals: "playing", timeout: 20)
+    waitForLabel(possible, equals: "yes", timeout: 15)
+    reveal(toggle)
+    toggle.tap()
+    waitForLabel(active, equals: "yes", timeout: 10)
+
+    XCUIDevice.shared.press(.home)
+    if let failure = captureSystemPictureInPictureMotion() {
+      XCTFail("Deferred-pause PiP motion failed before command testing: \(failure)")
+    }
+    app.activate()
+    waitForLabel(active, equals: "yes", timeout: 10)
+
+    reveal(run)
+    XCTAssertTrue(run.isEnabled)
+    run.tap()
+    waitForPrefix(result, prefix: "pass:", timeout: 40)
+    XCTAssertFalse(error.exists, "Validation surface reported: \(error.label)")
+
+    let evidence = try decodeEvidence(result.label)
+    XCTAssertEqual(value(at: ["permanentCase", "outcome"], in: evidence) as? String, "rejected")
+    XCTAssertEqual(value(at: ["transientCase", "outcome"], in: evidence) as? String, "issued")
+    XCTAssertEqual(evidence["cancellationCases"] as? String, "pass")
+    XCTAssertEqual(evidence["endlessTaskCount"] as? Int, 0)
+    XCTAssertEqual(evidence["duplicatePauseCount"] as? Int, 0)
+    XCTAssertEqual(evidence["truthfulControls"] as? Bool, true)
+    attachQualificationEvidence(evidence, scenario: "deferred-pause-rejection")
+    assertNoLibraryErrors()
+    #endif
+  }
+
+  private func decodeEvidence(_ label: String) throws -> [String: Any] {
+    let prefix = "pass:"
+    XCTAssertTrue(label.hasPrefix(prefix))
+    let encoded = String(label.dropFirst(prefix.count))
+    let data = try XCTUnwrap(Data(base64Encoded: encoded))
+    return try XCTUnwrap(
+      JSONSerialization.jsonObject(with: data) as? [String: Any]
+    )
+  }
+
+  private func value(at path: [String], in root: [String: Any]) -> Any? {
+    path.reduce(root as Any?) { value, key in
+      (value as? [String: Any])?[key]
+    }
+  }
+
+  private func element(_ identifier: String) -> XCUIElement {
+    app.descendants(matching: .any)[identifier]
+  }
+
+  private func waitForPrefix(
+    _ element: XCUIElement,
+    prefix: String,
+    timeout: TimeInterval
+  ) {
+    let predicate = NSPredicate { _, _ in
+      element.exists && element.label.hasPrefix(prefix)
+    }
+    let expectation = expectation(for: predicate, evaluatedWith: NSObject())
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [expectation], timeout: timeout),
+      .completed,
+      "Expected prefix \(prefix), got: \(element.label)"
+    )
+  }
+
+  private func reveal(_ element: XCUIElement) {
+    for _ in 0..<10 where !element.isHittable {
+      app.swipeUp()
+    }
+    XCTAssertTrue(element.isHittable)
+  }
+}

--- a/Showcase/iOS/Internal/UITestSupport.swift
+++ b/Showcase/iOS/Internal/UITestSupport.swift
@@ -127,6 +127,7 @@ extension UITestRoute {
     case .harnessHome: HarnessHome()
     case .pipLiveValidation: PiPLiveValidationCase()
     case .pipCapabilityValidation: PiPCapabilityValidationCase()
+    case .pipDeferredPauseValidation: PiPDeferredPauseValidationCase()
     }
   }
 }

--- a/Showcase/iOS/ValidationHarness/PiPDeferredPauseValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/PiPDeferredPauseValidationCase.swift
@@ -1,0 +1,331 @@
+import SwiftUI
+@_spi(Qualification) import SwiftVLC
+
+/// Candidate-bound physical-device exercise of the exact AVKit deferred-pause
+/// command path. Fault injection changes only libVLC's pause-capability answer;
+/// all command ownership, retries, native issuance, and reconciliation remain
+/// the Release library implementation.
+struct PiPDeferredPauseValidationCase: View {
+  @State private var player = Player()
+  @State private var controller: PiPController?
+  @State private var result = "not-run"
+  @State private var playbackError: String?
+  @State private var isRunning = false
+
+  private let streams = HarnessStreams.load()?.streams
+
+  var body: some View {
+    _ = player.currentTime
+    return Form {
+      Section {
+        DirectPiPValidationSurface(player: player, controller: $controller)
+          .frame(height: 220)
+          .listRowInsets(EdgeInsets())
+          .accessibilityIdentifier(AccessibilityID.PiPDeferredPauseValidation.videoView)
+      }
+
+      Section("Measured state") {
+        valueRow(
+          "Playback",
+          value: String(describing: player.state),
+          identifier: AccessibilityID.PiPDeferredPauseValidation.stateLabel
+        )
+        valueRow(
+          "Playback intent",
+          value: player.isPlaybackRequestedActive ? "playing" : "paused",
+          identifier: AccessibilityID.PiPDeferredPauseValidation.intentLabel
+        )
+        valueRow(
+          "PiP possible",
+          value: controller?.isPossible == true ? "yes" : "no",
+          identifier: AccessibilityID.PiPDeferredPauseValidation.possibleLabel
+        )
+        valueRow(
+          "PiP active",
+          value: controller?.isActive == true ? "yes" : "no",
+          identifier: AccessibilityID.PiPDeferredPauseValidation.activeLabel
+        )
+        valueRow(
+          "Qualification",
+          value: result,
+          identifier: AccessibilityID.PiPDeferredPauseValidation.resultLabel
+        )
+      }
+
+      Section("Picture in Picture") {
+        Button(
+          controller?.isActive == true ? "Stop PiP" : "Start PiP",
+          systemImage: "pip",
+          action: { controller?.toggle() }
+        )
+        .accessibilityIdentifier(AccessibilityID.PiPDeferredPauseValidation.toggleButton)
+        .disabled(controller?.isPossible != true || isRunning)
+
+        Button("Run deferred-pause qualification") {
+          Task { await runQualification() }
+        }
+        .accessibilityIdentifier(AccessibilityID.PiPDeferredPauseValidation.runButton)
+        .disabled(
+          isRunning
+            || controller?.isActive != true
+            || player.state != .playing
+            || streams?.vod == nil
+        )
+
+        if let playbackError {
+          Text(playbackError)
+            .foregroundStyle(.red)
+            .accessibilityIdentifier(AccessibilityID.PiPDeferredPauseValidation.errorLabel)
+        }
+      }
+    }
+    .showcaseFormStyle()
+    .navigationTitle("Deferred PiP pause")
+    .task { startPlayback() }
+    .onDisappear {
+      player.configureDeferredPauseQualificationFault(.disabled)
+      player.stop()
+    }
+  }
+
+  private func startPlayback() {
+    guard let url = streams?.vod else {
+      playbackError = "Missing validation VOD"
+      return
+    }
+    do {
+      try player.play(url: url)
+    } catch {
+      playbackError = String(describing: error)
+    }
+  }
+
+  private func runQualification() async {
+    guard let controller, let url = streams?.vod else { return }
+    isRunning = true
+    result = "running"
+    playbackError = nil
+    defer {
+      player.configureDeferredPauseQualificationFault(.disabled)
+      isRunning = false
+    }
+
+    do {
+      let permanent = try await runPermanentCase(controller: controller)
+      let transient = try await runTransientCase(controller: controller)
+      let cancellations = try await runCancellationCases(
+        controller: controller,
+        url: url
+      )
+      let truthfulControls = permanent.truthfulControls
+        && transient.truthfulControls
+        && cancellations.truthfulControls
+      let evidence = QualificationEvidence(
+        permanentCase: permanent,
+        transientCase: transient,
+        cancellationCases: cancellations.allPassed ? "pass" : "failed",
+        cancellationResults: cancellations.results,
+        endlessTaskCount: permanent.taskStayedSettled ? 0 : 1,
+        duplicatePauseCount: transient.nativePauseCommandCount > 1
+          ? transient.nativePauseCommandCount - 1 : 0,
+        truthfulControls: truthfulControls
+      )
+      guard
+        evidence.permanentCase.outcome == "rejected",
+        evidence.permanentCase.forcedRejectionCount > 0,
+        evidence.permanentCase.nativePauseCommandCount == 0,
+        evidence.transientCase.outcome == "issued",
+        evidence.transientCase.forcedRejectionCount == 3,
+        evidence.transientCase.nativePauseCommandCount == 1,
+        evidence.cancellationCases == "pass",
+        evidence.endlessTaskCount == 0,
+        evidence.duplicatePauseCount == 0,
+        evidence.truthfulControls
+      else {
+        throw ValidationFailure("One or more acceptance conditions failed")
+      }
+      let data = try JSONEncoder().encode(evidence)
+      result = "pass:\(data.base64EncodedString())"
+    } catch {
+      playbackError = String(describing: error)
+      result = "failed"
+    }
+  }
+
+  private func runPermanentCase(
+    controller: PiPController
+  )
+    async throws -> PauseCaseEvidence {
+    player.configureDeferredPauseQualificationFault(.permanentRejection)
+    controller.performDeferredPauseQualificationCommand(playing: false)
+    let outcome = try await awaitOutcome(controller, timeout: .seconds(12))
+    let settledSnapshot = player.deferredPauseQualificationSnapshot
+    try await Task.sleep(for: .milliseconds(750))
+    let laterSnapshot = player.deferredPauseQualificationSnapshot
+    let taskStayedSettled = !controller.isDeferredPauseQualificationInFlight
+      && settledSnapshot == laterSnapshot
+    return PauseCaseEvidence(
+      outcome: outcome.name,
+      forcedRejectionCount: settledSnapshot.forcedRejectionCount,
+      nativePauseCommandCount: settledSnapshot.nativePauseCommandCount,
+      taskStayedSettled: taskStayedSettled,
+      truthfulControls: player.state == .playing
+        && controller.deferredPauseQualificationControlsArePlaying
+    )
+  }
+
+  private func runTransientCase(
+    controller: PiPController
+  )
+    async throws -> PauseCaseEvidence {
+    player.configureDeferredPauseQualificationFault(
+      .transientRejection(attempts: 3)
+    )
+    controller.performDeferredPauseQualificationCommand(playing: false)
+    let outcome = try await awaitOutcome(controller, timeout: .seconds(8))
+    try await awaitPlayerState(.paused, timeout: .seconds(3))
+    let snapshot = player.deferredPauseQualificationSnapshot
+    let truthful = !controller.deferredPauseQualificationControlsArePlaying
+      && !player.isPlaybackRequestedActive
+      && player.state == .paused
+    controller.performDeferredPauseQualificationCommand(playing: true)
+    try await awaitPlayerState(.playing, timeout: .seconds(3))
+    return PauseCaseEvidence(
+      outcome: outcome.name,
+      forcedRejectionCount: snapshot.forcedRejectionCount,
+      nativePauseCommandCount: snapshot.nativePauseCommandCount,
+      taskStayedSettled: !controller.isDeferredPauseQualificationInFlight,
+      truthfulControls: truthful
+    )
+  }
+
+  private func runCancellationCases(
+    controller: PiPController,
+    url: URL
+  )
+    async throws -> CancellationEvidence {
+    var cases: [String: String] = [:]
+    var truthfulControls = true
+
+    player.configureDeferredPauseQualificationFault(.permanentRejection)
+    controller.performDeferredPauseQualificationCommand(playing: false)
+    try await Task.sleep(for: .milliseconds(50))
+    controller.performDeferredPauseQualificationCommand(playing: true)
+    cases["newerCommand"] = try await awaitOutcome(controller, timeout: .seconds(2)).name
+    truthfulControls = truthfulControls
+      && controller.deferredPauseQualificationControlsArePlaying
+
+    player.configureDeferredPauseQualificationFault(.permanentRejection)
+    controller.performDeferredPauseQualificationCommand(playing: false)
+    try await Task.sleep(for: .milliseconds(50))
+    try player.play(url: url)
+    cases["replacement"] = try await awaitOutcome(controller, timeout: .seconds(3)).name
+    try await awaitPlayerState(.playing, timeout: .seconds(5))
+    truthfulControls = truthfulControls
+      && controller.deferredPauseQualificationControlsArePlaying
+
+    player.configureDeferredPauseQualificationFault(.permanentRejection)
+    controller.performDeferredPauseQualificationCommand(playing: false)
+    try await Task.sleep(for: .milliseconds(50))
+    player.stop()
+    cases["stop"] = try await awaitOutcome(controller, timeout: .seconds(3)).name
+    try player.play(url: url)
+    try await awaitPlayerState(.playing, timeout: .seconds(5))
+
+    try await Task.sleep(for: .milliseconds(500))
+    let noLatePause = player.deferredPauseQualificationSnapshot.nativePauseCommandCount == 0
+      && !controller.isDeferredPauseQualificationInFlight
+    let allPassed = cases.values.allSatisfy { $0 == "cancelled" }
+      && cases.count == 3
+      && noLatePause
+    return CancellationEvidence(
+      results: cases,
+      allPassed: allPassed,
+      truthfulControls: truthfulControls && player.isPlaybackRequestedActive
+    )
+  }
+
+  private func awaitOutcome(
+    _ controller: PiPController,
+    timeout: Duration
+  )
+    async throws -> PiPController.DeferredPauseOutcome {
+    let deadline = ContinuousClock.now + timeout
+    while controller.deferredPauseOutcome == nil {
+      guard ContinuousClock.now < deadline else {
+        throw ValidationFailure("Deferred-pause outcome timed out")
+      }
+      try await Task.sleep(for: .milliseconds(20))
+    }
+    guard let outcome = controller.deferredPauseOutcome else {
+      throw ValidationFailure("Deferred-pause outcome disappeared")
+    }
+    return outcome
+  }
+
+  private func awaitPlayerState(
+    _ expected: PlayerState,
+    timeout: Duration
+  )
+    async throws {
+    let deadline = ContinuousClock.now + timeout
+    while player.state != expected {
+      guard ContinuousClock.now < deadline else {
+        throw ValidationFailure("Expected \(expected), got \(player.state)")
+      }
+      try await Task.sleep(for: .milliseconds(20))
+    }
+  }
+
+  private func valueRow(_ title: String, value: String, identifier: String) -> some View {
+    HStack {
+      Text(title)
+      Spacer()
+      Text(value)
+        .foregroundStyle(.secondary)
+        .accessibilityIdentifier(identifier)
+    }
+  }
+}
+
+private struct PauseCaseEvidence: Codable {
+  let outcome: String
+  let forcedRejectionCount: Int
+  let nativePauseCommandCount: Int
+  let taskStayedSettled: Bool
+  let truthfulControls: Bool
+}
+
+private struct CancellationEvidence {
+  let results: [String: String]
+  let allPassed: Bool
+  let truthfulControls: Bool
+}
+
+private struct QualificationEvidence: Codable {
+  let permanentCase: PauseCaseEvidence
+  let transientCase: PauseCaseEvidence
+  let cancellationCases: String
+  let cancellationResults: [String: String]
+  let endlessTaskCount: Int
+  let duplicatePauseCount: Int
+  let truthfulControls: Bool
+}
+
+private struct ValidationFailure: Error, CustomStringConvertible {
+  let description: String
+
+  init(_ description: String) {
+    self.description = description
+  }
+}
+
+extension PiPController.DeferredPauseOutcome {
+  fileprivate var name: String {
+    switch self {
+    case .issued: "issued"
+    case .cancelled: "cancelled"
+    case .rejected: "rejected"
+    }
+  }
+}

--- a/Showcase/iOS/ValidationHarness/PiPDeferredPauseValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/PiPDeferredPauseValidationCase.swift
@@ -303,6 +303,8 @@ private struct CancellationEvidence {
 }
 
 private struct QualificationEvidence: Codable {
+  let formatVersion = 1
+  let scenario = "deferred-pause-rejection"
   let permanentCase: PauseCaseEvidence
   let transientCase: PauseCaseEvidence
   let cancellationCases: String

--- a/Showcase/iOS/ValidationHarness/PiPDeferredPauseValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/PiPDeferredPauseValidationCase.swift
@@ -288,7 +288,7 @@ struct PiPDeferredPauseValidationCase: View {
   }
 }
 
-private struct PauseCaseEvidence: Codable {
+private struct PauseCaseEvidence: Encodable {
   let outcome: String
   let forcedRejectionCount: Int
   let nativePauseCommandCount: Int
@@ -302,7 +302,7 @@ private struct CancellationEvidence {
   let truthfulControls: Bool
 }
 
-private struct QualificationEvidence: Codable {
+private struct QualificationEvidence: Encodable {
   let formatVersion = 1
   let scenario = "deferred-pause-rejection"
   let permanentCase: PauseCaseEvidence

--- a/Showcase/macOS/Internal/MacShowcaseRootView.swift
+++ b/Showcase/macOS/Internal/MacShowcaseRootView.swift
@@ -405,7 +405,11 @@ extension MacShowcase {
     case .multiConsumer: self = .multiConsumerEvents
     case .statistics: self = .statistics
     case .logs: self = .logs
-    case .harnessHome, .pipLiveValidation, .pipCapabilityValidation: return nil
+    case .harnessHome,
+         .pipLiveValidation,
+         .pipCapabilityValidation,
+         .pipDeferredPauseValidation:
+      return nil
     }
   }
 }

--- a/Showcase/tvOS/Internal/TVShowcaseRootView.swift
+++ b/Showcase/tvOS/Internal/TVShowcaseRootView.swift
@@ -515,7 +515,8 @@ extension TVShowcase {
          .multiConsumer,
          .harnessHome,
          .pipLiveValidation,
-         .pipCapabilityValidation:
+         .pipCapabilityValidation,
+         .pipDeferredPauseValidation:
       return nil
     }
   }

--- a/Sources/SwiftVLC/PiP/PiPController+Validation.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Validation.swift
@@ -77,6 +77,28 @@ public struct RawCapabilityEventSuppressionSnapshot: Sendable, Equatable {
   public let suppressedSeekableEventCount: Int
 }
 
+/// Deterministic native-pause capability fault used by the physical
+/// deferred-pause qualification lane.
+@_spi(Qualification)
+public enum DeferredPauseQualificationFault: Sendable, Equatable {
+  /// Restore the live libVLC capability probe and clear prior counters.
+  case disabled
+  /// Reject every native pause probe until explicitly disabled.
+  case permanentRejection
+  /// Reject a fixed number of probes, then return authority to libVLC.
+  case transientRejection(attempts: Int)
+}
+
+/// Counters captured from the live Player pause path while qualification fault
+/// injection is enabled.
+@_spi(Qualification)
+public struct DeferredPauseQualificationSnapshot: Sendable, Equatable {
+  public let isEnabled: Bool
+  public let forcedRejectionCount: Int
+  public let nativePauseCommandCount: Int
+  public let remainingTransientRejections: Int
+}
+
 extension PiPController {
   /// A snapshot of the iOS native PiP backend's private wiring, or
   /// `nil` when this controller doesn't drive the native backend (the
@@ -139,6 +161,29 @@ extension PiPController {
     )
     return await request.outcome == .settled
   }
+
+  /// Exercises the same controller command entry point used by AVKit's
+  /// sample-buffer playback delegate.
+  @_spi(Qualification)
+  public func performDeferredPauseQualificationCommand(playing: Bool) {
+    handleSetPlaying(playing)
+  }
+
+  /// Whether the bounded controller task is still scheduled.
+  @_spi(Qualification)
+  public var isDeferredPauseQualificationInFlight: Bool {
+    if case .scheduled = deferredPause {
+      true
+    } else {
+      false
+    }
+  }
+
+  /// Truth reported to AVKit's playback controls after a deferred command.
+  @_spi(Qualification)
+  public var deferredPauseQualificationControlsArePlaying: Bool {
+    pipPlaybackActive && player.isPlaybackRequestedActive
+  }
 }
 
 extension Player {
@@ -160,12 +205,43 @@ extension Player {
     }
   }
 
+  /// Configures candidate-bound pause-capability fault injection. This alters
+  /// only the capability decision; generation binding, retained commands,
+  /// native command issuance, and outcome reconciliation remain live.
+  @_spi(Qualification)
+  public func configureDeferredPauseQualificationFault(
+    _ fault: DeferredPauseQualificationFault
+  ) {
+    switch fault {
+    case .disabled:
+      configureQualificationPauseFault(mode: .disabled)
+    case .permanentRejection:
+      configureQualificationPauseFault(mode: .permanentRejection)
+    case .transientRejection(let attempts):
+      configureQualificationPauseFault(
+        mode: .transientRejection,
+        transientRejections: attempts
+      )
+    }
+  }
+
   @_spi(Qualification)
   public var rawCapabilityEventSuppressionSnapshot: RawCapabilityEventSuppressionSnapshot {
     RawCapabilityEventSuppressionSnapshot(
       isEnabled: isSuppressingRawCapabilityEvents,
       suppressedLengthEventCount: suppressedRawLengthEventCount,
       suppressedSeekableEventCount: suppressedRawSeekableEventCount
+    )
+  }
+
+  @_spi(Qualification)
+  public var deferredPauseQualificationSnapshot: DeferredPauseQualificationSnapshot {
+    let snapshot = qualificationPauseFaultSnapshot
+    return DeferredPauseQualificationSnapshot(
+      isEnabled: snapshot.isEnabled,
+      forcedRejectionCount: snapshot.forcedRejectionCount,
+      nativePauseCommandCount: snapshot.nativePauseCommandCount,
+      remainingTransientRejections: snapshot.remainingTransientRejections
     )
   }
 }

--- a/Sources/SwiftVLC/Player/Player+Pause.swift
+++ b/Sources/SwiftVLC/Player/Player+Pause.swift
@@ -258,10 +258,16 @@ extension Player {
       // Refreshing observable capabilities here could publish values from a
       // successor under the outgoing media's generation.
       #if DEBUG
-      let nativeCanPause = _nativeCanPauseOverrideForTesting
+      let probedNativeCanPause = _nativeCanPauseOverrideForTesting
         ?? libvlc_media_player_can_pause(pointer)
       #else
-      let nativeCanPause = libvlc_media_player_can_pause(pointer)
+      let probedNativeCanPause = libvlc_media_player_can_pause(pointer)
+      #endif
+      #if os(iOS) || os(macOS)
+      let nativeCanPause = consumeQualificationNativeCanPauseOverride()
+        ?? probedNativeCanPause
+      #else
+      let nativeCanPause = probedNativeCanPause
       #endif
       let nativePauseIsSafe = canIssueNativePause
       #if DEBUG
@@ -308,6 +314,9 @@ extension Player {
       publishPauseIntent()
       let issuedPlaybackControlRevision = playbackControlIntentRevision
       libvlc_media_player_set_pause(pointer, 1)
+      #if os(iOS) || os(macOS)
+      recordQualificationNativePauseCommand()
+      #endif
       #if DEBUG
       _pauseProbeHookForTesting?(.nativePause)
       #endif

--- a/Sources/SwiftVLC/Player/Player+Qualification.swift
+++ b/Sources/SwiftVLC/Player/Player+Qualification.swift
@@ -1,0 +1,69 @@
+#if os(iOS) || os(macOS)
+
+extension Player {
+  enum QualificationPauseFaultMode: Equatable {
+    case disabled
+    case permanentRejection
+    case transientRejection
+  }
+
+  struct QualificationPauseFaultSnapshot: Sendable, Equatable {
+    let isEnabled: Bool
+    let forcedRejectionCount: Int
+    let nativePauseCommandCount: Int
+    let remainingTransientRejections: Int
+  }
+
+  struct QualificationPauseFaultState {
+    var mode: QualificationPauseFaultMode = .disabled
+    var remainingTransientRejections = 0
+    var forcedRejectionCount = 0
+    var nativePauseCommandCount = 0
+  }
+
+  func configureQualificationPauseFault(
+    mode: QualificationPauseFaultMode,
+    transientRejections: Int = 0
+  ) {
+    qualificationPauseFault = QualificationPauseFaultState(
+      mode: mode,
+      remainingTransientRejections: max(0, transientRejections)
+    )
+  }
+
+  /// Returns `false` while qualification deliberately suppresses native pause
+  /// capability, or `nil` when the real libVLC probe remains authoritative.
+  func consumeQualificationNativeCanPauseOverride() -> Bool? {
+    switch qualificationPauseFault.mode {
+    case .disabled:
+      return nil
+    case .permanentRejection:
+      qualificationPauseFault.forcedRejectionCount += 1
+      return false
+    case .transientRejection:
+      guard qualificationPauseFault.remainingTransientRejections > 0 else {
+        return nil
+      }
+      qualificationPauseFault.remainingTransientRejections -= 1
+      qualificationPauseFault.forcedRejectionCount += 1
+      return false
+    }
+  }
+
+  func recordQualificationNativePauseCommand() {
+    guard qualificationPauseFault.mode != .disabled else { return }
+    qualificationPauseFault.nativePauseCommandCount += 1
+  }
+
+  var qualificationPauseFaultSnapshot: QualificationPauseFaultSnapshot {
+    QualificationPauseFaultSnapshot(
+      isEnabled: qualificationPauseFault.mode != .disabled,
+      forcedRejectionCount: qualificationPauseFault.forcedRejectionCount,
+      nativePauseCommandCount: qualificationPauseFault.nativePauseCommandCount,
+      remainingTransientRejections:
+      qualificationPauseFault.remainingTransientRejections
+    )
+  }
+}
+
+#endif

--- a/Sources/SwiftVLC/Player/Player.swift
+++ b/Sources/SwiftVLC/Player/Player.swift
@@ -435,6 +435,15 @@ public final class Player {
   @ObservationIgnored
   var lastIssuedPausePlaybackControlRevision: UInt64?
 
+  #if os(iOS) || os(macOS)
+  /// Candidate-bound fault state for the physical deferred-pause lane.
+  /// Mutation is reachable only through qualification SPI; keeping the state
+  /// in the live Player path ensures Release builds exercise the same pause
+  /// generation and cleanup machinery as production.
+  @ObservationIgnored
+  var qualificationPauseFault = QualificationPauseFaultState()
+  #endif
+
   #if DEBUG
   /// Lets deterministic tests advance the callback-lane generation at the
   /// otherwise unschedulable boundaries between a native probe and its

--- a/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPControllerTests.swift
@@ -102,7 +102,7 @@ extension Integration {
     func `Terminal rejection retires the player-owned deferred pause`() async {
       let player = Player(instance: TestInstance.makeAudioOnly())
       player._nativePlaybackStateOverrideForTesting = .playing
-      player._nativeCanPauseOverrideForTesting = false
+      player.configureQualificationPauseFault(mode: .permanentRejection)
       player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
       let controller = PiPController(
         player: player,
@@ -118,6 +118,37 @@ extension Integration {
       #expect(player.deferredPauseCommandPlaybackGeneration == nil)
       #expect(player.playbackControlIntent == .resume)
       #expect(player.isPlaybackRequestedActive)
+      #expect(player.qualificationPauseFaultSnapshot.forcedRejectionCount >= 1)
+      #expect(player.qualificationPauseFaultSnapshot.nativePauseCommandCount == 0)
+    }
+
+    @Test
+    func `Transient qualification rejection returns to the live pause path`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._nativePlaybackStateOverrideForTesting = .playing
+      player._nativeCanPauseOverrideForTesting = true
+      player._nativePauseSafetyOverrideForTesting = true
+      player.configureQualificationPauseFault(
+        mode: .transientRejection,
+        transientRejections: 3
+      )
+      player._setStateForTesting(state: .playing, isPlaybackRequestedActive: true)
+      let controller = PiPController(
+        player: player,
+        playbackDriver: .live(player: player),
+        pauseDebounce: .milliseconds(1)
+      )
+      controller._deferredPauseRetryHookForTesting = {
+        player.performDeferredPauseCommandIfNeeded()
+      }
+
+      controller._setPlayingForTesting(false)
+
+      #expect(await awaitDeferredPauseOutcome(controller))
+      #expect(controller.deferredPauseOutcome == .issued)
+      #expect(player.qualificationPauseFaultSnapshot.forcedRejectionCount == 3)
+      #expect(player.qualificationPauseFaultSnapshot.nativePauseCommandCount == 1)
+      #expect(player.qualificationPauseFaultSnapshot.remainingTransientRejections == 0)
     }
 
     /// Apps need to react when a deferred pause settles, rather than polling

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -107,6 +107,17 @@ library errors before emitting the combined `capability-convergence` row. The
 default run omits this lane on other hardware rows, and an explicit unsupported
 request fails before testing rather than producing evidence for an unknown row.
 
+The iPhone-current-only deferred-pause-rejection lane drives the exact AVKit
+playback command entry point while a qualification SPI changes only libVLC's
+native pause-capability answer. It proves a permanently unpausable input
+settles to `rejected` within the production retry bound without a late pause,
+a transient three-probe rejection issues exactly one native pause, and newer
+play, media replacement, and stop commands cancel pending work. The attached
+evidence includes the individual counters and requires truthful AVKit/player
+controls, zero endless tasks, zero duplicate pauses, and zero library errors.
+The default run omits this lane on other hardware rows, and an explicit
+unsupported request fails before testing.
+
 The HLS seek lane is another complete machine-readable matrix slice. It
 executes forward, backward, and absolute seeks, measures the return of decoded
 video, checks ordered PiP continuity, samples real system-PiP motion after each

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -33,7 +33,8 @@ Options:
   --output PATH           Evidence output root
   --only SCENARIO         Repeat to select: analyzer, ui-suite, native-live,
                           direct-live, live-media, background-audio,
-                          continuity, capability-convergence, hls-seek,
+                          continuity, capability-convergence,
+                          deferred-pause-rejection, hls-seek,
                           harness-regressions, ui-failures, thumbnail-preview
   --require-stable        Refuse beta/unknown OS or a non-matching matrix row
   --skip-build            Reuse an existing signed runner in derived data
@@ -225,6 +226,7 @@ python3 "$SCRIPT_DIR/prepare-xctestrun.py" "$XCTESTRUN" "$DESTINATION_XCTESTRUN"
   --environment SWIFTVLC_PIP_LIVE_URL_BASE64="$PIP_LIVE_URL_BASE64" \
   --environment SWIFTVLC_PIP_CONTINUITY_DEVICE=YES \
   --environment SWIFTVLC_PIP_CAPABILITY_DEVICE=YES \
+  --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
   --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
   --environment SWIFTVLC_PIP_SEEK_DEVICE=YES
 cp "$DESTINATION_XCTESTRUN" "$OUTPUT_DIR/destination.xctestrun"
@@ -276,7 +278,7 @@ xcrun devicectl device copy to \
   --destination Documents/streams.local.json \
   > "$OUTPUT_DIR/stage-streams.log"
 
-DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence hls-seek)
+DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence deferred-pause-rejection hls-seek)
 SCENARIOS_WERE_EXPLICIT=false
 if [[ ${#ONLY_SCENARIOS[@]} -eq 0 ]]; then
   ONLY_SCENARIOS=("${DEFAULT_SCENARIOS[@]}")
@@ -285,7 +287,7 @@ else
 fi
 for scenario in "${ONLY_SCENARIOS[@]}"; do
   case "$scenario" in
-    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
+    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|deferred-pause-rejection|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
     *) echo "Error: unknown scenario: $scenario" >&2; exit 2 ;;
   esac
 done
@@ -300,20 +302,20 @@ device_matches_hardware_row() {
 if ! device_matches_hardware_row "iphone-current"; then
   if [[ "$SCENARIOS_WERE_EXPLICIT" == true ]]; then
     for scenario in "${ONLY_SCENARIOS[@]}"; do
-      if [[ "$scenario" == "capability-convergence" ]]; then
-        echo "Error: capability-convergence requires the iphone-current hardware row." >&2
+      if [[ "$scenario" == "capability-convergence" || "$scenario" == "deferred-pause-rejection" ]]; then
+        echo "Error: $scenario requires the iphone-current hardware row." >&2
         exit 2
       fi
     done
   else
     FILTERED_SCENARIOS=()
     for scenario in "${ONLY_SCENARIOS[@]}"; do
-      if [[ "$scenario" != "capability-convergence" ]]; then
+      if [[ "$scenario" != "capability-convergence" && "$scenario" != "deferred-pause-rejection" ]]; then
         FILTERED_SCENARIOS+=("$scenario")
       fi
     done
     ONLY_SCENARIOS=("${FILTERED_SCENARIOS[@]}")
-    echo "Skipping capability-convergence: selected device does not match iphone-current."
+    echo "Skipping iphone-current-only qualification scenarios: selected device does not match iphone-current."
   fi
 fi
 
@@ -384,6 +386,13 @@ run_scenario() {
       route="PiPCapabilityValidation"
       selected_xctestrun="$DESTINATION_XCTESTRUN"
       ;;
+    deferred-pause-rejection)
+      test_identifiers=(
+        "iOSUITests/PiPDeferredPauseDeviceUITests/test_deferredPauseRejectionAndCancellationStayTruthful"
+      )
+      route="PiPDeferredPauseValidation"
+      selected_xctestrun="$DESTINATION_XCTESTRUN"
+      ;;
     hls-seek)
       test_identifiers=("iOSUITests/PiPOverlayDeviceUITests/test_nativePiPHLSSeekAndReloadRemainActive")
       route="HarnessHome"
@@ -424,6 +433,7 @@ run_scenario() {
       --environment SWIFTVLC_PIP_LIVE_URL_BASE64="$PIP_LIVE_URL_BASE64" \
       --environment SWIFTVLC_PIP_CONTINUITY_DEVICE=YES \
       --environment SWIFTVLC_PIP_CAPABILITY_DEVICE=YES \
+      --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
       --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
       --environment SWIFTVLC_PIP_SEEK_DEVICE=YES \
       --environment SWIFTVLC_DEVICE_LOG_PREFIX="$run_id-$scenario"
@@ -449,6 +459,7 @@ run_scenario() {
       -skip-testing:iOSUITests/PiPLiveDeviceUITests
       -skip-testing:iOSUITests/PiPContinuityDeviceUITests
       -skip-testing:iOSUITests/PiPCapabilityDeviceUITests
+      -skip-testing:iOSUITests/PiPDeferredPauseDeviceUITests
       -skip-testing:iOSUITests/PiPOverlayDeviceUITests
     )
   fi
@@ -606,6 +617,10 @@ PY
     capability-convergence)
       qualification_scenarios=("capability-convergence")
       qualification_attachments=("qualification-capability-convergence.json")
+      ;;
+    deferred-pause-rejection)
+      qualification_scenarios=("deferred-pause-rejection")
+      qualification_attachments=("qualification-deferred-pause-rejection.json")
       ;;
   esac
   if [[ ${#qualification_scenarios[@]} -gt 0 ]]; then

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -390,6 +390,56 @@ class QualificationEvidenceTests(unittest.TestCase):
             self.assertEqual(evidence["skipControls"], "pass")
             self.assertTrue(evidence["faultInjection"]["rawEventsSuppressed"])
 
+    def test_materializes_deferred_pause_rejection_evidence(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.make_export(
+                root,
+                {
+                    "formatVersion": 1,
+                    "scenario": "deferred-pause-rejection",
+                    "permanentCase": {
+                        "outcome": "rejected",
+                        "forcedRejectionCount": 40,
+                        "nativePauseCommandCount": 0,
+                        "taskStayedSettled": True,
+                        "truthfulControls": True,
+                    },
+                    "transientCase": {
+                        "outcome": "issued",
+                        "forcedRejectionCount": 3,
+                        "nativePauseCommandCount": 1,
+                        "taskStayedSettled": True,
+                        "truthfulControls": True,
+                    },
+                    "cancellationCases": "pass",
+                    "cancellationResults": {
+                        "newerCommand": "cancelled",
+                        "replacement": "cancelled",
+                        "stop": "cancelled",
+                    },
+                    "endlessTaskCount": 0,
+                    "duplicatePauseCount": 0,
+                    "truthfulControls": True,
+                },
+                attachment_name="qualification-deferred-pause-rejection.json",
+                test_identifier="PiPDeferredPauseDeviceUITests/test_deferredPauseRejectionAndCancellationStayTruthful",
+            )
+            evidence = materialize_evidence.materialize(
+                root,
+                "qualification-deferred-pause-rejection.json",
+                "deferred-pause-rejection",
+                "iphone-current",
+                "a" * 64,
+                "b" * 64,
+            )
+            self.assertEqual(evidence["permanentCase"]["outcome"], "rejected")
+            self.assertEqual(evidence["transientCase"]["outcome"], "issued")
+            self.assertEqual(evidence["cancellationCases"], "pass")
+            self.assertEqual(evidence["endlessTaskCount"], 0)
+            self.assertEqual(evidence["duplicatePauseCount"], 0)
+            self.assertTrue(evidence["truthfulControls"])
+
     def test_materializes_focused_replacement_evidence(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
## Summary
- add Release-capable qualification fault injection that changes only the native can-pause answer
- exercise permanent rejection, transient recovery, newer-command, replacement, and stop cancellation through the AVKit command entry path
- emit candidate-bound evidence for the iphone-current deferred-pause-rejection matrix row
- harden XCTest evidence attachments so their scenario identity is always bound before host materialization

## Validation
- SwiftFormat strict
- SwiftLint strict
- 26 qualification harness tests
- release-integrity checks
- 38 focused PiPController tests
- iOS Showcase app and UI-test runner build-for-testing against the local branch source
- prior full branch validation: 1,996 Swift tests in 168 suites, plus generic tvOS and macOS Showcase builds

## Release-gate note
This PR automates the row for issue #103. It does not claim a physical-device pass, close the issue, or qualify a release candidate; those actions still require candidate-bound evidence from matching hardware.