### PR TITLE
Automate system PiP restore and close qualification

### DIFF
--- a/Showcase/Shared/AccessibilityID.swift
+++ b/Showcase/Shared/AccessibilityID.swift
@@ -258,6 +258,17 @@ enum AccessibilityID {
     static let errorLabel = "pipLongStall.error"
   }
 
+  enum PiPDismissalValidation {
+    static let videoView = "pipDismissal.videoView"
+    static let stateLabel = "pipDismissal.state"
+    static let possibleLabel = "pipDismissal.possible"
+    static let activeLabel = "pipDismissal.active"
+    static let lifecycleEventsLabel = "pipDismissal.lifecycleEvents"
+    static let restoreCountLabel = "pipDismissal.restoreCount"
+    static let startButton = "pipDismissal.start"
+    static let errorLabel = "pipDismissal.error"
+  }
+
   enum MatrixHValidation {
     static let stateLabel = "validation.matrixH.state"
     static let currentTimeLabel = "validation.matrixH.currentTime"

--- a/Showcase/Shared/LaunchArguments.swift
+++ b/Showcase/Shared/LaunchArguments.swift
@@ -168,6 +168,7 @@ enum UITestRoute: String, CaseIterable {
   case pipDelayedStartFailureValidation = "PiPDelayedStartFailureValidation"
   case pipVODControlsValidation = "PiPVODControlsValidation"
   case pipLongStallValidation = "PiPLongStallValidation"
+  case pipDismissalValidation = "PiPDismissalValidation"
 
   static var current: UITestRoute? {
     LaunchArguments.routeValue.flatMap(UITestRoute.init(rawValue:))

--- a/Showcase/UITests/iOS/Support/ShowcaseIOSTestCase.swift
+++ b/Showcase/UITests/iOS/Support/ShowcaseIOSTestCase.swift
@@ -1,6 +1,28 @@
 import UIKit
 import XCTest
 
+struct SystemPictureInPictureWindowRegion: Equatable {
+  let normalizedX: Double
+  let normalizedY: Double
+  let normalizedWidth: Double
+  let normalizedHeight: Double
+
+  func normalizedPoint(x: Double, y: Double) -> CGVector {
+    CGVector(
+      dx: normalizedX + normalizedWidth * x,
+      dy: normalizedY + normalizedHeight * y
+    )
+  }
+}
+
+private struct SystemPictureInPictureInspectionFailure: Error, CustomStringConvertible {
+  let description: String
+
+  init(_ description: String) {
+    self.description = description
+  }
+}
+
 /// Base class for every iOS showcase UI test.
 ///
 /// Owns the `XCUIApplication` instance, configures the launch-arg contract
@@ -331,6 +353,32 @@ class ShowcaseIOSTestCase: XCTestCase {
     samples: Int = 6,
     interval: TimeInterval = 0.75
   ) -> String? {
+    inspectSystemPictureInPictureMotion(samples: samples, interval: interval).failure
+  }
+
+  /// Returns the stable system-PiP bounds proven by the same moving-pixel
+  /// oracle used for visual qualification. Coordinates are normalized to the
+  /// full screen so UI tests can exercise the real restore and close controls
+  /// without depending on localized SpringBoard accessibility labels.
+  func locateSystemPictureInPictureWindow(
+    samples: Int = 6,
+    interval: TimeInterval = 0.75
+  )
+    throws -> SystemPictureInPictureWindowRegion {
+    let inspection = inspectSystemPictureInPictureMotion(samples: samples, interval: interval)
+    if let failure = inspection.failure {
+      throw SystemPictureInPictureInspectionFailure(failure)
+    }
+    guard let region = inspection.region else {
+      throw SystemPictureInPictureInspectionFailure("System PiP bounds were not detected")
+    }
+    return region
+  }
+
+  private func inspectSystemPictureInPictureMotion(
+    samples: Int,
+    interval: TimeInterval
+  ) -> (region: SystemPictureInPictureWindowRegion?, failure: String?) {
     precondition(samples >= 5)
 
     var screenshots: [XCUIScreenshot] = []
@@ -358,7 +406,7 @@ class ShowcaseIOSTestCase: XCTestCase {
       attachment.name = "system-pip-motion-diagnostics"
       attachment.lifetime = .keepAlways
       add(attachment)
-      return "Could not rasterize system PiP screenshots"
+      return (nil, "Could not rasterize system PiP screenshots")
     }
 
     let analysis = PiPMotionRegionAnalyzer().analyze(frames)
@@ -388,8 +436,19 @@ class ShowcaseIOSTestCase: XCTestCase {
       }
     }
 
-    guard let failure = analysis.failure else { return nil }
-    return "System PiP image oracle failed: \(failure.rawValue). \(diagnostics)"
+    let normalizedRegion = analysis.region.map {
+      SystemPictureInPictureWindowRegion(
+        normalizedX: Double($0.x) / Double(analysis.frameWidth),
+        normalizedY: Double($0.y) / Double(analysis.frameHeight),
+        normalizedWidth: Double($0.width) / Double(analysis.frameWidth),
+        normalizedHeight: Double($0.height) / Double(analysis.frameHeight)
+      )
+    }
+    guard let failure = analysis.failure else { return (normalizedRegion, nil) }
+    return (
+      normalizedRegion,
+      "System PiP image oracle failed: \(failure.rawValue). \(diagnostics)"
+    )
   }
 
   // MARK: - Fixtures

--- a/Showcase/UITests/iOS/Tests/PiPDismissalDeviceUITests.swift
+++ b/Showcase/UITests/iOS/Tests/PiPDismissalDeviceUITests.swift
@@ -1,0 +1,261 @@
+import XCTest
+
+/// Candidate-bound proof that the actual system PiP restore and close
+/// affordances remain distinguishable across both rendering backends.
+final class PiPDismissalDeviceUITests: ShowcaseIOSTestCase {
+  private enum Affordance: String {
+    case restore
+    case close
+
+    var relativePoint: (x: Double, y: Double) {
+      switch self {
+      case .restore: (0.88, 0.18)
+      case .close: (0.12, 0.18)
+      }
+    }
+
+    var expectedReason: String {
+      switch self {
+      case .restore: "restoreRequested"
+      case .close: "userClosed"
+      }
+    }
+  }
+
+  private struct CycleEvidence {
+    let backend: String
+    let affordance: Affordance
+    let orderedEvents: [String]
+    let restoreCount: Int
+
+    var json: [String: Any] {
+      [
+        "backend": backend,
+        "affordance": affordance.rawValue,
+        "orderedEvents": orderedEvents,
+        "restoreCallbackCount": restoreCount,
+        "systemPiPMotion": "pass",
+        "reason": affordance.expectedReason
+      ]
+    }
+  }
+
+  func test_systemRestoreAndCloseAcrossNativeAndDirectBackends() throws {
+    #if targetEnvironment(simulator)
+    throw XCTSkip("System Picture in Picture requires a physical iOS device")
+    #else
+    guard ProcessInfo.processInfo.environment["SWIFTVLC_PIP_DISMISSAL_DEVICE"] == "YES" else {
+      throw XCTSkip("Set SWIFTVLC_PIP_DISMISSAL_DEVICE=YES for candidate-bound hardware runs")
+    }
+
+    addUIInterruptionMonitor(withDescription: "Local network permission") { alert in
+      let allow = alert.buttons["Allow"]
+      guard allow.exists else { return false }
+      allow.tap()
+      return true
+    }
+    let baseLogPath = try XCTUnwrap(
+      launchArgumentValue(for: LaunchArguments.logPath),
+      "Missing qualification log launch argument"
+    )
+
+    var cycles: [CycleEvidence] = []
+    for backend in ["native", "direct"] {
+      for affordance in [Affordance.restore, .close] {
+        try cycles.append(
+          runCycle(backend: backend, affordance: affordance, baseLogPath: baseLogPath)
+        )
+      }
+    }
+    let restoreCycles = cycles.filter { $0.affordance == .restore }
+    let closeCycles = cycles.filter { $0.affordance == .close }
+    XCTAssertEqual(restoreCycles.count, 2)
+    XCTAssertEqual(closeCycles.count, 2)
+    attachQualificationEvidence(
+      [
+        "formatVersion": 1,
+        "scenario": "restore",
+        "events": [
+          "didStartCount": 1,
+          "willStopReason": Affordance.restore.expectedReason,
+          "didStopReason": Affordance.restore.expectedReason,
+          "order": "pass"
+        ],
+        "restoreResult": "pass",
+        "completionCount": 1,
+        "backends": Dictionary(
+          uniqueKeysWithValues: restoreCycles.map { ($0.backend, $0.json) }
+        ),
+        "aggregationBasis": "per-backend invariant",
+        "systemAffordance": "pass"
+      ],
+      scenario: "restore"
+    )
+    attachQualificationEvidence(
+      [
+        "formatVersion": 1,
+        "scenario": "close",
+        "events": [
+          "didStartCount": 1,
+          "willStopReason": Affordance.close.expectedReason,
+          "didStopReason": Affordance.close.expectedReason,
+          "order": "pass"
+        ],
+        "stopReason": Affordance.close.expectedReason,
+        "backends": Dictionary(
+          uniqueKeysWithValues: closeCycles.map { ($0.backend, $0.json) }
+        ),
+        "aggregationBasis": "per-backend invariant",
+        "systemAffordance": "pass"
+      ],
+      scenario: "close"
+    )
+    #endif
+  }
+
+  private func runCycle(
+    backend: String,
+    affordance: Affordance,
+    baseLogPath: String
+  )
+    throws -> CycleEvidence {
+    app.terminate()
+    replaceLaunchArgument(LaunchArguments.route, with: UITestRoute.pipDismissalValidation.rawValue)
+    replaceLaunchArgument(LaunchArguments.pipRenderingPath, with: backend)
+    let cycleLogPath =
+      (baseLogPath as NSString).deletingPathExtension
+        + "-\(backend)-\(affordance.rawValue).jsonl"
+    replaceLaunchArgument(LaunchArguments.logPath, with: cycleLogPath)
+    app.launch()
+    app.tap()
+
+    let state = element(AccessibilityID.PiPDismissalValidation.stateLabel)
+    let possible = element(AccessibilityID.PiPDismissalValidation.possibleLabel)
+    let active = element(AccessibilityID.PiPDismissalValidation.activeLabel)
+    let lifecycle = element(AccessibilityID.PiPDismissalValidation.lifecycleEventsLabel)
+    let restoreCount = element(AccessibilityID.PiPDismissalValidation.restoreCountLabel)
+    let start = app.buttons[AccessibilityID.PiPDismissalValidation.startButton]
+    let error = element(AccessibilityID.PiPDismissalValidation.errorLabel)
+
+    waitForLabel(state, equals: "playing", timeout: 20)
+    waitForLabel(possible, equals: "yes", timeout: 15)
+    reveal(start)
+    XCTAssertTrue(start.isEnabled)
+    start.tap()
+    waitForLabel(active, equals: "yes", timeout: 10)
+    waitForLifecyclePrefix(lifecycle, prefix: "willStart|didStart", timeout: 10)
+
+    XCUIDevice.shared.press(.home)
+    let region = try locateSystemPictureInPictureWindow()
+    tap(affordance, in: region)
+
+    // Restore normally foregrounds the app while close intentionally does not.
+    // Give AVKit time to finish the system action before foregrounding a close
+    // cycle solely to inspect the already-published lifecycle.
+    RunLoop.current.run(until: Date().addingTimeInterval(2))
+    if app.state != .runningForeground {
+      app.activate()
+    }
+    waitForLabel(active, equals: "no", timeout: 10)
+    let expectedLifecycle =
+      "willStart|didStart|willStop:\(affordance.expectedReason)|didStop:\(affordance.expectedReason)"
+    waitForLabel(lifecycle, equals: expectedLifecycle, timeout: 10)
+    RunLoop.current.run(until: Date().addingTimeInterval(1))
+    XCTAssertEqual(
+      lifecycle.label,
+      expectedLifecycle,
+      "Unexpected trailing dismissal lifecycle event"
+    )
+    XCTAssertFalse(error.exists, "\(backend) \(affordance.rawValue) failed: \(error.label)")
+
+    let count = Int(restoreCount.label) ?? -1
+    XCTAssertEqual(count, affordance == .restore ? 1 : 0)
+    return CycleEvidence(
+      backend: backend,
+      affordance: affordance,
+      orderedEvents: lifecycle.label.split(separator: "|").map(String.init),
+      restoreCount: count
+    )
+  }
+
+  private func tap(
+    _ affordance: Affordance,
+    in region: SystemPictureInPictureWindowRegion
+  ) {
+    let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+
+    // Controls auto-hide; a center tap reveals them without relying on their
+    // localized accessibility labels. Waiting first avoids toggling playback
+    // if controls happened to be visible immediately after backgrounding.
+    RunLoop.current.run(until: Date().addingTimeInterval(3))
+    springboard.coordinate(
+      withNormalizedOffset: region.normalizedPoint(x: 0.5, y: 0.5)
+    ).tap()
+    RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+
+    let point = affordance.relativePoint
+    let screenPoint = region.normalizedPoint(x: point.x, y: point.y)
+    let diagnostics = XCTAttachment(
+      string: """
+      affordance=\(affordance.rawValue)
+      window=\(region)
+      normalizedTap=(\(screenPoint.dx), \(screenPoint.dy))
+      """
+    )
+    diagnostics.name = "system-pip-\(affordance.rawValue)-tap"
+    diagnostics.lifetime = .keepAlways
+    add(diagnostics)
+    let screenshot = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
+    screenshot.name = "system-pip-\(affordance.rawValue)-controls"
+    screenshot.lifetime = .keepAlways
+    add(screenshot)
+    springboard.coordinate(
+      withNormalizedOffset: screenPoint
+    ).tap()
+  }
+
+  private func waitForLifecyclePrefix(
+    _ element: XCUIElement,
+    prefix: String,
+    timeout: TimeInterval
+  ) {
+    let predicate = NSPredicate { _, _ in
+      element.exists && element.label.hasPrefix(prefix)
+    }
+    let expectation = expectation(for: predicate, evaluatedWith: NSObject())
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [expectation], timeout: timeout),
+      .completed,
+      "Expected lifecycle prefix \(prefix), got: \(element.label)"
+    )
+  }
+
+  private func element(_ identifier: String) -> XCUIElement {
+    app.descendants(matching: .any)[identifier]
+  }
+
+  private func replaceLaunchArgument(_ name: String, with value: String) {
+    while let index = app.launchArguments.firstIndex(of: name) {
+      app.launchArguments.remove(at: index)
+      if index < app.launchArguments.endIndex {
+        app.launchArguments.remove(at: index)
+      }
+    }
+    app.launchArguments += [name, value]
+  }
+
+  private func launchArgumentValue(for name: String) -> String? {
+    guard
+      let index = app.launchArguments.lastIndex(of: name),
+      app.launchArguments.indices.contains(index + 1)
+    else { return nil }
+    return app.launchArguments[index + 1]
+  }
+
+  private func reveal(_ element: XCUIElement) {
+    for _ in 0..<10 where !element.isHittable {
+      app.swipeUp()
+    }
+    XCTAssertTrue(element.isHittable)
+  }
+}

