### PR TITLE
Automate native PiP lifecycle qualification

### DIFF
--- a/Showcase/Shared/AccessibilityID.swift
+++ b/Showcase/Shared/AccessibilityID.swift
@@ -285,6 +285,17 @@ enum AccessibilityID {
     static let errorLabel = "pipInterruption.error"
   }
 
+  enum PiPNativeLifecycleValidation {
+    static let videoView = "pipNativeLifecycle.videoView"
+    static let stateLabel = "pipNativeLifecycle.state"
+    static let possibleLabel = "pipNativeLifecycle.possible"
+    static let activeLabel = "pipNativeLifecycle.active"
+    static let lifecycleEventsLabel = "pipNativeLifecycle.lifecycleEvents"
+    static let resultLabel = "pipNativeLifecycle.result"
+    static let runButton = "pipNativeLifecycle.run"
+    static let errorLabel = "pipNativeLifecycle.error"
+  }
+
   enum MatrixHValidation {
     static let stateLabel = "validation.matrixH.state"
     static let currentTimeLabel = "validation.matrixH.currentTime"

--- a/Showcase/Shared/LaunchArguments.swift
+++ b/Showcase/Shared/LaunchArguments.swift
@@ -38,6 +38,12 @@ enum LaunchArguments {
   /// `PiPController.layer`.
   static let pipRenderingPath = "-UITestPiPRenderingPath"
 
+  /// Selects one isolated action for the native-lifecycle qualification
+  /// surface. Each action launches a fresh process so an earlier terminal
+  /// transition cannot leak into the next case's evidence.
+  static let pipNativeLifecycleAction = "-UITestPiPNativeLifecycleAction"
+  static let pipNativeLifecycleToken = "-UITestPiPNativeLifecycleToken"
+
   /// Name of a showcase to deep-link to on launch (e.g. `"SimplePlayback"`).
   /// When unset, the showcase opens its normal navigation tree.
   static let route = "-UITestRoute"
@@ -85,6 +91,14 @@ enum LaunchArguments {
 
   static var pipRenderingPathValue: String? {
     UserDefaults.standard.string(forKey: key(pipRenderingPath))
+  }
+
+  static var pipNativeLifecycleActionValue: String? {
+    UserDefaults.standard.string(forKey: key(pipNativeLifecycleAction))
+  }
+
+  static var pipNativeLifecycleTokenValue: String? {
+    UserDefaults.standard.string(forKey: key(pipNativeLifecycleToken))
   }
 
   static var routeValue: String? {
@@ -170,6 +184,7 @@ enum UITestRoute: String, CaseIterable {
   case pipLongStallValidation = "PiPLongStallValidation"
   case pipDismissalValidation = "PiPDismissalValidation"
   case pipInterruptionValidation = "PiPInterruptionValidation"
+  case pipNativeLifecycleValidation = "PiPNativeLifecycleValidation"
 
   static var current: UITestRoute? {
     LaunchArguments.routeValue.flatMap(UITestRoute.init(rawValue:))

--- a/Showcase/UITests/iOS/Tests/PiPNativeLifecycleDeviceUITests.swift
+++ b/Showcase/UITests/iOS/Tests/PiPNativeLifecycleDeviceUITests.swift
@@ -1,0 +1,333 @@
+import XCTest
+
+/// Candidate-bound proof for every native-drawable lifecycle transition in
+/// the v1.1.0 matrix. Each transition gets a fresh app process so terminal
+/// state from one case cannot make a later case pass.
+final class PiPNativeLifecycleDeviceUITests: ShowcaseIOSTestCase {
+  private enum Affordance: String {
+    case restore
+    case close
+
+    var expectedReason: String {
+      switch self {
+      case .restore: "restoreRequested"
+      case .close: "userClosed"
+      }
+    }
+
+    var relativePoint: (x: Double, y: Double) {
+      switch self {
+      case .restore: (0.88, 0.18)
+      case .close: (0.12, 0.18)
+      }
+    }
+  }
+
+  func test_nativeLifecyclePublishesAuthoritativeOrderedEvents() throws {
+    #if targetEnvironment(simulator)
+    throw XCTSkip("Native Picture in Picture requires a physical iOS device")
+    #else
+    guard ProcessInfo.processInfo.environment["SWIFTVLC_PIP_NATIVE_LIFECYCLE_DEVICE"] == "YES"
+    else {
+      throw XCTSkip(
+        "Set SWIFTVLC_PIP_NATIVE_LIFECYCLE_DEVICE=YES for candidate-bound hardware runs"
+      )
+    }
+
+    addUIInterruptionMonitor(withDescription: "Local network permission") { alert in
+      let allow = alert.buttons["Allow"]
+      guard allow.exists else { return false }
+      allow.tap()
+      return true
+    }
+    let baseLogPath = try XCTUnwrap(
+      launchArgumentValue(for: LaunchArguments.logPath),
+      "Missing qualification log launch argument"
+    )
+
+    var cases: [String: Any] = [:]
+    var orderedEvents: [String: [String]] = [:]
+    for affordance in [Affordance.restore, .close] {
+      let evidence = try runSystemCycle(affordance, baseLogPath: baseLogPath)
+      let events = try XCTUnwrap(evidence["orderedEvents"] as? [String])
+      cases[affordance.rawValue] = evidence
+      orderedEvents[affordance.rawValue] = events
+    }
+
+    let expectedActions: [(action: String, reason: String?)] = [
+      ("failed-start", nil),
+      ("programmatic", "programmatic"),
+      ("media-end", "mediaEnded"),
+      ("failure", "failure"),
+      ("recast", "controllerReplaced"),
+      ("replacement", "controllerReplaced")
+    ]
+    var bridgeChecks: [Bool] = []
+    for expected in expectedActions {
+      let actionResult = try runAction(
+        expected.action,
+        terminalReason: expected.reason,
+        baseLogPath: baseLogPath
+      )
+      let bridge = try XCTUnwrap(actionResult.evidence["bridge"] as? [String: Any])
+      try bridgeChecks.append(validateBridge(bridge))
+      cases[expected.action] = actionResult.evidence
+      orderedEvents[expected.action] = actionResult.names
+    }
+
+    XCTAssertEqual(cases.count, 8)
+    XCTAssertEqual(bridgeChecks.count, 6)
+    XCTAssertTrue(bridgeChecks.allSatisfy(\.self))
+    let restore = try XCTUnwrap(cases[Affordance.restore.rawValue] as? [String: Any])
+    XCTAssertEqual(restore["restoreCallbackCount"] as? Int, 1)
+
+    attachQualificationEvidence(
+      [
+        "formatVersion": 1,
+        "scenario": "native-lifecycle",
+        "bridgeProbe": true,
+        "cases": cases,
+        "orderedEvents": orderedEvents,
+        "authoritativeStopReasons": true,
+        "restoreExactlyOnce": true,
+        "unsupportedBridgeVisible": true,
+        "unsupportedBridgeVisibility": "typed-probe-required",
+        "unsupportedRevisionExercised": false,
+        "processIsolation": "one-launch-per-transition"
+      ],
+      scenario: "native-lifecycle"
+    )
+    #endif
+  }
+
+  private func runAction(
+    _ action: String,
+    terminalReason: String?,
+    baseLogPath: String
+  )
+    throws -> (evidence: [String: Any], names: [String]) {
+    app.terminate()
+    replaceLaunchArgument(
+      LaunchArguments.route,
+      with: UITestRoute.pipNativeLifecycleValidation.rawValue
+    )
+    replaceLaunchArgument(LaunchArguments.pipNativeLifecycleAction, with: action)
+    replaceLaunchArgument(
+      LaunchArguments.pipNativeLifecycleToken,
+      with: "native-lifecycle-\(action)-\(UUID().uuidString.lowercased())"
+    )
+    replaceLaunchArgument(
+      LaunchArguments.logPath,
+      with: perCaseLogPath(action, baseLogPath: baseLogPath)
+    )
+    app.launch()
+    app.tap()
+
+    let state = element(AccessibilityID.PiPNativeLifecycleValidation.stateLabel)
+    let possible = element(AccessibilityID.PiPNativeLifecycleValidation.possibleLabel)
+    let result = element(AccessibilityID.PiPNativeLifecycleValidation.resultLabel)
+    let run = app.buttons[AccessibilityID.PiPNativeLifecycleValidation.runButton]
+    let error = element(AccessibilityID.PiPNativeLifecycleValidation.errorLabel)
+
+    waitForLabel(state, equals: "playing", timeout: 20)
+    waitForLabel(possible, equals: "yes", timeout: 15)
+    reveal(run)
+    XCTAssertTrue(run.isEnabled)
+    run.tap()
+    waitForPrefix(result, prefix: "pass:", timeout: actionTimeout(action))
+    XCTAssertFalse(error.exists, "Native lifecycle \(action) failed: \(error.label)")
+
+    let evidence = try decodeEvidence(result.label)
+    XCTAssertEqual(evidence["action"] as? String, action)
+    let events = try XCTUnwrap(evidence["orderedEvents"] as? [[String: Any]])
+    let names = try events.map { try XCTUnwrap($0["name"] as? String) }
+    if action == "failed-start" {
+      XCTAssertEqual(names, ["willStart", "failedToStart"])
+      XCTAssertFalse(names.contains("didStart"))
+    } else {
+      let reason = try XCTUnwrap(terminalReason)
+      XCTAssertEqual(
+        names,
+        ["willStart", "didStart", "willStop:\(reason)", "didStop:\(reason)"]
+      )
+    }
+    return (evidence, names)
+  }
+
+  private func runSystemCycle(
+    _ affordance: Affordance,
+    baseLogPath: String
+  )
+    throws -> [String: Any] {
+    app.terminate()
+    replaceLaunchArgument(
+      LaunchArguments.route,
+      with: UITestRoute.pipDismissalValidation.rawValue
+    )
+    replaceLaunchArgument(LaunchArguments.pipRenderingPath, with: "native")
+    replaceLaunchArgument(
+      LaunchArguments.logPath,
+      with: perCaseLogPath(affordance.rawValue, baseLogPath: baseLogPath)
+    )
+    app.launch()
+    app.tap()
+
+    let state = element(AccessibilityID.PiPDismissalValidation.stateLabel)
+    let possible = element(AccessibilityID.PiPDismissalValidation.possibleLabel)
+    let active = element(AccessibilityID.PiPDismissalValidation.activeLabel)
+    let lifecycle = element(AccessibilityID.PiPDismissalValidation.lifecycleEventsLabel)
+    let restoreCount = element(AccessibilityID.PiPDismissalValidation.restoreCountLabel)
+    let start = app.buttons[AccessibilityID.PiPDismissalValidation.startButton]
+    let error = element(AccessibilityID.PiPDismissalValidation.errorLabel)
+
+    waitForLabel(state, equals: "playing", timeout: 20)
+    waitForLabel(possible, equals: "yes", timeout: 15)
+    reveal(start)
+    XCTAssertTrue(start.isEnabled)
+    start.tap()
+    waitForLabel(active, equals: "yes", timeout: 10)
+    waitForLifecyclePrefix(lifecycle, prefix: "willStart|didStart", timeout: 10)
+
+    XCUIDevice.shared.press(.home)
+    let region = try locateSystemPictureInPictureWindow()
+    tap(affordance, in: region)
+    RunLoop.current.run(until: Date().addingTimeInterval(2))
+    if app.state != .runningForeground {
+      app.activate()
+    }
+
+    waitForLabel(active, equals: "no", timeout: 10)
+    let expected = [
+      "willStart",
+      "didStart",
+      "willStop:\(affordance.expectedReason)",
+      "didStop:\(affordance.expectedReason)"
+    ]
+    waitForLifecyclePrefix(lifecycle, prefix: expected.joined(separator: "|"), timeout: 10)
+    RunLoop.current.run(until: Date().addingTimeInterval(1))
+    XCTAssertFalse(error.exists, "Native \(affordance.rawValue) failed: \(error.label)")
+    let actual = lifecycle.label.split(separator: "|").map(String.init)
+    XCTAssertEqual(actual, expected)
+    let count = Int(restoreCount.label) ?? -1
+    XCTAssertEqual(count, affordance == .restore ? 1 : 0)
+    return [
+      "actionOutcome": affordance.rawValue,
+      "orderedEvents": actual,
+      "restoreCallbackCount": count,
+      "systemPiPMotion": "pass"
+    ]
+  }
+
+  private func validateBridge(_ bridge: [String: Any]) throws -> Bool {
+    XCTAssertEqual(bridge["hasAVController"] as? Bool, true)
+    XCTAssertEqual(bridge["hasLifecycleDelegateBridge"] as? Bool, true)
+    XCTAssertNotNil(bridge["windowControllerClassName"] as? String)
+    XCTAssertNotNil(bridge["delegateClassName"] as? String)
+    let selectors = try XCTUnwrap(bridge["delegateResponds"] as? [String: Bool])
+    let required = [
+      "pictureInPictureControllerWillStartPictureInPicture:",
+      "pictureInPictureControllerDidStartPictureInPicture:",
+      "pictureInPictureController:failedToStartPictureInPictureWithError:",
+      "pictureInPictureControllerWillStopPictureInPicture:",
+      "pictureInPictureControllerDidStopPictureInPicture:",
+      "pictureInPictureController:restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:"
+    ]
+    XCTAssertTrue(required.allSatisfy { selectors[$0] == true })
+    return required.allSatisfy { selectors[$0] == true }
+      && bridge["hasAVController"] as? Bool == true
+      && bridge["hasLifecycleDelegateBridge"] as? Bool == true
+  }
+
+  private func tap(
+    _ affordance: Affordance,
+    in region: SystemPictureInPictureWindowRegion
+  ) {
+    let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+    RunLoop.current.run(until: Date().addingTimeInterval(3))
+    springboard.coordinate(
+      withNormalizedOffset: region.normalizedPoint(x: 0.5, y: 0.5)
+    ).tap()
+    RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+
+    let point = affordance.relativePoint
+    let screenPoint = region.normalizedPoint(x: point.x, y: point.y)
+    let screenshot = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
+    screenshot.name = "native-lifecycle-\(affordance.rawValue)-controls"
+    screenshot.lifetime = .keepAlways
+    add(screenshot)
+    springboard.coordinate(withNormalizedOffset: screenPoint).tap()
+  }
+
+  private func decodeEvidence(_ label: String) throws -> [String: Any] {
+    let prefix = "pass:"
+    XCTAssertTrue(label.hasPrefix(prefix))
+    let encoded = String(label.dropFirst(prefix.count))
+    let data = try XCTUnwrap(Data(base64Encoded: encoded))
+    return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+  }
+
+  private func actionTimeout(_ action: String) -> TimeInterval {
+    switch action {
+    case "failure", "media-end": 40
+    default: 20
+    }
+  }
+
+  private func perCaseLogPath(_ name: String, baseLogPath: String) -> String {
+    (baseLogPath as NSString).deletingPathExtension
+      + "-native-lifecycle-\(name).jsonl"
+  }
+
+  private func element(_ identifier: String) -> XCUIElement {
+    app.descendants(matching: .any)[identifier]
+  }
+
+  private func replaceLaunchArgument(_ name: String, with value: String) {
+    while let index = app.launchArguments.firstIndex(of: name) {
+      app.launchArguments.remove(at: index)
+      if index < app.launchArguments.endIndex {
+        app.launchArguments.remove(at: index)
+      }
+    }
+    app.launchArguments += [name, value]
+  }
+
+  private func launchArgumentValue(for name: String) -> String? {
+    guard
+      let index = app.launchArguments.lastIndex(of: name),
+      app.launchArguments.indices.contains(index + 1)
+    else { return nil }
+    return app.launchArguments[index + 1]
+  }
+
+  private func waitForPrefix(
+    _ element: XCUIElement,
+    prefix: String,
+    timeout: TimeInterval
+  ) {
+    let predicate = NSPredicate { _, _ in
+      element.exists && element.label.hasPrefix(prefix)
+    }
+    let expectation = expectation(for: predicate, evaluatedWith: NSObject())
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [expectation], timeout: timeout),
+      .completed,
+      "Expected prefix \(prefix), got: \(element.label)"
+    )
+  }
+
+  private func waitForLifecyclePrefix(
+    _ element: XCUIElement,
+    prefix: String,
+    timeout: TimeInterval
+  ) {
+    waitForPrefix(element, prefix: prefix, timeout: timeout)
+  }
+
+  private func reveal(_ element: XCUIElement) {
+    for _ in 0..<10 where !element.isHittable {
+      app.swipeUp()
+    }
+    XCTAssertTrue(element.isHittable)
+  }
+}

--- a/Showcase/iOS/Internal/UITestSupport.swift
+++ b/Showcase/iOS/Internal/UITestSupport.swift
@@ -133,6 +133,7 @@ extension UITestRoute {
     case .pipLongStallValidation: PiPLongStallValidationCase()
     case .pipDismissalValidation: PiPDismissalValidationCase()
     case .pipInterruptionValidation: PiPInterruptionValidationCase()
+    case .pipNativeLifecycleValidation: PiPNativeLifecycleValidationCase()
     }
   }
 }

--- a/Showcase/iOS/ValidationHarness/PiPNativeLifecycleValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/PiPNativeLifecycleValidationCase.swift
@@ -1,0 +1,363 @@
+import Foundation
+import SwiftUI
+@_spi(Qualification) @_spi(ValidationHarness) import SwiftVLC
+
+/// Runs one isolated native-drawable lifecycle transition against the exact
+/// candidate. System restore and close remain in the SpringBoard-driven
+/// dismissal test; this surface covers the transitions the app can initiate.
+struct PiPNativeLifecycleValidationCase: View {
+  @State private var player = Player()
+  @State private var controller: PiPController?
+  @State private var lifecycle: [LifecycleEvent] = []
+  @State private var result = "not-run"
+  @State private var playbackError: String?
+  @State private var isRunning = false
+
+  private let streams = HarnessStreams.load()?.streams
+
+  private var action: NativeLifecycleAction? {
+    LaunchArguments.pipNativeLifecycleActionValue.flatMap(NativeLifecycleAction.init(rawValue:))
+  }
+
+  var body: some View {
+    Form {
+      Section {
+        PiPVideoView(player, controller: $controller, startsAutomaticallyFromInline: false)
+          .frame(height: 220)
+          .listRowInsets(EdgeInsets())
+          .accessibilityIdentifier(AccessibilityID.PiPNativeLifecycleValidation.videoView)
+      }
+
+      Section("Measured state") {
+        valueRow(
+          "Playback",
+          value: String(describing: player.state),
+          identifier: AccessibilityID.PiPNativeLifecycleValidation.stateLabel
+        )
+        valueRow(
+          "PiP possible",
+          value: controller?.isPossible == true ? "yes" : "no",
+          identifier: AccessibilityID.PiPNativeLifecycleValidation.possibleLabel
+        )
+        valueRow(
+          "PiP active",
+          value: controller?.isActive == true ? "yes" : "no",
+          identifier: AccessibilityID.PiPNativeLifecycleValidation.activeLabel
+        )
+        valueRow(
+          "Lifecycle",
+          value: lifecycle.map(\.name).joined(separator: "|"),
+          identifier: AccessibilityID.PiPNativeLifecycleValidation.lifecycleEventsLabel
+        )
+        valueRow(
+          "Qualification",
+          value: result,
+          identifier: AccessibilityID.PiPNativeLifecycleValidation.resultLabel
+        )
+      }
+
+      Section("Native lifecycle") {
+        Button("Run \(action?.rawValue ?? "invalid")") {
+          Task { await run() }
+        }
+        .accessibilityIdentifier(AccessibilityID.PiPNativeLifecycleValidation.runButton)
+        .disabled(
+          isRunning || action == nil || controller?.isPossible != true
+            || player.state != .playing
+        )
+
+        if let playbackError {
+          Text(playbackError)
+            .foregroundStyle(.red)
+            .accessibilityIdentifier(AccessibilityID.PiPNativeLifecycleValidation.errorLabel)
+        }
+      }
+    }
+    .showcaseFormStyle()
+    .navigationTitle("Native PiP lifecycle")
+    .task { startPlayback() }
+    .task(id: controller.map(ObjectIdentifier.init)) {
+      guard let controller else { return }
+      for await envelope in controller.pipEventEnvelopes {
+        lifecycle.append(
+          LifecycleEvent(
+            name: envelope.event.nativeLifecycleQualificationName,
+            controllerGeneration: envelope.controllerGeneration,
+            mediaGeneration: envelope.mediaGeneration.qualificationValue
+          )
+        )
+      }
+    }
+    .onDisappear {
+      controller?.stop()
+      player.stop()
+    }
+  }
+
+  private func startPlayback() {
+    guard let action else {
+      playbackError = "Missing native lifecycle action"
+      return
+    }
+    let url: URL? = switch action {
+    case .failure:
+      gatedFailureURL
+    default:
+      streams?.vod
+    }
+    guard let url else {
+      playbackError = "Missing validation media for \(action.rawValue)"
+      return
+    }
+    do {
+      try player.play(url: url)
+    } catch {
+      playbackError = String(describing: error)
+    }
+  }
+
+  private func run() async {
+    guard let action, let controller else { return }
+    isRunning = true
+    playbackError = nil
+    result = "running"
+    do {
+      let probe = try await waitForBridgeProbe(controller)
+      lifecycle.removeAll(keepingCapacity: true)
+      let actionOutcome = try await execute(action, controller: controller)
+      let evidence = CaseEvidence(
+        action: action.rawValue,
+        actionOutcome: actionOutcome,
+        bridge: BridgeEvidence(probe),
+        orderedEvents: lifecycle
+      )
+      result = try "pass:\(JSONEncoder().encode(evidence).base64EncodedString())"
+    } catch is CancellationError {
+      result = "cancelled"
+    } catch {
+      playbackError = String(describing: error)
+      result = "failed"
+      controller.stop()
+    }
+    isRunning = false
+  }
+
+  private func execute(
+    _ action: NativeLifecycleAction,
+    controller: PiPController
+  )
+    async throws -> String {
+    switch action {
+    case .failedStart:
+      guard controller.performNativeAcceptedStartFailureQualification() == .accepted else {
+        throw NativeLifecycleFailure("Native PiP failure request was not accepted")
+      }
+      try await waitUntil("Native failedToStart event did not arrive") {
+        lifecycle.contains { $0.name == "failedToStart" }
+      }
+      // Keep observing the still-accepted AVKit request. A late native start
+      // invalidates the failure proof instead of arriving after a pass was
+      // already published to the UI-test process.
+      try await Task.sleep(for: .seconds(3))
+      guard
+        lifecycle.map(\.name) == ["willStart", "failedToStart"],
+        controller.isActive == false
+      else {
+        throw NativeLifecycleFailure("Native failed start produced late or reordered events")
+      }
+      return "failedToStart"
+
+    case .programmatic:
+      try await startAndWait(controller)
+      controller.stop()
+      try await waitForTerminal("programmatic")
+      return "stopped"
+
+    case .mediaEnd:
+      try await startAndWait(controller)
+      try await waitUntil("VOD duration did not become available") {
+        (player.duration?.milliseconds ?? 0) > 1500
+      }
+      guard let duration = player.duration else {
+        throw NativeLifecycleFailure("VOD duration disappeared before the end seek")
+      }
+      try player.seek(to: .milliseconds(max(0, duration.milliseconds - 500)))
+      try await waitForTerminal("mediaEnded", timeout: .seconds(20))
+      return "naturalEnd"
+
+    case .failure:
+      try await startAndWait(controller)
+      guard let triggerURL = failureTriggerURL else {
+        throw NativeLifecycleFailure("Missing gated failure trigger URL")
+      }
+      let (_, response) = try await URLSession.shared.data(from: triggerURL)
+      guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+        throw NativeLifecycleFailure("Fixture failure trigger was rejected")
+      }
+      try await waitForTerminal("failure", timeout: .seconds(30))
+      return "sourceFailure"
+
+    case .recast:
+      try await startAndWait(controller)
+      let outcome = try await player.recast(to: nil)
+      guard outcome == .settled else {
+        throw NativeLifecycleFailure("Recast did not settle: \(String(describing: outcome))")
+      }
+      try await waitForTerminal("controllerReplaced")
+      return "settled"
+
+    case .replacement:
+      try await startAndWait(controller)
+      guard let live = streams?.hlsLive ?? streams?.liveTS else {
+        throw NativeLifecycleFailure("Missing replacement stream")
+      }
+      let outgoingGeneration = player.playbackQualificationGeneration.qualificationValue
+      try player.play(url: live)
+      try await waitForTerminal("controllerReplaced")
+      try await waitUntil("Replacement playback did not start") {
+        player.playbackQualificationGeneration.qualificationValue > outgoingGeneration
+          && player.state == .playing
+      }
+      return "playingSuccessor"
+    }
+  }
+
+  private func startAndWait(_ controller: PiPController) async throws {
+    guard controller.start() == .accepted else {
+      throw NativeLifecycleFailure("Native PiP start was not accepted")
+    }
+    try await waitUntil("Native PiP did not become active") { controller.isActive }
+    try await waitUntil("Native start lifecycle was incomplete") {
+      lifecycle.contains { $0.name == "willStart" }
+        && lifecycle.contains { $0.name == "didStart" }
+    }
+  }
+
+  private func waitForTerminal(
+    _ reason: String,
+    timeout: Duration = .seconds(15)
+  )
+    async throws {
+    try await waitUntil("Missing authoritative \(reason) stop", timeout: timeout) {
+      lifecycle.contains { $0.name == "willStop:\(reason)" }
+        && lifecycle.contains { $0.name == "didStop:\(reason)" }
+    }
+  }
+
+  private func waitForBridgeProbe(_ controller: PiPController) async throws -> NativePiPProbe {
+    var captured: NativePiPProbe?
+    try await waitUntil("Native lifecycle bridge probe did not converge") {
+      guard let probe = controller.nativeValidationProbe else { return false }
+      captured = probe
+      return probe.hasAVController && probe.hasLifecycleDelegateBridge
+    }
+    guard let captured else {
+      throw NativeLifecycleFailure("Native lifecycle bridge probe disappeared")
+    }
+    return captured
+  }
+
+  private var fixtureBaseURL: URL? {
+    guard let live = streams?.liveTS else { return nil }
+    var components = URLComponents(url: live, resolvingAgainstBaseURL: false)
+    components?.path = ""
+    components?.query = nil
+    components?.fragment = nil
+    return components?.url
+  }
+
+  private var gatedFailureURL: URL? {
+    guard let token = LaunchArguments.pipNativeLifecycleTokenValue else { return nil }
+    return fixtureBaseURL?
+      .appending(path: "fault/gated-close/\(token)/live.ts")
+  }
+
+  private var failureTriggerURL: URL? {
+    guard let token = LaunchArguments.pipNativeLifecycleTokenValue else { return nil }
+    return fixtureBaseURL?
+      .appending(path: "fault/close-trigger/\(token)")
+  }
+
+  private func waitUntil(
+    _ failure: String,
+    timeout: Duration = .seconds(15),
+    condition: @escaping @MainActor () -> Bool
+  )
+    async throws {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
+    while !condition() {
+      try Task.checkCancellation()
+      guard clock.now < deadline else { throw NativeLifecycleFailure(failure) }
+      try await Task.sleep(for: .milliseconds(50))
+    }
+  }
+
+  private func valueRow(_ title: String, value: String, identifier: String) -> some View {
+    HStack {
+      Text(title)
+      Spacer()
+      Text(value)
+        .foregroundStyle(.secondary)
+        .accessibilityIdentifier(identifier)
+    }
+  }
+}
+
+private enum NativeLifecycleAction: String, CaseIterable {
+  case failedStart = "failed-start"
+  case programmatic
+  case mediaEnd = "media-end"
+  case failure
+  case recast
+  case replacement
+}
+
+private struct LifecycleEvent: Codable {
+  let name: String
+  let controllerGeneration: UInt64
+  let mediaGeneration: UInt64
+}
+
+private struct BridgeEvidence: Codable {
+  let windowControllerClassName: String?
+  let hasAVController: Bool
+  let delegateClassName: String?
+  let hasLifecycleDelegateBridge: Bool
+  let delegateResponds: [String: Bool]
+
+  init(_ probe: NativePiPProbe) {
+    windowControllerClassName = probe.windowControllerClassName
+    hasAVController = probe.hasAVController
+    delegateClassName = probe.avDelegateClassName
+    hasLifecycleDelegateBridge = probe.hasLifecycleDelegateBridge
+    delegateResponds = probe.delegateResponds
+  }
+}
+
+private struct CaseEvidence: Codable {
+  let action: String
+  let actionOutcome: String
+  let bridge: BridgeEvidence
+  let orderedEvents: [LifecycleEvent]
+}
+
+private struct NativeLifecycleFailure: Error, CustomStringConvertible {
+  let description: String
+
+  init(_ description: String) {
+    self.description = description
+  }
+}
+
+extension PiPEvent {
+  fileprivate var nativeLifecycleQualificationName: String {
+    switch self {
+    case .willStart: "willStart"
+    case .didStart: "didStart"
+    case .willStop(let reason): "willStop:\(String(describing: reason))"
+    case .didStop(let reason): "didStop:\(String(describing: reason))"
+    case .failedToStart: "failedToStart"
+    }
+  }
+}

--- a/Showcase/macOS/Internal/MacShowcaseRootView.swift
+++ b/Showcase/macOS/Internal/MacShowcaseRootView.swift
@@ -413,7 +413,8 @@ extension MacShowcase {
          .pipVODControlsValidation,
          .pipLongStallValidation,
          .pipDismissalValidation,
-         .pipInterruptionValidation:
+         .pipInterruptionValidation,
+         .pipNativeLifecycleValidation:
       return nil
     }
   }

