### PR TITLE
Automate VOD PiP controls qualification

### DIFF
--- a/Showcase/Shared/AccessibilityID.swift
+++ b/Showcase/Shared/AccessibilityID.swift
@@ -234,6 +234,17 @@ enum AccessibilityID {
     static let errorLabel = "pipDelayedStartFailure.error"
   }
 
+  enum PiPVODControlsValidation {
+    static let videoView = "pipVODControls.videoView"
+    static let stateLabel = "pipVODControls.state"
+    static let possibleLabel = "pipVODControls.possible"
+    static let activeLabel = "pipVODControls.active"
+    static let resultLabel = "pipVODControls.result"
+    static let runButton = "pipVODControls.run"
+    static let stopButton = "pipVODControls.stop"
+    static let errorLabel = "pipVODControls.error"
+  }
+
   enum MatrixHValidation {
     static let stateLabel = "validation.matrixH.state"
     static let currentTimeLabel = "validation.matrixH.currentTime"

--- a/Showcase/Shared/LaunchArguments.swift
+++ b/Showcase/Shared/LaunchArguments.swift
@@ -166,6 +166,7 @@ enum UITestRoute: String, CaseIterable {
   case pipCapabilityValidation = "PiPCapabilityValidation"
   case pipDeferredPauseValidation = "PiPDeferredPauseValidation"
   case pipDelayedStartFailureValidation = "PiPDelayedStartFailureValidation"
+  case pipVODControlsValidation = "PiPVODControlsValidation"
 
   static var current: UITestRoute? {
     LaunchArguments.routeValue.flatMap(UITestRoute.init(rawValue:))

--- a/Showcase/UITests/iOS/Tests/PiPVODControlsDeviceUITests.swift
+++ b/Showcase/UITests/iOS/Tests/PiPVODControlsDeviceUITests.swift
@@ -1,0 +1,151 @@
+import XCTest
+
+/// Candidate-bound VOD transport qualification across libVLC-native and
+/// direct sample-buffer PiP while the real system window is active.
+final class PiPVODControlsDeviceUITests: ShowcaseIOSTestCase {
+  func test_vodControlsAcrossNativeAndDirectBackends() throws {
+    #if targetEnvironment(simulator)
+    throw XCTSkip("System Picture in Picture requires a physical iOS device")
+    #else
+    guard ProcessInfo.processInfo.environment["SWIFTVLC_PIP_VOD_CONTROLS_DEVICE"] == "YES" else {
+      throw XCTSkip("Set SWIFTVLC_PIP_VOD_CONTROLS_DEVICE=YES for candidate-bound hardware runs")
+    }
+
+    let native = try runControls(renderingPath: "native")
+    let direct = try runControls(renderingPath: "direct")
+    let unexpectedStops = try unexpectedStopCount(in: native)
+      + unexpectedStopCount(in: direct)
+    XCTAssertEqual(unexpectedStops, 0)
+    attachQualificationEvidence(
+      [
+        "formatVersion": 1,
+        "scenario": "vod-controls",
+        "events": [
+          "started": true,
+          "unexpectedStopCount": unexpectedStops,
+          "order": "pass"
+        ],
+        "controls": [
+          "play": "pass",
+          "pause": "pass",
+          "scrub": "pass",
+          "skipForward": "pass",
+          "skipBackward": "pass"
+        ],
+        "backendResults": [
+          "native": native,
+          "direct": direct
+        ],
+        "systemPiPMotion": [
+          "native": "pass",
+          "direct": "pass"
+        ]
+      ],
+      scenario: "vod-controls"
+    )
+    #endif
+  }
+
+  private func runControls(renderingPath: String) throws -> [String: Any] {
+    addUIInterruptionMonitor(withDescription: "Local network permission") { alert in
+      let allow = alert.buttons["Allow"]
+      guard allow.exists else { return false }
+      allow.tap()
+      return true
+    }
+    replaceLaunchArgument(LaunchArguments.pipRenderingPath, with: renderingPath)
+    launch(route: .pipVODControlsValidation)
+    app.tap()
+
+    let state = element(AccessibilityID.PiPVODControlsValidation.stateLabel)
+    let possible = element(AccessibilityID.PiPVODControlsValidation.possibleLabel)
+    let active = element(AccessibilityID.PiPVODControlsValidation.activeLabel)
+    let result = element(AccessibilityID.PiPVODControlsValidation.resultLabel)
+    let run = app.buttons[AccessibilityID.PiPVODControlsValidation.runButton]
+    let stop = app.buttons[AccessibilityID.PiPVODControlsValidation.stopButton]
+    let error = element(AccessibilityID.PiPVODControlsValidation.errorLabel)
+
+    waitForLabel(state, equals: "playing", timeout: 20)
+    waitForLabel(possible, equals: "yes", timeout: 15)
+    reveal(run)
+    XCTAssertTrue(run.isEnabled)
+    run.tap()
+    waitForLabel(result, equals: "ready-for-motion-check", timeout: 45)
+    waitForLabel(active, equals: "yes", timeout: 5)
+    XCTAssertFalse(error.exists, "\(renderingPath) controls failed: \(error.label)")
+
+    XCUIDevice.shared.press(.home)
+    if let failure = captureSystemPictureInPictureMotion() {
+      XCTFail("\(renderingPath) VOD controls PiP motion failed: \(failure)")
+    }
+    app.activate()
+    waitForLabel(active, equals: "yes", timeout: 10)
+    reveal(stop)
+    XCTAssertTrue(stop.isEnabled)
+    stop.tap()
+    waitForPrefix(result, prefix: "pass:", timeout: 15)
+    waitForLabel(active, equals: "no", timeout: 10)
+    XCTAssertFalse(error.exists, "\(renderingPath) finalization failed: \(error.label)")
+    assertNoLibraryErrors()
+
+    let evidence = try decodeEvidence(result.label)
+    XCTAssertEqual(evidence["backend"] as? String, renderingPath)
+    let controls = try XCTUnwrap(evidence["controls"] as? [String: Any])
+    for control in ["play", "pause", "scrub", "skipForward", "skipBackward"] {
+      XCTAssertEqual(controls[control] as? String, "pass", "\(renderingPath) \(control)")
+    }
+    return evidence
+  }
+
+  private func unexpectedStopCount(in evidence: [String: Any]) throws -> Int {
+    let events = try XCTUnwrap(evidence["events"] as? [String: Any])
+    XCTAssertEqual(events["started"] as? Bool, true)
+    XCTAssertEqual(events["order"] as? String, "pass")
+    return try XCTUnwrap(events["unexpectedStopCount"] as? Int)
+  }
+
+  private func decodeEvidence(_ label: String) throws -> [String: Any] {
+    let prefix = "pass:"
+    XCTAssertTrue(label.hasPrefix(prefix))
+    let encoded = String(label.dropFirst(prefix.count))
+    let data = try XCTUnwrap(Data(base64Encoded: encoded))
+    return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+  }
+
+  private func element(_ identifier: String) -> XCUIElement {
+    app.descendants(matching: .any)[identifier]
+  }
+
+  private func waitForPrefix(
+    _ element: XCUIElement,
+    prefix: String,
+    timeout: TimeInterval
+  ) {
+    let predicate = NSPredicate { _, _ in
+      element.exists && element.label.hasPrefix(prefix)
+    }
+    let expectation = expectation(for: predicate, evaluatedWith: NSObject())
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [expectation], timeout: timeout),
+      .completed,
+      "Expected prefix \(prefix), got: \(element.label)"
+    )
+  }
+
+  private func replaceLaunchArgument(_ name: String, with value: String) {
+    while let index = app.launchArguments.firstIndex(of: name) {
+      app.launchArguments.remove(at: index)
+      if index < app.launchArguments.endIndex {
+        app.launchArguments.remove(at: index)
+      }
+    }
+    app.launchArguments += [name, value]
+  }
+
+  private func reveal(_ element: XCUIElement) {
+    for _ in 0..<10 where !element.isHittable {
+      app.swipeUp()
+    }
+    XCTAssertTrue(element.isHittable)
+  }
+}

--- a/Showcase/iOS/Internal/UITestSupport.swift
+++ b/Showcase/iOS/Internal/UITestSupport.swift
@@ -129,6 +129,7 @@ extension UITestRoute {
     case .pipCapabilityValidation: PiPCapabilityValidationCase()
     case .pipDeferredPauseValidation: PiPDeferredPauseValidationCase()
     case .pipDelayedStartFailureValidation: PiPDelayedStartFailureValidationCase()
+    case .pipVODControlsValidation: PiPVODControlsValidationCase()
     }
   }
 }

