### PR TITLE
Automate accepted PiP start failure qualification

### DIFF
--- a/Showcase/Shared/AccessibilityID.swift
+++ b/Showcase/Shared/AccessibilityID.swift
@@ -225,6 +225,15 @@ enum AccessibilityID {
     static let errorLabel = "pipDeferredPause.error"
   }
 
+  enum PiPDelayedStartFailureValidation {
+    static let videoView = "pipDelayedStartFailure.videoView"
+    static let stateLabel = "pipDelayedStartFailure.state"
+    static let possibleLabel = "pipDelayedStartFailure.possible"
+    static let resultLabel = "pipDelayedStartFailure.result"
+    static let runButton = "pipDelayedStartFailure.run"
+    static let errorLabel = "pipDelayedStartFailure.error"
+  }
+
   enum MatrixHValidation {
     static let stateLabel = "validation.matrixH.state"
     static let currentTimeLabel = "validation.matrixH.currentTime"

--- a/Showcase/Shared/LaunchArguments.swift
+++ b/Showcase/Shared/LaunchArguments.swift
@@ -165,6 +165,7 @@ enum UITestRoute: String, CaseIterable {
   case pipLiveValidation = "PiPLiveValidation"
   case pipCapabilityValidation = "PiPCapabilityValidation"
   case pipDeferredPauseValidation = "PiPDeferredPauseValidation"
+  case pipDelayedStartFailureValidation = "PiPDelayedStartFailureValidation"
 
   static var current: UITestRoute? {
     LaunchArguments.routeValue.flatMap(UITestRoute.init(rawValue:))

--- a/Showcase/UITests/iOS/Tests/PiPDelayedStartFailureDeviceUITests.swift
+++ b/Showcase/UITests/iOS/Tests/PiPDelayedStartFailureDeviceUITests.swift
@@ -49,8 +49,10 @@ final class PiPDelayedStartFailureDeviceUITests: ShowcaseIOSTestCase {
       evidence["expectedMediaGeneration"] as? Int
     )
     let events = try XCTUnwrap(evidence["orderedEvents"] as? [String])
-    XCTAssertEqual(events.last, "failedToStart")
+    XCTAssertTrue(events.contains("failedToStart"))
     XCTAssertFalse(events.contains("didStart"))
+    XCTAssertEqual(evidence["quiescenceMilliseconds"] as? Int, 3000)
+    XCTAssertEqual(evidence["controllerActiveAfterCleanup"] as? Bool, false)
     XCTAssertEqual(
       evidence["failureDomain"] as? String,
       "SwiftVLC.Qualification.DelayedPiPStartFailure"

--- a/Showcase/UITests/iOS/Tests/PiPDelayedStartFailureDeviceUITests.swift
+++ b/Showcase/UITests/iOS/Tests/PiPDelayedStartFailureDeviceUITests.swift
@@ -1,0 +1,99 @@
+import XCTest
+
+/// Candidate-bound proof that a real accepted AVKit start followed by a
+/// deterministic delayed delegate failure keeps ordered controller/media
+/// attribution.
+final class PiPDelayedStartFailureDeviceUITests: ShowcaseIOSTestCase {
+  func test_acceptedStartRetainsAttributionThroughDelayedFailure() throws {
+    #if targetEnvironment(simulator)
+    throw XCTSkip("System Picture in Picture requires a physical iOS device")
+    #else
+    guard ProcessInfo.processInfo.environment["SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE"] == "YES" else {
+      throw XCTSkip(
+        "Set SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE=YES for candidate-bound hardware runs"
+      )
+    }
+
+    addUIInterruptionMonitor(withDescription: "Local network permission") { alert in
+      let allow = alert.buttons["Allow"]
+      guard allow.exists else { return false }
+      allow.tap()
+      return true
+    }
+    launch(route: .pipDelayedStartFailureValidation)
+    app.tap()
+
+    let state = element(AccessibilityID.PiPDelayedStartFailureValidation.stateLabel)
+    let possible = element(AccessibilityID.PiPDelayedStartFailureValidation.possibleLabel)
+    let result = element(AccessibilityID.PiPDelayedStartFailureValidation.resultLabel)
+    let run = app.buttons[AccessibilityID.PiPDelayedStartFailureValidation.runButton]
+    let error = element(AccessibilityID.PiPDelayedStartFailureValidation.errorLabel)
+
+    waitForLabel(state, equals: "playing", timeout: 20)
+    waitForLabel(possible, equals: "yes", timeout: 15)
+    reveal(run)
+    XCTAssertTrue(run.isEnabled)
+    run.tap()
+    waitForPrefix(result, prefix: "pass:", timeout: 15)
+    XCTAssertFalse(error.exists, "Validation surface reported: \(error.label)")
+
+    let evidence = try decodeEvidence(result.label)
+    XCTAssertEqual(evidence["startResult"] as? String, "accepted")
+    XCTAssertEqual(evidence["orderedAttribution"] as? Bool, true)
+    XCTAssertEqual(
+      evidence["controllerGeneration"] as? Int,
+      evidence["expectedControllerGeneration"] as? Int
+    )
+    XCTAssertEqual(
+      evidence["mediaGeneration"] as? Int,
+      evidence["expectedMediaGeneration"] as? Int
+    )
+    let events = try XCTUnwrap(evidence["orderedEvents"] as? [String])
+    XCTAssertEqual(events.last, "failedToStart")
+    XCTAssertFalse(events.contains("didStart"))
+    XCTAssertEqual(
+      evidence["failureDomain"] as? String,
+      "SwiftVLC.Qualification.DelayedPiPStartFailure"
+    )
+    attachQualificationEvidence(evidence, scenario: "accepted-start-delayed-failure")
+    assertNoLibraryErrors()
+    #endif
+  }
+
+  private func decodeEvidence(_ label: String) throws -> [String: Any] {
+    let prefix = "pass:"
+    XCTAssertTrue(label.hasPrefix(prefix))
+    let encoded = String(label.dropFirst(prefix.count))
+    let data = try XCTUnwrap(Data(base64Encoded: encoded))
+    return try XCTUnwrap(
+      JSONSerialization.jsonObject(with: data) as? [String: Any]
+    )
+  }
+
+  private func element(_ identifier: String) -> XCUIElement {
+    app.descendants(matching: .any)[identifier]
+  }
+
+  private func waitForPrefix(
+    _ element: XCUIElement,
+    prefix: String,
+    timeout: TimeInterval
+  ) {
+    let predicate = NSPredicate { _, _ in
+      element.exists && element.label.hasPrefix(prefix)
+    }
+    let expectation = expectation(for: predicate, evaluatedWith: NSObject())
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [expectation], timeout: timeout),
+      .completed,
+      "Expected prefix \(prefix), got: \(element.label)"
+    )
+  }
+
+  private func reveal(_ element: XCUIElement) {
+    for _ in 0..<10 where !element.isHittable {
+      app.swipeUp()
+    }
+    XCTAssertTrue(element.isHittable)
+  }
+}

--- a/Showcase/iOS/Internal/UITestSupport.swift
+++ b/Showcase/iOS/Internal/UITestSupport.swift
@@ -128,6 +128,7 @@ extension UITestRoute {
     case .pipLiveValidation: PiPLiveValidationCase()
     case .pipCapabilityValidation: PiPCapabilityValidationCase()
     case .pipDeferredPauseValidation: PiPDeferredPauseValidationCase()
+    case .pipDelayedStartFailureValidation: PiPDelayedStartFailureValidationCase()
     }
   }
 }