--- a/Showcase/tvOS/Internal/TVShowcaseRootView.swift
+++ b/Showcase/tvOS/Internal/TVShowcaseRootView.swift
@@ -521,7 +521,8 @@ extension TVShowcase {
          .pipVODControlsValidation,
          .pipLongStallValidation,
          .pipDismissalValidation,
-         .pipInterruptionValidation:
+         .pipInterruptionValidation,
+         .pipNativeLifecycleValidation:
       return nil
     }
   }

--- a/Sources/SwiftVLC/PiP/PiPController+Validation.swift
+++ b/Sources/SwiftVLC/PiP/PiPController+Validation.swift
@@ -229,6 +229,21 @@ extension PiPController {
     return result
   }
 
+  /// Issues a real native-backend start request, then routes a deterministic
+  /// asynchronous failure through the installed libVLC/AVKit delegate bridge.
+  /// This is candidate-only integration proof that native failed-start events
+  /// are surfaced with their accepted request attribution intact.
+  @_spi(Qualification)
+  public func performNativeAcceptedStartFailureQualification() -> PiPStartResult {
+    guard let nativeBackend else { return .backendUnavailable }
+    let result = start()
+    guard result == .accepted else { return result }
+    guard nativeBackend.performAcceptedStartFailureQualification() else {
+      return .backendUnavailable
+    }
+    return result
+  }
+
   /// Exercises the same controller command entry point used by AVKit's
   /// sample-buffer playback delegate.
   @_spi(Qualification)

