### PR TITLE
Automate terminal outcome qualification

### DIFF
--- a/Showcase/Shared/AccessibilityID.swift
+++ b/Showcase/Shared/AccessibilityID.swift
@@ -296,6 +296,15 @@ enum AccessibilityID {
     static let errorLabel = "pipNativeLifecycle.error"
   }
 
+  enum TerminalOutcomesValidation {
+    static let videoView = "terminalOutcomes.videoView"
+    static let stateLabel = "terminalOutcomes.state"
+    static let actionLabel = "terminalOutcomes.action"
+    static let resultLabel = "terminalOutcomes.result"
+    static let runButton = "terminalOutcomes.run"
+    static let errorLabel = "terminalOutcomes.error"
+  }
+
   enum MatrixHValidation {
     static let stateLabel = "validation.matrixH.state"
     static let currentTimeLabel = "validation.matrixH.currentTime"

--- a/Showcase/Shared/LaunchArguments.swift
+++ b/Showcase/Shared/LaunchArguments.swift
@@ -44,6 +44,12 @@ enum LaunchArguments {
   static let pipNativeLifecycleAction = "-UITestPiPNativeLifecycleAction"
   static let pipNativeLifecycleToken = "-UITestPiPNativeLifecycleToken"
 
+  /// Selects one isolated playback terminal transition. The physical-device
+  /// test launches a fresh process for every action so one terminal generation
+  /// cannot contaminate another case's evidence.
+  static let terminalOutcomeAction = "-UITestTerminalOutcomeAction"
+  static let terminalOutcomeToken = "-UITestTerminalOutcomeToken"
+
   /// Name of a showcase to deep-link to on launch (e.g. `"SimplePlayback"`).
   /// When unset, the showcase opens its normal navigation tree.
   static let route = "-UITestRoute"
@@ -99,6 +105,14 @@ enum LaunchArguments {
 
   static var pipNativeLifecycleTokenValue: String? {
     UserDefaults.standard.string(forKey: key(pipNativeLifecycleToken))
+  }
+
+  static var terminalOutcomeActionValue: String? {
+    UserDefaults.standard.string(forKey: key(terminalOutcomeAction))
+  }
+
+  static var terminalOutcomeTokenValue: String? {
+    UserDefaults.standard.string(forKey: key(terminalOutcomeToken))
   }
 
   static var routeValue: String? {
@@ -185,6 +199,7 @@ enum UITestRoute: String, CaseIterable {
   case pipDismissalValidation = "PiPDismissalValidation"
   case pipInterruptionValidation = "PiPInterruptionValidation"
   case pipNativeLifecycleValidation = "PiPNativeLifecycleValidation"
+  case terminalOutcomesValidation = "TerminalOutcomesValidation"
 
   static var current: UITestRoute? {
     LaunchArguments.routeValue.flatMap(UITestRoute.init(rawValue:))

--- a/Showcase/UITests/iOS/Tests/TerminalOutcomesDeviceUITests.swift
+++ b/Showcase/UITests/iOS/Tests/TerminalOutcomesDeviceUITests.swift
@@ -1,0 +1,195 @@
+import XCTest
+
+/// Candidate-bound proof that every v1.1.0 terminal transition publishes one
+/// generation-scoped, immutable pre-reset payload to independent subscribers.
+final class TerminalOutcomesDeviceUITests: ShowcaseIOSTestCase {
+  private let expectedCauses: [(action: String, cause: String)] = [
+    ("clean-eof", "naturalEnd"),
+    ("explicit-stop", "requestedStop"),
+    ("replacement", "replacement"),
+    ("server-close", "failure:source"),
+    ("malformed", "failure:demux"),
+    ("decode-failure", "failure:decoder"),
+    ("renderer-failure", "failure:renderer"),
+    ("output-failure", "failure:output"),
+    ("network-loss", "failure:source")
+  ]
+
+  func test_terminalOutcomeMatrixIsGenerationScopedAndPreReset() throws {
+    #if targetEnvironment(simulator)
+    throw XCTSkip("Terminal failure attribution requires a physical iOS device")
+    #else
+    guard ProcessInfo.processInfo.environment["SWIFTVLC_TERMINAL_OUTCOMES_DEVICE"] == "YES"
+    else {
+      throw XCTSkip(
+        "Set SWIFTVLC_TERMINAL_OUTCOMES_DEVICE=YES for candidate-bound hardware runs"
+      )
+    }
+
+    addUIInterruptionMonitor(withDescription: "Local network permission") { alert in
+      let allow = alert.buttons["Allow"]
+      guard allow.exists else { return false }
+      allow.tap()
+      return true
+    }
+    let baseLogPath = try XCTUnwrap(
+      launchArgumentValue(for: LaunchArguments.logPath),
+      "Missing qualification log launch argument"
+    )
+
+    var cases: [String: Any] = [:]
+    var finalTimelines: [String: Any] = [:]
+    var failureClassifications: [String: String] = [:]
+    var maximumOutcomeCount = 0
+    var unattributedStopNaturalEndCount = 0
+    for expected in expectedCauses {
+      let evidence = try runAction(expected.action, baseLogPath: baseLogPath)
+      let outcome = try XCTUnwrap(evidence["outcome"] as? [String: Any])
+      let cause = try XCTUnwrap(outcome["cause"] as? String)
+      XCTAssertEqual(cause, expected.cause)
+      XCTAssertEqual(evidence["subscriberPayloadsIdentical"] as? Bool, true)
+      let libraryErrors = try XCTUnwrap(evidence["libraryErrors"] as? [[String: Any]])
+      if expected.cause.hasPrefix("failure:") {
+        XCTAssertFalse(
+          libraryErrors.isEmpty,
+          "Expected failure action \(expected.action) emitted no error-level native diagnostics"
+        )
+      } else {
+        XCTAssertTrue(
+          libraryErrors.isEmpty,
+          "Non-failure action \(expected.action) emitted error-level native diagnostics"
+        )
+      }
+      let count = try XCTUnwrap(evidence["outcomeCountPerSubscriber"] as? Int)
+      XCTAssertEqual(count, 1)
+      maximumOutcomeCount = max(maximumOutcomeCount, count)
+      if cause == "naturalEnd", expected.action != "clean-eof" {
+        unattributedStopNaturalEndCount += 1
+      }
+      if let classification = outcome["failureClassification"] as? String {
+        failureClassifications[classification] = classification
+      }
+      cases[expected.action] = evidence
+      finalTimelines[expected.action] = try XCTUnwrap(
+        outcome["finalTimeline"] as? [String: Any]
+      )
+    }
+
+    let replacement = try XCTUnwrap(cases["replacement"] as? [String: Any])
+    XCTAssertEqual(replacement["generationIsolation"] as? Bool, true)
+    XCTAssertEqual(Set(failureClassifications.keys), [
+      "source", "demux", "decoder", "renderer", "output"
+    ])
+    XCTAssertEqual(maximumOutcomeCount, 1)
+    XCTAssertEqual(unattributedStopNaturalEndCount, 0)
+
+    attachQualificationEvidence(
+      [
+        "formatVersion": 1,
+        "scenario": "terminal-outcomes",
+        "cases": cases,
+        "finalTimelines": finalTimelines,
+        "generationIsolation": true,
+        "failureClassifications": failureClassifications,
+        "maximumTerminalOutcomesPerGeneration": maximumOutcomeCount,
+        "unattributedStopNaturalEndCount": unattributedStopNaturalEndCount,
+        "subscriberPayloadsIdentical": true,
+        "expectedFailureLogsPreserved": true,
+        "processIsolation": "one-launch-per-transition"
+      ],
+      scenario: "terminal-outcomes"
+    )
+    #endif
+  }
+
+  private func runAction(_ action: String, baseLogPath: String) throws -> [String: Any] {
+    app.terminate()
+    replaceLaunchArgument(
+      LaunchArguments.route,
+      with: UITestRoute.terminalOutcomesValidation.rawValue
+    )
+    replaceLaunchArgument(LaunchArguments.terminalOutcomeAction, with: action)
+    replaceLaunchArgument(
+      LaunchArguments.terminalOutcomeToken,
+      with: "terminal-outcome-\(action)-\(UUID().uuidString.lowercased())"
+    )
+    replaceLaunchArgument(
+      LaunchArguments.logPath,
+      with: perCaseLogPath(action, baseLogPath: baseLogPath)
+    )
+    app.launch()
+    app.tap()
+
+    let actionLabel = element(AccessibilityID.TerminalOutcomesValidation.actionLabel)
+    let result = element(AccessibilityID.TerminalOutcomesValidation.resultLabel)
+    let run = app.buttons[AccessibilityID.TerminalOutcomesValidation.runButton]
+    let error = element(AccessibilityID.TerminalOutcomesValidation.errorLabel)
+    waitForLabel(actionLabel, equals: action, timeout: 10)
+    reveal(run)
+    XCTAssertTrue(run.isEnabled)
+    run.tap()
+    waitForPrefix(result, prefix: "pass:", timeout: 120)
+    XCTAssertFalse(error.exists, "Terminal action \(action) failed: \(error.label)")
+    let evidence = try decodeEvidence(result.label)
+    XCTAssertEqual(evidence["action"] as? String, action)
+    return evidence
+  }
+
+  private func decodeEvidence(_ label: String) throws -> [String: Any] {
+    let prefix = "pass:"
+    XCTAssertTrue(label.hasPrefix(prefix))
+    let encoded = String(label.dropFirst(prefix.count))
+    let data = try XCTUnwrap(Data(base64Encoded: encoded))
+    return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+  }
+
+  private func perCaseLogPath(_ action: String, baseLogPath: String) -> String {
+    (baseLogPath as NSString).deletingPathExtension
+      + "-terminal-outcomes-\(action).jsonl"
+  }
+
+  private func element(_ identifier: String) -> XCUIElement {
+    app.descendants(matching: .any)[identifier]
+  }
+
+  private func replaceLaunchArgument(_ name: String, with value: String) {
+    while let index = app.launchArguments.firstIndex(of: name) {
+      app.launchArguments.remove(at: index)
+      if index < app.launchArguments.endIndex {
+        app.launchArguments.remove(at: index)
+      }
+    }
+    app.launchArguments += [name, value]
+  }
+
+  private func launchArgumentValue(for name: String) -> String? {
+    guard
+      let index = app.launchArguments.lastIndex(of: name),
+      app.launchArguments.indices.contains(index + 1)
+    else { return nil }
+    return app.launchArguments[index + 1]
+  }
+
+  private func waitForPrefix(
+    _ element: XCUIElement,
+    prefix: String,
+    timeout: TimeInterval
+  ) {
+    let predicate = NSPredicate { _, _ in
+      element.exists && element.label.hasPrefix(prefix)
+    }
+    let expectation = expectation(for: predicate, evaluatedWith: NSObject())
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [expectation], timeout: timeout),
+      .completed,
+      "Expected prefix \(prefix), got: \(element.label)"
+    )
+  }
+
+  private func reveal(_ element: XCUIElement) {
+    for _ in 0..<10 where !element.isHittable {
+      app.swipeUp()
+    }
+    XCTAssertTrue(element.isHittable)
+  }
+}

--- a/Showcase/iOS/Internal/UITestSupport.swift
+++ b/Showcase/iOS/Internal/UITestSupport.swift
@@ -134,6 +134,7 @@ extension UITestRoute {
     case .pipDismissalValidation: PiPDismissalValidationCase()
     case .pipInterruptionValidation: PiPInterruptionValidationCase()
     case .pipNativeLifecycleValidation: PiPNativeLifecycleValidationCase()
+    case .terminalOutcomesValidation: TerminalOutcomesValidationCase()
     }
   }
 }

--- a/Showcase/iOS/ValidationHarness/TerminalOutcomesValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/TerminalOutcomesValidationCase.swift
@@ -1,0 +1,470 @@
+import Foundation
+import SwiftUI
+@_spi(Qualification) import SwiftVLC
+
+/// Runs one isolated terminal playback transition against the exact candidate.
+/// Two independent subscribers must observe the same immutable pre-reset
+/// payload, and the process remains alive briefly to reject duplicate results.
+struct TerminalOutcomesValidationCase: View {
+  @State private var player: Player
+  @State private var result = "not-run"
+  @State private var playbackError: String?
+  @State private var isRunning = false
+
+  private let action: TerminalAction?
+  private let instance: VLCInstance
+  private let streams: HarnessStreams?
+
+  init() {
+    let selected = LaunchArguments.terminalOutcomeActionValue
+      .flatMap(TerminalAction.init(rawValue:))
+    action = selected
+    let additionalArguments = selected?.instanceArguments ?? []
+    if additionalArguments.isEmpty {
+      instance = .shared
+    } else {
+      let arguments = VLCInstance.defaultArguments + additionalArguments
+      instance = (try? VLCInstance(arguments: arguments)) ?? .shared
+    }
+    _player = State(initialValue: Player(instance: instance))
+    streams = HarnessStreams.load()?.streams
+  }
+
+  var body: some View {
+    _ = player.currentTime
+    return Form {
+      Section {
+        VideoView(player)
+          .frame(height: 220)
+          .listRowInsets(EdgeInsets())
+          .accessibilityIdentifier(AccessibilityID.TerminalOutcomesValidation.videoView)
+      }
+
+      Section("Measured state") {
+        valueRow(
+          "Playback",
+          value: String(describing: player.state),
+          identifier: AccessibilityID.TerminalOutcomesValidation.stateLabel
+        )
+        valueRow(
+          "Action",
+          value: action?.rawValue ?? "invalid",
+          identifier: AccessibilityID.TerminalOutcomesValidation.actionLabel
+        )
+        valueRow(
+          "Qualification",
+          value: result,
+          identifier: AccessibilityID.TerminalOutcomesValidation.resultLabel
+        )
+      }
+
+      Section("Terminal outcome") {
+        Button("Run \(action?.rawValue ?? "invalid")") {
+          Task { await run() }
+        }
+        .accessibilityIdentifier(AccessibilityID.TerminalOutcomesValidation.runButton)
+        .disabled(action == nil || isRunning)
+
+        if let playbackError {
+          Text(playbackError)
+            .foregroundStyle(.red)
+            .accessibilityIdentifier(AccessibilityID.TerminalOutcomesValidation.errorLabel)
+        }
+      }
+    }
+    .showcaseFormStyle()
+    .navigationTitle("Terminal outcomes")
+    .onDisappear { player.stop() }
+  }
+
+  private func run() async {
+    guard let action else { return }
+    isRunning = true
+    result = "running"
+    playbackError = nil
+
+    let recorder = TerminalRecorder()
+    let firstStream = player.terminalOutcomes
+    let secondStream = player.terminalOutcomes
+    let firstSubscriber = Task {
+      for await outcome in firstStream {
+        await recorder.record(outcome, subscriber: 0)
+      }
+    }
+    let secondSubscriber = Task {
+      for await outcome in secondStream {
+        await recorder.record(outcome, subscriber: 1)
+      }
+    }
+    let errors = LibraryErrorRecorder()
+    let logTask = Task {
+      for await entry in instance.logStream(minimumLevel: .error) {
+        await errors.record(entry)
+      }
+    }
+    defer {
+      firstSubscriber.cancel()
+      secondSubscriber.cancel()
+      logTask.cancel()
+      isRunning = false
+    }
+
+    do {
+      // Ensure both async subscriptions and the native log callback are live
+      // before the transition can publish its one-shot terminal payload.
+      try await Task.sleep(for: .milliseconds(150))
+      let execution = try await execute(action)
+      try await waitUntil("Two terminal subscribers did not converge", timeout: .seconds(35)) {
+        await recorder.hasOutcomeFromBothSubscribers
+      }
+      try await Task.sleep(for: .seconds(2))
+
+      let snapshot = await recorder.snapshot
+      guard
+        snapshot.first.count == 1,
+        snapshot.second.count == 1,
+        let first = snapshot.first.first,
+        let second = snapshot.second.first,
+        first == second
+      else {
+        throw TerminalValidationFailure("Terminal subscribers diverged or received duplicates")
+      }
+      guard first.cause.qualificationName == action.expectedCause else {
+        throw TerminalValidationFailure(
+          "Expected \(action.expectedCause), received \(first.cause.qualificationName)"
+        )
+      }
+      guard
+        first.generation.qualificationValue == execution.terminalGeneration,
+        execution.successorPreserved
+      else {
+        throw TerminalValidationFailure(
+          "Terminal outcome escaped its owning generation"
+        )
+      }
+      let errorRecords = await errors.snapshot
+      let evidence = TerminalCaseEvidence(
+        action: action.rawValue,
+        outcome: OutcomeEvidence(first),
+        subscriberPayloadsIdentical: true,
+        outcomeCountPerSubscriber: 1,
+        generationIsolation: true,
+        libraryErrors: errorRecords
+      )
+      result = try "pass:\(JSONEncoder().encode(evidence).base64EncodedString())"
+    } catch is CancellationError {
+      result = "cancelled"
+    } catch {
+      playbackError = String(describing: error)
+      result = "failed"
+      player.stop()
+    }
+  }
+
+  private func execute(_ action: TerminalAction) async throws -> TerminalExecution {
+    switch action {
+    case .cleanEOF:
+      try play(requiredURL(streams?.vod, name: "VOD"))
+      let generation = player.playbackQualificationGeneration.qualificationValue
+      try await waitForPlaying()
+      try await waitUntil("VOD duration did not become available") {
+        (player.duration?.milliseconds ?? 0) > 1500
+      }
+      guard let duration = player.duration else {
+        throw TerminalValidationFailure("VOD duration disappeared")
+      }
+      try player.seek(to: .milliseconds(max(0, duration.milliseconds - 500)))
+      return TerminalExecution(terminalGeneration: generation)
+
+    case .explicitStop:
+      try play(requiredURL(streams?.vod, name: "VOD"))
+      let generation = player.playbackQualificationGeneration.qualificationValue
+      try await waitForPlaying()
+      try await Task.sleep(for: .milliseconds(500))
+      player.stop()
+      return TerminalExecution(terminalGeneration: generation)
+
+    case .replacement:
+      try play(requiredURL(streams?.vod, name: "VOD"))
+      try await waitForPlaying()
+      let outgoing = player.playbackQualificationGeneration.qualificationValue
+      try play(requiredURL(streams?.hlsLive ?? streams?.liveTS, name: "successor stream"))
+      try await waitUntil("Successor generation did not start", timeout: .seconds(20)) {
+        player.playbackQualificationGeneration.qualificationValue > outgoing
+          && player.state == .playing
+      }
+      try await Task.sleep(for: .seconds(1))
+      return TerminalExecution(
+        terminalGeneration: outgoing,
+        successorPreserved: player.playbackQualificationGeneration.qualificationValue > outgoing
+          && player.state == .playing
+      )
+
+    case .serverClose:
+      try play(requiredURL(serverCloseURL, name: "gated server-close stream"))
+      let generation = player.playbackQualificationGeneration.qualificationValue
+      try await waitForPlaying()
+      let (_, response) = try await URLSession.shared.data(
+        from: requiredURL(serverCloseTriggerURL, name: "server-close trigger")
+      )
+      guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+        throw TerminalValidationFailure("Server-close trigger was rejected")
+      }
+      return TerminalExecution(terminalGeneration: generation)
+
+    case .malformed:
+      try play(requiredURL(fileURL("malformed.mp4"), name: "malformed input"))
+      return TerminalExecution(
+        terminalGeneration: player.playbackQualificationGeneration.qualificationValue
+      )
+
+    case .decodeFailure:
+      try play(requiredURL(fileURL("unsupported-codec.mp4"), name: "unsupported codec"))
+      return TerminalExecution(
+        terminalGeneration: player.playbackQualificationGeneration.qualificationValue
+      )
+
+    case .rendererFailure:
+      try play(requiredURL(streams?.vod, name: "renderer VOD"))
+      return TerminalExecution(
+        terminalGeneration: player.playbackQualificationGeneration.qualificationValue
+      )
+
+    case .outputFailure:
+      try play(requiredURL(streams?.audioOnly, name: "audio fixture"))
+      return TerminalExecution(
+        terminalGeneration: player.playbackQualificationGeneration.qualificationValue
+      )
+
+    case .networkLoss:
+      try play(requiredURL(networkLossURL, name: "network-loss stream"))
+      return TerminalExecution(
+        terminalGeneration: player.playbackQualificationGeneration.qualificationValue
+      )
+    }
+  }
+
+  private func play(_ url: URL) throws {
+    try player.play(url: url)
+  }
+
+  private func waitForPlaying() async throws {
+    try await waitUntil("Playback did not start", timeout: .seconds(20)) {
+      player.state == .playing
+    }
+  }
+
+  private func requiredURL(_ url: URL?, name: String) throws -> URL {
+    guard let url else { throw TerminalValidationFailure("Missing \(name)") }
+    return url
+  }
+
+  private var fixtureBaseURL: URL? {
+    guard let vod = streams?.vod else { return nil }
+    var components = URLComponents(url: vod, resolvingAgainstBaseURL: false)
+    components?.path = ""
+    components?.query = nil
+    components?.fragment = nil
+    return components?.url
+  }
+
+  private func fileURL(_ name: String) -> URL? {
+    fixtureBaseURL?.appending(path: "files/\(name)")
+  }
+
+  private var serverCloseURL: URL? {
+    guard let token = LaunchArguments.terminalOutcomeTokenValue else { return nil }
+    return fixtureBaseURL?.appending(path: "fault/gated-close/\(token)/live.ts")
+  }
+
+  private var serverCloseTriggerURL: URL? {
+    guard let token = LaunchArguments.terminalOutcomeTokenValue else { return nil }
+    return fixtureBaseURL?.appending(path: "fault/close-trigger/\(token)")
+  }
+
+  private var networkLossURL: URL? {
+    fixtureBaseURL?.appending(path: "fault/close/32768/live.ts")
+  }
+
+  private func waitUntil(
+    _ failure: String,
+    timeout: Duration = .seconds(15),
+    condition: @escaping @MainActor () async -> Bool
+  )
+    async throws {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
+    while await condition() == false {
+      try Task.checkCancellation()
+      guard clock.now < deadline else { throw TerminalValidationFailure(failure) }
+      try await Task.sleep(for: .milliseconds(50))
+    }
+  }
+
+  private func valueRow(_ title: String, value: String, identifier: String) -> some View {
+    HStack {
+      Text(title)
+      Spacer()
+      Text(value)
+        .foregroundStyle(.secondary)
+        .accessibilityIdentifier(identifier)
+    }
+  }
+}
+
+private enum TerminalAction: String, CaseIterable {
+  case cleanEOF = "clean-eof"
+  case explicitStop = "explicit-stop"
+  case replacement
+  case serverClose = "server-close"
+  case malformed
+  case decodeFailure = "decode-failure"
+  case rendererFailure = "renderer-failure"
+  case outputFailure = "output-failure"
+  case networkLoss = "network-loss"
+
+  var instanceArguments: [String] {
+    switch self {
+    case .rendererFailure:
+      ["--vout=swiftvlc-qualification-missing-vout"]
+    case .outputFailure:
+      ["--aout=swiftvlc-qualification-missing-aout"]
+    default:
+      []
+    }
+  }
+
+  var expectedCause: String {
+    switch self {
+    case .cleanEOF: "naturalEnd"
+    case .explicitStop: "requestedStop"
+    case .replacement: "replacement"
+    case .serverClose, .networkLoss: "failure:source"
+    case .malformed: "failure:demux"
+    case .decodeFailure: "failure:decoder"
+    case .rendererFailure: "failure:renderer"
+    case .outputFailure: "failure:output"
+    }
+  }
+}
+
+private actor TerminalRecorder {
+  private var values: [Int: [PlaybackTerminalOutcome]] = [:]
+
+  func record(_ outcome: PlaybackTerminalOutcome, subscriber: Int) {
+    values[subscriber, default: []].append(outcome)
+  }
+
+  var hasOutcomeFromBothSubscribers: Bool {
+    values[0]?.isEmpty == false && values[1]?.isEmpty == false
+  }
+
+  var snapshot: (first: [PlaybackTerminalOutcome], second: [PlaybackTerminalOutcome]) {
+    (values[0] ?? [], values[1] ?? [])
+  }
+}
+
+private actor LibraryErrorRecorder {
+  private var values: [LibraryErrorEvidence] = []
+
+  func record(_ entry: LogEntry) {
+    values.append(
+      LibraryErrorEvidence(module: entry.module, message: entry.message)
+    )
+  }
+
+  var snapshot: [LibraryErrorEvidence] {
+    values
+  }
+}
+
+private struct TerminalCaseEvidence: Encodable {
+  let action: String
+  let outcome: OutcomeEvidence
+  let subscriberPayloadsIdentical: Bool
+  let outcomeCountPerSubscriber: Int
+  let generationIsolation: Bool
+  let libraryErrors: [LibraryErrorEvidence]
+}
+
+private struct TerminalExecution {
+  let terminalGeneration: UInt64
+  var successorPreserved = true
+}
+
+private struct OutcomeEvidence: Encodable {
+  let generation: UInt64
+  let cause: String
+  let failureClassification: String?
+  let finalTimeline: TimelineEvidence
+
+  init(_ outcome: PlaybackTerminalOutcome) {
+    generation = outcome.generation.qualificationValue
+    cause = outcome.cause.qualificationName
+    failureClassification = outcome.cause.failureQualificationName
+    finalTimeline = TimelineEvidence(outcome.finalTimeline)
+  }
+}
+
+private struct TimelineEvidence: Encodable {
+  let timeMilliseconds: Int64
+  let durationMilliseconds: Int64?
+  let position: Double
+  let bufferFill: Float
+  let activeVideoOutputs: Int
+
+  init(_ timeline: PlaybackFinalTimeline) {
+    timeMilliseconds = timeline.time.milliseconds
+    durationMilliseconds = timeline.duration?.milliseconds
+    position = timeline.position
+    bufferFill = timeline.bufferFill
+    activeVideoOutputs = timeline.activeVideoOutputs
+  }
+}
+
+private struct LibraryErrorEvidence: Encodable {
+  let module: String?
+  let message: String
+}
+
+private struct TerminalValidationFailure: Error, CustomStringConvertible {
+  let description: String
+
+  init(_ description: String) {
+    self.description = description
+  }
+}
+
+extension PlaybackTerminalCause {
+  fileprivate var qualificationName: String {
+    switch self {
+    case .naturalEnd: "naturalEnd"
+    case .requestedStop: "requestedStop"
+    case .replacement: "replacement"
+    case .cancellation: "cancellation"
+    case .failure(let failure): "failure:\(failure.qualificationName)"
+    case .unknownNativeStop: "unknownNativeStop"
+    }
+  }
+
+  fileprivate var failureQualificationName: String? {
+    if case .failure(let failure) = self {
+      failure.qualificationName
+    } else {
+      nil
+    }
+  }
+}
+
+extension PlaybackFailureKind {
+  fileprivate var qualificationName: String {
+    switch self {
+    case .source: "source"
+    case .demux: "demux"
+    case .decoder: "decoder"
+    case .renderer: "renderer"
+    case .output: "output"
+    case .unknown: "unknown"
+    }
+  }
+}

--- a/Showcase/macOS/Internal/MacShowcaseRootView.swift
+++ b/Showcase/macOS/Internal/MacShowcaseRootView.swift
@@ -414,7 +414,8 @@ extension MacShowcase {
          .pipLongStallValidation,
          .pipDismissalValidation,
          .pipInterruptionValidation,
-         .pipNativeLifecycleValidation:
+         .pipNativeLifecycleValidation,
+         .terminalOutcomesValidation:
       return nil
     }
   }

