### PR TITLE
Automate PiP audio disruption qualification

### DIFF
--- a/Showcase/Shared/AccessibilityID.swift
+++ b/Showcase/Shared/AccessibilityID.swift
@@ -269,6 +269,22 @@ enum AccessibilityID {
     static let errorLabel = "pipDismissal.error"
   }
 
+  enum PiPInterruptionValidation {
+    static let videoView = "pipInterruption.videoView"
+    static let stateLabel = "pipInterruption.state"
+    static let possibleLabel = "pipInterruption.possible"
+    static let activeLabel = "pipInterruption.active"
+    static let lifecycleEventsLabel = "pipInterruption.lifecycleEvents"
+    static let interruptionCountsLabel = "pipInterruption.interruptionCounts"
+    static let routeLossCountLabel = "pipInterruption.routeLossCount"
+    static let playedAudioBuffersLabel = "pipInterruption.playedAudioBuffers"
+    static let startButton = "pipInterruption.start"
+    static let injectRouteLossButton = "pipInterruption.injectRouteLoss"
+    static let resumeButton = "pipInterruption.resume"
+    static let stopButton = "pipInterruption.stop"
+    static let errorLabel = "pipInterruption.error"
+  }
+
   enum MatrixHValidation {
     static let stateLabel = "validation.matrixH.state"
     static let currentTimeLabel = "validation.matrixH.currentTime"

--- a/Showcase/Shared/LaunchArguments.swift
+++ b/Showcase/Shared/LaunchArguments.swift
@@ -169,6 +169,7 @@ enum UITestRoute: String, CaseIterable {
   case pipVODControlsValidation = "PiPVODControlsValidation"
   case pipLongStallValidation = "PiPLongStallValidation"
   case pipDismissalValidation = "PiPDismissalValidation"
+  case pipInterruptionValidation = "PiPInterruptionValidation"
 
   static var current: UITestRoute? {
     LaunchArguments.routeValue.flatMap(UITestRoute.init(rawValue:))

--- a/Showcase/UITests/iOS/Tests/PiPInterruptionDeviceUITests.swift
+++ b/Showcase/UITests/iOS/Tests/PiPInterruptionDeviceUITests.swift
@@ -1,0 +1,294 @@
+import AVFoundation
+import XCTest
+
+/// Candidate-bound proof of managed-audio recovery while real system PiP is
+/// active. A separate XCTest runner audio session takes and returns focus; the
+/// candidate also receives an explicitly recorded old-device-unavailable event.
+final class PiPInterruptionDeviceUITests: ShowcaseIOSTestCase {
+  private struct BackendEvidence {
+    let backend: String
+    let interruptionBeganCount: Int
+    let interruptionEndedCount: Int
+    let routeLossCount: Int
+    let audioBuffersBeforeRouteResume: Int
+    let audioBuffersAfterRouteResume: Int
+    let audioBuffersBeforeInterruption: Int
+    let audioBuffersAfterInterruption: Int
+    let orderedEvents: [String]
+
+    var json: [String: Any] {
+      [
+        "backend": backend,
+        "interruptionBeganCount": interruptionBeganCount,
+        "interruptionEndedCount": interruptionEndedCount,
+        "routeLossCount": routeLossCount,
+        "audioBuffersBeforeRouteResume": audioBuffersBeforeRouteResume,
+        "audioBuffersAfterRouteResume": audioBuffersAfterRouteResume,
+        "routeAudioRecovered": audioBuffersAfterRouteResume > audioBuffersBeforeRouteResume,
+        "audioBuffersBeforeInterruption": audioBuffersBeforeInterruption,
+        "audioBuffersAfterInterruption": audioBuffersAfterInterruption,
+        "audioRecovered": audioBuffersAfterInterruption > audioBuffersBeforeInterruption,
+        "orderedEvents": orderedEvents,
+        "activeAfterRecovery": true,
+        "systemPiPMotionAfterRecovery": "pass"
+      ]
+    }
+  }
+
+  func test_audioInterruptionAndRouteLossAcrossNativeAndDirectBackends() throws {
+    #if targetEnvironment(simulator)
+    throw XCTSkip("System Picture in Picture requires a physical iOS device")
+    #else
+    guard ProcessInfo.processInfo.environment["SWIFTVLC_PIP_INTERRUPTION_DEVICE"] == "YES" else {
+      throw XCTSkip("Set SWIFTVLC_PIP_INTERRUPTION_DEVICE=YES for candidate-bound hardware runs")
+    }
+
+    addUIInterruptionMonitor(withDescription: "Local network permission") { alert in
+      let allow = alert.buttons["Allow"]
+      guard allow.exists else { return false }
+      allow.tap()
+      return true
+    }
+    let baseLogPath = try XCTUnwrap(
+      launchArgumentValue(for: LaunchArguments.logPath),
+      "Missing qualification log launch argument"
+    )
+
+    let results = try ["native", "direct"].map {
+      try runBackend($0, baseLogPath: baseLogPath)
+    }
+    let unexpectedStops = results.reduce(0) { count, result in
+      count
+        + result.orderedEvents.filter {
+          $0.hasPrefix("didStop:") && $0 != "didStop:programmatic"
+        }.count
+    }
+    XCTAssertEqual(unexpectedStops, 0)
+    attachQualificationEvidence(
+      [
+        "formatVersion": 1,
+        "scenario": "interruptions",
+        "events": [
+          "started": true,
+          "unexpectedStopCount": unexpectedStops,
+          "order": "pass"
+        ],
+        "interruptionRecovery": "pass",
+        "routeChangeRecovery": "pass",
+        "interruptionSource": "exclusive-XCTest-runner-audio-session",
+        "routeLossSource": "deterministic-oldDeviceUnavailable-notification",
+        "backends": Dictionary(uniqueKeysWithValues: results.map { ($0.backend, $0.json) }),
+        "recoveryOutcome": "preserved",
+        "systemPiPMotionAfterRecovery": "pass"
+      ],
+      scenario: "interruptions"
+    )
+    #endif
+  }
+
+  private func runBackend(
+    _ backend: String,
+    baseLogPath: String
+  )
+    throws -> BackendEvidence {
+    app.terminate()
+    replaceLaunchArgument(
+      LaunchArguments.route,
+      with: UITestRoute.pipInterruptionValidation.rawValue
+    )
+    replaceLaunchArgument(LaunchArguments.pipRenderingPath, with: backend)
+    let cycleLogPath =
+      (baseLogPath as NSString).deletingPathExtension + "-\(backend).jsonl"
+    replaceLaunchArgument(LaunchArguments.logPath, with: cycleLogPath)
+    app.launch()
+    app.tap()
+
+    let state = element(AccessibilityID.PiPInterruptionValidation.stateLabel)
+    let possible = element(AccessibilityID.PiPInterruptionValidation.possibleLabel)
+    let active = element(AccessibilityID.PiPInterruptionValidation.activeLabel)
+    let lifecycle = element(AccessibilityID.PiPInterruptionValidation.lifecycleEventsLabel)
+    let interruptions = element(
+      AccessibilityID.PiPInterruptionValidation.interruptionCountsLabel
+    )
+    let routeLosses = element(AccessibilityID.PiPInterruptionValidation.routeLossCountLabel)
+    let playedAudioBuffers = element(
+      AccessibilityID.PiPInterruptionValidation.playedAudioBuffersLabel
+    )
+    let start = app.buttons[AccessibilityID.PiPInterruptionValidation.startButton]
+    let injectRouteLoss = app.buttons[
+      AccessibilityID.PiPInterruptionValidation.injectRouteLossButton
+    ]
+    let resume = app.buttons[AccessibilityID.PiPInterruptionValidation.resumeButton]
+    let stop = app.buttons[AccessibilityID.PiPInterruptionValidation.stopButton]
+    let error = element(AccessibilityID.PiPInterruptionValidation.errorLabel)
+
+    waitForLabel(state, equals: "playing", timeout: 20)
+    waitForLabel(possible, equals: "yes", timeout: 15)
+    reveal(start)
+    start.tap()
+    waitForLabel(active, equals: "yes", timeout: 10)
+    waitForLifecyclePrefix(lifecycle, prefix: "willStart|didStart", timeout: 10)
+    _ = waitForIntegerLabel(playedAudioBuffers, greaterThan: 0, timeout: 10)
+
+    reveal(injectRouteLoss)
+    injectRouteLoss.tap()
+    waitForLabel(routeLosses, equals: "1", timeout: 5)
+    waitForLabel(state, equals: "paused", timeout: 10)
+    waitForLabel(active, equals: "yes", timeout: 5)
+    RunLoop.current.run(until: Date().addingTimeInterval(1))
+    let audioBuffersBeforeRouteResume = Int(playedAudioBuffers.label) ?? -1
+    XCTAssertGreaterThanOrEqual(audioBuffersBeforeRouteResume, 0)
+    reveal(resume)
+    resume.tap()
+    waitForLabel(state, equals: "playing", timeout: 15)
+    let audioBuffersAfterRouteResume = waitForIntegerLabel(
+      playedAudioBuffers,
+      greaterThan: audioBuffersBeforeRouteResume,
+      timeout: 15
+    )
+
+    XCUIDevice.shared.press(.home)
+    if let failure = captureSystemPictureInPictureMotion() {
+      XCTFail("\(backend) PiP was not moving before interruption: \(failure)")
+    }
+    let audioBuffersBeforeInterruption = waitForIntegerLabel(
+      playedAudioBuffers,
+      greaterThan: audioBuffersAfterRouteResume,
+      timeout: 15
+    )
+    try interruptCandidateAudioSession()
+    if let failure = captureSystemPictureInPictureMotion() {
+      XCTFail("\(backend) PiP did not recover after interruption: \(failure)")
+    }
+    let audioBuffersAfterInterruption = waitForIntegerLabel(
+      playedAudioBuffers,
+      greaterThan: audioBuffersBeforeInterruption,
+      timeout: 15
+    )
+
+    app.activate()
+    waitForInterruptionPair(interruptions, timeout: 10)
+    waitForLabel(state, equals: "playing", timeout: 15)
+    waitForLabel(active, equals: "yes", timeout: 10)
+    reveal(stop)
+    stop.tap()
+    waitForLabel(active, equals: "no", timeout: 10)
+    let expectedLifecycle =
+      "willStart|didStart|willStop:programmatic|didStop:programmatic"
+    waitForLabel(lifecycle, equals: expectedLifecycle, timeout: 10)
+    RunLoop.current.run(until: Date().addingTimeInterval(1))
+    XCTAssertEqual(
+      lifecycle.label,
+      expectedLifecycle,
+      "Unexpected trailing interruption lifecycle event"
+    )
+    XCTAssertFalse(error.exists, "\(backend) disruption qualification failed: \(error.label)")
+
+    let counts = try parseInterruptionCounts(interruptions.label)
+    XCTAssertEqual(counts.began, 1)
+    XCTAssertEqual(counts.ended, 1)
+    let routeLossCount = Int(routeLosses.label) ?? -1
+    XCTAssertEqual(routeLossCount, 1)
+    return BackendEvidence(
+      backend: backend,
+      interruptionBeganCount: counts.began,
+      interruptionEndedCount: counts.ended,
+      routeLossCount: routeLossCount,
+      audioBuffersBeforeRouteResume: audioBuffersBeforeRouteResume,
+      audioBuffersAfterRouteResume: audioBuffersAfterRouteResume,
+      audioBuffersBeforeInterruption: audioBuffersBeforeInterruption,
+      audioBuffersAfterInterruption: audioBuffersAfterInterruption,
+      orderedEvents: lifecycle.label.split(separator: "|").map(String.init)
+    )
+  }
+
+  private func interruptCandidateAudioSession() throws {
+    let session = AVAudioSession.sharedInstance()
+    try session.setCategory(.playback, mode: .default)
+    try session.setActive(true)
+    var isActive = true
+    defer {
+      if isActive {
+        try? session.setActive(false, options: .notifyOthersOnDeactivation)
+      }
+    }
+    RunLoop.current.run(until: Date().addingTimeInterval(2))
+    try session.setActive(false, options: .notifyOthersOnDeactivation)
+    isActive = false
+    RunLoop.current.run(until: Date().addingTimeInterval(3))
+  }
+
+  private func waitForInterruptionPair(_ element: XCUIElement, timeout: TimeInterval) {
+    let predicate = NSPredicate { _, _ in
+      guard let counts = try? self.parseInterruptionCounts(element.label) else { return false }
+      return counts.began >= 1 && counts.began == counts.ended
+    }
+    let expectation = expectation(for: predicate, evaluatedWith: NSObject())
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [expectation], timeout: timeout),
+      .completed,
+      "Expected a balanced interruption pair, got: \(element.label)"
+    )
+  }
+
+  private func parseInterruptionCounts(_ label: String) throws -> (began: Int, ended: Int) {
+    let values = label.split(separator: ":").compactMap { Int($0) }
+    guard values.count == 2 else {
+      throw InterruptionEvidenceFailure("Malformed interruption counts: \(label)")
+    }
+    return (values[0], values[1])
+  }
+
+  private func waitForLifecyclePrefix(
+    _ element: XCUIElement,
+    prefix: String,
+    timeout: TimeInterval
+  ) {
+    let predicate = NSPredicate { _, _ in
+      element.exists && element.label.hasPrefix(prefix)
+    }
+    let expectation = expectation(for: predicate, evaluatedWith: NSObject())
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [expectation], timeout: timeout),
+      .completed,
+      "Expected lifecycle prefix \(prefix), got: \(element.label)"
+    )
+  }
+
+  private func element(_ identifier: String) -> XCUIElement {
+    app.descendants(matching: .any)[identifier]
+  }
+
+  private func replaceLaunchArgument(_ name: String, with value: String) {
+    while let index = app.launchArguments.firstIndex(of: name) {
+      app.launchArguments.remove(at: index)
+      if index < app.launchArguments.endIndex {
+        app.launchArguments.remove(at: index)
+      }
+    }
+    app.launchArguments += [name, value]
+  }
+
+  private func launchArgumentValue(for name: String) -> String? {
+    guard
+      let index = app.launchArguments.lastIndex(of: name),
+      app.launchArguments.indices.contains(index + 1)
+    else { return nil }
+    return app.launchArguments[index + 1]
+  }
+
+  private func reveal(_ element: XCUIElement) {
+    for _ in 0..<10 where !element.isHittable {
+      app.swipeUp()
+    }
+    XCTAssertTrue(element.isHittable)
+  }
+}
+
+private struct InterruptionEvidenceFailure: Error, CustomStringConvertible {
+  let description: String
+
+  init(_ description: String) {
+    self.description = description
+  }
+}