--- a/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
+++ b/Sources/SwiftVLC/PiP/PiPVideoView+iOSNative.swift
@@ -1296,29 +1296,53 @@ final class IOSNativePiPBackend: NSObject, @unchecked Sendable {
     let delegateSelectorNames = [
       "pictureInPictureControllerWillStartPictureInPicture:",
       "pictureInPictureControllerDidStartPictureInPicture:",
+      "pictureInPictureControllerWillStopPictureInPicture:",
       "pictureInPictureControllerDidStopPictureInPicture:",
       "pictureInPictureController:failedToStartPictureInPictureWithError:",
       "pictureInPictureController:restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:"
     ]
 
-    let delegate = delegateBridge?.downstream
+    let downstreamDelegate = delegateBridge?.downstream
       ?? avPictureInPictureController?.delegate
+    let activeDelegate = avPictureInPictureController?.delegate
     var delegateResponds: [String: Bool] = [:]
-    if let delegate {
+    if let activeDelegate {
       for name in delegateSelectorNames {
-        delegateResponds[name] = delegate.responds(to: Selector((name)))
+        delegateResponds[name] = activeDelegate.responds(to: Selector((name)))
       }
     }
 
     return NativePiPProbe(
       windowControllerClassName: windowController.map { NSStringFromClass(type(of: $0)) },
       hasAVController: avPictureInPictureController != nil,
-      avDelegateClassName: delegate.flatMap { object_getClass($0) }.map { NSStringFromClass($0) },
+      avDelegateClassName: downstreamDelegate
+        .flatMap { object_getClass($0) }
+        .map { NSStringFromClass($0) },
       hasLifecycleDelegateBridge: delegateBridge != nil,
       delegateResponds: delegateResponds,
       isPossible: isPossible,
       isActive: isActive
     )
+  }
+
+  /// Sends a deterministic start failure through the installed native AVKit
+  /// delegate bridge. The qualification controller first issues the real
+  /// native start request; this helper changes no lifecycle attribution state
+  /// directly and therefore exercises the same forwarding path as AVKit.
+  func performAcceptedStartFailureQualification() -> Bool {
+    guard
+      delegateBridge != nil,
+      let controller = avPictureInPictureController,
+      let delegate = controller.delegate
+    else { return false }
+    delegate.pictureInPictureController?(
+      controller,
+      failedToStartPictureInPictureWithError: NSError(
+        domain: "SwiftVLC.Qualification.NativePiPStartFailure",
+        code: 1
+      )
+    )
+    return true
   }
 
   @discardableResult

--- a/scripts/qualification/fixture-server.py
+++ b/scripts/qualification/fixture-server.py
@@ -57,6 +57,33 @@ class FixtureHandler(BaseHTTPRequestHandler):
                 transferred = len(payload)
                 return
 
+            match = re.fullmatch(r"/fault/close-trigger/([A-Za-z0-9._-]+)", route)
+            if match:
+                generation = self.server.trigger_close(match.group(1))
+                payload = json.dumps({"generation": generation}).encode()
+                self.send_response(HTTPStatus.OK)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+                transferred = len(payload)
+                return
+
+            match = re.fullmatch(
+                r"/fault/gated-close/([A-Za-z0-9._-]+)/(.+)", route
+            )
+            if match:
+                token = match.group(1)
+                if self.server.close_generation(token) > 0:
+                    status = HTTPStatus.SERVICE_UNAVAILABLE
+                    self.response_status = status
+                    self.send_error(status, "fixture connection was closed")
+                    return
+                transferred = self._serve_loop(
+                    self._safe_path(match.group(2)), close_token=token
+                )
+                return
+
             match = re.fullmatch(
                 r"/fault/gated-stall/([A-Za-z0-9._-]+)/([0-9]+(?:\.[0-9]+)?)/(.+)",
                 route,
@@ -144,6 +171,7 @@ class FixtureHandler(BaseHTTPRequestHandler):
         *,
         stall_token: str | None = None,
         stall_seconds: float = 0,
+        close_token: str | None = None,
     ) -> int:
         content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
         self.send_response(HTTPStatus.OK)
@@ -171,6 +199,9 @@ class FixtureHandler(BaseHTTPRequestHandler):
                             remaining = triggered_at + stall_seconds - time.monotonic()
                             if remaining > 0:
                                 time.sleep(remaining)
+                    if close_token and self.server.close_generation(close_token) > 0:
+                        self.close_connection = True
+                        return transferred
                     if self.server.chunk_delay:
                         time.sleep(self.server.chunk_delay)
 
@@ -268,6 +299,8 @@ class FixtureHTTPServer(ThreadingHTTPServer):
         self._stall_lock = threading.Lock()
         self._stall_generations: dict[str, int] = {}
         self._stall_triggered_at: dict[str, float] = {}
+        self._close_lock = threading.Lock()
+        self._close_generations: dict[str, int] = {}
 
     def trigger_stall(self, token: str) -> int:
         with self._stall_lock:
@@ -282,6 +315,16 @@ class FixtureHTTPServer(ThreadingHTTPServer):
                 self._stall_generations.get(token, 0),
                 self._stall_triggered_at.get(token, 0),
             )