--- a/Showcase/tvOS/Internal/TVShowcaseRootView.swift
+++ b/Showcase/tvOS/Internal/TVShowcaseRootView.swift
@@ -522,7 +522,8 @@ extension TVShowcase {
          .pipLongStallValidation,
          .pipDismissalValidation,
          .pipInterruptionValidation,
-         .pipNativeLifecycleValidation:
+         .pipNativeLifecycleValidation,
+         .terminalOutcomesValidation:
       return nil
     }
   }

--- a/scripts/qualification/generate-fixtures.sh
+++ b/scripts/qualification/generate-fixtures.sh
@@ -64,6 +64,17 @@ for segment in "$fixture_tmp"/vod-*.ts; do
   mv "$segment" "$OUTPUT_DIR/hls/$(basename "$segment")"
 done
 
+python3 - "$OUTPUT_DIR/vod.mp4" "$OUTPUT_DIR/unsupported-codec.mp4" <<'PY'
+import sys
+from pathlib import Path
+
+source, output = map(Path, sys.argv[1:])
+payload = source.read_bytes()
+if b"avc1" not in payload:
+    raise SystemExit("generated VOD has no avc1 sample entry to invalidate")
+output.write_bytes(payload.replace(b"avc1", b"zzzz"))
+PY
+
 python3 - "$OUTPUT_DIR" "$DURATION_SECONDS" "$LIVE_DURATION_SECONDS" <<'PY'
 import hashlib
 import json
