### PR TITLE
Automate sustained PiP stall recovery qualification

### DIFF
--- a/Showcase/Shared/AccessibilityID.swift
+++ b/Showcase/Shared/AccessibilityID.swift
@@ -245,6 +245,19 @@ enum AccessibilityID {
     static let errorLabel = "pipVODControls.error"
   }
 
+  enum PiPLongStallValidation {
+    static let videoView = "pipLongStall.videoView"
+    static let stateLabel = "pipLongStall.state"
+    static let possibleLabel = "pipLongStall.possible"
+    static let activeLabel = "pipLongStall.active"
+    static let healthLabel = "pipLongStall.health"
+    static let resultLabel = "pipLongStall.result"
+    static let runButton = "pipLongStall.run"
+    static let triggerButton = "pipLongStall.trigger"
+    static let stopButton = "pipLongStall.stop"
+    static let errorLabel = "pipLongStall.error"
+  }
+
   enum MatrixHValidation {
     static let stateLabel = "validation.matrixH.state"
     static let currentTimeLabel = "validation.matrixH.currentTime"

--- a/Showcase/Shared/LaunchArguments.swift
+++ b/Showcase/Shared/LaunchArguments.swift
@@ -167,6 +167,7 @@ enum UITestRoute: String, CaseIterable {
   case pipDeferredPauseValidation = "PiPDeferredPauseValidation"
   case pipDelayedStartFailureValidation = "PiPDelayedStartFailureValidation"
   case pipVODControlsValidation = "PiPVODControlsValidation"
+  case pipLongStallValidation = "PiPLongStallValidation"
 
   static var current: UITestRoute? {
     LaunchArguments.routeValue.flatMap(UITestRoute.init(rawValue:))

--- a/Showcase/UITests/iOS/Tests/PiPLongStallDeviceUITests.swift
+++ b/Showcase/UITests/iOS/Tests/PiPLongStallDeviceUITests.swift
@@ -1,0 +1,174 @@
+import XCTest
+
+/// Candidate-bound sustained source-stall and recovery qualification across
+/// native and direct PiP while the real system window remains active.
+final class PiPLongStallDeviceUITests: ShowcaseIOSTestCase {
+  func test_longStallRecoversAcrossNativeAndDirectBackends() throws {
+    #if targetEnvironment(simulator)
+    throw XCTSkip("System Picture in Picture requires a physical iOS device")
+    #else
+    guard ProcessInfo.processInfo.environment["SWIFTVLC_PIP_LONG_STALL_DEVICE"] == "YES" else {
+      throw XCTSkip("Set SWIFTVLC_PIP_LONG_STALL_DEVICE=YES for candidate-bound hardware runs")
+    }
+
+    let native = try runStall(renderingPath: "native")
+    let direct = try runStall(renderingPath: "direct")
+    let unexpectedStops = try unexpectedStopCount(in: native)
+      + unexpectedStopCount(in: direct)
+    XCTAssertEqual(unexpectedStops, 0)
+    attachQualificationEvidence(
+      [
+        "formatVersion": 1,
+        "scenario": "long-stall",
+        "events": [
+          "started": true,
+          "unexpectedStopCount": unexpectedStops,
+          "order": "pass"
+        ],
+        "recoveryOutcome": "recovered",
+        "boundedMemory": true,
+        "stall": [
+          "sustained": "pass",
+          "recovered": "pass",
+          "activeAfterRecovery": true
+        ],
+        "memory": [
+          "bounded": "pass",
+          "limitBytes": 96 * 1_048_576
+        ],
+        "backendResults": [
+          "native": native,
+          "direct": direct
+        ],
+        "systemPiPMotionAfterRecovery": [
+          "native": "pass",
+          "direct": "pass"
+        ]
+      ],
+      scenario: "long-stall"
+    )
+    #endif
+  }
+
+  private func runStall(renderingPath: String) throws -> [String: Any] {
+    addUIInterruptionMonitor(withDescription: "Local network permission") { alert in
+      let allow = alert.buttons["Allow"]
+      guard allow.exists else { return false }
+      allow.tap()
+      return true
+    }
+    let encodedURL = try XCTUnwrap(
+      ProcessInfo.processInfo.environment["SWIFTVLC_PIP_LONG_STALL_URL_BASE64"]
+    )
+    replaceLaunchArgument(LaunchArguments.pipRenderingPath, with: renderingPath)
+    replaceLaunchArgument(LaunchArguments.pipLiveURLBase64, with: encodedURL)
+    launch(route: .pipLongStallValidation)
+    app.tap()
+
+    let state = element(AccessibilityID.PiPLongStallValidation.stateLabel)
+    let possible = element(AccessibilityID.PiPLongStallValidation.possibleLabel)
+    let active = element(AccessibilityID.PiPLongStallValidation.activeLabel)
+    let result = element(AccessibilityID.PiPLongStallValidation.resultLabel)
+    let run = app.buttons[AccessibilityID.PiPLongStallValidation.runButton]
+    let trigger = app.buttons[AccessibilityID.PiPLongStallValidation.triggerButton]
+    let stop = app.buttons[AccessibilityID.PiPLongStallValidation.stopButton]
+    let error = element(AccessibilityID.PiPLongStallValidation.errorLabel)
+
+    waitForLabel(state, equals: "playing", timeout: 20)
+    waitForLabel(possible, equals: "yes", timeout: 15)
+    reveal(run)
+    XCTAssertTrue(run.isEnabled)
+    run.tap()
+    waitForLabel(result, equals: "armed", timeout: 20)
+    waitForLabel(active, equals: "yes", timeout: 5)
+
+    reveal(trigger)
+    XCTAssertTrue(trigger.isEnabled)
+    trigger.tap()
+    waitForLabel(result, equals: "triggered", timeout: 5)
+    XCUIDevice.shared.press(.home)
+
+    // The fixture withholds every active media connection for twelve seconds.
+    // Allow the public two-second classifier, decoder refill, and presentation
+    // recovery enough time to publish a paired transition before inspecting
+    // real system-PiP pixels again.
+    Thread.sleep(forTimeInterval: 20)
+    if let failure = captureSystemPictureInPictureMotion() {
+      XCTFail("\(renderingPath) PiP did not recover moving pixels: \(failure)")
+    }
+
+    app.activate()
+    waitForLabel(active, equals: "yes", timeout: 10)
+    waitForLabel(result, equals: "ready-for-stop", timeout: 15)
+    reveal(stop)
+    XCTAssertTrue(stop.isEnabled)
+    stop.tap()
+    waitForPrefix(result, prefix: "pass:", timeout: 15)
+    waitForLabel(active, equals: "no", timeout: 10)
+    XCTAssertFalse(error.exists, "\(renderingPath) stall recovery failed: \(error.label)")
+    assertNoLibraryErrors()
+
+    let evidence = try decodeEvidence(result.label)
+    XCTAssertEqual(evidence["backend"] as? String, renderingPath)
+    let stall = try XCTUnwrap(evidence["stall"] as? [String: Any])
+    XCTAssertEqual(stall["activeAfterRecovery"] as? Bool, true)
+    XCTAssertGreaterThanOrEqual(try XCTUnwrap(stall["durationMilliseconds"] as? Int), 2000)
+    let memory = try XCTUnwrap(evidence["memory"] as? [String: Any])
+    let growth = try XCTUnwrap(memory["growthBytes"] as? Int)
+    let limit = try XCTUnwrap(memory["limitBytes"] as? Int)
+    XCTAssertLessThanOrEqual(growth, limit)
+    return evidence
+  }
+
+  private func unexpectedStopCount(in evidence: [String: Any]) throws -> Int {
+    let events = try XCTUnwrap(evidence["events"] as? [String: Any])
+    XCTAssertEqual(events["started"] as? Bool, true)
+    XCTAssertEqual(events["order"] as? String, "pass")
+    return try XCTUnwrap(events["unexpectedStopCount"] as? Int)
+  }
+
+  private func decodeEvidence(_ label: String) throws -> [String: Any] {
+    let prefix = "pass:"
+    XCTAssertTrue(label.hasPrefix(prefix))
+    let encoded = String(label.dropFirst(prefix.count))
+    let data = try XCTUnwrap(Data(base64Encoded: encoded))
+    return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+  }
+
+  private func element(_ identifier: String) -> XCUIElement {
+    app.descendants(matching: .any)[identifier]
+  }
+
+  private func waitForPrefix(
+    _ element: XCUIElement,
+    prefix: String,
+    timeout: TimeInterval
+  ) {
+    let predicate = NSPredicate { _, _ in
+      element.exists && element.label.hasPrefix(prefix)
+    }
+    let expectation = expectation(for: predicate, evaluatedWith: NSObject())
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [expectation], timeout: timeout),
+      .completed,
+      "Expected prefix \(prefix), got: \(element.label)"
+    )
+  }
+
+  private func replaceLaunchArgument(_ name: String, with value: String) {
+    while let index = app.launchArguments.firstIndex(of: name) {
+      app.launchArguments.remove(at: index)
+      if index < app.launchArguments.endIndex {
+        app.launchArguments.remove(at: index)
+      }
+    }
+    app.launchArguments += [name, value]
+  }
+
+  private func reveal(_ element: XCUIElement) {
+    for _ in 0..<10 where !element.isHittable {
+      app.swipeUp()
+    }
+    XCTAssertTrue(element.isHittable)
+  }
+}

--- a/Showcase/iOS/Internal/UITestSupport.swift
+++ b/Showcase/iOS/Internal/UITestSupport.swift
@@ -130,6 +130,7 @@ extension UITestRoute {
     case .pipDeferredPauseValidation: PiPDeferredPauseValidationCase()
     case .pipDelayedStartFailureValidation: PiPDelayedStartFailureValidationCase()
     case .pipVODControlsValidation: PiPVODControlsValidationCase()
+    case .pipLongStallValidation: PiPLongStallValidationCase()
     }
   }
 }