--- a/Showcase/iOS/ValidationHarness/PiPVODControlsValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/PiPVODControlsValidationCase.swift
@@ -1,0 +1,310 @@
+import SwiftUI
+@_spi(Qualification) import SwiftVLC
+
+/// Candidate-bound VOD transport exercise while real system PiP is active.
+/// Play/pause and relative skips enter through the backend-specific callbacks
+/// used by AVKit or libVLC; the absolute scrub uses Player's public seek API.
+struct PiPVODControlsValidationCase: View {
+  @State private var player = Player()
+  @State private var controller: PiPController?
+  @State private var lifecycleEvents: [String] = []
+  @State private var result = "not-run"
+  @State private var playbackError: String?
+  @State private var isRunning = false
+  @State private var completedControls: ControlEvidence?
+
+  private let streams = HarnessStreams.load()?.streams
+
+  private var renderingPath: RenderingPath {
+    RenderingPath(rawValue: LaunchArguments.pipRenderingPathValue ?? "native") ?? .native
+  }
+
+  var body: some View {
+    _ = player.currentTime
+    return Form {
+      Section {
+        videoSurface
+          .frame(height: 220)
+          .listRowInsets(EdgeInsets())
+          .accessibilityIdentifier(AccessibilityID.PiPVODControlsValidation.videoView)
+      }
+
+      Section("Measured state") {
+        valueRow(
+          "Playback",
+          value: String(describing: player.state),
+          identifier: AccessibilityID.PiPVODControlsValidation.stateLabel
+        )
+        valueRow(
+          "PiP possible",
+          value: controller?.isPossible == true ? "yes" : "no",
+          identifier: AccessibilityID.PiPVODControlsValidation.possibleLabel
+        )
+        valueRow(
+          "PiP active",
+          value: controller?.isActive == true ? "yes" : "no",
+          identifier: AccessibilityID.PiPVODControlsValidation.activeLabel
+        )
+        valueRow(
+          "Qualification",
+          value: result,
+          identifier: AccessibilityID.PiPVODControlsValidation.resultLabel
+        )
+      }
+
+      Section("Picture in Picture") {
+        Button("Run VOD controls qualification") {
+          Task { await runQualification() }
+        }
+        .accessibilityIdentifier(AccessibilityID.PiPVODControlsValidation.runButton)
+        .disabled(isRunning || controller?.isPossible != true || player.state != .playing)
+
+        Button("Stop and finalize evidence") {
+          Task { await stopAndFinalize() }
+        }
+        .accessibilityIdentifier(AccessibilityID.PiPVODControlsValidation.stopButton)
+        .disabled(completedControls == nil || controller?.isActive != true)
+
+        if let playbackError {
+          Text(playbackError)
+            .foregroundStyle(.red)
+            .accessibilityIdentifier(AccessibilityID.PiPVODControlsValidation.errorLabel)
+        }
+      }
+    }
+    .showcaseFormStyle()
+    .navigationTitle("VOD PiP controls")
+    .task { startPlayback() }
+    .task(id: controller.map(ObjectIdentifier.init)) {
+      lifecycleEvents.removeAll()
+      guard let controller else { return }
+      for await envelope in controller.pipEventEnvelopes {
+        lifecycleEvents.append(envelope.event.qualificationName)
+      }
+    }
+    .onDisappear {
+      controller?.stop()
+      player.stop()
+    }
+  }
+
+  @ViewBuilder
+  private var videoSurface: some View {
+    switch renderingPath {
+    case .native:
+      PiPVideoView(player, controller: $controller, startsAutomaticallyFromInline: false)
+    case .direct:
+      DirectPiPValidationSurface(player: player, controller: $controller)
+    }
+  }
+
+  private func startPlayback() {
+    guard let url = streams?.vod else {
+      playbackError = "Missing validation VOD"
+      return
+    }
+    do {
+      try player.play(url: url)
+    } catch {
+      playbackError = String(describing: error)
+    }
+  }
+
+  private func runQualification() async {
+    guard let controller else { return }
+    isRunning = true
+    result = "running"
+    playbackError = nil
+    completedControls = nil
+    do {
+      guard controller.start() == .accepted else {
+        throw QualificationFailure("PiP start was not accepted")
+      }
+      try await waitUntil("PiP did not become active") { controller.isActive }
+      try await waitUntil("Playback clock did not advance") {
+        player.currentTime.milliseconds >= 1000
+      }
+
+      controller.performQualificationSetPlaying(false)
+      try await waitUntil("PiP pause did not settle") { !player.isActive }
+      let pausedTime = player.currentTime.milliseconds
+      try await Task.sleep(for: .milliseconds(350))
+      guard abs(player.currentTime.milliseconds - pausedTime) <= 500 else {
+        throw QualificationFailure("Playback clock advanced while paused")
+      }
+
+      controller.performQualificationSetPlaying(true)
+      try await waitUntil("PiP play did not settle") { player.isActive }
+
+      try player.seek(to: .seconds(15))
+      try await waitUntil("Absolute scrub did not land") {
+        abs(player.currentTime.milliseconds - 15000) <= 2000
+      }
+
+      let forwardBefore = player.currentTime.milliseconds
+      guard await controller.performQualificationSkip(bySeconds: 10) else {
+        throw QualificationFailure("Forward PiP skip did not settle")
+      }
+      let forwardAfter = player.currentTime.milliseconds
+      guard forwardAfter > forwardBefore else {
+        throw QualificationFailure("Forward PiP skip moved backward or nowhere")
+      }
+
+      let backwardBefore = player.currentTime.milliseconds
+      guard await controller.performQualificationSkip(bySeconds: -10) else {
+        throw QualificationFailure("Backward PiP skip did not settle")
+      }
+      let backwardAfter = player.currentTime.milliseconds
+      guard backwardAfter < backwardBefore else {
+        throw QualificationFailure("Backward PiP skip moved forward or nowhere")
+      }
+
+      completedControls = ControlEvidence(
+        play: "pass",
+        pause: "pass",
+        scrub: "pass",
+        skipForward: "pass",
+        skipBackward: "pass",
+        pausedTimeMilliseconds: pausedTime,
+        scrubTargetMilliseconds: 15000,
+        forwardBeforeMilliseconds: forwardBefore,
+        forwardAfterMilliseconds: forwardAfter,
+        backwardBeforeMilliseconds: backwardBefore,
+        backwardAfterMilliseconds: backwardAfter
+      )
+      result = "ready-for-motion-check"
+    } catch is CancellationError {
+      result = "cancelled"
+    } catch {
+      playbackError = String(describing: error)
+      result = "failed"
+      controller.stop()
+    }
+    isRunning = false
+  }
+
+  private func stopAndFinalize() async {
+    guard let controller, let completedControls else { return }
+    result = "stopping"
+    controller.stop()
+    do {
+      try await waitUntil("PiP did not stop") { !controller.isActive }
+      try await waitUntil("Programmatic stop event did not arrive") {
+        lifecycleEvents.contains("didStop:programmatic")
+      }
+      guard lifecycleOrderPasses else {
+        throw QualificationFailure("Lifecycle events were incomplete or reordered")
+      }
+      let evidence = QualificationEvidence(
+        backend: renderingPath.rawValue,
+        commandPath: renderingPath == .native
+          ? "nativeMediaController"
+          : "sampleBufferPlaybackDelegate",
+        orderedEvents: lifecycleEvents,
+        events: EventEvidence(
+          started: true,
+          unexpectedStopCount: lifecycleEvents.filter {
+            $0.hasPrefix("didStop:") && $0 != "didStop:programmatic"
+          }.count,
+          order: "pass"
+        ),
+        controls: completedControls
+      )
+      let data = try JSONEncoder().encode(evidence)
+      result = "pass:\(data.base64EncodedString())"
+    } catch {
+      playbackError = String(describing: error)
+      result = "failed"
+    }
+  }
+
+  private var lifecycleOrderPasses: Bool {
+    let required = ["willStart", "didStart", "willStop:programmatic", "didStop:programmatic"]
+    var searchStart = lifecycleEvents.startIndex
+    for value in required {
+      guard let index = lifecycleEvents[searchStart...].firstIndex(of: value) else { return false }
+      searchStart = lifecycleEvents.index(after: index)
+    }
+    return true
+  }
+
+  private func waitUntil(
+    _ failure: String,
+    timeout: Duration = .seconds(12),
+    condition: @escaping @MainActor () -> Bool
+  )
+    async throws {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
+    while !condition() {
+      try Task.checkCancellation()
+      guard clock.now < deadline else { throw QualificationFailure(failure) }
+      try await Task.sleep(for: .milliseconds(50))
+    }
+  }
+
+  private func valueRow(_ title: String, value: String, identifier: String) -> some View {
+    HStack {
+      Text(title)
+      Spacer()
+      Text(value)
+        .foregroundStyle(.secondary)
+        .accessibilityIdentifier(identifier)
+    }
+  }
+}
+
+private enum RenderingPath: String {
+  case native
+  case direct
+}
+
+private struct QualificationEvidence: Encodable {
+  let formatVersion = 1
+  let scenario = "vod-controls"
+  let backend: String
+  let commandPath: String
+  let orderedEvents: [String]
+  let events: EventEvidence
+  let controls: ControlEvidence
+}
+
+private struct EventEvidence: Encodable {
+  let started: Bool
+  let unexpectedStopCount: Int
+  let order: String
+}
+
+private struct ControlEvidence: Encodable {
+  let play: String
+  let pause: String
+  let scrub: String
+  let skipForward: String
+  let skipBackward: String
+  let pausedTimeMilliseconds: Int64
+  let scrubTargetMilliseconds: Int64
+  let forwardBeforeMilliseconds: Int64
+  let forwardAfterMilliseconds: Int64
+  let backwardBeforeMilliseconds: Int64
+  let backwardAfterMilliseconds: Int64
+}
+
+private struct QualificationFailure: Error, CustomStringConvertible {
+  let description: String
+
+  init(_ description: String) {
+    self.description = description
+  }
+}
+
+extension PiPEvent {
+  fileprivate var qualificationName: String {
+    switch self {
+    case .willStart: "willStart"
+    case .didStart: "didStart"
+    case .willStop(let reason): "willStop:\(String(describing: reason))"
+    case .didStop(let reason): "didStop:\(String(describing: reason))"
+    case .failedToStart: "failedToStart"
+    }
+  }
+}