--- a/Showcase/UITests/iOS/Tests/PiPMotionRegionAnalyzerTests.swift
+++ b/Showcase/UITests/iOS/Tests/PiPMotionRegionAnalyzerTests.swift
@@ -6,6 +6,23 @@ final class PiPMotionRegionAnalyzerTests: XCTestCase {
   private let screenHeight = 240
   private let expectedPiP = PiPMotionRegion(x: 64, y: 156, width: 80, height: 45)
 
+  func testNormalizedSystemPiPControlPointUsesDetectedBounds() {
+    let region = SystemPictureInPictureWindowRegion(
+      normalizedX: 0.4,
+      normalizedY: 0.65,
+      normalizedWidth: 0.5,
+      normalizedHeight: 0.1875
+    )
+
+    let close = region.normalizedPoint(x: 0.12, y: 0.18)
+    let restore = region.normalizedPoint(x: 0.88, y: 0.18)
+
+    XCTAssertEqual(close.dx, 0.46, accuracy: 0.0001)
+    XCTAssertEqual(close.dy, 0.68375, accuracy: 0.0001)
+    XCTAssertEqual(restore.dx, 0.84, accuracy: 0.0001)
+    XCTAssertEqual(restore.dy, close.dy, accuracy: 0.0001)
+  }
+
   func testMovingVideoInsideFixedSixteenByNinePiPRegionPasses() throws {
     let frames = syntheticFrames { _, _, _, frameIndex in
       .animated(region: self.expectedPiP, frameIndex: frameIndex)

--- a/Showcase/iOS/Internal/UITestSupport.swift
+++ b/Showcase/iOS/Internal/UITestSupport.swift
@@ -131,6 +131,7 @@ extension UITestRoute {
     case .pipDelayedStartFailureValidation: PiPDelayedStartFailureValidationCase()
     case .pipVODControlsValidation: PiPVODControlsValidationCase()
     case .pipLongStallValidation: PiPLongStallValidationCase()
+    case .pipDismissalValidation: PiPDismissalValidationCase()
     }
   }
 }

--- a/Showcase/iOS/ValidationHarness/PiPDismissalValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/PiPDismissalValidationCase.swift
@@ -1,0 +1,151 @@
+import SwiftUI
+@_spi(Qualification) import SwiftVLC
+
+/// Candidate-bound surface for exercising the real system PiP restore and
+/// close affordances. The UI test interacts with SpringBoard; this view only
+/// starts a selected backend and exposes the public lifecycle that results.
+struct PiPDismissalValidationCase: View {
+  @State private var player = Player()
+  @State private var controller: PiPController?
+  @State private var lifecycleEvents: [String] = []
+  @State private var restoreCount = 0
+  @State private var playbackError: String?
+
+  private let streams = HarnessStreams.load()?.streams
+
+  private var renderingPath: DismissalRenderingPath {
+    DismissalRenderingPath(
+      rawValue: LaunchArguments.pipRenderingPathValue ?? "native"
+    ) ?? .native
+  }
+
+  var body: some View {
+    Form {
+      Section {
+        videoSurface
+          .frame(height: 220)
+          .listRowInsets(EdgeInsets())
+          .accessibilityIdentifier(AccessibilityID.PiPDismissalValidation.videoView)
+      }
+
+      Section("Measured state") {
+        valueRow(
+          "Playback",
+          value: String(describing: player.state),
+          identifier: AccessibilityID.PiPDismissalValidation.stateLabel
+        )
+        valueRow(
+          "PiP possible",
+          value: controller?.isPossible == true ? "yes" : "no",
+          identifier: AccessibilityID.PiPDismissalValidation.possibleLabel
+        )
+        valueRow(
+          "PiP active",
+          value: controller?.isActive == true ? "yes" : "no",
+          identifier: AccessibilityID.PiPDismissalValidation.activeLabel
+        )
+        valueRow(
+          "Lifecycle",
+          value: lifecycleEvents.joined(separator: "|"),
+          identifier: AccessibilityID.PiPDismissalValidation.lifecycleEventsLabel
+        )
+        valueRow(
+          "Restore callbacks",
+          value: String(restoreCount),
+          identifier: AccessibilityID.PiPDismissalValidation.restoreCountLabel
+        )
+      }
+
+      Section("Picture in Picture") {
+        Button("Start PiP") {
+          startPictureInPicture()
+        }
+        .accessibilityIdentifier(AccessibilityID.PiPDismissalValidation.startButton)
+        .disabled(controller?.isPossible != true || controller?.isActive == true)
+
+        if let playbackError {
+          Text(playbackError)
+            .foregroundStyle(.red)
+            .accessibilityIdentifier(AccessibilityID.PiPDismissalValidation.errorLabel)
+        }
+      }
+    }
+    .showcaseFormStyle()
+    .navigationTitle("PiP restore and close")
+    .task { startPlayback() }
+    .task(id: controller.map(ObjectIdentifier.init)) {
+      lifecycleEvents.removeAll()
+      restoreCount = 0
+      guard let controller else { return }
+      controller.onRestoreUserInterface = { answer in
+        restoreCount += 1
+        answer(true)
+      }
+      for await envelope in controller.pipEventEnvelopes {
+        lifecycleEvents.append(envelope.event.dismissalQualificationName)
+      }
+    }
+    .onDisappear {
+      controller?.stop()
+      player.stop()
+    }
+  }
+
+  @ViewBuilder
+  private var videoSurface: some View {
+    switch renderingPath {
+    case .native:
+      PiPVideoView(player, controller: $controller, startsAutomaticallyFromInline: false)
+    case .direct:
+      DirectPiPValidationSurface(player: player, controller: $controller)
+    }
+  }
+
+  private func startPlayback() {
+    guard let url = streams?.vod else {
+      playbackError = "Missing validation VOD"
+      return
+    }
+    do {
+      try player.play(url: url)
+    } catch {
+      playbackError = String(describing: error)
+    }
+  }
+
+  private func startPictureInPicture() {
+    guard let controller else { return }
+    playbackError = nil
+    guard controller.start() == .accepted else {
+      playbackError = "PiP start was not accepted"
+      return
+    }
+  }
+
+  private func valueRow(_ title: String, value: String, identifier: String) -> some View {
+    HStack {
+      Text(title)
+      Spacer()
+      Text(value)
+        .foregroundStyle(.secondary)
+        .accessibilityIdentifier(identifier)
+    }
+  }
+}
+
+private enum DismissalRenderingPath: String {
+  case native
+  case direct
+}
+
+extension PiPEvent {
+  fileprivate var dismissalQualificationName: String {
+    switch self {
+    case .willStart: "willStart"
+    case .didStart: "didStart"
+    case .willStop(let reason): "willStop:\(String(describing: reason))"
+    case .didStop(let reason): "didStop:\(String(describing: reason))"
+    case .failedToStart: "failedToStart"
+    }
+  }
+}

--- a/Showcase/macOS/Internal/MacShowcaseRootView.swift
+++ b/Showcase/macOS/Internal/MacShowcaseRootView.swift
@@ -411,7 +411,8 @@ extension MacShowcase {
          .pipDeferredPauseValidation,
          .pipDelayedStartFailureValidation,
          .pipVODControlsValidation,
-         .pipLongStallValidation:
+         .pipLongStallValidation,
+         .pipDismissalValidation:
       return nil
     }
   }