--- a/Showcase/iOS/ValidationHarness/PiPLongStallValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/PiPLongStallValidationCase.swift
@@ -1,0 +1,472 @@
+import Darwin
+import SwiftUI
+@_spi(Qualification) import SwiftVLC
+
+/// Candidate-bound recovery exercise for an externally gated network stall.
+/// The UI test triggers the fixture only after system PiP is active, avoiding
+/// false passes where libVLC prefetched through a byte-position-based stall.
+struct PiPLongStallValidationCase: View {
+  @State private var player = Player()
+  @State private var controller: PiPController?
+  @State private var lifecycleEvents: [String] = []
+  @State private var healthEvents: [String] = []
+  @State private var stallObservation: StallObservation?
+  @State private var bufferingBeganAt: ContinuousClock.Instant?
+  @State private var result = "not-run"
+  @State private var playbackError: String?
+  @State private var isRunning = false
+  @State private var baselineResidentBytes: UInt64 = 0
+  @State private var peakResidentBytes: UInt64 = 0
+  @State private var memorySampler: Task<Void, Never>?
+
+  private var renderingPath: LongStallRenderingPath {
+    LongStallRenderingPath(
+      rawValue: LaunchArguments.pipRenderingPathValue ?? "native"
+    ) ?? .native
+  }
+
+  var body: some View {
+    _ = player.currentTime
+    return Form {
+      Section {
+        videoSurface
+          .frame(height: 220)
+          .listRowInsets(EdgeInsets())
+          .accessibilityIdentifier(AccessibilityID.PiPLongStallValidation.videoView)
+      }
+
+      Section("Measured state") {
+        valueRow(
+          "Playback",
+          value: String(describing: player.state),
+          identifier: AccessibilityID.PiPLongStallValidation.stateLabel
+        )
+        valueRow(
+          "PiP possible",
+          value: controller?.isPossible == true ? "yes" : "no",
+          identifier: AccessibilityID.PiPLongStallValidation.possibleLabel
+        )
+        valueRow(
+          "PiP active",
+          value: controller?.isActive == true ? "yes" : "no",
+          identifier: AccessibilityID.PiPLongStallValidation.activeLabel
+        )
+        valueRow(
+          "Playback health",
+          value: healthEvents.last ?? "none",
+          identifier: AccessibilityID.PiPLongStallValidation.healthLabel
+        )
+        valueRow(
+          "Qualification",
+          value: result,
+          identifier: AccessibilityID.PiPLongStallValidation.resultLabel
+        )
+      }
+
+      Section("Picture in Picture") {
+        Button("Arm sustained-stall qualification") {
+          Task { await runQualification() }
+        }
+        .accessibilityIdentifier(AccessibilityID.PiPLongStallValidation.runButton)
+        .disabled(isRunning || controller?.isPossible != true || player.state != .playing)
+
+        Button("Trigger controlled network stall") {
+          Task { await triggerStall() }
+        }
+        .accessibilityIdentifier(AccessibilityID.PiPLongStallValidation.triggerButton)
+        .disabled(result != "armed" || controller?.isActive != true)
+
+        Button("Stop and finalize evidence") {
+          Task { await stopAndFinalize() }
+        }
+        .accessibilityIdentifier(AccessibilityID.PiPLongStallValidation.stopButton)
+        .disabled(result != "ready-for-stop" || controller?.isActive != true)
+
+        if let playbackError {
+          Text(playbackError)
+            .foregroundStyle(.red)
+            .accessibilityIdentifier(AccessibilityID.PiPLongStallValidation.errorLabel)
+        }
+      }
+    }
+    .showcaseFormStyle()
+    .navigationTitle("PiP stall recovery")
+    .task { startPlayback() }
+    .task(id: controller.map(ObjectIdentifier.init)) {
+      lifecycleEvents.removeAll()
+      guard let controller else { return }
+      for await envelope in controller.pipEventEnvelopes {
+        lifecycleEvents.append(envelope.event.longStallQualificationName)
+      }
+    }
+    .task(id: player.generation) {
+      healthEvents.removeAll()
+      stallObservation = nil
+      bufferingBeganAt = nil
+      for await event in player.playbackHealthEvents {
+        recordHealthEvent(event)
+      }
+    }
+    .task(id: player.generation) {
+      for await snapshot in player.playbackHealthSnapshots {
+        recordHealthSnapshot(snapshot)
+      }
+    }
+    .onDisappear {
+      memorySampler?.cancel()
+      controller?.stop()
+      player.stop()
+    }
+  }
+
+  @ViewBuilder
+  private var videoSurface: some View {
+    switch renderingPath {
+    case .native:
+      PiPVideoView(player, controller: $controller, startsAutomaticallyFromInline: false)
+    case .direct:
+      DirectPiPValidationSurface(player: player, controller: $controller)
+    }
+  }
+
+  private func startPlayback() {
+    guard let url = LaunchArguments.pipLiveURLValue else {
+      playbackError = "Missing gated-stall validation stream"
+      return
+    }
+    do {
+      try player.play(url: url)
+    } catch {
+      playbackError = String(describing: error)
+    }
+  }
+
+  private func runQualification() async {
+    guard let controller else { return }
+    isRunning = true
+    result = "starting"
+    playbackError = nil
+    healthEvents.removeAll()
+    stallObservation = nil
+    bufferingBeganAt = nil
+    do {
+      guard controller.start() == .accepted else {
+        throw LongStallQualificationFailure("PiP start was not accepted")
+      }
+      try await waitUntil("PiP did not become active") { controller.isActive }
+      try await waitUntil("Playback did not become healthy") {
+        if case .healthy = player.playbackHealth.state {
+          return true
+        }
+        return false
+      }
+      baselineResidentBytes = Self.residentBytes()
+      guard baselineResidentBytes > 0 else {
+        throw LongStallQualificationFailure("Resident-memory sampling failed")
+      }
+      peakResidentBytes = baselineResidentBytes
+      startMemorySampling()
+      result = "armed"
+    } catch is CancellationError {
+      result = "cancelled"
+    } catch {
+      playbackError = String(describing: error)
+      result = "failed"
+      controller.stop()
+    }
+    isRunning = false
+  }
+
+  private func recordHealthEvent(_ event: PlaybackHealthEvent) {
+    switch event.kind {
+    case .stalled(let reason):
+      let name = String(describing: reason)
+      healthEvents.append("stalled:\(name)")
+      stallObservation = StallObservation(
+        reason: name,
+        stalledAtMilliseconds: event.snapshot.lastStalledAt.map(Self.milliseconds),
+        recoveredAtMilliseconds: nil,
+        durationMilliseconds: nil
+      )
+    case .recovered(let reason):
+      let name = String(describing: reason)
+      healthEvents.append("recovered:\(name)")
+      guard var observation = stallObservation, observation.reason == name else { return }
+      observation.recoveredAtMilliseconds = event.snapshot.lastRecoveredAt.map(Self.milliseconds)
+      if
+        let stalledAt = observation.stalledAtMilliseconds,
+        let recoveredAt = observation.recoveredAtMilliseconds {
+        observation.durationMilliseconds = recoveredAt - stalledAt
+      }
+      stallObservation = observation
+      if isFaultArmed, controller?.isActive == true {
+        result = "ready-for-stop"
+      }
+    case .terminalFailure(let failure):
+      healthEvents.append("terminalFailure:\(String(describing: failure))")
+      playbackError = "Playback health reached a terminal failure"
+      result = "failed"
+    case .firstDecodedFrame:
+      healthEvents.append("firstDecodedFrame")
+    case .firstPresentedFrame:
+      healthEvents.append("firstPresentedFrame")
+    case .waiting(let reason):
+      healthEvents.append("waiting:\(String(describing: reason))")
+      if reason == .buffering, isFaultArmed, bufferingBeganAt == nil {
+        bufferingBeganAt = ContinuousClock.now
+      }
+    }
+  }
+
+  private func recordHealthSnapshot(_ snapshot: PlaybackHealthSnapshot) {
+    guard
+      case .healthy = snapshot.state,
+      let beganAt = bufferingBeganAt,
+      stallObservation == nil,
+      isFaultArmed,
+      controller?.isActive == true
+    else { return }
+    let elapsed = Self.milliseconds(beganAt.duration(to: ContinuousClock.now))
+    guard elapsed >= 2000 else { return }
+    healthEvents.append("recovered:buffering")
+    stallObservation = StallObservation(
+      reason: "buffering",
+      stalledAtMilliseconds: 0,
+      recoveredAtMilliseconds: elapsed,
+      durationMilliseconds: elapsed
+    )
+    result = "ready-for-stop"
+  }
+
+  private var isFaultArmed: Bool {
+    result == "armed" || result == "triggering" || result == "triggered"
+  }
+
+  private func startMemorySampling() {
+    memorySampler?.cancel()
+    memorySampler = Task { @MainActor in
+      while !Task.isCancelled {
+        peakResidentBytes = max(peakResidentBytes, Self.residentBytes())
+        try? await Task.sleep(for: .milliseconds(250))
+      }
+    }
+  }
+
+  private func triggerStall() async {
+    guard
+      let streamURL = LaunchArguments.pipLiveURLValue,
+      var components = URLComponents(url: streamURL, resolvingAgainstBaseURL: false)
+    else {
+      playbackError = "Cannot construct controlled-stall trigger URL"
+      result = "failed"
+      return
+    }
+    components.path = "/fault/trigger/long-stall"
+    components.query = nil
+    components.fragment = nil
+    guard let triggerURL = components.url else {
+      playbackError = "Cannot construct controlled-stall trigger URL"
+      result = "failed"
+      return
+    }
+    result = "triggering"
+    do {
+      let (_, response) = try await URLSession.shared.data(from: triggerURL)
+      guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+        throw LongStallQualificationFailure("Fixture rejected controlled-stall trigger")
+      }
+      result = "triggered"
+    } catch {
+      playbackError = String(describing: error)
+      result = "failed"
+    }
+  }
+
+  private func stopAndFinalize() async {
+    guard let controller, let observation = stallObservation else { return }
+    result = "stopping"
+    memorySampler?.cancel()
+    peakResidentBytes = max(peakResidentBytes, Self.residentBytes())
+    do {
+      guard
+        let stalledAt = observation.stalledAtMilliseconds,
+        let recoveredAt = observation.recoveredAtMilliseconds,
+        let duration = observation.durationMilliseconds,
+        duration >= 2000
+      else {
+        throw LongStallQualificationFailure("Observed stall was shorter than two seconds")
+      }
+      guard controller.isActive else {
+        throw LongStallQualificationFailure("PiP stopped before recovery evidence finalized")
+      }
+      let memoryGrowthBytes = peakResidentBytes > baselineResidentBytes
+        ? peakResidentBytes - baselineResidentBytes
+        : 0
+      let memoryLimitBytes: UInt64 = 96 * 1_048_576
+      guard memoryGrowthBytes <= memoryLimitBytes else {
+        throw LongStallQualificationFailure("Resident-memory growth exceeded 96 MiB")
+      }
+
+      controller.stop()
+      try await waitUntil("PiP did not stop") { !controller.isActive }
+      try await waitUntil("Programmatic stop event did not arrive") {
+        lifecycleEvents.contains("didStop:programmatic")
+      }
+      guard lifecycleOrderPasses else {
+        throw LongStallQualificationFailure("Lifecycle events were incomplete or reordered")
+      }
+
+      let unexpectedStops = lifecycleEvents.filter {
+        $0.hasPrefix("didStop:") && $0 != "didStop:programmatic"
+      }.count
+      guard unexpectedStops == 0 else {
+        throw LongStallQualificationFailure("PiP stopped unexpectedly during stall recovery")
+      }
+      let evidence = LongStallQualificationEvidence(
+        backend: renderingPath.rawValue,
+        orderedEvents: lifecycleEvents,
+        healthEvents: healthEvents,
+        events: LongStallEventEvidence(
+          started: true,
+          unexpectedStopCount: unexpectedStops,
+          order: "pass"
+        ),
+        stall: LongStallEvidence(
+          reason: observation.reason,
+          stalledAtMilliseconds: stalledAt,
+          recoveredAtMilliseconds: recoveredAt,
+          durationMilliseconds: duration,
+          activeAfterRecovery: true
+        ),
+        memory: LongStallMemoryEvidence(
+          baselineResidentBytes: baselineResidentBytes,
+          peakResidentBytes: peakResidentBytes,
+          growthBytes: memoryGrowthBytes,
+          limitBytes: memoryLimitBytes
+        )
+      )
+      let data = try JSONEncoder().encode(evidence)
+      result = "pass:\(data.base64EncodedString())"
+    } catch {
+      playbackError = String(describing: error)
+      result = "failed"
+    }
+  }
+
+  private var lifecycleOrderPasses: Bool {
+    let required = ["willStart", "didStart", "willStop:programmatic", "didStop:programmatic"]
+    var searchStart = lifecycleEvents.startIndex
+    for value in required {
+      guard let index = lifecycleEvents[searchStart...].firstIndex(of: value) else { return false }
+      searchStart = lifecycleEvents.index(after: index)
+    }
+    return true
+  }
+
+  private func waitUntil(
+    _ failure: String,
+    timeout: Duration = .seconds(15),
+    condition: @escaping @MainActor () -> Bool
+  )
+    async throws {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
+    while !condition() {
+      try Task.checkCancellation()
+      guard clock.now < deadline else { throw LongStallQualificationFailure(failure) }
+      try await Task.sleep(for: .milliseconds(50))
+    }
+  }
+
+  private func valueRow(_ title: String, value: String, identifier: String) -> some View {
+    HStack {
+      Text(title)
+      Spacer()
+      Text(value)
+        .foregroundStyle(.secondary)
+        .accessibilityIdentifier(identifier)
+    }
+  }
+
+  private static func residentBytes() -> UInt64 {
+    var info = mach_task_basic_info()
+    var count = mach_msg_type_number_t(
+      MemoryLayout<mach_task_basic_info>.size / MemoryLayout<natural_t>.size
+    )
+    let status = withUnsafeMutablePointer(to: &info) { pointer in
+      pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { rebound in
+        task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), rebound, &count)
+      }
+    }
+    return status == KERN_SUCCESS ? info.resident_size : 0
+  }
+
+  private static func milliseconds(_ duration: Duration) -> Int64 {
+    let components = duration.components
+    return components.seconds * 1000 + Int64(components.attoseconds / 1_000_000_000_000_000)
+  }
+}
+
+private enum LongStallRenderingPath: String {
+  case native
+  case direct
+}
+
+private struct StallObservation {
+  let reason: String
+  let stalledAtMilliseconds: Int64?
+  var recoveredAtMilliseconds: Int64?
+  var durationMilliseconds: Int64?
+}
+
+private struct LongStallQualificationEvidence: Encodable {
+  let formatVersion = 1
+  let scenario = "long-stall"
+  let backend: String
+  let orderedEvents: [String]
+  let healthEvents: [String]
+  let events: LongStallEventEvidence
+  let stall: LongStallEvidence
+  let memory: LongStallMemoryEvidence
+}
+
+private struct LongStallEventEvidence: Encodable {
+  let started: Bool
+  let unexpectedStopCount: Int
+  let order: String
+}
+
+private struct LongStallEvidence: Encodable {
+  let reason: String
+  let stalledAtMilliseconds: Int64
+  let recoveredAtMilliseconds: Int64
+  let durationMilliseconds: Int64
+  let activeAfterRecovery: Bool
+}
+
+private struct LongStallMemoryEvidence: Encodable {
+  let baselineResidentBytes: UInt64
+  let peakResidentBytes: UInt64
+  let growthBytes: UInt64
+  let limitBytes: UInt64
+}
+
+private struct LongStallQualificationFailure: Error, CustomStringConvertible {
+  let description: String
+
+  init(_ description: String) {
+    self.description = description
+  }
+}
+
+extension PiPEvent {
+  fileprivate var longStallQualificationName: String {
+    switch self {
+    case .willStart: "willStart"
+    case .didStart: "didStart"
+    case .willStop(let reason): "willStop:\(String(describing: reason))"
+    case .didStop(let reason): "didStop:\(String(describing: reason))"
+    case .failedToStart: "failedToStart"
+    }
+  }
+}