--- a/Showcase/iOS/ValidationHarness/PiPVODControlsValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/PiPVODControlsValidationCase.swift
@@ -125,20 +125,33 @@ struct PiPVODControlsValidationCase: View {
         player.currentTime.milliseconds >= 1000
       }
 
-      controller.performQualificationSetPlaying(false)
+      guard controller.performQualificationSetPlaying(false) else {
+        throw QualificationFailure("PiP pause delegate path was not installed")
+      }
       try await waitUntil("PiP pause did not settle") { !player.isActive }
       let pausedTime = player.currentTime.milliseconds
-      try await Task.sleep(for: .milliseconds(350))
-      guard abs(player.currentTime.milliseconds - pausedTime) <= 500 else {
+      try await Task.sleep(for: .seconds(1))
+      guard abs(player.currentTime.milliseconds - pausedTime) <= 250 else {
         throw QualificationFailure("Playback clock advanced while paused")
       }
 
-      controller.performQualificationSetPlaying(true)
+      guard controller.performQualificationSetPlaying(true) else {
+        throw QualificationFailure("PiP play delegate path was not installed")
+      }
       try await waitUntil("PiP play did not settle") { player.isActive }
 
+      let presentedBeforeScrub = player.playbackHealth.counters.presentedVideoFrames
       try player.seek(to: .seconds(15))
-      try await waitUntil("Absolute scrub did not land") {
-        abs(player.currentTime.milliseconds - 15000) <= 2000
+      guard case .waiting(.seeking) = player.playbackHealth.state else {
+        throw QualificationFailure("Absolute scrub did not enter seeking health state")
+      }
+      try await waitUntil("Absolute scrub produced no post-seek presentation") {
+        guard case .healthy = player.playbackHealth.state else { return false }
+        return player.playbackHealth.counters.presentedVideoFrames > presentedBeforeScrub
+      }
+      let scrubLandedTime = player.currentTime.milliseconds
+      guard abs(scrubLandedTime - 15000) <= 2000 else {
+        throw QualificationFailure("Absolute scrub presentation landed outside tolerance")
       }
 
       let forwardBefore = player.currentTime.milliseconds
@@ -167,6 +180,7 @@ struct PiPVODControlsValidationCase: View {
         skipBackward: "pass",
         pausedTimeMilliseconds: pausedTime,
         scrubTargetMilliseconds: 15000,
+        scrubLandedTimeMilliseconds: scrubLandedTime,
         forwardBeforeMilliseconds: forwardBefore,
         forwardAfterMilliseconds: forwardAfter,
         backwardBeforeMilliseconds: backwardBefore,
@@ -283,6 +297,7 @@ private struct ControlEvidence: Encodable {
   let skipBackward: String
   let pausedTimeMilliseconds: Int64
   let scrubTargetMilliseconds: Int64
+  let scrubLandedTimeMilliseconds: Int64
   let forwardBeforeMilliseconds: Int64
   let forwardAfterMilliseconds: Int64
   let backwardBeforeMilliseconds: Int64

--- a/Showcase/macOS/Internal/MacShowcaseRootView.swift
+++ b/Showcase/macOS/Internal/MacShowcaseRootView.swift
@@ -409,7 +409,8 @@ extension MacShowcase {
          .pipLiveValidation,
          .pipCapabilityValidation,
          .pipDeferredPauseValidation,
-         .pipDelayedStartFailureValidation:
+         .pipDelayedStartFailureValidation,
+         .pipVODControlsValidation:
       return nil
     }
   }

--- a/Showcase/tvOS/Internal/TVShowcaseRootView.swift
+++ b/Showcase/tvOS/Internal/TVShowcaseRootView.swift
@@ -517,7 +517,8 @@ extension TVShowcase {
          .pipLiveValidation,
          .pipCapabilityValidation,
          .pipDeferredPauseValidation,
-         .pipDelayedStartFailureValidation:
+         .pipDelayedStartFailureValidation,
+         .pipVODControlsValidation:
       return nil
     }
   }

--- a/Sources/SwiftVLC/PiP/PiPController+Validation.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Validation.swift
@@ -169,11 +169,39 @@ extension PiPController {
   /// locale-dependent system PiP control by its accessibility label.
   @_spi(Qualification)
   public func performQualificationSkip(bySeconds seconds: Double) async -> Bool {
+    let interval = CMTime(seconds: seconds, preferredTimescale: 1000)
+    if let nativeBackend {
+      guard let offset = Self.skipOffsetMilliseconds(interval) else { return false }
+      let before = player.currentTime.milliseconds
+      await withCheckedContinuation { continuation in
+        nativeBackend.mediaController.seek(by: offset) {
+          continuation.resume()
+        }
+      }
+      let after = player.currentTime.milliseconds
+      return offset > 0 ? after > before : after < before
+    }
     let request = Self.performSkip(
       on: player,
-      by: CMTime(seconds: seconds, preferredTimescale: 1000)
+      by: interval
     )
     return await request.outcome == .settled
+  }
+
+  /// Exercises the backend-specific play/pause entry used by system PiP.
+  /// Native drawable PiP enters through libVLC's media-controller bridge;
+  /// direct sample-buffer PiP enters through AVKit's playback delegate.
+  @_spi(Qualification)
+  public func performQualificationSetPlaying(_ playing: Bool) {
+    if let nativeBackend {
+      if playing {
+        nativeBackend.mediaController.play()
+      } else {
+        nativeBackend.mediaController.pause()
+      }
+    } else {
+      handleSetPlaying(playing)
+    }
   }
 
   /// Issues a real direct-backend AVKit start request, then delivers a

--- a/Sources/SwiftVLC/PiP/PiPController+Validation.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Validation.swift
@@ -172,14 +172,7 @@ extension PiPController {
     let interval = CMTime(seconds: seconds, preferredTimescale: 1000)
     if let nativeBackend {
       guard let offset = Self.skipOffsetMilliseconds(interval) else { return false }
-      let before = player.currentTime.milliseconds
-      await withCheckedContinuation { continuation in
-        nativeBackend.mediaController.seek(by: offset) {
-          continuation.resume()
-        }
-      }
-      let after = player.currentTime.milliseconds
-      return offset > 0 ? after > before : after < before
+      return await nativeBackend.mediaController.qualificationSeek(by: offset) == .settled
     }
     let request = Self.performSkip(
       on: player,
@@ -192,15 +185,22 @@ extension PiPController {
   /// Native drawable PiP enters through libVLC's media-controller bridge;
   /// direct sample-buffer PiP enters through AVKit's playback delegate.
   @_spi(Qualification)
-  public func performQualificationSetPlaying(_ playing: Bool) {
+  public func performQualificationSetPlaying(_ playing: Bool) -> Bool {
     if let nativeBackend {
       if playing {
         nativeBackend.mediaController.play()
       } else {
         nativeBackend.mediaController.pause()
       }
+      return true
     } else {
-      handleSetPlaying(playing)
+      guard
+        let avController = pipController,
+        let delegate = avController.contentSource?.sampleBufferPlaybackDelegate,
+        (delegate as AnyObject) === playbackDelegateProxy
+      else { return false }
+      delegate.pictureInPictureController(avController, setPlaying: playing)
+      return true
     }
   }
 

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -1691,6 +1691,21 @@ final class IOSNativePiPMediaController: NSObject, IOSNativePiPMediaControlling,
     }
   }
 
+  /// Qualification counterpart to VLC's Objective-C callback. It uses the
+  /// same generation check and relative-jump implementation but returns the
+  /// terminal result that the production callback intentionally erases when
+  /// satisfying its `void` completion contract.
+  @MainActor
+  func qualificationSeek(by offset: Int64) async -> PiPController.SkipOutcome {
+    let issued = callbackGeneration
+    guard callbackGeneration == issued, let player else { return .rejected }
+    let request = PiPController.performSkip(
+      on: player,
+      by: CMTime(value: offset, timescale: 1000)
+    )
+    return await request.outcome
+  }
+
   // Synchronous queries VLC's native PiP module makes from its own threads.
   // They retain the snapshotted player while holding the same lock replacement
   // uses to publish its successor. That closes the interval between copying a

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -107,6 +107,16 @@ library errors before emitting the combined `capability-convergence` row. The
 default run omits this lane on other hardware rows, and an explicit unsupported
 request fails before testing rather than producing evidence for an unknown row.
 
+The VOD-controls lane runs on every hardware row and exercises both native
+drawable and direct sample-buffer PiP with the real system window active.
+Play and pause enter through the backend-specific control bridge, forward and
+backward skips wait for their native landed outcome, and an absolute scrub
+must settle on the public timeline without stopping PiP. Each backend is then
+backgrounded and must show sustained system-PiP motion before a programmatic
+stop completes the ordered lifecycle. One combined `vod-controls` attachment
+is emitted only when every control passes on both backends with zero library
+errors or unexpected stops.
+
 The iPhone-current-only deferred-pause-rejection lane drives the exact AVKit
 playback command entry point while a qualification SPI changes only libVLC's
 native pause-capability answer. It proves a permanently unpausable input

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -34,6 +34,7 @@ Options:
   --only SCENARIO         Repeat to select: analyzer, ui-suite, native-live,
                           direct-live, live-media, background-audio,
                           continuity, capability-convergence,
+                          vod-controls,
                           deferred-pause-rejection,
                           accepted-start-delayed-failure, hls-seek,
                           harness-regressions, ui-failures, thumbnail-preview
@@ -227,6 +228,7 @@ python3 "$SCRIPT_DIR/prepare-xctestrun.py" "$XCTESTRUN" "$DESTINATION_XCTESTRUN"
   --environment SWIFTVLC_PIP_LIVE_URL_BASE64="$PIP_LIVE_URL_BASE64" \
   --environment SWIFTVLC_PIP_CONTINUITY_DEVICE=YES \
   --environment SWIFTVLC_PIP_CAPABILITY_DEVICE=YES \
+  --environment SWIFTVLC_PIP_VOD_CONTROLS_DEVICE=YES \
   --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
   --environment SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE=YES \
   --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
@@ -280,7 +282,7 @@ xcrun devicectl device copy to \
   --destination Documents/streams.local.json \
   > "$OUTPUT_DIR/stage-streams.log"
 
-DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence deferred-pause-rejection accepted-start-delayed-failure hls-seek)
+DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence vod-controls deferred-pause-rejection accepted-start-delayed-failure hls-seek)
 SCENARIOS_WERE_EXPLICIT=false
 if [[ ${#ONLY_SCENARIOS[@]} -eq 0 ]]; then
   ONLY_SCENARIOS=("${DEFAULT_SCENARIOS[@]}")
@@ -289,7 +291,7 @@ else
 fi
 for scenario in "${ONLY_SCENARIOS[@]}"; do
   case "$scenario" in
-    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
+    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|vod-controls|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
     *) echo "Error: unknown scenario: $scenario" >&2; exit 2 ;;
   esac
 done
@@ -388,6 +390,13 @@ run_scenario() {
       route="PiPCapabilityValidation"
       selected_xctestrun="$DESTINATION_XCTESTRUN"
       ;;
+    vod-controls)
+      test_identifiers=(
+        "iOSUITests/PiPVODControlsDeviceUITests/test_vodControlsAcrossNativeAndDirectBackends"
+      )
+      route="PiPVODControlsValidation"
+      selected_xctestrun="$DESTINATION_XCTESTRUN"
+      ;;
     deferred-pause-rejection)
       test_identifiers=(
         "iOSUITests/PiPDeferredPauseDeviceUITests/test_deferredPauseRejectionAndCancellationStayTruthful"
@@ -442,6 +451,7 @@ run_scenario() {
       --environment SWIFTVLC_PIP_LIVE_URL_BASE64="$PIP_LIVE_URL_BASE64" \
       --environment SWIFTVLC_PIP_CONTINUITY_DEVICE=YES \
       --environment SWIFTVLC_PIP_CAPABILITY_DEVICE=YES \
+      --environment SWIFTVLC_PIP_VOD_CONTROLS_DEVICE=YES \
       --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
       --environment SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE=YES \
       --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
@@ -469,6 +479,7 @@ run_scenario() {
       -skip-testing:iOSUITests/PiPLiveDeviceUITests
       -skip-testing:iOSUITests/PiPContinuityDeviceUITests
       -skip-testing:iOSUITests/PiPCapabilityDeviceUITests
+      -skip-testing:iOSUITests/PiPVODControlsDeviceUITests
       -skip-testing:iOSUITests/PiPDeferredPauseDeviceUITests
       -skip-testing:iOSUITests/PiPDelayedStartFailureDeviceUITests
       -skip-testing:iOSUITests/PiPOverlayDeviceUITests
@@ -628,6 +639,10 @@ PY
     capability-convergence)
       qualification_scenarios=("capability-convergence")
       qualification_attachments=("qualification-capability-convergence.json")
+      ;;
+    vod-controls)
+      qualification_scenarios=("vod-controls")
+      qualification_attachments=("qualification-vod-controls.json")
       ;;
     deferred-pause-rejection)
       qualification_scenarios=("deferred-pause-rejection")

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -440,6 +440,45 @@ class QualificationEvidenceTests(unittest.TestCase):
             self.assertEqual(evidence["duplicatePauseCount"], 0)
             self.assertTrue(evidence["truthfulControls"])
 
+    def test_materializes_vod_controls_evidence(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.make_export(
+                root,
+                {
+                    "formatVersion": 1,
+                    "scenario": "vod-controls",
+                    "events": {
+                        "started": True,
+                        "unexpectedStopCount": 0,
+                        "order": "pass",
+                    },
+                    "controls": {
+                        "play": "pass",
+                        "pause": "pass",
+                        "scrub": "pass",
+                        "skipForward": "pass",
+                        "skipBackward": "pass",
+                    },
+                    "backendResults": {"native": {}, "direct": {}},
+                    "systemPiPMotion": {"native": "pass", "direct": "pass"},
+                },
+                attachment_name="qualification-vod-controls.json",
+                test_identifier="PiPVODControlsDeviceUITests/test_vodControlsAcrossNativeAndDirectBackends",
+            )
+            evidence = materialize_evidence.materialize(
+                root,
+                "qualification-vod-controls.json",
+                "vod-controls",
+                "ipad-minimum",
+                "a" * 64,
+                "b" * 64,
+            )
+            self.assertEqual(evidence["hardware"], "ipad-minimum")
+            self.assertEqual(evidence["events"]["unexpectedStopCount"], 0)
+            self.assertEqual(evidence["controls"]["scrub"], "pass")
+            self.assertEqual(evidence["systemPiPMotion"]["native"], "pass")
+
     def test_materializes_accepted_start_delayed_failure_evidence(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
## Summary

- automate candidate-bound `vod-controls` qualification on every hardware row for native and direct PiP backends
- exercise backend-specific play/pause and skip commands, absolute scrubbing, real system-PiP motion, backgrounding, and ordered teardown
- materialize provenance-bound evidence and document the new lane

## Validation

- SwiftFormat strict check
- SwiftLint strict check
- 28 qualification harness tests
- qualification shell syntax check
- local-source Release iOS app and UI-test runner build-for-testing

This adds automation only. It does not claim a physical-device pass or close any milestone issue.