+
+    def trigger_close(self, token: str) -> int:
+        with self._close_lock:
+            generation = self._close_generations.get(token, 0) + 1
+            self._close_generations[token] = generation
+            return generation
+
+    def close_generation(self, token: str) -> int:
+        with self._close_lock:
+            return self._close_generations.get(token, 0)
 
     def handle_error(self, request: object, client_address: tuple[str, int]) -> None:
         # Media clients commonly abandon a keep-alive connection after a seek

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -236,6 +236,7 @@ python3 "$SCRIPT_DIR/prepare-xctestrun.py" "$XCTESTRUN" "$DESTINATION_XCTESTRUN"
   --environment SWIFTVLC_PIP_LONG_STALL_URL_BASE64="$PIP_LONG_STALL_URL_BASE64" \
   --environment SWIFTVLC_PIP_DISMISSAL_DEVICE=YES \
   --environment SWIFTVLC_PIP_INTERRUPTION_DEVICE=YES \
+  --environment SWIFTVLC_PIP_NATIVE_LIFECYCLE_DEVICE=YES \
   --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
   --environment SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE=YES \
   --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
@@ -289,7 +290,7 @@ xcrun devicectl device copy to \
   --destination Documents/streams.local.json \
   > "$OUTPUT_DIR/stage-streams.log"
 
-DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence vod-controls long-stall failed-start dismissal interruptions deferred-pause-rejection accepted-start-delayed-failure hls-seek)
+DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence vod-controls long-stall failed-start dismissal interruptions native-lifecycle deferred-pause-rejection accepted-start-delayed-failure hls-seek)
 SCENARIOS_WERE_EXPLICIT=false
 if [[ ${#ONLY_SCENARIOS[@]} -eq 0 ]]; then
   ONLY_SCENARIOS=("${DEFAULT_SCENARIOS[@]}")
@@ -298,7 +299,7 @@ else
 fi
 for scenario in "${ONLY_SCENARIOS[@]}"; do
   case "$scenario" in
-    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|vod-controls|long-stall|failed-start|dismissal|interruptions|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
+    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|vod-controls|long-stall|failed-start|dismissal|interruptions|native-lifecycle|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
     *) echo "Error: unknown scenario: $scenario" >&2; exit 2 ;;
   esac
 done
@@ -313,7 +314,7 @@ device_matches_hardware_row() {
 if ! device_matches_hardware_row "iphone-current"; then
   if [[ "$SCENARIOS_WERE_EXPLICIT" == true ]]; then
     for scenario in "${ONLY_SCENARIOS[@]}"; do
-      if [[ "$scenario" == "capability-convergence" || "$scenario" == "deferred-pause-rejection" || "$scenario" == "accepted-start-delayed-failure" ]]; then
+      if [[ "$scenario" == "capability-convergence" || "$scenario" == "native-lifecycle" || "$scenario" == "deferred-pause-rejection" || "$scenario" == "accepted-start-delayed-failure" ]]; then
         echo "Error: $scenario requires the iphone-current hardware row." >&2
         exit 2
       fi
@@ -321,7 +322,7 @@ if ! device_matches_hardware_row "iphone-current"; then
   else
     FILTERED_SCENARIOS=()
     for scenario in "${ONLY_SCENARIOS[@]}"; do
-      if [[ "$scenario" != "capability-convergence" && "$scenario" != "deferred-pause-rejection" && "$scenario" != "accepted-start-delayed-failure" ]]; then
+      if [[ "$scenario" != "capability-convergence" && "$scenario" != "native-lifecycle" && "$scenario" != "deferred-pause-rejection" && "$scenario" != "accepted-start-delayed-failure" ]]; then
         FILTERED_SCENARIOS+=("$scenario")
       fi
     done
@@ -440,6 +441,13 @@ run_scenario() {
       route="PiPInterruptionValidation"
       selected_xctestrun="$DESTINATION_XCTESTRUN"
       ;;
+    native-lifecycle)
+      test_identifiers=(
+        "iOSUITests/PiPNativeLifecycleDeviceUITests/test_nativeLifecyclePublishesAuthoritativeOrderedEvents"
+      )
+      route="PiPNativeLifecycleValidation"
+      selected_xctestrun="$DESTINATION_XCTESTRUN"
+      ;;
     deferred-pause-rejection)
       test_identifiers=(
         "iOSUITests/PiPDeferredPauseDeviceUITests/test_deferredPauseRejectionAndCancellationStayTruthful"
@@ -499,6 +507,7 @@ run_scenario() {
       --environment SWIFTVLC_PIP_LONG_STALL_URL_BASE64="$PIP_LONG_STALL_URL_BASE64" \
       --environment SWIFTVLC_PIP_DISMISSAL_DEVICE=YES \
       --environment SWIFTVLC_PIP_INTERRUPTION_DEVICE=YES \
+      --environment SWIFTVLC_PIP_NATIVE_LIFECYCLE_DEVICE=YES \
       --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
       --environment SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE=YES \
       --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
@@ -530,6 +539,7 @@ run_scenario() {
       -skip-testing:iOSUITests/PiPLongStallDeviceUITests
       -skip-testing:iOSUITests/PiPDismissalDeviceUITests
       -skip-testing:iOSUITests/PiPInterruptionDeviceUITests
+      -skip-testing:iOSUITests/PiPNativeLifecycleDeviceUITests
       -skip-testing:iOSUITests/PiPDeferredPauseDeviceUITests
       -skip-testing:iOSUITests/PiPDelayedStartFailureDeviceUITests
       -skip-testing:iOSUITests/PiPOverlayDeviceUITests
@@ -714,6 +724,10 @@ PY
     interruptions)
       qualification_scenarios=("interruptions")
       qualification_attachments=("qualification-interruptions.json")
+      ;;
+    native-lifecycle)
+      qualification_scenarios=("native-lifecycle")
+      qualification_attachments=("qualification-native-lifecycle.json")
       ;;
     deferred-pause-rejection)
       qualification_scenarios=("deferred-pause-rejection")

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -631,6 +631,113 @@ class QualificationEvidenceTests(unittest.TestCase):
             self.assertTrue(evidence["backends"]["native"]["audioRecovered"])
             self.assertEqual(evidence["recoveryOutcome"], "preserved")
 
+    def test_materializes_native_lifecycle_evidence(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            cases = {
+                "restore": {
+                    "orderedEvents": [
+                        "willStart",
+                        "didStart",
+                        "willStop:restoreRequested",
+                        "didStop:restoreRequested",
+                    ],
+                    "restoreCallbackCount": 1,
+                },
+                "close": {
+                    "orderedEvents": [
+                        "willStart",
+                        "didStart",
+                        "willStop:userClosed",
+                        "didStop:userClosed",
+                    ],
+                    "restoreCallbackCount": 0,
+                },
+                "failed-start": {
+                    "orderedEvents": ["willStart", "failedToStart"]
+                },
+                "programmatic": {
+                    "orderedEvents": [
+                        "willStart",
+                        "didStart",
+                        "willStop:programmatic",
+                        "didStop:programmatic",
+                    ]
+                },
+                "media-end": {
+                    "orderedEvents": [
+                        "willStart",
+                        "didStart",
+                        "willStop:mediaEnded",
+                        "didStop:mediaEnded",
+                    ]
+                },
+                "failure": {
+                    "orderedEvents": [
+                        "willStart",
+                        "didStart",
+                        "willStop:failure",
+                        "didStop:failure",
+                    ]
+                },
+                "recast": {
+                    "orderedEvents": [
+                        "willStart",
+                        "didStart",
+                        "willStop:controllerReplaced",
+                        "didStop:controllerReplaced",
+                    ]
+                },
+                "replacement": {
+                    "orderedEvents": [
+                        "willStart",
+                        "didStart",
+                        "willStop:controllerReplaced",
+                        "didStop:controllerReplaced",
+                    ]
+                },
+            }
+            self.make_export(
+                root,
+                {
+                    "formatVersion": 1,
+                    "scenario": "native-lifecycle",
+                    "bridgeProbe": True,
+                    "cases": cases,
+                    "orderedEvents": {
+                        name: value["orderedEvents"] for name, value in cases.items()
+                    },
+                    "authoritativeStopReasons": True,
+                    "restoreExactlyOnce": True,
+                    "unsupportedBridgeVisible": True,
+                    "unsupportedBridgeVisibility": "typed-probe-required",
+                    "unsupportedRevisionExercised": False,
+                    "processIsolation": "one-launch-per-transition",
+                },
+                attachment_name="qualification-native-lifecycle.json",
+                test_identifier="PiPNativeLifecycleDeviceUITests/test_nativeLifecyclePublishesAuthoritativeOrderedEvents",
+            )
+            evidence = materialize_evidence.materialize(
+                root,
+                "qualification-native-lifecycle.json",
+                "native-lifecycle",
+                "iphone-current",
+                "a" * 64,
+                "b" * 64,
+            )
+            self.assertEqual(evidence["hardware"], "iphone-current")
+            self.assertTrue(evidence["bridgeProbe"])
+            self.assertEqual(len(evidence["cases"]), 8)
+            self.assertEqual(evidence["cases"]["restore"]["restoreCallbackCount"], 1)
+            self.assertEqual(
+                evidence["orderedEvents"]["failed-start"],
+                ["willStart", "failedToStart"],
+            )
+            self.assertTrue(evidence["authoritativeStopReasons"])
+            self.assertTrue(evidence["restoreExactlyOnce"])
+            self.assertTrue(evidence["unsupportedBridgeVisible"])
+            self.assertFalse(evidence["unsupportedRevisionExercised"])
+
     def test_materializes_accepted_start_delayed_failure_evidence(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -1056,6 +1163,34 @@ class FixtureServerTests(unittest.TestCase):
         self.assertEqual(len(response.read(512)), 512)
         self.assertGreaterEqual(time.monotonic() - started, 0.13)
         connection.close()
+
+    def test_gated_close_terminates_active_and_rejects_new_connections(self):
+        self.server.chunk_delay = 0.01
+        connection, response = self.request("/fault/gated-close/source-loss/sample.bin")
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.read(512), (self.root / "sample.bin").read_bytes()[:512])
+
+        trigger_connection, trigger_response = self.request(
+            "/fault/close-trigger/source-loss"
+        )
+        self.assertEqual(trigger_response.status, 200)
+        self.assertEqual(json.loads(trigger_response.read()), {"generation": 1})
+        trigger_connection.close()
+
+        buffered_after_trigger = response.read()
+        unread_remainder = (self.root / "sample.bin").stat().st_size - 512
+        self.assertLess(
+            len(buffered_after_trigger),
+            unread_remainder,
+        )
+        connection.close()
+
+        rejected_connection, rejected_response = self.request(
+            "/fault/gated-close/source-loss/sample.bin"
+        )
+        self.assertEqual(rejected_response.status, 503)
+        rejected_response.read()
+        rejected_connection.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a physical-device native PiP lifecycle lane for restore, close, failed start, programmatic stop, media end, source failure, recast, and replacement
- capture ordered generation-bound lifecycle events and verify the installed libVLC/AVKit forwarding bridge
- add a deterministic gated-close fixture fault and candidate-bound evidence materialization

## Release-gate behavior
This PR automates the remaining physical acceptance work for #84 but intentionally does not close it. The issue stays open until the exact frozen candidate passes the native-lifecycle row on qualifying hardware.

## Validation
- local-source Release iOS Showcase UI-test build passed for the fully composed qualification stack
- 36 qualification harness tests passed before publication
- SwiftFormat lint, strict SwiftLint, shell syntax, and release-integrity checks passed
- device-only XCTest skips on Simulator and requires the explicit qualification environment gate

## Review policy
Use the repository automatic Codex review once. No repeated review request will be made.