--- a/Showcase/macOS/Internal/MacShowcaseRootView.swift
+++ b/Showcase/macOS/Internal/MacShowcaseRootView.swift
@@ -410,7 +410,8 @@ extension MacShowcase {
          .pipCapabilityValidation,
          .pipDeferredPauseValidation,
          .pipDelayedStartFailureValidation,
-         .pipVODControlsValidation:
+         .pipVODControlsValidation,
+         .pipLongStallValidation:
       return nil
     }
   }

--- a/Showcase/tvOS/Internal/TVShowcaseRootView.swift
+++ b/Showcase/tvOS/Internal/TVShowcaseRootView.swift
@@ -518,7 +518,8 @@ extension TVShowcase {
          .pipCapabilityValidation,
          .pipDeferredPauseValidation,
          .pipDelayedStartFailureValidation,
-         .pipVODControlsValidation:
+         .pipVODControlsValidation,
+         .pipLongStallValidation:
       return nil
     }
   }

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -117,6 +117,17 @@ stop completes the ordered lifecycle. One combined `vod-controls` attachment
 is emitted only when every control passes on both backends with zero library
 errors or unexpected stops.
 
+The long-stall lane also runs on every hardware row. Its local fixture keeps a
+continuous MPEG-TS connection flowing until the candidate has entered real
+system PiP, then an explicit in-app trigger stalls every active connection for
+twelve seconds. Both native and direct backends must publish either the public
+stalled/recovered pair or the expected buffering/healthy transition, remain in
+PiP, resume moving system-PiP pixels, and complete ordered teardown without
+library errors. The app samples its own
+resident memory throughout the fault and rejects growth beyond a 96 MiB bound;
+the combined attachment records the raw per-backend timings and memory values
+as well as the matrix-required recovery and bounded-memory outcomes.
+
 The iPhone-current-only deferred-pause-rejection lane drives the exact AVKit
 playback command entry point while a qualification SPI changes only libVLC's
 native pause-capability answer. It proves a permanently unpausable input

