### PR TITLE
Materialize failed PiP start qualification on every device

### DIFF
--- a/Showcase/UITests/iOS/Tests/PiPDelayedStartFailureDeviceUITests.swift
+++ b/Showcase/UITests/iOS/Tests/PiPDelayedStartFailureDeviceUITests.swift
@@ -49,13 +49,31 @@ final class PiPDelayedStartFailureDeviceUITests: ShowcaseIOSTestCase {
       evidence["expectedMediaGeneration"] as? Int
     )
     let events = try XCTUnwrap(evidence["orderedEvents"] as? [String])
-    XCTAssertTrue(events.contains("failedToStart"))
-    XCTAssertFalse(events.contains("didStart"))
+    let failedToStartCount = events.filter { $0 == "failedToStart" }.count
+    let didStartCount = events.filter { $0 == "didStart" }.count
+    XCTAssertEqual(failedToStartCount, 1)
+    XCTAssertEqual(didStartCount, 0)
     XCTAssertEqual(evidence["quiescenceMilliseconds"] as? Int, 3000)
     XCTAssertEqual(evidence["controllerActiveAfterCleanup"] as? Bool, false)
     XCTAssertEqual(
       evidence["failureDomain"] as? String,
       "SwiftVLC.Qualification.DelayedPiPStartFailure"
+    )
+    try attachQualificationEvidence(
+      [
+        "formatVersion": 1,
+        "scenario": "failed-start",
+        "events": [
+          "failedToStartCount": failedToStartCount,
+          "didStartCount": didStartCount,
+          "order": "pass"
+        ],
+        "failureSurfaced": true,
+        "orderedEvents": events,
+        "failureDomain": XCTUnwrap(evidence["failureDomain"] as? String),
+        "failureCode": XCTUnwrap(evidence["failureCode"] as? Int)
+      ],
+      scenario: "failed-start"
     )
     attachQualificationEvidence(evidence, scenario: "accepted-start-delayed-failure")
     assertNoLibraryErrors()

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -149,6 +149,17 @@ attached evidence records those identities, ordered events, and injected error
 domain. The default run omits this lane on other hardware rows, and an explicit
 unsupported request fails before testing.
 
+The same deterministic delegate-failure exercise also emits the matrix-wide
+`failed-start` attachment on every hardware row. That narrower record requires
+exactly one surfaced failure, no successful start, and ordered events; the
+additional controller/media attribution fields remain reserved for the
+iPhone-current `accepted-start-delayed-failure` row. The all-hardware lane
+therefore closes the original functional matrix gap without weakening the
+focused issue-104 qualification.
+On the default `iphone-current` run, the harness materializes both attachments
+from this single execution; either scenario remains independently selectable
+with `--only`.
+
 The HLS seek lane is another complete machine-readable matrix slice. It
 executes forward, backward, and absolute seeks, measures the return of decoded
 video, checks ordered PiP continuity, samples real system-PiP motion after each

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -34,7 +34,7 @@ Options:
   --only SCENARIO         Repeat to select: analyzer, ui-suite, native-live,
                           direct-live, live-media, background-audio,
                           continuity, capability-convergence,
-                          vod-controls, long-stall,
+                          vod-controls, long-stall, failed-start,
                           deferred-pause-rejection,
                           accepted-start-delayed-failure, hls-seek,
                           harness-regressions, ui-failures, thumbnail-preview
@@ -286,7 +286,7 @@ xcrun devicectl device copy to \
   --destination Documents/streams.local.json \
   > "$OUTPUT_DIR/stage-streams.log"
 
-DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence vod-controls long-stall deferred-pause-rejection accepted-start-delayed-failure hls-seek)
+DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence vod-controls long-stall failed-start deferred-pause-rejection accepted-start-delayed-failure hls-seek)
 SCENARIOS_WERE_EXPLICIT=false
 if [[ ${#ONLY_SCENARIOS[@]} -eq 0 ]]; then
   ONLY_SCENARIOS=("${DEFAULT_SCENARIOS[@]}")
@@ -295,7 +295,7 @@ else
 fi
 for scenario in "${ONLY_SCENARIOS[@]}"; do
   case "$scenario" in
-    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|vod-controls|long-stall|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
+    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|vod-controls|long-stall|failed-start|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
     *) echo "Error: unknown scenario: $scenario" >&2; exit 2 ;;
   esac
 done
@@ -325,6 +325,14 @@ if ! device_matches_hardware_row "iphone-current"; then
     ONLY_SCENARIOS=("${FILTERED_SCENARIOS[@]}")
     echo "Skipping iphone-current-only qualification scenarios: selected device does not match iphone-current."
   fi
+elif [[ "$SCENARIOS_WERE_EXPLICIT" == false ]]; then
+  FILTERED_SCENARIOS=()
+  for scenario in "${ONLY_SCENARIOS[@]}"; do
+    if [[ "$scenario" != "accepted-start-delayed-failure" ]]; then
+      FILTERED_SCENARIOS+=("$scenario")
+    fi
+  done
+  ONLY_SCENARIOS=("${FILTERED_SCENARIOS[@]}")
 fi
 
 RESULTS_TSV="$WORK_DIR/results.tsv"
@@ -406,6 +414,13 @@ run_scenario() {
         "iOSUITests/PiPLongStallDeviceUITests/test_longStallRecoversAcrossNativeAndDirectBackends"
       )
       route="PiPLongStallValidation"
+      selected_xctestrun="$DESTINATION_XCTESTRUN"
+      ;;
+    failed-start)
+      test_identifiers=(
+        "iOSUITests/PiPDelayedStartFailureDeviceUITests/test_acceptedStartRetainsAttributionThroughDelayedFailure"
+      )
+      route="PiPDelayedStartFailureValidation"
       selected_xctestrun="$DESTINATION_XCTESTRUN"
       ;;
     deferred-pause-rejection)
@@ -661,6 +676,15 @@ PY
     long-stall)
       qualification_scenarios=("long-stall")
       qualification_attachments=("qualification-long-stall.json")
+      ;;
+    failed-start)
+      qualification_scenarios=("failed-start")
+      qualification_attachments=("qualification-failed-start.json")
+      if [[ "$SCENARIOS_WERE_EXPLICIT" == false ]] \
+        && device_matches_hardware_row "iphone-current"; then
+        qualification_scenarios+=("accepted-start-delayed-failure")
+        qualification_attachments+=("qualification-accepted-start-delayed-failure.json")
+      fi
       ;;
     deferred-pause-rejection)
       qualification_scenarios=("deferred-pause-rejection")

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -556,6 +556,40 @@ class QualificationEvidenceTests(unittest.TestCase):
             self.assertEqual(evidence["mediaGeneration"], 7)
             self.assertTrue(evidence["orderedAttribution"])
 
+    def test_materializes_failed_start_evidence(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.make_export(
+                root,
+                {
+                    "formatVersion": 1,
+                    "scenario": "failed-start",
+                    "events": {
+                        "failedToStartCount": 1,
+                        "didStartCount": 0,
+                        "order": "pass",
+                    },
+                    "failureSurfaced": True,
+                    "orderedEvents": ["willStart", "failedToStart"],
+                    "failureDomain": "SwiftVLC.Qualification.DelayedPiPStartFailure",
+                    "failureCode": 1,
+                },
+                attachment_name="qualification-failed-start.json",
+                test_identifier="PiPDelayedStartFailureDeviceUITests/test_acceptedStartRetainsAttributionThroughDelayedFailure",
+            )
+            evidence = materialize_evidence.materialize(
+                root,
+                "qualification-failed-start.json",
+                "failed-start",
+                "ipad-current",
+                "a" * 64,
+                "b" * 64,
+            )
+            self.assertEqual(evidence["hardware"], "ipad-current")
+            self.assertEqual(evidence["events"]["failedToStartCount"], 1)
+            self.assertEqual(evidence["events"]["didStartCount"], 0)
+            self.assertTrue(evidence["failureSurfaced"])
+
     def test_materializes_focused_replacement_evidence(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
## Summary

- run the deterministic delayed-start failure exercise on every required hardware row
- emit a matrix-wide `failed-start` evidence attachment with exactly one surfaced failure, no successful start, and ordered events
- retain the focused `accepted-start-delayed-failure` row on `iphone-current` without duplicating the physical execution
- make both scenarios independently selectable while keeping the default device lane fail-closed

## Validation

- 32 qualification harness tests pass
- strict Swift formatting and repository lint checks pass locally
- `bash -n scripts/qualification/run-device-tests.sh`
- Release generic-iOS app and UI-test `build-for-testing` succeeds against the repo-local SwiftVLC sources

Physical evidence is intentionally not claimed by this PR. The lane must still run against the frozen candidate on each matching device before either matrix row can pass.