--- a/Showcase/iOS/ValidationHarness/PiPDelayedStartFailureValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/PiPDelayedStartFailureValidationCase.swift
@@ -1,0 +1,230 @@
+import SwiftUI
+@_spi(Qualification) import SwiftVLC
+
+/// Candidate-bound exercise of an accepted direct AVKit start followed by an
+/// asynchronous delegate failure. The qualification SPI issues the real start
+/// request first; only the delayed failure callback is deterministic.
+struct PiPDelayedStartFailureValidationCase: View {
+  @State private var player = Player()
+  @State private var controller: PiPController?
+  @State private var result = "not-run"
+  @State private var playbackError: String?
+  @State private var isRunning = false
+
+  private let streams = HarnessStreams.load()?.streams
+
+  var body: some View {
+    _ = player.currentTime
+    return Form {
+      Section {
+        DirectPiPValidationSurface(player: player, controller: $controller)
+          .frame(height: 220)
+          .listRowInsets(EdgeInsets())
+          .accessibilityIdentifier(AccessibilityID.PiPDelayedStartFailureValidation.videoView)
+      }
+
+      Section("Measured state") {
+        valueRow(
+          "Playback",
+          value: String(describing: player.state),
+          identifier: AccessibilityID.PiPDelayedStartFailureValidation.stateLabel
+        )
+        valueRow(
+          "PiP possible",
+          value: controller?.isPossible == true ? "yes" : "no",
+          identifier: AccessibilityID.PiPDelayedStartFailureValidation.possibleLabel
+        )
+        valueRow(
+          "Qualification",
+          value: result,
+          identifier: AccessibilityID.PiPDelayedStartFailureValidation.resultLabel
+        )
+      }
+
+      Section("Picture in Picture") {
+        Button("Run accepted-start failure qualification") {
+          Task { await runQualification() }
+        }
+        .accessibilityIdentifier(AccessibilityID.PiPDelayedStartFailureValidation.runButton)
+        .disabled(
+          isRunning
+            || controller?.isPossible != true
+            || player.state != .playing
+        )
+
+        if let playbackError {
+          Text(playbackError)
+            .foregroundStyle(.red)
+            .accessibilityIdentifier(AccessibilityID.PiPDelayedStartFailureValidation.errorLabel)
+        }
+      }
+    }
+    .showcaseFormStyle()
+    .navigationTitle("Delayed PiP start failure")
+    .task { startPlayback() }
+    .onDisappear {
+      controller?.stop()
+      player.stop()
+    }
+  }
+
+  private func startPlayback() {
+    guard let url = streams?.vod else {
+      playbackError = "Missing validation VOD"
+      return
+    }
+    do {
+      try player.play(url: url)
+    } catch {
+      playbackError = String(describing: error)
+    }
+  }
+
+  private func runQualification() async {
+    guard let controller else { return }
+    isRunning = true
+    result = "running"
+    playbackError = nil
+    defer {
+      controller.stop()
+      isRunning = false
+    }
+
+    do {
+      let expectedControllerGeneration = controller.qualificationControllerGeneration
+      let expectedMediaGeneration = player.playbackQualificationGeneration
+      let stream = controller.pipEventEnvelopes
+      let collector = Task {
+        try await collectFailure(from: stream, timeout: .seconds(5))
+      }
+      let startResult = controller.performAcceptedStartDelayedFailureQualification()
+      guard startResult == .accepted else {
+        collector.cancel()
+        throw ValidationFailure("Start returned \(startResult.name)")
+      }
+      let collection = try await collector.value
+      let orderedAttribution = collection.events.last == "failedToStart"
+        && !collection.events.contains("didStart")
+        && collection.failure.controllerGeneration == expectedControllerGeneration
+        && collection.failure.mediaGeneration == expectedMediaGeneration
+      let evidence = QualificationEvidence(
+        startResult: startResult.name,
+        orderedEvents: collection.events,
+        controllerGeneration: collection.failure.controllerGeneration,
+        mediaGeneration: collection.failure.mediaGeneration.qualificationValue,
+        expectedControllerGeneration: expectedControllerGeneration,
+        expectedMediaGeneration: expectedMediaGeneration.qualificationValue,
+        orderedAttribution: orderedAttribution,
+        failureDomain: collection.failureDomain,
+        failureCode: collection.failureCode
+      )
+      guard evidence.orderedAttribution else {
+        throw ValidationFailure("Failure attribution was late, reordered, or mismatched")
+      }
+      let data = try JSONEncoder().encode(evidence)
+      result = "pass:\(data.base64EncodedString())"
+    } catch is CancellationError {
+      result = "cancelled"
+    } catch {
+      playbackError = String(describing: error)
+      result = "failed"
+    }
+  }
+
+  private func collectFailure(
+    from stream: AsyncStream<PiPEventEnvelope>,
+    timeout: Duration
+  )
+    async throws -> FailureCollection {
+    try await withThrowingTaskGroup(of: FailureCollection.self) { group in
+      group.addTask {
+        var events: [String] = []
+        for await envelope in stream {
+          let eventName = envelope.event.name
+          events.append(eventName)
+          if case .failedToStart(let error) = envelope.event {
+            let failure = error as NSError
+            return FailureCollection(
+              events: events,
+              failure: envelope,
+              failureDomain: failure.domain,
+              failureCode: failure.code
+            )
+          }
+        }
+        throw ValidationFailure("Lifecycle stream ended before start failure")
+      }
+      group.addTask {
+        try await Task.sleep(for: timeout)
+        throw ValidationFailure("Delayed start failure timed out")
+      }
+      defer { group.cancelAll() }
+      guard let first = try await group.next() else {
+        throw ValidationFailure("No lifecycle result")
+      }
+      return first
+    }
+  }
+
+  private func valueRow(_ title: String, value: String, identifier: String) -> some View {
+    HStack {
+      Text(title)
+      Spacer()
+      Text(value)
+        .foregroundStyle(.secondary)
+        .accessibilityIdentifier(identifier)
+    }
+  }
+}
+
+private struct FailureCollection: Sendable {
+  let events: [String]
+  let failure: PiPEventEnvelope
+  let failureDomain: String
+  let failureCode: Int
+}
+
+private struct QualificationEvidence: Encodable {
+  let formatVersion = 1
+  let scenario = "accepted-start-delayed-failure"
+  let startResult: String
+  let orderedEvents: [String]
+  let controllerGeneration: UInt64
+  let mediaGeneration: UInt64
+  let expectedControllerGeneration: UInt64
+  let expectedMediaGeneration: UInt64
+  let orderedAttribution: Bool
+  let failureDomain: String
+  let failureCode: Int
+}
+
+private struct ValidationFailure: Error, CustomStringConvertible {
+  let description: String
+
+  init(_ description: String) {
+    self.description = description
+  }
+}
+
+extension PiPEvent {
+  fileprivate var name: String {
+    switch self {
+    case .willStart: "willStart"
+    case .didStart: "didStart"
+    case .willStop: "willStop"
+    case .didStop: "didStop"
+    case .failedToStart: "failedToStart"
+    }
+  }
+}
+
+extension PiPStartResult {
+  fileprivate var name: String {
+    switch self {
+    case .accepted: "accepted"
+    case .noMedia: "noMedia"
+    case .notPossible: "notPossible"
+    case .backendUnavailable: "backendUnavailable"
+    }
+  }
+}