--- a/scripts/qualification/fixture-server.py
+++ b/scripts/qualification/fixture-server.py
@@ -10,6 +10,7 @@ import os
 import re
 import socket
 import sys
+import threading
 import time
 from datetime import datetime, timezone
 from http import HTTPStatus
@@ -42,6 +43,30 @@ class FixtureHandler(BaseHTTPRequestHandler):
                 self.end_headers()
                 self.wfile.write(payload)
                 transferred = len(payload)
+                return
+
+            match = re.fullmatch(r"/fault/trigger/([A-Za-z0-9._-]+)", route)
+            if match:
+                generation = self.server.trigger_stall(match.group(1))
+                payload = json.dumps({"generation": generation}).encode()
+                self.send_response(HTTPStatus.OK)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+                transferred = len(payload)
+                return
+
+            match = re.fullmatch(
+                r"/fault/gated-stall/([A-Za-z0-9._-]+)/([0-9]+(?:\.[0-9]+)?)/(.+)",
+                route,
+            )
+            if match:
+                transferred = self._serve_loop(
+                    self._safe_path(match.group(3)),
+                    stall_token=match.group(1),
+                    stall_seconds=float(match.group(2)),
+                )
                 return
 
             match = re.fullmatch(r"/live/(.+)", route)
@@ -113,7 +138,13 @@ class FixtureHandler(BaseHTTPRequestHandler):
             raise FileNotFoundError(candidate)
         return candidate
 