--- a/Showcase/tvOS/Internal/TVShowcaseRootView.swift
+++ b/Showcase/tvOS/Internal/TVShowcaseRootView.swift
@@ -519,7 +519,8 @@ extension TVShowcase {
          .pipDeferredPauseValidation,
          .pipDelayedStartFailureValidation,
          .pipVODControlsValidation,
-         .pipLongStallValidation:
+         .pipLongStallValidation,
+         .pipDismissalValidation:
       return nil
     }
   }

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -128,6 +128,17 @@ resident memory throughout the fault and rejects growth beyond a 96 MiB bound;
 the combined attachment records the raw per-backend timings and memory values
 as well as the matrix-required recovery and bounded-memory outcomes.
 
+The dismissal lane materializes the matrix-wide `restore` and `close` rows in
+one hardware run. For native and direct backends, it starts real system PiP,
+uses the moving-pixel oracle to locate the window, reveals SpringBoard's
+controls, and taps the restore or close corner by normalized coordinates. This
+avoids localized system labels while still exercising the real affordances.
+Evidence is emitted only when restore invokes the host callback exactly once,
+close invokes it zero times, and public lifecycle events report ordered
+`restoreRequested` or `userClosed` reasons respectively. Each of the four app
+launches writes a separate library log so an earlier backend/action error
+cannot be overwritten by a later cycle.
+
 The iPhone-current-only deferred-pause-rejection lane drives the exact AVKit
 playback command entry point while a qualification SPI changes only libVLC's
 native pause-capability answer. It proves a permanently unpausable input

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -34,7 +34,7 @@ Options:
   --only SCENARIO         Repeat to select: analyzer, ui-suite, native-live,
                           direct-live, live-media, background-audio,
                           continuity, capability-convergence,