--- a/Showcase/iOS/Internal/UITestSupport.swift
+++ b/Showcase/iOS/Internal/UITestSupport.swift
@@ -132,6 +132,7 @@ extension UITestRoute {
     case .pipVODControlsValidation: PiPVODControlsValidationCase()
     case .pipLongStallValidation: PiPLongStallValidationCase()
     case .pipDismissalValidation: PiPDismissalValidationCase()
+    case .pipInterruptionValidation: PiPInterruptionValidationCase()
     }
   }
 }

--- a/Showcase/iOS/ValidationHarness/PiPInterruptionValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/PiPInterruptionValidationCase.swift
@@ -1,0 +1,230 @@
+import AVFoundation
+import Combine
+import SwiftUI
+@_spi(Qualification) import SwiftVLC
+
+/// Candidate-bound surface for a real cross-process audio-session
+/// interruption plus a deterministic old-device-unavailable route-loss event.
+struct PiPInterruptionValidationCase: View {
+  @State private var player = Player()
+  @State private var controller: PiPController?
+  @State private var lifecycleEvents: [String] = []
+  @State private var interruptionBeganCount = 0
+  @State private var interruptionEndedCount = 0
+  @State private var routeLossCount = 0
+  @State private var playbackError: String?
+
+  private let streams = HarnessStreams.load()?.streams
+
+  private var renderingPath: InterruptionRenderingPath {
+    InterruptionRenderingPath(
+      rawValue: LaunchArguments.pipRenderingPathValue ?? "native"
+    ) ?? .native
+  }
+
+  var body: some View {
+    _ = player.currentTime
+    return Form {
+      Section {
+        videoSurface
+          .frame(height: 220)
+          .listRowInsets(EdgeInsets())
+          .accessibilityIdentifier(AccessibilityID.PiPInterruptionValidation.videoView)
+      }
+
+      Section("Measured state") {
+        valueRow(
+          "Playback",
+          value: String(describing: player.state),
+          identifier: AccessibilityID.PiPInterruptionValidation.stateLabel
+        )
+        valueRow(
+          "PiP possible",
+          value: controller?.isPossible == true ? "yes" : "no",
+          identifier: AccessibilityID.PiPInterruptionValidation.possibleLabel
+        )
+        valueRow(
+          "PiP active",
+          value: controller?.isActive == true ? "yes" : "no",
+          identifier: AccessibilityID.PiPInterruptionValidation.activeLabel
+        )
+        valueRow(
+          "Lifecycle",
+          value: lifecycleEvents.joined(separator: "|"),
+          identifier: AccessibilityID.PiPInterruptionValidation.lifecycleEventsLabel
+        )
+        valueRow(
+          "Interruptions",
+          value: "\(interruptionBeganCount):\(interruptionEndedCount)",
+          identifier: AccessibilityID.PiPInterruptionValidation.interruptionCountsLabel
+        )
+        valueRow(
+          "Route losses",
+          value: String(routeLossCount),
+          identifier: AccessibilityID.PiPInterruptionValidation.routeLossCountLabel
+        )
+        valueRow(
+          "Played audio buffers",
+          value: String(player.statistics?.playedAudioBuffers ?? 0),
+          identifier: AccessibilityID.PiPInterruptionValidation.playedAudioBuffersLabel
+        )
+      }
+
+      Section("Qualification controls") {
+        Button("Start PiP", action: startPictureInPicture)
+          .accessibilityIdentifier(AccessibilityID.PiPInterruptionValidation.startButton)
+          .disabled(controller?.isPossible != true || controller?.isActive == true)
+
+        Button("Inject old-device-unavailable route loss", action: injectRouteLoss)
+          .accessibilityIdentifier(
+            AccessibilityID.PiPInterruptionValidation.injectRouteLossButton
+          )
+          .disabled(controller?.isActive != true)
+
+        Button("Resume after route loss", action: resumePlayback)
+          .accessibilityIdentifier(AccessibilityID.PiPInterruptionValidation.resumeButton)
+          .disabled(player.state != .paused)
+
+        Button("Stop PiP", action: { controller?.stop() })
+          .accessibilityIdentifier(AccessibilityID.PiPInterruptionValidation.stopButton)
+          .disabled(controller?.isActive != true)
+
+        if let playbackError {
+          Text(playbackError)
+            .foregroundStyle(.red)
+            .accessibilityIdentifier(AccessibilityID.PiPInterruptionValidation.errorLabel)
+        }
+      }
+    }
+    .showcaseFormStyle()
+    .navigationTitle("PiP audio disruptions")
+    .task { startPlayback() }
+    .task(id: controller.map(ObjectIdentifier.init)) {
+      lifecycleEvents.removeAll()
+      guard let controller else { return }
+      for await envelope in controller.pipEventEnvelopes {
+        lifecycleEvents.append(envelope.event.interruptionQualificationName)
+      }
+    }
+    .onReceive(
+      NotificationCenter.default.publisher(
+        for: AVAudioSession.interruptionNotification,
+        object: AVAudioSession.sharedInstance()
+      )
+    ) { notification in
+      recordInterruption(notification)
+    }
+    .onReceive(
+      NotificationCenter.default.publisher(
+        for: AVAudioSession.routeChangeNotification,
+        object: AVAudioSession.sharedInstance()
+      )
+    ) { notification in
+      recordRouteChange(notification)
+    }
+    .onDisappear {
+      controller?.stop()
+      player.stop()
+    }
+  }
+
+  @ViewBuilder
+  private var videoSurface: some View {
+    switch renderingPath {
+    case .native:
+      PiPVideoView(player, controller: $controller, startsAutomaticallyFromInline: false)
+    case .direct:
+      DirectPiPValidationSurface(player: player, controller: $controller)
+    }
+  }
+
+  private func startPlayback() {
+    guard let url = streams?.vod else {
+      playbackError = "Missing validation VOD"
+      return
+    }
+    do {
+      try player.play(url: url)
+    } catch {
+      playbackError = String(describing: error)
+    }
+  }
+
+  private func startPictureInPicture() {
+    guard let controller else { return }
+    playbackError = nil
+    guard controller.start() == .accepted else {
+      playbackError = "PiP start was not accepted"
+      return
+    }
+  }
+
+  private func injectRouteLoss() {
+    NotificationCenter.default.post(
+      name: AVAudioSession.routeChangeNotification,
+      object: AVAudioSession.sharedInstance(),
+      userInfo: [
+        AVAudioSessionRouteChangeReasonKey:
+          AVAudioSession.RouteChangeReason.oldDeviceUnavailable.rawValue
+      ]
+    )
+  }
+
+  private func resumePlayback() {
+    do {
+      try player.play()
+    } catch {
+      playbackError = String(describing: error)
+    }
+  }
+
+  private func recordInterruption(_ notification: Notification) {
+    guard
+      let rawType = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+      let type = AVAudioSession.InterruptionType(rawValue: rawType)
+    else { return }
+    switch type {
+    case .began:
+      interruptionBeganCount += 1
+    case .ended:
+      interruptionEndedCount += 1
+    @unknown default:
+      break
+    }
+  }
+
+  private func recordRouteChange(_ notification: Notification) {
+    guard
+      let rawReason = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt,
+      AVAudioSession.RouteChangeReason(rawValue: rawReason) == .oldDeviceUnavailable
+    else { return }
+    routeLossCount += 1
+  }
+
+  private func valueRow(_ title: String, value: String, identifier: String) -> some View {
+    HStack {
+      Text(title)
+      Spacer()
+      Text(value)
+        .foregroundStyle(.secondary)
+        .accessibilityIdentifier(identifier)
+    }
+  }
+}
+
+private enum InterruptionRenderingPath: String {
+  case native
+  case direct
+}
+
+extension PiPEvent {
+  fileprivate var interruptionQualificationName: String {
+    switch self {
+    case .willStart: "willStart"
+    case .didStart: "didStart"
+    case .willStop(let reason): "willStop:\(String(describing: reason))"
+    case .didStop(let reason): "didStop:\(String(describing: reason))"
+    case .failedToStart: "failedToStart"
+    }
+  }
+}