-    def _serve_loop(self, path: Path) -> int:
+    def _serve_loop(
+        self,
+        path: Path,
+        *,
+        stall_token: str | None = None,
+        stall_seconds: float = 0,
+    ) -> int:
         content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
         self.send_response(HTTPStatus.OK)
         self.send_header("Content-Type", content_type)
@@ -121,12 +152,25 @@ class FixtureHandler(BaseHTTPRequestHandler):
         self.send_header("Connection", "close")
         self.end_headers()
         transferred = 0
+        observed_stall_generation = 0
+        if stall_token:
+            observed_stall_generation, triggered_at = self.server.stall_state(stall_token)
+            remaining = triggered_at + stall_seconds - time.monotonic()
+            if observed_stall_generation > 0 and remaining > 0:
+                time.sleep(remaining)
         while True:
             with path.open("rb") as source:
                 while chunk := source.read(self.server.chunk_size):
                     self.wfile.write(chunk)
                     self.wfile.flush()
                     transferred += len(chunk)
+                    if stall_token:
+                        generation, triggered_at = self.server.stall_state(stall_token)
+                        if generation > observed_stall_generation:
+                            observed_stall_generation = generation
+                            remaining = triggered_at + stall_seconds - time.monotonic()
+                            if remaining > 0:
+                                time.sleep(remaining)
                     if self.server.chunk_delay:
                         time.sleep(self.server.chunk_delay)
 