-                          vod-controls, long-stall, failed-start,
+                          vod-controls, long-stall, failed-start, dismissal,
                           deferred-pause-rejection,
                           accepted-start-delayed-failure, hls-seek,
                           harness-regressions, ui-failures, thumbnail-preview
@@ -233,6 +233,7 @@ python3 "$SCRIPT_DIR/prepare-xctestrun.py" "$XCTESTRUN" "$DESTINATION_XCTESTRUN"
   --environment SWIFTVLC_PIP_VOD_CONTROLS_DEVICE=YES \
   --environment SWIFTVLC_PIP_LONG_STALL_DEVICE=YES \
   --environment SWIFTVLC_PIP_LONG_STALL_URL_BASE64="$PIP_LONG_STALL_URL_BASE64" \
+  --environment SWIFTVLC_PIP_DISMISSAL_DEVICE=YES \
   --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
   --environment SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE=YES \
   --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
@@ -286,7 +287,7 @@ xcrun devicectl device copy to \
   --destination Documents/streams.local.json \
   > "$OUTPUT_DIR/stage-streams.log"
 
-DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence vod-controls long-stall failed-start deferred-pause-rejection accepted-start-delayed-failure hls-seek)
+DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence vod-controls long-stall failed-start dismissal deferred-pause-rejection accepted-start-delayed-failure hls-seek)
 SCENARIOS_WERE_EXPLICIT=false
 if [[ ${#ONLY_SCENARIOS[@]} -eq 0 ]]; then
   ONLY_SCENARIOS=("${DEFAULT_SCENARIOS[@]}")
@@ -295,7 +296,7 @@ else
 fi
 for scenario in "${ONLY_SCENARIOS[@]}"; do
   case "$scenario" in
-    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|vod-controls|long-stall|failed-start|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
+    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|vod-controls|long-stall|failed-start|dismissal|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
     *) echo "Error: unknown scenario: $scenario" >&2; exit 2 ;;
   esac
 done
@@ -423,6 +424,13 @@ run_scenario() {
       route="PiPDelayedStartFailureValidation"
       selected_xctestrun="$DESTINATION_XCTESTRUN"
       ;;
+    dismissal)
+      test_identifiers=(
+        "iOSUITests/PiPDismissalDeviceUITests/test_systemRestoreAndCloseAcrossNativeAndDirectBackends"
+      )
+      route="PiPDismissalValidation"
+      selected_xctestrun="$DESTINATION_XCTESTRUN"
+      ;;
     deferred-pause-rejection)
       test_identifiers=(
         "iOSUITests/PiPDeferredPauseDeviceUITests/test_deferredPauseRejectionAndCancellationStayTruthful"
@@ -480,6 +488,7 @@ run_scenario() {
       --environment SWIFTVLC_PIP_VOD_CONTROLS_DEVICE=YES \
       --environment SWIFTVLC_PIP_LONG_STALL_DEVICE=YES \
       --environment SWIFTVLC_PIP_LONG_STALL_URL_BASE64="$PIP_LONG_STALL_URL_BASE64" \
+      --environment SWIFTVLC_PIP_DISMISSAL_DEVICE=YES \
       --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
       --environment SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE=YES \
       --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
@@ -509,6 +518,7 @@ run_scenario() {
       -skip-testing:iOSUITests/PiPCapabilityDeviceUITests
       -skip-testing:iOSUITests/PiPVODControlsDeviceUITests
       -skip-testing:iOSUITests/PiPLongStallDeviceUITests
+      -skip-testing:iOSUITests/PiPDismissalDeviceUITests
       -skip-testing:iOSUITests/PiPDeferredPauseDeviceUITests
       -skip-testing:iOSUITests/PiPDelayedStartFailureDeviceUITests
       -skip-testing:iOSUITests/PiPOverlayDeviceUITests
@@ -685,6 +695,10 @@ PY
         qualification_scenarios+=("accepted-start-delayed-failure")
         qualification_attachments+=("qualification-accepted-start-delayed-failure.json")
       fi
+      ;;
+    dismissal)
+      qualification_scenarios=("restore" "close")
+      qualification_attachments=("qualification-restore.json" "qualification-close.json")
       ;;
     deferred-pause-rejection)
       qualification_scenarios=("deferred-pause-rejection")

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -519,6 +519,67 @@ class QualificationEvidenceTests(unittest.TestCase):
             self.assertTrue(evidence["boundedMemory"])
             self.assertEqual(evidence["backendResults"]["direct"]["memory"]["growthBytes"], 2048)
 
+    def test_materializes_restore_and_close_evidence(self):
+        for scenario, restore_count, reason in (
+            ("restore", 1, "restoreRequested"),
+            ("close", 0, "userClosed"),
+        ):
+            with self.subTest(scenario=scenario), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                self.make_export(
+                    root,
+                    {
+                        "formatVersion": 1,
+                        "scenario": scenario,
+                        "events": {
+                            "didStartCount": 1,
+                            "willStopReason": reason,
+                            "didStopReason": reason,
+                            "order": "pass",
+                        },
+                        "backends": {
+                            "native": {
+                                "reason": reason,
+                                "restoreCallbackCount": restore_count,
+                                "systemPiPMotion": "pass",
+                            },
+                            "direct": {
+                                "reason": reason,
+                                "restoreCallbackCount": restore_count,
+                                "systemPiPMotion": "pass",
+                            },
+                        },
+                        **(
+                            {"restoreResult": "pass", "completionCount": 1}
+                            if scenario == "restore"
+                            else {"stopReason": "userClosed"}
+                        ),
+                        "aggregationBasis": "per-backend invariant",
+                        "systemAffordance": "pass",
+                    },
+                    attachment_name=f"qualification-{scenario}.json",
+                    test_identifier="PiPDismissalDeviceUITests/test_systemRestoreAndCloseAcrossNativeAndDirectBackends",
+                )
+                evidence = materialize_evidence.materialize(
+                    root,
+                    f"qualification-{scenario}.json",
+                    scenario,
+                    "ipad-current",
+                    "a" * 64,
+                    "b" * 64,
+                )
+                self.assertEqual(evidence["hardware"], "ipad-current")
+                self.assertEqual(evidence["events"]["didStartCount"], 1)
+                self.assertEqual(evidence["events"]["willStopReason"], reason)
+                self.assertEqual(evidence["events"]["didStopReason"], reason)
+                self.assertEqual(evidence["backends"]["native"]["reason"], reason)
+                self.assertEqual(evidence["systemAffordance"], "pass")
+                if scenario == "restore":
+                    self.assertEqual(evidence["restoreResult"], "pass")
+                    self.assertEqual(evidence["completionCount"], 1)
+                else:
+                    self.assertEqual(evidence["stopReason"], "userClosed")
+
     def test_materializes_accepted_start_delayed_failure_evidence(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
## Summary

- drive the real system PiP restore and close affordances for native and direct backends
- prove callback order, stop reasons, restore completion count, and moving video through candidate-bound attachments
- locate system PiP controls geometrically so the lane does not depend on localized accessibility labels
- add fail-closed restore/close scenarios to the physical qualification runner

## Validation

- 33 qualification harness tests pass
- release-integrity tests pass
- strict Swift formatting and repository lint checks pass
- bash syntax validation passes for the device runner

Physical evidence is intentionally not claimed by this PR. The rows remain pending until the frozen candidate passes on matching hardware.