@@ -76,6 +87,7 @@ live_duration = int(sys.argv[3])
 vod = (root / "vod.mp4").read_bytes()
 (root / "truncated.mp4").write_bytes(vod[: max(1, len(vod) // 3)])
 (root / "malformed.bin").write_bytes(b"not-a-media-container\x00" * 256)
+(root / "malformed.mp4").write_bytes(b"not-a-media-container\x00" * 256)
 
 files = {}
 for path in sorted(root.rglob("*")):

--- a/scripts/qualification/matrix.json
+++ b/scripts/qualification/matrix.json
@@ -230,7 +230,7 @@
       "id": "terminal-outcomes",
       "issues": [85],
       "hardware": ["iphone-current"],
-      "summary": "EOF, stop, replacement, server close, malformed input, decode, renderer, and network failures produce one generation-scoped terminal outcome",
+      "summary": "EOF, stop, replacement, server close, malformed input, decode, renderer, output, and network failures produce one generation-scoped terminal outcome",
       "requiredEvidenceFields": [
         "cases",
         "finalTimelines",
@@ -241,7 +241,10 @@
         "failureClassifications.renderer",
         "failureClassifications.output",
         "maximumTerminalOutcomesPerGeneration",
-        "unattributedStopNaturalEndCount"
+        "unattributedStopNaturalEndCount",
+        "subscriberPayloadsIdentical",
+        "expectedFailureLogsPreserved",
+        "processIsolation"
       ],
       "expectedEvidenceValues": {
         "generationIsolation": true,
@@ -251,7 +254,10 @@
         "failureClassifications.renderer": "renderer",
         "failureClassifications.output": "output",
         "maximumTerminalOutcomesPerGeneration": 1,
-        "unattributedStopNaturalEndCount": 0
+        "unattributedStopNaturalEndCount": 0,
+        "subscriberPayloadsIdentical": true,
+        "expectedFailureLogsPreserved": true,
+        "processIsolation": "one-launch-per-transition"
       }
     },
     {

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -113,7 +113,7 @@ DEVICE_ECID=$(jq -r '.selected.ecidHex' "$OUTPUT_DIR/device.json")
 RUN_MODE=$(jq -r '.mode' "$OUTPUT_DIR/device.json")
 echo "Selected $(jq -r '.selected.marketingName' "$OUTPUT_DIR/device.json") on $(jq -r '.selected.osVersion' "$OUTPUT_DIR/device.json") ($RUN_MODE)."
 
-if [[ ! -f "$FIXTURES/manifest.json" ]]; then
+if [[ ! -f "$FIXTURES/manifest.json" || ! -f "$FIXTURES/unsupported-codec.mp4" ]]; then
   "$SCRIPT_DIR/generate-fixtures.sh" "$FIXTURES"
 fi
 python3 "$SCRIPT_DIR/verify-fixtures.py" "$FIXTURES" > /dev/null
@@ -237,6 +237,7 @@ python3 "$SCRIPT_DIR/prepare-xctestrun.py" "$XCTESTRUN" "$DESTINATION_XCTESTRUN"
   --environment SWIFTVLC_PIP_DISMISSAL_DEVICE=YES \
   --environment SWIFTVLC_PIP_INTERRUPTION_DEVICE=YES \
   --environment SWIFTVLC_PIP_NATIVE_LIFECYCLE_DEVICE=YES \
+  --environment SWIFTVLC_TERMINAL_OUTCOMES_DEVICE=YES \
   --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
   --environment SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE=YES \
   --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
@@ -290,7 +291,7 @@ xcrun devicectl device copy to \
   --destination Documents/streams.local.json \
   > "$OUTPUT_DIR/stage-streams.log"
 
-DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence vod-controls long-stall failed-start dismissal interruptions native-lifecycle deferred-pause-rejection accepted-start-delayed-failure hls-seek)
+DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence vod-controls long-stall failed-start dismissal interruptions native-lifecycle terminal-outcomes deferred-pause-rejection accepted-start-delayed-failure hls-seek)
 SCENARIOS_WERE_EXPLICIT=false
 if [[ ${#ONLY_SCENARIOS[@]} -eq 0 ]]; then
   ONLY_SCENARIOS=("${DEFAULT_SCENARIOS[@]}")
@@ -299,7 +300,7 @@ else
 fi
 for scenario in "${ONLY_SCENARIOS[@]}"; do
   case "$scenario" in
-    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|vod-controls|long-stall|failed-start|dismissal|interruptions|native-lifecycle|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
+    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|vod-controls|long-stall|failed-start|dismissal|interruptions|native-lifecycle|terminal-outcomes|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
     *) echo "Error: unknown scenario: $scenario" >&2; exit 2 ;;
   esac
 done
@@ -314,7 +315,7 @@ device_matches_hardware_row() {
 if ! device_matches_hardware_row "iphone-current"; then
   if [[ "$SCENARIOS_WERE_EXPLICIT" == true ]]; then
     for scenario in "${ONLY_SCENARIOS[@]}"; do
-      if [[ "$scenario" == "capability-convergence" || "$scenario" == "native-lifecycle" || "$scenario" == "deferred-pause-rejection" || "$scenario" == "accepted-start-delayed-failure" ]]; then
+      if [[ "$scenario" == "capability-convergence" || "$scenario" == "native-lifecycle" || "$scenario" == "terminal-outcomes" || "$scenario" == "deferred-pause-rejection" || "$scenario" == "accepted-start-delayed-failure" ]]; then
         echo "Error: $scenario requires the iphone-current hardware row." >&2
         exit 2
       fi
@@ -322,7 +323,7 @@ if ! device_matches_hardware_row "iphone-current"; then
   else
     FILTERED_SCENARIOS=()
     for scenario in "${ONLY_SCENARIOS[@]}"; do
-      if [[ "$scenario" != "capability-convergence" && "$scenario" != "native-lifecycle" && "$scenario" != "deferred-pause-rejection" && "$scenario" != "accepted-start-delayed-failure" ]]; then
+      if [[ "$scenario" != "capability-convergence" && "$scenario" != "native-lifecycle" && "$scenario" != "terminal-outcomes" && "$scenario" != "deferred-pause-rejection" && "$scenario" != "accepted-start-delayed-failure" ]]; then
         FILTERED_SCENARIOS+=("$scenario")
       fi
     done
@@ -448,6 +449,13 @@ run_scenario() {
       route="PiPNativeLifecycleValidation"
       selected_xctestrun="$DESTINATION_XCTESTRUN"
       ;;
+    terminal-outcomes)
+      test_identifiers=(
+        "iOSUITests/TerminalOutcomesDeviceUITests/test_terminalOutcomeMatrixIsGenerationScopedAndPreReset"
+      )
+      route="TerminalOutcomesValidation"
+      selected_xctestrun="$DESTINATION_XCTESTRUN"
+      ;;
     deferred-pause-rejection)
       test_identifiers=(
         "iOSUITests/PiPDeferredPauseDeviceUITests/test_deferredPauseRejectionAndCancellationStayTruthful"
@@ -508,6 +516,7 @@ run_scenario() {
       --environment SWIFTVLC_PIP_DISMISSAL_DEVICE=YES \
       --environment SWIFTVLC_PIP_INTERRUPTION_DEVICE=YES \
       --environment SWIFTVLC_PIP_NATIVE_LIFECYCLE_DEVICE=YES \
+      --environment SWIFTVLC_TERMINAL_OUTCOMES_DEVICE=YES \
       --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
       --environment SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE=YES \
       --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
@@ -540,20 +549,33 @@ run_scenario() {
       -skip-testing:iOSUITests/PiPDismissalDeviceUITests
       -skip-testing:iOSUITests/PiPInterruptionDeviceUITests
       -skip-testing:iOSUITests/PiPNativeLifecycleDeviceUITests
+      -skip-testing:iOSUITests/TerminalOutcomesDeviceUITests
       -skip-testing:iOSUITests/PiPDeferredPauseDeviceUITests
       -skip-testing:iOSUITests/PiPDelayedStartFailureDeviceUITests
       -skip-testing:iOSUITests/PiPOverlayDeviceUITests
     )
   fi
+
   started=$(date +%s)
-  local attempt attempt_log attempt_bundle retryable_pattern
+  local attempt attempt_log attempt_bundle attempt_xctestrun final_log_prefix retryable_pattern
+  final_log_prefix="$run_id-$scenario"
   retryable_pattern='LaunchServicesDataMismatch|LaunchServices GUID and sequence number do not match|Early unexpected exit, operation never finished bootstrapping|signal kill before establishing connection|Failed to resume target process|process may have already terminated|reason: Busy|is installing or uninstalling'
   for attempt in 1 2 3; do
     attempt_log="$OUTPUT_DIR/$scenario-xcodebuild-attempt$attempt.log"
     attempt_bundle="$OUTPUT_DIR/$scenario-attempt$attempt.xcresult"
+    attempt_xctestrun="$selected_xctestrun"
+    if [[ "$scenario" != "analyzer" ]]; then
+      final_log_prefix="$run_id-$scenario-attempt$attempt"
+      attempt_xctestrun="$WORK_DIR/destination-$scenario-attempt$attempt.xctestrun"
+      python3 "$SCRIPT_DIR/prepare-xctestrun.py" \
+        "$selected_xctestrun" "$attempt_xctestrun" \
+        --environment SWIFTVLC_DEVICE_LOG_PREFIX="$final_log_prefix"
+      cp "$attempt_xctestrun" \
+        "$OUTPUT_DIR/destination-$scenario-attempt$attempt.xctestrun"
+    fi
     set +e
     xcodebuild test-without-building \
-      -xctestrun "$selected_xctestrun" \
+      -xctestrun "$attempt_xctestrun" \
       -destination "platform=iOS,id=$DEVICE_UDID" \
       -collect-test-diagnostics never \
       "${test_selection_args[@]}" \
@@ -592,7 +614,7 @@ run_scenario() {
     set -e
     if [[ "$pull_status" -eq 0 ]]; then
       set +e
-      error_count=$(python3 - "$document_capture" "$run_id-$scenario" <<'PY'
+      error_count=$(python3 - "$document_capture" "$final_log_prefix" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -638,7 +660,7 @@ PY
     set -e
     if [[ "$pull_status" -eq 0 ]]; then
       set +e
-      error_count=$(python3 - "$document_capture" "$run_id-$scenario" <<'PY'
+      error_count=$(python3 - "$document_capture" "$final_log_prefix" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -670,6 +692,15 @@ PY
     else
       log_status="missing"
     fi
+  fi
+
+  # This scenario deliberately drives six terminal engine failures. Preserve
+  # their raw error-level logs and report the count, but let the typed outcome
+  # assertions decide whether they are the expected failures. Every other
+  # scenario retains the strict zero-error gate.
+  local log_errors_acceptable=false
+  if [[ "$error_count" -eq 0 || "$scenario" == "terminal-outcomes" ]]; then
+    log_errors_acceptable=true
   fi
 
   local qualification_scenarios=()
@@ -729,6 +760,10 @@ PY
       qualification_scenarios=("native-lifecycle")
       qualification_attachments=("qualification-native-lifecycle.json")
       ;;
+    terminal-outcomes)
+      qualification_scenarios=("terminal-outcomes")
+      qualification_attachments=("qualification-terminal-outcomes.json")
+      ;;
     deferred-pause-rejection)
       qualification_scenarios=("deferred-pause-rejection")
       qualification_attachments=("qualification-deferred-pause-rejection.json")
@@ -740,7 +775,7 @@ PY
   esac
   if [[ ${#qualification_scenarios[@]} -gt 0 ]]; then
     evidence_status="missing"
-    if [[ "$test_status" -eq 0 ]] && [[ "$error_count" -eq 0 ]] \
+    if [[ "$test_status" -eq 0 ]] && [[ "$log_errors_acceptable" == true ]] \
       && [[ "$log_status" == "captured" ]] && [[ -d "$result_bundle" ]]; then
       local attachments="$OUTPUT_DIR/$scenario-attachments"
       local hardware_id evidence_file evidence_relative export_status materialize_status
@@ -820,7 +855,7 @@ PY
   fi
 
   result="pass"
-  if [[ "$test_status" -ne 0 ]] || [[ "$error_count" -ne 0 ]] || [[ "$log_status" == "missing" ]] \
+  if [[ "$test_status" -ne 0 ]] || [[ "$log_errors_acceptable" != true ]] || [[ "$log_status" == "missing" ]] \
     || [[ "$evidence_status" == "missing" ]]; then
     result="fail"
   fi

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -738,6 +738,72 @@ class QualificationEvidenceTests(unittest.TestCase):
             self.assertTrue(evidence["unsupportedBridgeVisible"])
             self.assertFalse(evidence["unsupportedRevisionExercised"])
 
+    def test_materializes_terminal_outcome_evidence(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            failure_classifications = {
+                "source": "source",
+                "demux": "demux",
+                "decoder": "decoder",
+                "renderer": "renderer",
+                "output": "output",
+            }
+            cases = {
+                "clean-eof": {"cause": "naturalEnd"},
+                "explicit-stop": {"cause": "requestedStop"},
+                "replacement": {"cause": "replacement"},
+                "server-close": {"cause": "failure:source"},
+                "malformed": {"cause": "failure:demux"},
+                "decode-failure": {"cause": "failure:decoder"},
+                "renderer-failure": {"cause": "failure:renderer"},
+                "output-failure": {"cause": "failure:output"},
+                "network-loss": {"cause": "failure:source"},
+            }
+            final_timelines = {
+                name: {
+                    "timeMilliseconds": index * 100,
+                    "durationMilliseconds": 60000,
+                    "position": index / 10,
+                    "bufferFill": 1,
+                    "activeVideoOutputs": 1,
+                }
+                for index, name in enumerate(cases)
+            }
+            self.make_export(
+                root,
+                {
+                    "formatVersion": 1,
+                    "scenario": "terminal-outcomes",
+                    "cases": cases,
+                    "finalTimelines": final_timelines,
+                    "generationIsolation": True,
+                    "failureClassifications": failure_classifications,
+                    "maximumTerminalOutcomesPerGeneration": 1,
+                    "unattributedStopNaturalEndCount": 0,
+                    "subscriberPayloadsIdentical": True,
+                    "expectedFailureLogsPreserved": True,
+                    "processIsolation": "one-launch-per-transition",
+                },
+                attachment_name="qualification-terminal-outcomes.json",
+                test_identifier="TerminalOutcomesDeviceUITests/test_terminalOutcomeMatrixIsGenerationScopedAndPreReset",
+            )
+            evidence = materialize_evidence.materialize(
+                root,
+                "qualification-terminal-outcomes.json",
+                "terminal-outcomes",
+                "iphone-current",
+                "a" * 64,
+                "b" * 64,
+            )
+            self.assertEqual(evidence["hardware"], "iphone-current")
+            self.assertEqual(len(evidence["cases"]), 9)
+            self.assertEqual(len(evidence["finalTimelines"]), 9)
+            self.assertTrue(evidence["generationIsolation"])
+            self.assertEqual(evidence["failureClassifications"], failure_classifications)
+            self.assertEqual(evidence["maximumTerminalOutcomesPerGeneration"], 1)
+            self.assertEqual(evidence["unattributedStopNaturalEndCount"], 0)
+            self.assertTrue(evidence["subscriberPayloadsIdentical"])
+
     def test_materializes_accepted_start_delayed_failure_evidence(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -1191,6 +1257,16 @@ class FixtureServerTests(unittest.TestCase):
         self.assertEqual(rejected_response.status, 503)
         rejected_response.read()
         rejected_connection.close()
+
+        retry_connection, retry_response = self.request(
+            "/fault/gated-close/source-loss-retry/sample.bin"
+        )
+        self.assertEqual(retry_response.status, 200)
+        self.assertEqual(
+            retry_response.read(512),
+            (self.root / "sample.bin").read_bytes()[:512],
+        )
+        retry_connection.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- adds a physical-device qualification scenario for nine isolated terminal transitions
- proves one immutable, generation-bound outcome per subscriber and preserves the replacement successor generation
- classifies source, demux, decoder, renderer, and output failures while retaining their native error diagnostics
- extends the fixture server and runner with candidate-bound evidence export and retry-safe process isolation
- handles the iOS-only validation route explicitly on macOS and tvOS

## Validation

- composed iOS Release build-for-testing
- composed macOS and tvOS Showcase builds
- strict SwiftFormat and SwiftLint
- 46 Python qualification harness tests

Physical execution remains intentionally gated until a candidate-bound device run.