@@ -221,6 +265,23 @@ class FixtureHTTPServer(ThreadingHTTPServer):
         self.chunk_size = chunk_size
         self.chunk_delay = chunk_delay
         self.verbose = verbose
+        self._stall_lock = threading.Lock()
+        self._stall_generations: dict[str, int] = {}
+        self._stall_triggered_at: dict[str, float] = {}
+
+    def trigger_stall(self, token: str) -> int:
+        with self._stall_lock:
+            generation = self._stall_generations.get(token, 0) + 1
+            self._stall_generations[token] = generation
+            self._stall_triggered_at[token] = time.monotonic()
+            return generation
+
+    def stall_state(self, token: str) -> tuple[int, float]:
+        with self._stall_lock:
+            return (
+                self._stall_generations.get(token, 0),
+                self._stall_triggered_at.get(token, 0),
+            )
 
     def handle_error(self, request: object, client_address: tuple[str, int]) -> None:
         # Media clients commonly abandon a keep-alive connection after a seek

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -34,7 +34,7 @@ Options:
   --only SCENARIO         Repeat to select: analyzer, ui-suite, native-live,
                           direct-live, live-media, background-audio,
                           continuity, capability-convergence,
-                          vod-controls,
+                          vod-controls, long-stall,
                           deferred-pause-rejection,
                           accepted-start-delayed-failure, hls-seek,
                           harness-regressions, ui-failures, thumbnail-preview