--- a/Showcase/iOS/ValidationHarness/PiPDelayedStartFailureValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/PiPDelayedStartFailureValidationCase.swift
@@ -93,18 +93,37 @@ struct PiPDelayedStartFailureValidationCase: View {
     do {
       let expectedControllerGeneration = controller.qualificationControllerGeneration
       let expectedMediaGeneration = player.playbackQualificationGeneration
+      let recorder = FailureRecorder()
       let stream = controller.pipEventEnvelopes
       let collector = Task {
-        try await collectFailure(from: stream, timeout: .seconds(5))
+        for await envelope in stream {
+          await recorder.record(envelope)
+        }
       }
+      defer { collector.cancel() }
       let startResult = controller.performAcceptedStartDelayedFailureQualification()
       guard startResult == .accepted else {
-        collector.cancel()
         throw ValidationFailure("Start returned \(startResult.name)")
       }
-      let collection = try await collector.value
-      let orderedAttribution = collection.events.last == "failedToStart"
+      try await waitForFailure(in: recorder, timeout: .seconds(5))
+      // Keep the stream live after the injected callback. A real AVKit start
+      // from the still-accepted request must invalidate this evidence rather
+      // than arriving after the collector has already declared a pass.
+      try await Task.sleep(for: .seconds(3))
+      controller.stop()
+      try await Task.sleep(for: .seconds(1))
+      guard let collection = await recorder.snapshot() else {
+        throw ValidationFailure("Failure disappeared before evidence capture")
+      }
+      let failureIndex = collection.events.firstIndex(of: "failedToStart")
+      let laterStartSignal = failureIndex.map { index in
+        collection.events[collection.events.index(after: index)...].contains {
+          $0 == "willStart" || $0 == "didStart" || $0 == "failedToStart"
+        }
+      } ?? true
+      let orderedAttribution = !laterStartSignal
         && !collection.events.contains("didStart")
+        && controller.isActive == false
         && collection.failure.controllerGeneration == expectedControllerGeneration
         && collection.failure.mediaGeneration == expectedMediaGeneration
       let evidence = QualificationEvidence(
@@ -115,6 +134,8 @@ struct PiPDelayedStartFailureValidationCase: View {
         expectedControllerGeneration: expectedControllerGeneration,
         expectedMediaGeneration: expectedMediaGeneration.qualificationValue,
         orderedAttribution: orderedAttribution,
+        quiescenceMilliseconds: 3000,
+        controllerActiveAfterCleanup: controller.isActive,
         failureDomain: collection.failureDomain,
         failureCode: collection.failureCode
       )
@@ -131,38 +152,19 @@ struct PiPDelayedStartFailureValidationCase: View {
     }
   }
 
-  private func collectFailure(
-    from stream: AsyncStream<PiPEventEnvelope>,
+  private func waitForFailure(
+    in recorder: FailureRecorder,
     timeout: Duration
   )
-    async throws -> FailureCollection {
-    try await withThrowingTaskGroup(of: FailureCollection.self) { group in
-      group.addTask {
-        var events: [String] = []
-        for await envelope in stream {
-          let eventName = envelope.event.name
-          events.append(eventName)
-          if case .failedToStart(let error) = envelope.event {
-            let failure = error as NSError
-            return FailureCollection(
-              events: events,
-              failure: envelope,
-              failureDomain: failure.domain,
-              failureCode: failure.code
-            )
-          }
-        }
-        throw ValidationFailure("Lifecycle stream ended before start failure")
-      }
-      group.addTask {
-        try await Task.sleep(for: timeout)
+    async throws {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
+    while await recorder.hasFailure == false {
+      try Task.checkCancellation()
+      guard clock.now < deadline else {
         throw ValidationFailure("Delayed start failure timed out")
       }
-      defer { group.cancelAll() }
-      guard let first = try await group.next() else {
-        throw ValidationFailure("No lifecycle result")
-      }
-      return first
+      try await Task.sleep(for: .milliseconds(50))
     }
   }
 
@@ -184,6 +186,37 @@ private struct FailureCollection: Sendable {
   let failureCode: Int
 }
 
+private actor FailureRecorder {
+  private var events: [String] = []
+  private var failure: PiPEventEnvelope?
+  private var failureDomain: String?
+  private var failureCode: Int?
+
+  var hasFailure: Bool {
+    failure != nil
+  }
+
+  func record(_ envelope: PiPEventEnvelope) {
+    events.append(envelope.event.name)
+    if case .failedToStart(let error) = envelope.event, failure == nil {
+      let value = error as NSError
+      failure = envelope
+      failureDomain = value.domain
+      failureCode = value.code
+    }
+  }
+
+  func snapshot() -> FailureCollection? {
+    guard let failure, let failureDomain, let failureCode else { return nil }
+    return FailureCollection(
+      events: events,
+      failure: failure,
+      failureDomain: failureDomain,
+      failureCode: failureCode
+    )
+  }
+}
+
 private struct QualificationEvidence: Encodable {
   let formatVersion = 1
   let scenario = "accepted-start-delayed-failure"
@@ -194,6 +227,8 @@ private struct QualificationEvidence: Encodable {
   let expectedControllerGeneration: UInt64
   let expectedMediaGeneration: UInt64
   let orderedAttribution: Bool
+  let quiescenceMilliseconds: Int
+  let controllerActiveAfterCleanup: Bool
   let failureDomain: String
   let failureCode: Int
 }

--- a/Showcase/macOS/Internal/MacShowcaseRootView.swift
+++ b/Showcase/macOS/Internal/MacShowcaseRootView.swift
@@ -408,7 +408,8 @@ extension MacShowcase {
     case .harnessHome,
          .pipLiveValidation,
          .pipCapabilityValidation,
-         .pipDeferredPauseValidation:
+         .pipDeferredPauseValidation,
+         .pipDelayedStartFailureValidation:
       return nil
     }
   }

--- a/Showcase/tvOS/Internal/TVShowcaseRootView.swift
+++ b/Showcase/tvOS/Internal/TVShowcaseRootView.swift
@@ -516,7 +516,8 @@ extension TVShowcase {
          .harnessHome,
          .pipLiveValidation,
          .pipCapabilityValidation,
-         .pipDeferredPauseValidation:
+         .pipDeferredPauseValidation,
+         .pipDelayedStartFailureValidation:
       return nil
     }
   }

--- a/Sources/SwiftVLC/PiP/PiPController+Validation.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Validation.swift
@@ -99,7 +99,21 @@ public struct DeferredPauseQualificationSnapshot: Sendable, Equatable {
   public let remainingTransientRejections: Int
 }
 
+extension PlaybackGeneration {
+  /// Numeric form used only for machine-readable qualification evidence.
+  @_spi(Qualification)
+  public var qualificationValue: UInt64 {
+    value
+  }
+}
+
 extension PiPController {
+  /// The AVKit-controller identity that qualification lifecycle envelopes use.
+  @_spi(Qualification)
+  public var qualificationControllerGeneration: UInt64 {
+    pipControllerGeneration
+  }
+
   /// A snapshot of the iOS native PiP backend's private wiring, or
   /// `nil` when this controller doesn't drive the native backend (the
   /// direct sample-buffer path).
@@ -160,6 +174,26 @@ extension PiPController {
       by: CMTime(seconds: seconds, preferredTimescale: 1000)
     )
     return await request.outcome == .settled
+  }
+
+  /// Issues a real direct-backend AVKit start request, then delivers a
+  /// deterministic asynchronous failure through the installed delegate path.
+  /// The request must first reach AVKit and return `.accepted`; the injected
+  /// callback changes no attribution state directly and is filtered by the
+  /// same current-controller identity check as a system callback.
+  @_spi(Qualification)
+  public func performAcceptedStartDelayedFailureQualification() -> PiPStartResult {
+    guard nativeBackend == nil else { return .backendUnavailable }
+    let result = start()
+    guard result == .accepted, let avController = pipController else { return result }
+    pictureInPictureController(
+      avController,
+      failedToStartPictureInPictureWithError: NSError(
+        domain: "SwiftVLC.Qualification.DelayedPiPStartFailure",
+        code: 1
+      )
+    )
+    return result
   }
 
   /// Exercises the same controller command entry point used by AVKit's

--- a/Sources/SwiftVLC/PiP/PiPController+Validation.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Validation.swift
@@ -185,8 +185,13 @@ extension PiPController {
   public func performAcceptedStartDelayedFailureQualification() -> PiPStartResult {
     guard nativeBackend == nil else { return .backendUnavailable }
     let result = start()
-    guard result == .accepted, let avController = pipController else { return result }
-    pictureInPictureController(
+    guard
+      result == .accepted,
+      let avController = pipController,
+      let delegate = avController.delegate,
+      (delegate as AnyObject) === self
+    else { return result }
+    delegate.pictureInPictureController?(
       avController,
       failedToStartPictureInPictureWithError: NSError(
         domain: "SwiftVLC.Qualification.DelayedPiPStartFailure",

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -118,6 +118,16 @@ controls, zero endless tasks, zero duplicate pauses, and zero library errors.
 The default run omits this lane on other hardware rows, and an explicit
 unsupported request fails before testing.
 
+The iPhone-current-only accepted-start-delayed-failure lane uses the direct
+sample-buffer backend to issue a real AVKit start request, requires the
+immediate result to be `accepted`, and then sends a deterministic asynchronous
+failure through the installed AVKit delegate path. The candidate passes only
+when the failure arrives before `didStart`, is the terminal recorded event, and
+retains the controller and media generations captured at request time. The
+attached evidence records those identities, ordered events, and injected error
+domain. The default run omits this lane on other hardware rows, and an explicit
+unsupported request fails before testing.
+
 The HLS seek lane is another complete machine-readable matrix slice. It
 executes forward, backward, and absolute seeks, measures the return of decoded
 video, checks ordered PiP continuity, samples real system-PiP motion after each

--- a/scripts/qualification/matrix.json
+++ b/scripts/qualification/matrix.json
@@ -442,11 +442,13 @@
       "id": "accepted-start-delayed-failure",
       "issues": [104],
       "hardware": ["iphone-current"],
-      "summary": "An accepted native start followed by delayed AVKit failure retains ordered controller/media attribution",
-      "requiredEvidenceFields": ["startResult", "orderedEvents", "controllerGeneration", "mediaGeneration"],
+      "summary": "An accepted direct AVKit start followed by delayed failure retains ordered controller/media attribution",
+      "requiredEvidenceFields": ["startResult", "orderedEvents", "controllerGeneration", "mediaGeneration", "quiescenceMilliseconds", "controllerActiveAfterCleanup"],
       "expectedEvidenceValues": {
         "startResult": "accepted",
-        "orderedAttribution": true
+        "orderedAttribution": true,
+        "quiescenceMilliseconds": 3000,
+        "controllerActiveAfterCleanup": false
       }
     }
   ],

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -34,7 +34,8 @@ Options:
   --only SCENARIO         Repeat to select: analyzer, ui-suite, native-live,
                           direct-live, live-media, background-audio,
                           continuity, capability-convergence,
-                          deferred-pause-rejection, hls-seek,
+                          deferred-pause-rejection,
+                          accepted-start-delayed-failure, hls-seek,
                           harness-regressions, ui-failures, thumbnail-preview
   --require-stable        Refuse beta/unknown OS or a non-matching matrix row
   --skip-build            Reuse an existing signed runner in derived data
@@ -227,6 +228,7 @@ python3 "$SCRIPT_DIR/prepare-xctestrun.py" "$XCTESTRUN" "$DESTINATION_XCTESTRUN"
   --environment SWIFTVLC_PIP_CONTINUITY_DEVICE=YES \
   --environment SWIFTVLC_PIP_CAPABILITY_DEVICE=YES \
   --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
+  --environment SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE=YES \
   --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
   --environment SWIFTVLC_PIP_SEEK_DEVICE=YES
 cp "$DESTINATION_XCTESTRUN" "$OUTPUT_DIR/destination.xctestrun"
@@ -278,7 +280,7 @@ xcrun devicectl device copy to \
   --destination Documents/streams.local.json \
   > "$OUTPUT_DIR/stage-streams.log"
 
-DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence deferred-pause-rejection hls-seek)
+DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence deferred-pause-rejection accepted-start-delayed-failure hls-seek)
 SCENARIOS_WERE_EXPLICIT=false
 if [[ ${#ONLY_SCENARIOS[@]} -eq 0 ]]; then
   ONLY_SCENARIOS=("${DEFAULT_SCENARIOS[@]}")
@@ -287,7 +289,7 @@ else
 fi
 for scenario in "${ONLY_SCENARIOS[@]}"; do
   case "$scenario" in
-    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|deferred-pause-rejection|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
+    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
     *) echo "Error: unknown scenario: $scenario" >&2; exit 2 ;;
   esac
 done
@@ -302,7 +304,7 @@ device_matches_hardware_row() {
 if ! device_matches_hardware_row "iphone-current"; then
   if [[ "$SCENARIOS_WERE_EXPLICIT" == true ]]; then
     for scenario in "${ONLY_SCENARIOS[@]}"; do
-      if [[ "$scenario" == "capability-convergence" || "$scenario" == "deferred-pause-rejection" ]]; then
+      if [[ "$scenario" == "capability-convergence" || "$scenario" == "deferred-pause-rejection" || "$scenario" == "accepted-start-delayed-failure" ]]; then
         echo "Error: $scenario requires the iphone-current hardware row." >&2
         exit 2
       fi
@@ -310,7 +312,7 @@ if ! device_matches_hardware_row "iphone-current"; then
   else
     FILTERED_SCENARIOS=()
     for scenario in "${ONLY_SCENARIOS[@]}"; do
-      if [[ "$scenario" != "capability-convergence" && "$scenario" != "deferred-pause-rejection" ]]; then
+      if [[ "$scenario" != "capability-convergence" && "$scenario" != "deferred-pause-rejection" && "$scenario" != "accepted-start-delayed-failure" ]]; then
         FILTERED_SCENARIOS+=("$scenario")
       fi
     done
@@ -393,6 +395,13 @@ run_scenario() {
       route="PiPDeferredPauseValidation"
       selected_xctestrun="$DESTINATION_XCTESTRUN"
       ;;
+    accepted-start-delayed-failure)
+      test_identifiers=(
+        "iOSUITests/PiPDelayedStartFailureDeviceUITests/test_acceptedStartRetainsAttributionThroughDelayedFailure"
+      )
+      route="PiPDelayedStartFailureValidation"
+      selected_xctestrun="$DESTINATION_XCTESTRUN"
+      ;;
     hls-seek)
       test_identifiers=("iOSUITests/PiPOverlayDeviceUITests/test_nativePiPHLSSeekAndReloadRemainActive")
       route="HarnessHome"
@@ -434,6 +443,7 @@ run_scenario() {
       --environment SWIFTVLC_PIP_CONTINUITY_DEVICE=YES \
       --environment SWIFTVLC_PIP_CAPABILITY_DEVICE=YES \
       --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
+      --environment SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE=YES \
       --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
       --environment SWIFTVLC_PIP_SEEK_DEVICE=YES \
       --environment SWIFTVLC_DEVICE_LOG_PREFIX="$run_id-$scenario"
@@ -460,6 +470,7 @@ run_scenario() {
       -skip-testing:iOSUITests/PiPContinuityDeviceUITests
       -skip-testing:iOSUITests/PiPCapabilityDeviceUITests
       -skip-testing:iOSUITests/PiPDeferredPauseDeviceUITests
+      -skip-testing:iOSUITests/PiPDelayedStartFailureDeviceUITests
       -skip-testing:iOSUITests/PiPOverlayDeviceUITests
     )
   fi
@@ -621,6 +632,10 @@ PY
     deferred-pause-rejection)
       qualification_scenarios=("deferred-pause-rejection")
       qualification_attachments=("qualification-deferred-pause-rejection.json")
+      ;;
+    accepted-start-delayed-failure)
+      qualification_scenarios=("accepted-start-delayed-failure")
+      qualification_attachments=("qualification-accepted-start-delayed-failure.json")
       ;;
   esac
   if [[ ${#qualification_scenarios[@]} -gt 0 ]]; then

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -440,6 +440,41 @@ class QualificationEvidenceTests(unittest.TestCase):
             self.assertEqual(evidence["duplicatePauseCount"], 0)
             self.assertTrue(evidence["truthfulControls"])
 
+    def test_materializes_accepted_start_delayed_failure_evidence(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.make_export(
+                root,
+                {
+                    "formatVersion": 1,
+                    "scenario": "accepted-start-delayed-failure",
+                    "startResult": "accepted",
+                    "orderedEvents": ["willStart", "failedToStart"],
+                    "controllerGeneration": 3,
+                    "mediaGeneration": 7,
+                    "expectedControllerGeneration": 3,
+                    "expectedMediaGeneration": 7,
+                    "orderedAttribution": True,
+                    "failureDomain": "SwiftVLC.Qualification.DelayedPiPStartFailure",
+                    "failureCode": 1,
+                },
+                attachment_name="qualification-accepted-start-delayed-failure.json",
+                test_identifier="PiPDelayedStartFailureDeviceUITests/test_acceptedStartRetainsAttributionThroughDelayedFailure",
+            )
+            evidence = materialize_evidence.materialize(
+                root,
+                "qualification-accepted-start-delayed-failure.json",
+                "accepted-start-delayed-failure",
+                "iphone-current",
+                "a" * 64,
+                "b" * 64,
+            )
+            self.assertEqual(evidence["startResult"], "accepted")
+            self.assertEqual(evidence["orderedEvents"][-1], "failedToStart")
+            self.assertEqual(evidence["controllerGeneration"], 3)
+            self.assertEqual(evidence["mediaGeneration"], 7)
+            self.assertTrue(evidence["orderedAttribution"])
+
     def test_materializes_focused_replacement_evidence(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -455,6 +455,8 @@ class QualificationEvidenceTests(unittest.TestCase):
                     "expectedControllerGeneration": 3,
                     "expectedMediaGeneration": 7,
                     "orderedAttribution": True,
+                    "quiescenceMilliseconds": 3000,
+                    "controllerActiveAfterCleanup": False,
                     "failureDomain": "SwiftVLC.Qualification.DelayedPiPStartFailure",
                     "failureCode": 1,
                 },


### PR DESCRIPTION
## Summary
- issue a real direct-backend AVKit start request and require an immediate accepted result
- deliver a deterministic asynchronous failure through the installed AVKit delegate entry point
- prove ordered controller/media generation attribution and reject any didStart-before-failure race
- add candidate-bound runner and evidence materialization for the iphone-current accepted-start-delayed-failure matrix row

## Validation
- SwiftFormat strict
- SwiftLint strict
- 27 qualification harness tests
- release-integrity checks
- iOS Showcase app and UI-test runner build-for-testing against local branch source
- clean rebase onto the fully green PR #195 merge

## Release-gate note
This PR automates the remaining physical row for issue #104. It does not claim a physical-device pass, close the issue, or qualify a release candidate; those actions still require candidate-bound evidence from matching hardware.