--- a/Showcase/macOS/Internal/MacShowcaseRootView.swift
+++ b/Showcase/macOS/Internal/MacShowcaseRootView.swift
@@ -412,7 +412,8 @@ extension MacShowcase {
          .pipDelayedStartFailureValidation,
          .pipVODControlsValidation,
          .pipLongStallValidation,
-         .pipDismissalValidation:
+         .pipDismissalValidation,
+         .pipInterruptionValidation:
       return nil
     }
   }

--- a/Showcase/tvOS/Internal/TVShowcaseRootView.swift
+++ b/Showcase/tvOS/Internal/TVShowcaseRootView.swift
@@ -520,7 +520,8 @@ extension TVShowcase {
          .pipDelayedStartFailureValidation,
          .pipVODControlsValidation,
          .pipLongStallValidation,
-         .pipDismissalValidation:
+         .pipDismissalValidation,
+         .pipInterruptionValidation:
       return nil
     }
   }

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -139,6 +139,21 @@ close invokes it zero times, and public lifecycle events report ordered
 launches writes a separate library log so an earlier backend/action error
 cannot be overwritten by a later cycle.
 
+The interruptions lane runs both PiP backends on every hardware row. The
+separately installed XCTest runner activates a non-mixable playback audio
+session while the candidate is backgrounded in real system PiP, then returns
+focus with `notifyOthersOnDeactivation`; the candidate must observe a balanced
+system interruption pair, recover playback, retain PiP, and render moving
+pixels. Its libVLC played-audio-buffer counter must also advance beyond the
+pre-interruption value, proving audio resumed rather than merely leaving the
+player in a nominal playing state. Route-loss behavior is a distinct, explicitly labelled deterministic
+injection: the candidate posts an `oldDeviceUnavailable` route-change
+notification through the same shared `AVAudioSession` object observed by the
+library. SwiftVLC must pause without closing PiP, accept an explicit resume,
+and finish with ordered teardown. Evidence records both sources verbatim so a
+controlled notification is never misrepresented as a physical Bluetooth
+disconnect.
+
 The iPhone-current-only deferred-pause-rejection lane drives the exact AVKit
 playback command entry point while a qualification SPI changes only libVLC's
 native pause-capability answer. It proves a permanently unpausable input

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -35,6 +35,7 @@ Options:
                           direct-live, live-media, background-audio,
                           continuity, capability-convergence,
                           vod-controls, long-stall, failed-start, dismissal,