@@ -141,6 +141,8 @@ fi
 cp "$READY_FILE" "$OUTPUT_DIR/fixture-server.json"
 BASE_URL=$(jq -r '.baseURL' "$READY_FILE")
 PIP_LIVE_URL_BASE64=$(printf '%s' "$BASE_URL/live/live.ts" | base64)
+PIP_LONG_STALL_URL_BASE64=$(printf '%s' \
+  "$BASE_URL/fault/gated-stall/long-stall/12/live.ts" | base64)
 VOD_URL_BASE64=$(printf '%s' "$BASE_URL/files/vod.mp4" | base64)
 
 if [[ "$SKIP_BUILD" == false ]]; then
@@ -229,6 +231,8 @@ python3 "$SCRIPT_DIR/prepare-xctestrun.py" "$XCTESTRUN" "$DESTINATION_XCTESTRUN"
   --environment SWIFTVLC_PIP_CONTINUITY_DEVICE=YES \
   --environment SWIFTVLC_PIP_CAPABILITY_DEVICE=YES \
   --environment SWIFTVLC_PIP_VOD_CONTROLS_DEVICE=YES \
+  --environment SWIFTVLC_PIP_LONG_STALL_DEVICE=YES \
+  --environment SWIFTVLC_PIP_LONG_STALL_URL_BASE64="$PIP_LONG_STALL_URL_BASE64" \
   --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
   --environment SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE=YES \
   --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
@@ -282,7 +286,7 @@ xcrun devicectl device copy to \
   --destination Documents/streams.local.json \
   > "$OUTPUT_DIR/stage-streams.log"
 
-DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence vod-controls deferred-pause-rejection accepted-start-delayed-failure hls-seek)
+DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence vod-controls long-stall deferred-pause-rejection accepted-start-delayed-failure hls-seek)
 SCENARIOS_WERE_EXPLICIT=false
 if [[ ${#ONLY_SCENARIOS[@]} -eq 0 ]]; then
   ONLY_SCENARIOS=("${DEFAULT_SCENARIOS[@]}")
@@ -291,7 +295,7 @@ else
 fi
 for scenario in "${ONLY_SCENARIOS[@]}"; do
   case "$scenario" in
-    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|vod-controls|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
+    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|vod-controls|long-stall|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
     *) echo "Error: unknown scenario: $scenario" >&2; exit 2 ;;
   esac
 done
@@ -397,6 +401,13 @@ run_scenario() {
       route="PiPVODControlsValidation"
       selected_xctestrun="$DESTINATION_XCTESTRUN"
       ;;
+    long-stall)
+      test_identifiers=(
+        "iOSUITests/PiPLongStallDeviceUITests/test_longStallRecoversAcrossNativeAndDirectBackends"
+      )
+      route="PiPLongStallValidation"
+      selected_xctestrun="$DESTINATION_XCTESTRUN"
+      ;;
     deferred-pause-rejection)
       test_identifiers=(
         "iOSUITests/PiPDeferredPauseDeviceUITests/test_deferredPauseRejectionAndCancellationStayTruthful"
@@ -452,6 +463,8 @@ run_scenario() {
       --environment SWIFTVLC_PIP_CONTINUITY_DEVICE=YES \
       --environment SWIFTVLC_PIP_CAPABILITY_DEVICE=YES \
       --environment SWIFTVLC_PIP_VOD_CONTROLS_DEVICE=YES \
+      --environment SWIFTVLC_PIP_LONG_STALL_DEVICE=YES \
+      --environment SWIFTVLC_PIP_LONG_STALL_URL_BASE64="$PIP_LONG_STALL_URL_BASE64" \
       --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
       --environment SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE=YES \
       --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
@@ -480,6 +493,7 @@ run_scenario() {
       -skip-testing:iOSUITests/PiPContinuityDeviceUITests
       -skip-testing:iOSUITests/PiPCapabilityDeviceUITests
       -skip-testing:iOSUITests/PiPVODControlsDeviceUITests
+      -skip-testing:iOSUITests/PiPLongStallDeviceUITests
       -skip-testing:iOSUITests/PiPDeferredPauseDeviceUITests
       -skip-testing:iOSUITests/PiPDelayedStartFailureDeviceUITests
       -skip-testing:iOSUITests/PiPOverlayDeviceUITests
@@ -643,6 +657,10 @@ PY
     vod-controls)
       qualification_scenarios=("vod-controls")
       qualification_attachments=("qualification-vod-controls.json")
+      ;;
+    long-stall)
+      qualification_scenarios=("long-stall")
+      qualification_attachments=("qualification-long-stall.json")
       ;;
     deferred-pause-rejection)
       qualification_scenarios=("deferred-pause-rejection")

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -140,10 +140,10 @@ if [[ ! -s "$READY_FILE" ]]; then
 fi
 cp "$READY_FILE" "$OUTPUT_DIR/fixture-server.json"
 BASE_URL=$(jq -r '.baseURL' "$READY_FILE")
-PIP_LIVE_URL_BASE64=$(printf '%s' "$BASE_URL/live/live.ts" | base64)
+PIP_LIVE_URL_BASE64=$(printf '%s' "$BASE_URL/live/live.ts" | base64 | tr -d '\r\n')
 PIP_LONG_STALL_URL_BASE64=$(printf '%s' \
-  "$BASE_URL/fault/gated-stall/long-stall/12/live.ts" | base64)
-VOD_URL_BASE64=$(printf '%s' "$BASE_URL/files/vod.mp4" | base64)
+  "$BASE_URL/fault/gated-stall/long-stall/12/live.ts" | base64 | tr -d '\r\n')
+VOD_URL_BASE64=$(printf '%s' "$BASE_URL/files/vod.mp4" | base64 | tr -d '\r\n')
 
 if [[ "$SKIP_BUILD" == false ]]; then
   if [[ ! -d "$ROOT_DIR/Vendor/libvlc.xcframework" ]]; then

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -479,6 +479,46 @@ class QualificationEvidenceTests(unittest.TestCase):
             self.assertEqual(evidence["controls"]["scrub"], "pass")
             self.assertEqual(evidence["systemPiPMotion"]["native"], "pass")
 
+    def test_materializes_long_stall_evidence(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.make_export(
+                root,
+                {
+                    "formatVersion": 1,
+                    "scenario": "long-stall",
+                    "events": {
+                        "started": True,
+                        "unexpectedStopCount": 0,
+                        "order": "pass",
+                    },
+                    "recoveryOutcome": "recovered",
+                    "boundedMemory": True,
+                    "backendResults": {
+                        "native": {"memory": {"growthBytes": 1024}},
+                        "direct": {"memory": {"growthBytes": 2048}},
+                    },
+                    "systemPiPMotionAfterRecovery": {
+                        "native": "pass",
+                        "direct": "pass",
+                    },
+                },
+                attachment_name="qualification-long-stall.json",
+                test_identifier="PiPLongStallDeviceUITests/test_longStallRecoversAcrossNativeAndDirectBackends",
+            )
+            evidence = materialize_evidence.materialize(
+                root,
+                "qualification-long-stall.json",
+                "long-stall",
+                "iphone-minimum",
+                "a" * 64,
+                "b" * 64,
+            )
+            self.assertEqual(evidence["hardware"], "iphone-minimum")
+            self.assertEqual(evidence["recoveryOutcome"], "recovered")
+            self.assertTrue(evidence["boundedMemory"])
+            self.assertEqual(evidence["backendResults"]["direct"]["memory"]["growthBytes"], 2048)
+
     def test_materializes_accepted_start_delayed_failure_evidence(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -841,6 +881,34 @@ class FixtureServerTests(unittest.TestCase):
         connection, response = self.request("/live/sample.bin")
         sample = (self.root / "sample.bin").read_bytes()
         self.assertEqual(response.read(len(sample) + 32), sample + sample[:32])
+        connection.close()
+
+    def test_gated_stall_waits_only_after_trigger(self):
+        self.server.chunk_delay = 0.01
+        connection, response = self.request("/fault/gated-stall/test/0.15/sample.bin")
+        self.assertEqual(response.read(512), (self.root / "sample.bin").read_bytes()[:512])
+
+        trigger_connection, trigger_response = self.request("/fault/trigger/test")
+        self.assertEqual(trigger_response.status, 200)
+        self.assertEqual(json.loads(trigger_response.read()), {"generation": 1})
+        trigger_connection.close()
+
+        started = time.monotonic()
+        self.assertEqual(len(response.read(4096)), 4096)
+        self.assertGreaterEqual(time.monotonic() - started, 0.14)
+        connection.close()
+
+    def test_gated_stall_also_holds_connections_opened_after_trigger(self):
+        trigger_connection, trigger_response = self.request("/fault/trigger/new-client")
+        self.assertEqual(json.loads(trigger_response.read()), {"generation": 1})
+        trigger_connection.close()
+
+        connection, response = self.request(
+            "/fault/gated-stall/new-client/0.15/sample.bin"
+        )
+        started = time.monotonic()
+        self.assertEqual(len(response.read(512)), 512)
+        self.assertGreaterEqual(time.monotonic() - started, 0.13)
         connection.close()
 
 


### PR DESCRIPTION
## Summary
- add a controlled fixture stall triggered only after real system PiP is active
- qualify native and direct public stall/buffering recovery, system PiP motion, lifecycle, and error behavior
- capture bounded app RSS and materialize candidate-bound `long-stall` evidence on every hardware row
- exclude the iOS-only validation route from macOS and tvOS Showcase navigation

## Validation
- SwiftFormat strict
- SwiftLint strict
- shell syntax and Python compilation
- 31 qualification harness tests
- local-source Release iOS app/UI runner build-for-testing
- generic tvOS Showcase build

No physical-device pass is claimed by this PR and no milestone issue should close until candidate-bound hardware evidence passes.