+                          interruptions,
                           deferred-pause-rejection,
                           accepted-start-delayed-failure, hls-seek,
                           harness-regressions, ui-failures, thumbnail-preview
@@ -234,6 +235,7 @@ python3 "$SCRIPT_DIR/prepare-xctestrun.py" "$XCTESTRUN" "$DESTINATION_XCTESTRUN"
   --environment SWIFTVLC_PIP_LONG_STALL_DEVICE=YES \
   --environment SWIFTVLC_PIP_LONG_STALL_URL_BASE64="$PIP_LONG_STALL_URL_BASE64" \
   --environment SWIFTVLC_PIP_DISMISSAL_DEVICE=YES \
+  --environment SWIFTVLC_PIP_INTERRUPTION_DEVICE=YES \
   --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
   --environment SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE=YES \
   --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
@@ -287,7 +289,7 @@ xcrun devicectl device copy to \
   --destination Documents/streams.local.json \
   > "$OUTPUT_DIR/stage-streams.log"
 
-DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence vod-controls long-stall failed-start dismissal deferred-pause-rejection accepted-start-delayed-failure hls-seek)
+DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence vod-controls long-stall failed-start dismissal interruptions deferred-pause-rejection accepted-start-delayed-failure hls-seek)
 SCENARIOS_WERE_EXPLICIT=false
 if [[ ${#ONLY_SCENARIOS[@]} -eq 0 ]]; then
   ONLY_SCENARIOS=("${DEFAULT_SCENARIOS[@]}")
@@ -296,7 +298,7 @@ else
 fi
 for scenario in "${ONLY_SCENARIOS[@]}"; do
   case "$scenario" in
-    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|vod-controls|long-stall|failed-start|dismissal|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
+    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|vod-controls|long-stall|failed-start|dismissal|interruptions|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
     *) echo "Error: unknown scenario: $scenario" >&2; exit 2 ;;
   esac
 done
@@ -431,6 +433,13 @@ run_scenario() {
       route="PiPDismissalValidation"
       selected_xctestrun="$DESTINATION_XCTESTRUN"
       ;;
+    interruptions)
+      test_identifiers=(
+        "iOSUITests/PiPInterruptionDeviceUITests/test_audioInterruptionAndRouteLossAcrossNativeAndDirectBackends"
+      )
+      route="PiPInterruptionValidation"
+      selected_xctestrun="$DESTINATION_XCTESTRUN"
+      ;;
     deferred-pause-rejection)
       test_identifiers=(
         "iOSUITests/PiPDeferredPauseDeviceUITests/test_deferredPauseRejectionAndCancellationStayTruthful"
@@ -489,6 +498,7 @@ run_scenario() {
       --environment SWIFTVLC_PIP_LONG_STALL_DEVICE=YES \
       --environment SWIFTVLC_PIP_LONG_STALL_URL_BASE64="$PIP_LONG_STALL_URL_BASE64" \
       --environment SWIFTVLC_PIP_DISMISSAL_DEVICE=YES \
+      --environment SWIFTVLC_PIP_INTERRUPTION_DEVICE=YES \
       --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
       --environment SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE=YES \
       --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
@@ -519,6 +529,7 @@ run_scenario() {
       -skip-testing:iOSUITests/PiPVODControlsDeviceUITests
       -skip-testing:iOSUITests/PiPLongStallDeviceUITests
       -skip-testing:iOSUITests/PiPDismissalDeviceUITests
+      -skip-testing:iOSUITests/PiPInterruptionDeviceUITests
       -skip-testing:iOSUITests/PiPDeferredPauseDeviceUITests
       -skip-testing:iOSUITests/PiPDelayedStartFailureDeviceUITests
       -skip-testing:iOSUITests/PiPOverlayDeviceUITests
@@ -699,6 +710,10 @@ PY
     dismissal)
       qualification_scenarios=("restore" "close")
       qualification_attachments=("qualification-restore.json" "qualification-close.json")
+      ;;
+    interruptions)
+      qualification_scenarios=("interruptions")
+      qualification_attachments=("qualification-interruptions.json")
       ;;
     deferred-pause-rejection)
       qualification_scenarios=("deferred-pause-rejection")

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -580,6 +580,57 @@ class QualificationEvidenceTests(unittest.TestCase):
                 else:
                     self.assertEqual(evidence["stopReason"], "userClosed")
 
+    def test_materializes_interruption_evidence(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.make_export(
+                root,
+                {
+                    "formatVersion": 1,
+                    "scenario": "interruptions",
+                    "events": {
+                        "started": True,
+                        "unexpectedStopCount": 0,
+                        "order": "pass",
+                    },
+                    "interruptionRecovery": "pass",
+                    "routeChangeRecovery": "pass",
+                    "interruptionSource": "exclusive-XCTest-runner-audio-session",
+                    "routeLossSource": "deterministic-oldDeviceUnavailable-notification",
+                    "backends": {
+                        "native": {
+                            "interruptionBeganCount": 1,
+                            "routeLossCount": 1,
+                            "audioRecovered": True,
+                        },
+                        "direct": {
+                            "interruptionBeganCount": 1,
+                            "routeLossCount": 1,
+                            "audioRecovered": True,
+                        },
+                    },
+                    "recoveryOutcome": "preserved",
+                    "systemPiPMotionAfterRecovery": "pass",
+                },
+                attachment_name="qualification-interruptions.json",
+                test_identifier="PiPInterruptionDeviceUITests/test_audioInterruptionAndRouteLossAcrossNativeAndDirectBackends",
+            )
+            evidence = materialize_evidence.materialize(
+                root,
+                "qualification-interruptions.json",
+                "interruptions",
+                "iphone-current",
+                "a" * 64,
+                "b" * 64,
+            )
+            self.assertEqual(evidence["hardware"], "iphone-current")
+            self.assertEqual(evidence["events"]["unexpectedStopCount"], 0)
+            self.assertEqual(evidence["interruptionRecovery"], "pass")
+            self.assertEqual(evidence["routeChangeRecovery"], "pass")
+            self.assertEqual(evidence["backends"]["direct"]["routeLossCount"], 1)
+            self.assertTrue(evidence["backends"]["native"]["audioRecovered"])
+            self.assertEqual(evidence["recoveryOutcome"], "preserved")
+
     def test_materializes_accepted_start_delayed_failure_evidence(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
## Summary

- exercise real system audio interruption recovery in active PiP for native and direct rendering backends
- prove playback, PiP motion, and decoded audio-buffer progress recover after focus returns
- add an explicitly labelled deterministic old-device-unavailable route-loss injection, pause/resume validation, ordered teardown, and candidate-bound evidence materialization
- add the interruptions lane to the physical-device qualification runner and host regression coverage

## Validation

- 34 qualification host tests pass
- SwiftFormat lint and strict SwiftLint pass
- qualification shell syntax and release-integrity checks pass
- the branch patch is unchanged from its validated pre-rebase form

## Release gate

This PR adds automation and does not claim a physical-device pass. Milestone issues remain open until the exact frozen candidate produces passing hardware evidence.