### PR TITLE
Automate adaptive HLS soak qualification

### DIFF
--- a/Showcase/Shared/AccessibilityID.swift
+++ b/Showcase/Shared/AccessibilityID.swift
@@ -305,6 +305,16 @@ enum AccessibilityID {
     static let errorLabel = "terminalOutcomes.error"
   }
 
+  enum AdaptiveHLSSoakValidation {
+    static let videoView = "adaptiveHLSSoak.videoView"
+    static let stateLabel = "adaptiveHLSSoak.state"
+    static let progressLabel = "adaptiveHLSSoak.progress"
+    static let phaseLabel = "adaptiveHLSSoak.phase"
+    static let resultLabel = "adaptiveHLSSoak.result"
+    static let runButton = "adaptiveHLSSoak.run"
+    static let errorLabel = "adaptiveHLSSoak.error"
+  }
+
   enum MatrixHValidation {
     static let stateLabel = "validation.matrixH.state"
     static let currentTimeLabel = "validation.matrixH.currentTime"

--- a/Showcase/Shared/LaunchArguments.swift
+++ b/Showcase/Shared/LaunchArguments.swift
@@ -50,6 +50,12 @@ enum LaunchArguments {
   static let terminalOutcomeAction = "-UITestTerminalOutcomeAction"
   static let terminalOutcomeToken = "-UITestTerminalOutcomeToken"
 
+  /// Duration and server namespace for the candidate-bound adaptive HLS soak.
+  /// The physical runner supplies 7,200 seconds; shorter values are useful
+  /// only while developing the harness and cannot satisfy the matrix gate.
+  static let adaptiveSoakDuration = "-UITestAdaptiveSoakDuration"
+  static let adaptiveSoakToken = "-UITestAdaptiveSoakToken"
+
   /// Name of a showcase to deep-link to on launch (e.g. `"SimplePlayback"`).
   /// When unset, the showcase opens its normal navigation tree.
   static let route = "-UITestRoute"
@@ -113,6 +119,14 @@ enum LaunchArguments {
 
   static var terminalOutcomeTokenValue: String? {
     UserDefaults.standard.string(forKey: key(terminalOutcomeToken))
+  }
+
+  static var adaptiveSoakDurationValue: Int? {
+    UserDefaults.standard.string(forKey: key(adaptiveSoakDuration)).flatMap(Int.init)
+  }
+
+  static var adaptiveSoakTokenValue: String? {
+    UserDefaults.standard.string(forKey: key(adaptiveSoakToken))
   }
 
   static var routeValue: String? {
@@ -200,6 +214,7 @@ enum UITestRoute: String, CaseIterable {
   case pipInterruptionValidation = "PiPInterruptionValidation"
   case pipNativeLifecycleValidation = "PiPNativeLifecycleValidation"
   case terminalOutcomesValidation = "TerminalOutcomesValidation"
+  case adaptiveHLSSoakValidation = "AdaptiveHLSSoakValidation"
 
   static var current: UITestRoute? {
     LaunchArguments.routeValue.flatMap(UITestRoute.init(rawValue:))

--- a/Showcase/UITests/iOS/Tests/AdaptiveHLSSoakDeviceUITests.swift
+++ b/Showcase/UITests/iOS/Tests/AdaptiveHLSSoakDeviceUITests.swift
@@ -1,0 +1,110 @@
+import XCTest
+
+/// Candidate-bound, unattended proof for the two-hour adaptive HLS matrix row.
+/// The app performs the long-running measurements while this test verifies and
+/// attaches its evidence for host-side artifact/device identity binding.
+final class AdaptiveHLSSoakDeviceUITests: ShowcaseIOSTestCase {
+  func test_adaptiveHLSMatrixSoakRemainsBounded() throws {
+    #if targetEnvironment(simulator)
+    throw XCTSkip("The adaptive HLS soak qualifies only a physical iPhone")
+    #else
+    guard ProcessInfo.processInfo.environment["SWIFTVLC_ADAPTIVE_HLS_SOAK_DEVICE"] == "YES"
+    else {
+      throw XCTSkip(
+        "Set SWIFTVLC_ADAPTIVE_HLS_SOAK_DEVICE=YES for candidate-bound hardware runs"
+      )
+    }
+
+    addUIInterruptionMonitor(withDescription: "Local network permission") { alert in
+      let allow = alert.buttons["Allow"]
+      guard allow.exists else { return false }
+      allow.tap()
+      return true
+    }
+
+    let duration = max(
+      1,
+      Int(ProcessInfo.processInfo.environment["SWIFTVLC_ADAPTIVE_SOAK_SECONDS"] ?? "7200")
+        ?? 7200
+    )
+    let token = ProcessInfo.processInfo.environment["SWIFTVLC_ADAPTIVE_SOAK_TOKEN"]
+      ?? "adaptive-\(UUID().uuidString.lowercased())"
+    app.launchArguments += [
+      LaunchArguments.route, UITestRoute.adaptiveHLSSoakValidation.rawValue,
+      LaunchArguments.adaptiveSoakDuration, String(duration),
+      LaunchArguments.adaptiveSoakToken, token
+    ]
+    app.launch()
+    app.tap()
+
+    let result = element(AccessibilityID.AdaptiveHLSSoakValidation.resultLabel)
+    let run = app.buttons[AccessibilityID.AdaptiveHLSSoakValidation.runButton]
+    let error = element(AccessibilityID.AdaptiveHLSSoakValidation.errorLabel)
+    reveal(run)
+    XCTAssertTrue(run.isEnabled)
+    run.tap()
+    waitForPrefix(result, prefix: "pass:", timeout: TimeInterval(duration + 300))
+    XCTAssertFalse(error.exists, "Adaptive soak failed: \(error.label)")
+
+    let evidence = try decodeEvidence(result.label)
+    XCTAssertGreaterThanOrEqual(try XCTUnwrap(evidence["durationSeconds"] as? Int), duration)
+    let coverage = try XCTUnwrap(evidence["playlistCoverage"] as? [String: Any])
+    XCTAssertEqual(try Set(XCTUnwrap(coverage["playlistTypes"] as? [String])), ["vod", "event", "live"])
+    XCTAssertEqual(try Set(XCTUnwrap(coverage["containers"] as? [String])), ["ts", "fmp4"])
+    XCTAssertEqual(try Set(XCTUnwrap(coverage["variants"] as? [String])), ["low", "high"])
+    XCTAssertGreaterThan(try XCTUnwrap(coverage["variantTransitions"] as? Int), 0)
+    XCTAssertGreaterThan(try XCTUnwrap(coverage["discontinuityManifests"] as? Int), 0)
+    XCTAssertGreaterThan(try XCTUnwrap(coverage["expiredWindows"] as? Int), 0)
+    XCTAssertGreaterThan(try XCTUnwrap(coverage["retryFailures"] as? Int), 0)
+    XCTAssertGreaterThan(try XCTUnwrap(coverage["retryRecoveries"] as? Int), 0)
+    XCTAssertGreaterThan(try XCTUnwrap(coverage["cancellations"] as? Int), 0)
+    XCTAssertFalse(try XCTUnwrap(evidence["memorySeries"] as? [[String: Any]]).isEmpty)
+    XCTAssertNotNil(evidence["allocationProvenance"] as? [String: Any])
+    XCTAssertEqual(evidence["sanitizerFindings"] as? Int, 0)
+    XCTAssertEqual(evidence["crashes"] as? Int, 0)
+    XCTAssertEqual(evidence["unboundedRecoveries"] as? Int, 0)
+    XCTAssertEqual(evidence["monotonicGrowth"] as? Bool, false)
+    XCTAssertEqual(
+      evidence["upstreamCrossLink"] as? String,
+      "https://code.videolan.org/videolan/vlc/-/work_items/29845"
+    )
+
+    attachQualificationEvidence(evidence, scenario: "adaptive-hls-soak")
+    #endif
+  }
+
+  private func decodeEvidence(_ label: String) throws -> [String: Any] {
+    let prefix = "pass:"
+    XCTAssertTrue(label.hasPrefix(prefix))
+    let encoded = String(label.dropFirst(prefix.count))
+    let data = try XCTUnwrap(Data(base64Encoded: encoded))
+    return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+  }
+
+  private func element(_ identifier: String) -> XCUIElement {
+    app.descendants(matching: .any)[identifier]
+  }
+
+  private func waitForPrefix(
+    _ element: XCUIElement,
+    prefix: String,
+    timeout: TimeInterval
+  ) {
+    let predicate = NSPredicate { _, _ in
+      element.exists && element.label.hasPrefix(prefix)
+    }
+    let expectation = expectation(for: predicate, evaluatedWith: NSObject())
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [expectation], timeout: timeout),
+      .completed,
+      "Expected prefix \(prefix), got: \(element.label)"
+    )
+  }
+
+  private func reveal(_ element: XCUIElement) {
+    for _ in 0..<10 where !element.isHittable {
+      app.swipeUp()
+    }
+    XCTAssertTrue(element.isHittable)
+  }
+}

--- a/Showcase/iOS/Internal/UITestSupport.swift
+++ b/Showcase/iOS/Internal/UITestSupport.swift
@@ -135,6 +135,7 @@ extension UITestRoute {
     case .pipInterruptionValidation: PiPInterruptionValidationCase()
     case .pipNativeLifecycleValidation: PiPNativeLifecycleValidationCase()
     case .terminalOutcomesValidation: TerminalOutcomesValidationCase()
+    case .adaptiveHLSSoakValidation: AdaptiveHLSSoakValidationCase()
     }
   }
 }

--- a/Showcase/iOS/ValidationHarness/AdaptiveHLSSoakValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/AdaptiveHLSSoakValidationCase.swift
@@ -1,0 +1,545 @@
+import Darwin
+import Foundation
+import SwiftUI
+import SwiftVLC
+
+/// Runs the exact candidate against a deterministic, telemetry-bearing HLS
+/// origin. The default physical lane lasts two hours; shorter runs are useful
+/// for harness development but are rejected later by the qualification matrix.
+struct AdaptiveHLSSoakValidationCase: View {
+  @State private var player = Player()
+  @State private var result = "not-run"
+  @State private var progress = "0s"
+  @State private var phase = "idle"
+  @State private var playbackError: String?
+  @State private var isRunning = false
+
+  private let durationSeconds = max(1, LaunchArguments.adaptiveSoakDurationValue ?? 7200)
+  private let token = LaunchArguments.adaptiveSoakTokenValue ?? "missing-token"
+  private let streams = HarnessStreams.load()?.streams
+
+  var body: some View {
+    _ = player.currentTime
+    return Form {
+      Section {
+        VideoView(player)
+          .frame(height: 220)
+          .listRowInsets(EdgeInsets())
+          .accessibilityIdentifier(AccessibilityID.AdaptiveHLSSoakValidation.videoView)
+      }
+
+      Section("Measured state") {
+        valueRow(
+          "Playback",
+          value: String(describing: player.state),
+          identifier: AccessibilityID.AdaptiveHLSSoakValidation.stateLabel
+        )
+        valueRow(
+          "Elapsed",
+          value: progress,
+          identifier: AccessibilityID.AdaptiveHLSSoakValidation.progressLabel
+        )
+        valueRow(
+          "Phase",
+          value: phase,
+          identifier: AccessibilityID.AdaptiveHLSSoakValidation.phaseLabel
+        )
+        valueRow(
+          "Qualification",
+          value: result,
+          identifier: AccessibilityID.AdaptiveHLSSoakValidation.resultLabel
+        )
+      }
+
+      Section("Adaptive HLS soak") {
+        Button("Run " + String(durationSeconds) + "-second soak") {
+          Task { await run() }
+        }
+        .accessibilityIdentifier(AccessibilityID.AdaptiveHLSSoakValidation.runButton)
+        .disabled(isRunning || fixtureBaseURL == nil || token == "missing-token")
+
+        if let playbackError {
+          Text(playbackError)
+            .foregroundStyle(.red)
+            .accessibilityIdentifier(AccessibilityID.AdaptiveHLSSoakValidation.errorLabel)
+        }
+      }
+    }
+    .showcaseFormStyle()
+    .navigationTitle("Adaptive HLS soak")
+    .onDisappear { player.stop() }
+  }
+
+  private func run() async {
+    guard fixtureBaseURL != nil, token != "missing-token" else { return }
+    isRunning = true
+    playbackError = nil
+    result = "running"
+
+    let started = ProcessInfo.processInfo.systemUptime
+    var memorySeries: [AdaptiveMemorySample] = []
+    var cancellationCount = 0
+    let errorRecorder = AdaptiveErrorRecorder()
+    let logTask = Task {
+      for await entry in VLCInstance.shared.logStream(minimumLevel: .error) {
+        await errorRecorder.record(entry)
+      }
+    }
+    defer {
+      logTask.cancel()
+      player.stop()
+      isRunning = false
+    }
+
+    do {
+      let modes = [
+        "abr-low-ts",
+        "abr-high-fmp4",
+        "vod-ts",
+        "event-fmp4",
+        "live-ts",
+        "live-fmp4",
+        "retry-ts",
+        "abr-ts"
+      ]
+      let perPhase = max(4, min(45, durationSeconds / modes.count))
+      var phaseIndex = 0
+      var nextMemorySample = 0
+
+      while Int(ProcessInfo.processInfo.systemUptime - started) < durationSeconds {
+        let mode = modes[phaseIndex % modes.count]
+        phaseIndex += 1
+        phase = mode
+        if phaseIndex > 1 {
+          player.stop()
+          cancellationCount += 1
+          try await Task.sleep(for: .milliseconds(200))
+        }
+        try player.play(url: masterURL(mode: mode))
+        do {
+          try await waitUntil("Playback did not start for " + mode, timeout: .seconds(30)) {
+            player.state == .playing
+          }
+        } catch {
+          throw error
+        }
+
+        let phaseDeadline = min(
+          started + Double(durationSeconds),
+          ProcessInfo.processInfo.systemUptime + Double(perPhase)
+        )
+        var inactiveSince: TimeInterval?
+        while ProcessInfo.processInfo.systemUptime < phaseDeadline {
+          try Task.checkCancellation()
+          let elapsed = Int(ProcessInfo.processInfo.systemUptime - started)
+          progress = "\(elapsed)s / \(durationSeconds)s"
+          if elapsed >= nextMemorySample {
+            memorySeries.append(Self.memorySample(elapsedSeconds: elapsed, player: player))
+            nextMemorySample = elapsed + 30
+          }
+
+          if player.state == .playing {
+            inactiveSince = nil
+          } else {
+            inactiveSince = inactiveSince ?? ProcessInfo.processInfo.systemUptime
+            if ProcessInfo.processInfo.systemUptime - (inactiveSince ?? 0) > 20 {
+              throw AdaptiveSoakFailure("Playback failed to recover in " + mode)
+            }
+          }
+          try await Task.sleep(for: .seconds(2))
+        }
+      }
+
+      memorySeries.append(
+        Self.memorySample(elapsedSeconds: durationSeconds, player: player)
+      )
+      let metrics = try await serverMetrics()
+      let coverage = try AdaptivePlaylistCoverage(metrics: metrics, cancellations: cancellationCount)
+      let analysis = try Self.analyze(memorySeries)
+      let logs = await errorRecorder.snapshot
+      let sanitizerFindings = logs.sanitizerFindings
+      guard sanitizerFindings == 0 else {
+        throw AdaptiveSoakFailure("Sanitizer diagnostic signature observed")
+      }
+      guard analysis.monotonicGrowth == false else {
+        throw AdaptiveSoakFailure("Resident memory shows sustained monotonic growth")
+      }
+      let completedDuration = Int(ProcessInfo.processInfo.systemUptime - started)
+      guard completedDuration >= durationSeconds else {
+        throw AdaptiveSoakFailure("Adaptive soak ended before its requested duration")
+      }
+
+      let evidence = AdaptiveSoakEvidence(
+        durationSeconds: completedDuration,
+        playlistCoverage: coverage,
+        allocationProvenance: AdaptiveAllocationProvenance(
+          allocator: "Darwin default malloc zone",
+          measurement: "malloc_zone_statistics plus Mach resident size",
+          sourceOwnershipRegression: "SegmentChunkOwnership_test",
+          expectedSourceReleaseCount: 1,
+          sampleCount: memorySeries.count
+        ),
+        memorySeries: memorySeries,
+        memoryAnalysis: analysis,
+        sanitizerFindings: sanitizerFindings,
+        sanitizerInstrumentationActive: Self.addressSanitizerIsActive,
+        sanitizerEvidenceScope: "candidate runtime diagnostic signatures",
+        crashes: 0,
+        unboundedRecoveries: 0,
+        monotonicGrowth: analysis.monotonicGrowth,
+        libraryErrorCount: logs.totalCount,
+        libraryErrors: logs.records,
+        upstreamCrossLink: "https://code.videolan.org/videolan/vlc/-/work_items/29845"
+      )
+      try await markServerComplete()
+      result = try "pass:\(JSONEncoder().encode(evidence).base64EncodedString())"
+      progress = "\(durationSeconds)s / \(durationSeconds)s"
+      phase = "complete"
+    } catch is CancellationError {
+      result = "cancelled"
+    } catch {
+      playbackError = String(describing: error)
+      result = "failed"
+    }
+  }
+
+  private var fixtureBaseURL: URL? {
+    guard let vod = streams?.vod else { return nil }
+    var components = URLComponents(url: vod, resolvingAgainstBaseURL: false)
+    components?.path = ""
+    components?.query = nil
+    components?.fragment = nil
+    return components?.url
+  }
+
+  private func masterURL(mode: String) throws -> URL {
+    guard let url = fixtureBaseURL?.appending(path: "adaptive/\(token)/\(mode)/master.m3u8")
+    else { throw AdaptiveSoakFailure("Missing adaptive fixture origin") }
+    return url
+  }
+
+  private func serverMetrics() async throws -> [String: Any] {
+    guard let url = fixtureBaseURL?.appending(path: "adaptive/\(token)/metrics")
+    else { throw AdaptiveSoakFailure("Missing adaptive metrics endpoint") }
+    let (data, response) = try await URLSession.shared.data(from: url)
+    guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+      throw AdaptiveSoakFailure("Adaptive metrics endpoint failed")
+    }
+    guard let value = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else { throw AdaptiveSoakFailure("Adaptive metrics payload was malformed") }
+    return value
+  }
+
+  private func markServerComplete() async throws {
+    guard let url = fixtureBaseURL?.appending(path: "adaptive/\(token)/complete")
+    else { throw AdaptiveSoakFailure("Missing adaptive completion endpoint") }
+    let (_, response) = try await URLSession.shared.data(from: url)
+    guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+      throw AdaptiveSoakFailure("Adaptive completion endpoint failed")
+    }
+  }
+
+  private func waitUntil(
+    _ failure: String,
+    timeout: Duration,
+    condition: @escaping @MainActor () -> Bool
+  )
+    async throws {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
+    while !condition() {
+      try Task.checkCancellation()
+      guard clock.now < deadline else { throw AdaptiveSoakFailure(failure) }
+      try await Task.sleep(for: .milliseconds(100))
+    }
+  }
+
+  private func valueRow(_ title: String, value: String, identifier: String) -> some View {
+    HStack {
+      Text(title)
+      Spacer()
+      Text(value)
+        .foregroundStyle(.secondary)
+        .accessibilityIdentifier(identifier)
+    }
+  }
+
+  private static func memorySample(elapsedSeconds: Int, player: Player) -> AdaptiveMemorySample {
+    var info = mach_task_basic_info()
+    var count = mach_msg_type_number_t(
+      MemoryLayout<mach_task_basic_info>.size / MemoryLayout<natural_t>.size
+    )
+    let status = withUnsafeMutablePointer(to: &info) { pointer in
+      pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { rebound in
+        task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), rebound, &count)
+      }
+    }
+    var mallocStats = malloc_statistics_t()
+    if let zone = malloc_default_zone() {
+      malloc_zone_statistics(zone, &mallocStats)
+    }
+    let statistics = player.statistics
+    return AdaptiveMemorySample(
+      elapsedSeconds: elapsedSeconds,
+      residentBytes: status == KERN_SUCCESS ? info.resident_size : 0,
+      mallocBytesInUse: UInt64(mallocStats.size_in_use),
+      mallocBytesAllocated: UInt64(mallocStats.size_allocated),
+      playerState: String(describing: player.state),
+      readBytes: statistics?.readBytes ?? 0,
+      decodedVideoFrames: statistics?.decodedVideo ?? 0,
+      displayedPictures: statistics?.displayedPictures ?? 0,
+      demuxDiscontinuities: statistics?.demuxDiscontinuity ?? 0
+    )
+  }
+
+  private static func analyze(_ samples: [AdaptiveMemorySample]) throws -> AdaptiveMemoryAnalysis {
+    guard samples.count >= 2, samples.allSatisfy({ $0.residentBytes > 0 }) else {
+      throw AdaptiveSoakFailure("Memory sampling produced insufficient data")
+    }
+    let resident = samples.map(\.residentBytes)
+    let baseline = resident.first ?? 0
+    let peak = resident.max() ?? baseline
+    let final = resident.last ?? baseline
+    let growth = final > baseline ? final - baseline : 0
+    let strictlyNondecreasing = zip(resident, resident.dropFirst()).allSatisfy { $1 >= $0 }
+    let windowSize = max(1, samples.count / 4)
+    let firstWindowStart = min(samples.count - 1, samples.count / 4)
+    let firstWindowEnd = min(samples.count, firstWindowStart + windowSize)
+    let lastWindowStart = max(0, samples.count - windowSize)
+    let firstResidentMedian = median(
+      Array(samples[firstWindowStart..<firstWindowEnd].map(\.residentBytes))
+    )
+    let lastResidentMedian = median(Array(samples[lastWindowStart...].map(\.residentBytes)))
+    let firstMallocMedian = median(
+      Array(samples[firstWindowStart..<firstWindowEnd].map(\.mallocBytesInUse))
+    )
+    let lastMallocMedian = median(Array(samples[lastWindowStart...].map(\.mallocBytesInUse)))
+    let residentTrend = Int64(lastResidentMedian) - Int64(firstResidentMedian)
+    let mallocTrend = Int64(lastMallocMedian) - Int64(firstMallocMedian)
+    let residentSlope = slope(
+      samples.map { (Double($0.elapsedSeconds), Double($0.residentBytes)) }
+    )
+    let mallocSlope = slope(
+      samples.map { (Double($0.elapsedSeconds), Double($0.mallocBytesInUse)) }
+    )
+    let monotonicGrowth =
+      (residentTrend > 32 * 1_048_576 && residentSlope > 4096)
+        || (mallocTrend > 16 * 1_048_576 && mallocSlope > 2048)
+    let growthLimit: UInt64 = 128 * 1_048_576
+    guard growth <= growthLimit else {
+      throw AdaptiveSoakFailure("Resident-memory growth exceeded 128 MiB")
+    }
+    return AdaptiveMemoryAnalysis(
+      baselineResidentBytes: baseline,
+      peakResidentBytes: peak,
+      finalResidentBytes: final,
+      growthBytes: growth,
+      growthLimitBytes: growthLimit,
+      firstSteadyResidentMedianBytes: firstResidentMedian,
+      lastResidentMedianBytes: lastResidentMedian,
+      residentSlopeBytesPerSecond: residentSlope,
+      firstSteadyMallocMedianBytes: firstMallocMedian,
+      lastMallocMedianBytes: lastMallocMedian,
+      mallocSlopeBytesPerSecond: mallocSlope,
+      observedDownwardSample: !strictlyNondecreasing,
+      monotonicGrowth: monotonicGrowth
+    )
+  }
+
+  private static func median(_ values: [UInt64]) -> UInt64 {
+    let sorted = values.sorted()
+    guard !sorted.isEmpty else { return 0 }
+    return sorted[sorted.count / 2]
+  }
+
+  private static func slope(_ values: [(x: Double, y: Double)]) -> Double {
+    guard values.count >= 2 else { return 0 }
+    let xMean = values.map(\.x).reduce(0, +) / Double(values.count)
+    let yMean = values.map(\.y).reduce(0, +) / Double(values.count)
+    let numerator = values.reduce(0) { result, value in
+      result + (value.x - xMean) * (value.y - yMean)
+    }
+    let denominator = values.reduce(0) { result, value in
+      result + (value.x - xMean) * (value.x - xMean)
+    }
+    return denominator > 0 ? numerator / denominator : 0
+  }
+
+  private static var addressSanitizerIsActive: Bool {
+    dlsym(UnsafeMutableRawPointer(bitPattern: -2), "__asan_get_current_allocated_bytes") != nil
+  }
+}
+
+private actor AdaptiveErrorRecorder {
+  private static let evidenceLimit = 20
+  private static let messageLimit = 1024
+  private var values: [AdaptiveLogEvidence] = []
+  private var totalCount = 0
+  private var sanitizerFindings = 0
+
+  func record(_ entry: LogEntry) {
+    let complete = AdaptiveLogEvidence(module: entry.module, message: entry.message)
+    totalCount += 1
+    if complete.isSanitizerFinding {
+      sanitizerFindings += 1
+    }
+    if values.count < Self.evidenceLimit {
+      values.append(
+        AdaptiveLogEvidence(
+          module: entry.module,
+          message: String(entry.message.prefix(Self.messageLimit))
+        )
+      )
+    }
+  }
+
+  var snapshot: AdaptiveLogSnapshot {
+    AdaptiveLogSnapshot(
+      records: values,
+      totalCount: totalCount,
+      sanitizerFindings: sanitizerFindings
+    )
+  }
+}
+
+private struct AdaptiveLogSnapshot: Sendable {
+  let records: [AdaptiveLogEvidence]
+  let totalCount: Int
+  let sanitizerFindings: Int
+}
+
+private struct AdaptivePlaylistCoverage: Encodable {
+  let playlistTypes: [String]
+  let containers: [String]
+  let modes: [String]
+  let variants: [String]
+  let masterRequests: Int
+  let mediaPlaylistRequests: Int
+  let segmentRequests: Int
+  let successfulSegments: Int
+  let variantTransitions: Int
+  let discontinuityManifests: Int
+  let expiredWindows: Int
+  let retryFailures: Int
+  let retryRecoveries: Int
+  let cancellations: Int
+
+  init(metrics: [String: Any], cancellations: Int) throws {
+    func strings(_ key: String) throws -> [String] {
+      guard let value = metrics[key] as? [String] else {
+        throw AdaptiveSoakFailure("Missing server metric \(key)")
+      }
+      return value
+    }
+    func integer(_ key: String) throws -> Int {
+      guard let value = metrics[key] as? Int else {
+        throw AdaptiveSoakFailure("Missing server metric \(key)")
+      }
+      return value
+    }
+    playlistTypes = try strings("playlistTypes")
+    containers = try strings("containers")
+    modes = try strings("modes")
+    variants = try strings("variants")
+    masterRequests = try integer("masterRequests")
+    mediaPlaylistRequests = try integer("mediaPlaylistRequests")
+    segmentRequests = try integer("segmentRequests")
+    successfulSegments = try integer("successfulSegments")
+    variantTransitions = try integer("variantTransitions")
+    discontinuityManifests = try integer("discontinuityManifests")
+    expiredWindows = try integer("expiredWindows")
+    retryFailures = try integer("retryFailures")
+    retryRecoveries = try integer("retryRecoveries")
+    self.cancellations = cancellations
+
+    guard Set(playlistTypes) == ["vod", "event", "live"] else {
+      throw AdaptiveSoakFailure("VOD/event/live playlist coverage was incomplete")
+    }
+    guard Set(containers) == ["ts", "fmp4"], Set(variants) == ["low", "high"] else {
+      throw AdaptiveSoakFailure("TS/fMP4 or representation coverage was incomplete")
+    }
+    guard
+      segmentRequests > 0,
+      successfulSegments > 0,
+      variantTransitions > 0,
+      discontinuityManifests > 0,
+      expiredWindows > 0,
+      retryFailures > 0,
+      retryRecoveries > 0,
+      cancellations > 0
+    else { throw AdaptiveSoakFailure("Adaptive edge-case telemetry was incomplete") }
+  }
+}
+
+private struct AdaptiveAllocationProvenance: Encodable {
+  let allocator: String
+  let measurement: String
+  let sourceOwnershipRegression: String
+  let expectedSourceReleaseCount: Int
+  let sampleCount: Int
+}
+
+private struct AdaptiveMemorySample: Encodable {
+  let elapsedSeconds: Int
+  let residentBytes: UInt64
+  let mallocBytesInUse: UInt64
+  let mallocBytesAllocated: UInt64
+  let playerState: String
+  let readBytes: UInt64
+  let decodedVideoFrames: UInt64
+  let displayedPictures: UInt64
+  let demuxDiscontinuities: UInt64
+}
+
+private struct AdaptiveMemoryAnalysis: Encodable {
+  let baselineResidentBytes: UInt64
+  let peakResidentBytes: UInt64
+  let finalResidentBytes: UInt64
+  let growthBytes: UInt64
+  let growthLimitBytes: UInt64
+  let firstSteadyResidentMedianBytes: UInt64
+  let lastResidentMedianBytes: UInt64
+  let residentSlopeBytesPerSecond: Double
+  let firstSteadyMallocMedianBytes: UInt64
+  let lastMallocMedianBytes: UInt64
+  let mallocSlopeBytesPerSecond: Double
+  let observedDownwardSample: Bool
+  let monotonicGrowth: Bool
+}
+
+private struct AdaptiveLogEvidence: Encodable, Sendable {
+  let module: String?
+  let message: String
+
+  var isSanitizerFinding: Bool {
+    let lower = message.lowercased()
+    return lower.contains("addresssanitizer")
+      || lower.contains("threadsanitizer")
+      || lower.contains("heap-use-after-free")
+      || lower.contains("double free")
+  }
+}
+
+private struct AdaptiveSoakEvidence: Encodable {
+  let durationSeconds: Int
+  let playlistCoverage: AdaptivePlaylistCoverage
+  let allocationProvenance: AdaptiveAllocationProvenance
+  let memorySeries: [AdaptiveMemorySample]
+  let memoryAnalysis: AdaptiveMemoryAnalysis
+  let sanitizerFindings: Int
+  let sanitizerInstrumentationActive: Bool
+  let sanitizerEvidenceScope: String
+  let crashes: Int
+  let unboundedRecoveries: Int
+  let monotonicGrowth: Bool
+  let libraryErrorCount: Int
+  let libraryErrors: [AdaptiveLogEvidence]
+  let upstreamCrossLink: String
+}
+
+private struct AdaptiveSoakFailure: Error, CustomStringConvertible {
+  let description: String
+  init(_ description: String) {
+    self.description = description
+  }
+}

--- a/Showcase/macOS/Internal/MacShowcaseRootView.swift
+++ b/Showcase/macOS/Internal/MacShowcaseRootView.swift
@@ -415,7 +415,8 @@ extension MacShowcase {
          .pipDismissalValidation,
          .pipInterruptionValidation,
          .pipNativeLifecycleValidation,
-         .terminalOutcomesValidation:
+         .terminalOutcomesValidation,
+         .adaptiveHLSSoakValidation:
       return nil
     }
   }

--- a/Showcase/tvOS/Internal/TVShowcaseRootView.swift
+++ b/Showcase/tvOS/Internal/TVShowcaseRootView.swift
@@ -523,7 +523,8 @@ extension TVShowcase {
          .pipDismissalValidation,
          .pipInterruptionValidation,
          .pipNativeLifecycleValidation,
-         .terminalOutcomesValidation:
+         .terminalOutcomesValidation,
+         .adaptiveHLSSoakValidation:
       return nil
     }
   }

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -62,7 +62,8 @@ engine artifact.
 The command identifies the physical device and OS release type, generates and
 serves deterministic local media, installs the exact signed candidate and UI
 test runner, executes the analyzer, general UI stress suite, native/direct live
-PiP, same-player continuity, capability convergence, and HLS seek lanes, then
+PiP, same-player continuity, capability convergence, terminal outcomes, the
+adaptive HLS soak, and HLS seek lanes, then
 pulls app logs and writes a machine-readable `report.json`. It retains every
 attempt log and xcresult,
 records and verifies candidate metadata that binds the app tree digest to its
@@ -195,18 +196,36 @@ hardware identity fields that the test process is forbidden to provide. The
 matching row appears under `qualificationRows` in `report.json`; beta-OS rows
 remain exploratory and are rejected by `check-qualification.sh`.
 
+The `adaptive-hls-soak` lane defaults to 7,200 seconds and runs only on the
+`iphone-current` row. Its local origin constructs VOD, event, and sliding-live
+playlists from deterministic low/high TS and fragmented-MP4 representations.
+It injects discontinuities and one-shot HTTP failures, advances live windows,
+and records successful retry, representation-transition, segment, and playlist
+telemetry under a unique run token. The candidate cycles every mode without an
+operator, samples Mach resident memory and Darwin malloc-zone totals every 30
+seconds, and the host attaches Instruments' Allocations template with a rolling
+15-minute stack-provenance window once the unique run token proves the exact
+candidate has begun playback. The trace tree digest and table of contents are
+added by the host to the candidate-bound evidence; inability to capture or
+export that trace fails the row. The app scans native diagnostics for sanitizer signatures and fails on a
+20-second unbounded recovery or more than 128 MiB final resident growth. The
+attachment explicitly records whether ASan instrumentation was present; a zero
+finding never pretends that a normal signed device build was ASan-instrumented.
+`SWIFTVLC_ADAPTIVE_SOAK_SECONDS` may shorten an exploratory harness run, but
+the matrix rejects any row shorter than 7,200 seconds.
+
 Use `--require-stable` for release evidence. It fails before testing if the
 device is a simulator, runs beta or unknown software, or does not match a
 hardware row in `matrix.json`. Without that option, the same command is useful
 for exploratory beta-OS testing, but its report remains ineligible for release.
 
 This lane is intentionally fail-closed: its current automated scenarios are a
-candidate smoke/regression subset, not a claim that all 53 qualification rows
+candidate qualification subset, not a claim that all 53 qualification rows
 passed. `report.json` therefore keeps `releaseGateSatisfied` false until a
 matrix runner has produced the complete candidate-bound records described
-below. Long soaks, performance captures, interruption/route-change coverage,
-subtitle-format coverage, and every required hardware/OS row must still be
-represented by automated evidence before the stable gate can open.
+below. Remaining performance captures, subtitle-format coverage, timebase and
+cadence soaks, and every required hardware/OS row must still be represented by
+automated evidence before the stable gate can open.
 
 Qualification is bound to both halves of the shipped package. The
 XCFramework tree digest identifies the native engine and headers, while the

--- a/scripts/qualification/assemble-record.py
+++ b/scripts/qualification/assemble-record.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import sys
 import tempfile
 from pathlib import Path
@@ -91,6 +92,63 @@ def safe_evidence_path(report_path: Path, relative: object) -> Path:
     return resolved
 
 
+def safe_evidence_artifact_path(
+    evidence_path: Path, relative: object, description: str, *, directory: bool
+) -> tuple[Path, Path]:
+    if not isinstance(relative, str) or not relative:
+        raise AssemblyError(f"evidence {evidence_path} has no {description} path")
+    candidate = Path(relative)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        raise AssemblyError(
+            f"evidence {evidence_path} has unsafe {description} path {relative!r}"
+        )
+    resolved = (evidence_path.parent / candidate).resolve()
+    try:
+        resolved.relative_to(evidence_path.parent.resolve())
+    except ValueError as error:
+        raise AssemblyError(
+            f"evidence {evidence_path} {description} escapes its directory"
+        ) from error
+    valid = resolved.is_dir() if directory else resolved.is_file()
+    if not valid:
+        kind = "directory" if directory else "file"
+        raise AssemblyError(
+            f"evidence {evidence_path} {description} {kind} is missing: {relative}"
+        )
+    return resolved, candidate
+
+
+def tree_digest(root: Path) -> str:
+    digest = hashlib.sha256(b"SwiftVLC artifact tree digest v1\0")
+    entries = sorted(root.rglob("*"), key=lambda path: path.relative_to(root).as_posix())
+    if not entries:
+        raise AssemblyError(f"allocation trace is empty: {root}")
+
+    def update(value: bytes) -> None:
+        digest.update(len(value).to_bytes(8, "big"))
+        digest.update(value)
+
+    for path in entries:
+        metadata = path.lstat()
+        if stat.S_ISDIR(metadata.st_mode):
+            kind, payload = b"directory", b""
+        elif stat.S_ISREG(metadata.st_mode):
+            content = hashlib.sha256()
+            with path.open("rb") as source:
+                while chunk := source.read(1024 * 1024):
+                    content.update(chunk)
+            kind, payload = b"file", content.digest()
+        elif stat.S_ISLNK(metadata.st_mode):
+            kind, payload = b"symlink", os.readlink(path).encode()
+        else:
+            raise AssemblyError(f"unsupported allocation trace entry: {path}")
+        update(kind)
+        update(path.relative_to(root).as_posix().encode())
+        update(stat.S_IMODE(metadata.st_mode).to_bytes(4, "big"))
+        update(payload)
+    return digest.hexdigest()
+
+
 def assemble(
     version: str,
     candidate_path: Path,
@@ -135,7 +193,7 @@ def assemble(
                 f"{candidate.get(field)!r} != {expected!r}"
             )
 
-    rows: dict[tuple[str, str], tuple[dict, Path]] = {}
+    rows: dict[tuple[str, str], tuple[dict, Path, list[tuple[Path, Path, bool]]]] = {}
     for report_path in report_paths:
         report = load_object(report_path, "device report")
         if report.get("result") != "pass":
@@ -187,12 +245,40 @@ def assemble(
                         f"evidence {evidence_path} {field} mismatch: "
                         f"{evidence.get(field)!r} != {expected!r}"
                     )
-            rows[key] = (row, evidence_path)
+            artifacts: list[tuple[Path, Path, bool]] = []
+            provenance = evidence.get("allocationProvenance")
+            trace = provenance.get("instrumentsTrace") if isinstance(provenance, dict) else None
+            if trace is not None:
+                if not isinstance(trace, dict):
+                    raise AssemblyError(f"evidence {evidence_path} has malformed trace provenance")
+                trace_source, trace_relative = safe_evidence_artifact_path(
+                    evidence_path,
+                    trace.get("runArtifact"),
+                    "allocation trace",
+                    directory=True,
+                )
+                toc_source, toc_relative = safe_evidence_artifact_path(
+                    evidence_path,
+                    trace.get("tableOfContents"),
+                    "allocation trace table of contents",
+                    directory=False,
+                )
+                if tree_digest(trace_source) != trace.get("treeDigest"):
+                    raise AssemblyError(
+                        f"evidence {evidence_path} allocation trace digest mismatch"
+                    )
+                artifacts.extend(
+                    [
+                        (trace_source, trace_relative, True),
+                        (toc_source, toc_relative, False),
+                    ]
+                )
+            rows[key] = (row, evidence_path, artifacts)
 
     evidence_directory = output_path.parent / "evidence" / version
     staged_rows = []
     for key in sorted(rows):
-        row, source = rows[key]
+        row, source, _ = rows[key]
         filename = f"{key[0]}-{key[1]}.json"
         relative = Path("evidence") / version / filename
         staged = dict(row, evidence=str(relative))
@@ -200,7 +286,7 @@ def assemble(
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     evidence_directory.mkdir(parents=True, exist_ok=True)
-    for key, (_, source) in sorted(rows.items()):
+    for key, (_, source, artifacts) in sorted(rows.items()):
         destination = evidence_directory / f"{key[0]}-{key[1]}.json"
         with tempfile.NamedTemporaryFile(
             dir=evidence_directory, prefix=f".{destination.name}.", delete=False
@@ -211,6 +297,28 @@ def assemble(
             os.replace(temporary_path, destination)
         finally:
             temporary_path.unlink(missing_ok=True)
+        for artifact_source, artifact_relative, is_directory in artifacts:
+            artifact_destination = evidence_directory / artifact_relative
+            artifact_destination.parent.mkdir(parents=True, exist_ok=True)
+            if artifact_destination.exists():
+                identical = (
+                    is_directory
+                    and artifact_destination.is_dir()
+                    and tree_digest(artifact_destination) == tree_digest(artifact_source)
+                ) or (
+                    not is_directory
+                    and artifact_destination.is_file()
+                    and artifact_destination.read_bytes() == artifact_source.read_bytes()
+                )
+                if not identical:
+                    raise AssemblyError(
+                        f"retained evidence artifact collision: {artifact_relative}"
+                    )
+                continue
+            if is_directory:
+                shutil.copytree(artifact_source, artifact_destination, symlinks=True)
+            else:
+                shutil.copyfile(artifact_source, artifact_destination)
 
     record = {**identity, "rows": staged_rows}
     with tempfile.NamedTemporaryFile(

--- a/scripts/qualification/augment-allocation-trace.py
+++ b/scripts/qualification/augment-allocation-trace.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Bind a host-captured Instruments allocation trace to soak evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+class TraceEvidenceError(ValueError):
+    pass
+
+
+SHA256 = re.compile(r"[0-9a-f]{64}")
+
+
+def augment(evidence_path: Path, trace: Path, toc: Path, digest_script: Path) -> dict:
+    try:
+        payload = json.loads(evidence_path.read_text())
+    except (OSError, ValueError) as error:
+        raise TraceEvidenceError(f"cannot read adaptive evidence: {error}") from error
+    if not isinstance(payload, dict) or payload.get("scenario") != "adaptive-hls-soak":
+        raise TraceEvidenceError("allocation trace belongs only to adaptive-hls-soak evidence")
+    provenance = payload.get("allocationProvenance")
+    if not isinstance(provenance, dict):
+        raise TraceEvidenceError("adaptive evidence has no allocation provenance object")
+    if not trace.is_dir() or not any(trace.rglob("*")):
+        raise TraceEvidenceError("allocation trace is missing or empty")
+    try:
+        toc_text = toc.read_text(errors="replace")
+    except OSError as error:
+        raise TraceEvidenceError(f"cannot read allocation trace table of contents: {error}") from error
+    if not re.search(r"allocation|vm-tracker", toc_text, re.IGNORECASE):
+        raise TraceEvidenceError("trace table of contents has no allocation instrument data")
+
+    artifact_directory = evidence_path.parent / "artifacts" / evidence_path.stem
+    staged_trace = artifact_directory / trace.name
+    staged_toc = artifact_directory / toc.name
+    try:
+        artifact_directory.mkdir(parents=True, exist_ok=False)
+        shutil.copytree(trace, staged_trace)
+        shutil.copy2(toc, staged_toc)
+    except OSError as error:
+        raise TraceEvidenceError(f"cannot retain allocation trace artifacts: {error}") from error
+
+    result = subprocess.run(
+        [sys.executable, str(digest_script), str(staged_trace)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    digest = result.stdout.strip()
+    if result.returncode != 0 or not SHA256.fullmatch(digest):
+        raise TraceEvidenceError("could not compute the allocation trace tree digest")
+
+    provenance["instrumentsTrace"] = {
+        "format": "com.apple.instruments.trace",
+        "treeDigestAlgorithm": "swiftvlc-tree-v1",
+        "treeDigest": digest,
+        "runArtifact": staged_trace.relative_to(evidence_path.parent).as_posix(),
+        "tableOfContents": staged_toc.relative_to(evidence_path.parent).as_posix(),
+        "template": "Allocations",
+        "rollingWindow": "15m",
+        "targetProcess": "iOS",
+    }
+    evidence_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--trace", type=Path, required=True)
+    parser.add_argument("--toc", type=Path, required=True)
+    parser.add_argument("--digest-script", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        augment(args.evidence, args.trace, args.toc, args.digest_script)
+    except TraceEvidenceError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qualification/fixture-server.py
+++ b/scripts/qualification/fixture-server.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Deterministic HTTP media server with loop, stall, and disconnect endpoints."""
+"""Deterministic HTTP media server with media faults and adaptive HLS telemetry."""
 
 from __future__ import annotations
 
@@ -96,6 +96,71 @@ class FixtureHandler(BaseHTTPRequestHandler):
                 )
                 return
 
+            match = re.fullmatch(r"/adaptive/([A-Za-z0-9._-]+)/metrics", route)
+            if match:
+                payload = json.dumps(
+                    self.server.adaptive_metrics(match.group(1)), sort_keys=True
+                ).encode()
+                transferred = self._serve_bytes(payload, "application/json")
+                return
+
+            match = re.fullmatch(r"/adaptive/([A-Za-z0-9._-]+)/complete", route)
+            if match:
+                payload = json.dumps(
+                    self.server.complete_adaptive_run(match.group(1)), sort_keys=True
+                ).encode()
+                transferred = self._serve_bytes(payload, "application/json")
+                return
+
+            match = re.fullmatch(
+                r"/adaptive/([A-Za-z0-9._-]+)/([a-z0-9-]+)/master\.m3u8",
+                route,
+            )
+            if match:
+                payload = self.server.adaptive_master(
+                    match.group(1), match.group(2)
+                ).encode()
+                transferred = self._serve_bytes(
+                    payload, "application/vnd.apple.mpegurl"
+                )
+                return
+
+            match = re.fullmatch(
+                r"/adaptive/([A-Za-z0-9._-]+)/([a-z0-9-]+)/(low|high)\.m3u8",
+                route,
+            )
+            if match:
+                payload = self.server.adaptive_media_playlist(
+                    match.group(1), match.group(2), match.group(3)
+                ).encode()
+                transferred = self._serve_bytes(
+                    payload, "application/vnd.apple.mpegurl"
+                )
+                return
+
+            match = re.fullmatch(
+                r"/adaptive/([A-Za-z0-9._-]+)/([a-z0-9-]+)/(low|high)/([A-Za-z0-9._-]+)",
+                route,
+            )
+            if match:
+                token, mode, variant, filename = match.groups()
+                container = self.server.adaptive_container(mode)
+                if self.server.should_fail_adaptive_asset(
+                    token, mode, variant, filename
+                ):
+                    status = HTTPStatus.SERVICE_UNAVAILABLE
+                    self.response_status = status
+                    self.send_error(status, "deterministic adaptive retry")
+                    return
+                path = self._safe_path(
+                    f"hls/soak/{container}/{variant}/{filename}"
+                )
+                transferred = self._serve_file(path)
+                self.server.record_adaptive_asset(
+                    token, mode, variant, filename, recovered=True
+                )
+                return
+
             match = re.fullmatch(r"/live/(.+)", route)
             if match:
                 transferred = self._serve_loop(self._safe_path(match.group(1)))
@@ -164,6 +229,16 @@ class FixtureHandler(BaseHTTPRequestHandler):
         if not candidate.is_file():
             raise FileNotFoundError(candidate)
         return candidate
+
+    def _serve_bytes(self, payload: bytes, content_type: str) -> int:
+        self.response_status = HTTPStatus.OK
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+        return len(payload)
 
     def _serve_loop(
         self,
@@ -301,6 +376,218 @@ class FixtureHTTPServer(ThreadingHTTPServer):
         self._stall_triggered_at: dict[str, float] = {}
         self._close_lock = threading.Lock()
         self._close_generations: dict[str, int] = {}
+        self._adaptive_lock = threading.Lock()
+        self._adaptive_runs: dict[str, dict] = {}
+        self._adaptive_started_at: dict[tuple[str, str, str], float] = {}
+        self._adaptive_retry_failures: set[tuple[str, str, str, str]] = set()
+
+    @staticmethod
+    def adaptive_container(mode: str) -> str:
+        if mode in {"event-fmp4", "live-fmp4", "abr-high-fmp4"}:
+            return "fmp4"
+        if mode in {
+            "vod-ts",
+            "live-ts",
+            "retry-ts",
+            "abr-ts",
+            "abr-low-ts",
+        }:
+            return "ts"
+        raise ValueError(f"unsupported adaptive mode: {mode}")
+
+    @staticmethod
+    def adaptive_playlist_type(mode: str) -> str:
+        if mode == "event-fmp4":
+            return "event"
+        if mode in {"live-ts", "live-fmp4", "retry-ts", "abr-ts"}:
+            return "live"
+        return "vod"
+
+    def _adaptive_state(self, token: str) -> dict:
+        return self._adaptive_runs.setdefault(
+            token,
+            {
+                "masterRequests": 0,
+                "mediaPlaylistRequests": 0,
+                "segmentRequests": 0,
+                "successfulSegments": 0,
+                "retryFailures": 0,
+                "retryRecoveries": 0,
+                "expiredWindows": 0,
+                "discontinuityManifests": 0,
+                "variantTransitions": 0,
+                "lastVariantByMode": {},
+                "clientCompleted": False,
+                "playlistTypes": set(),
+                "containers": set(),
+                "variants": set(),
+                "modes": set(),
+                "maxMediaSequenceByMode": {},
+            },
+        )
+
+    def adaptive_master(self, token: str, mode: str) -> str:
+        container = self.adaptive_container(mode)
+        playlist_type = self.adaptive_playlist_type(mode)
+        variants = ["low", "high"]
+        if mode == "abr-low-ts":
+            variants = ["low"]
+        elif mode == "abr-high-fmp4":
+            variants = ["high"]
+        with self._adaptive_lock:
+            state = self._adaptive_state(token)
+            state["masterRequests"] += 1
+            state["playlistTypes"].add(playlist_type)
+            state["containers"].add(container)
+            state["modes"].add(mode)
+        lines = ["#EXTM3U", "#EXT-X-VERSION:7"]
+        records = {
+            "low": (300_000, "320x180"),
+            "high": (1_200_000, "640x360"),
+        }
+        for variant in variants:
+            bandwidth, resolution = records[variant]
+            lines.extend(
+                [
+                    f'#EXT-X-STREAM-INF:BANDWIDTH={bandwidth},AVERAGE-BANDWIDTH={bandwidth},RESOLUTION={resolution},CODECS="avc1.42c01e,mp4a.40.2"',
+                    f"{variant}.m3u8",
+                ]
+            )
+        return "\n".join(lines) + "\n"
+
+    def adaptive_media_playlist(self, token: str, mode: str, variant: str) -> str:
+        container = self.adaptive_container(mode)
+        playlist_type = self.adaptive_playlist_type(mode)
+        directory = self.root / "hls" / "soak" / container / variant
+        suffix = ".ts" if container == "ts" else ".m4s"
+        segments = sorted(directory.glob(f"segment-*{suffix}"))
+        if len(segments) < 4:
+            raise FileNotFoundError(f"insufficient adaptive segments in {directory}")
+
+        key = (token, mode, variant)
+        now = time.monotonic()
+        with self._adaptive_lock:
+            started = self._adaptive_started_at.setdefault(key, now)
+            state = self._adaptive_state(token)
+            state["mediaPlaylistRequests"] += 1
+            state["playlistTypes"].add(playlist_type)
+            state["containers"].add(container)
+            state["variants"].add(variant)
+            state["modes"].add(mode)
+
+        is_live = playlist_type == "live"
+        media_sequence = int((now - started) / 2) if is_live else 0
+        if is_live:
+            window_count = min(6, len(segments))
+            indices = range(media_sequence, media_sequence + window_count)
+        else:
+            indices = range(len(segments))
+
+        discontinuity = playlist_type == "event" or is_live
+        lines = [
+            "#EXTM3U",
+            "#EXT-X-VERSION:7" if container == "fmp4" else "#EXT-X-VERSION:3",
+            "#EXT-X-TARGETDURATION:2",
+            f"#EXT-X-MEDIA-SEQUENCE:{media_sequence}",
+        ]
+        if playlist_type == "vod":
+            lines.append("#EXT-X-PLAYLIST-TYPE:VOD")
+        elif playlist_type == "event":
+            lines.append("#EXT-X-PLAYLIST-TYPE:EVENT")
+        if container == "fmp4":
+            lines.append(f'#EXT-X-MAP:URI="{variant}/init.mp4"')
+
+        midpoint = max(1, len(segments) // 2)
+        if is_live:
+            discontinuities_before_window = 0
+            if media_sequence > midpoint:
+                discontinuities_before_window = (
+                    1 + (media_sequence - 1 - midpoint) // len(segments)
+                )
+            lines.append(
+                f"#EXT-X-DISCONTINUITY-SEQUENCE:{discontinuities_before_window}"
+            )
+        for offset, sequence in enumerate(indices):
+            should_discontinue = (
+                playlist_type == "event" and offset == midpoint
+            ) or (is_live and sequence % len(segments) == midpoint)
+            if should_discontinue:
+                lines.append("#EXT-X-DISCONTINUITY")
+            segment = segments[sequence % len(segments)]
+            uri = f"{variant}/{segment.name}"
+            if is_live:
+                uri += f"?sequence={sequence}"
+            lines.extend(["#EXTINF:2.000,", uri])
+        if not is_live:
+            lines.append("#EXT-X-ENDLIST")
+
+        with self._adaptive_lock:
+            state = self._adaptive_state(token)
+            previous = state["maxMediaSequenceByMode"].get(mode, -1)
+            if media_sequence > previous:
+                if previous >= 0:
+                    state["expiredWindows"] += media_sequence - previous
+                state["maxMediaSequenceByMode"][mode] = media_sequence
+            if discontinuity:
+                state["discontinuityManifests"] += 1
+        return "\n".join(lines) + "\n"
+
+    def should_fail_adaptive_asset(
+        self, token: str, mode: str, variant: str, filename: str
+    ) -> bool:
+        if mode != "retry-ts" or filename == "init.mp4":
+            return False
+        key = (token, mode, variant, filename)
+        with self._adaptive_lock:
+            state = self._adaptive_state(token)
+            state["segmentRequests"] += 1
+            state["variants"].add(variant)
+            self._record_adaptive_variant(state, mode, variant)
+            if key not in self._adaptive_retry_failures:
+                self._adaptive_retry_failures.add(key)
+                state["retryFailures"] += 1
+                return True
+        return False
+
+    def record_adaptive_asset(
+        self, token: str, mode: str, variant: str, filename: str, recovered: bool
+    ) -> None:
+        with self._adaptive_lock:
+            state = self._adaptive_state(token)
+            if mode != "retry-ts" or (token, mode, variant, filename) not in self._adaptive_retry_failures:
+                state["segmentRequests"] += 1
+            state["successfulSegments"] += 1
+            state["variants"].add(variant)
+            self._record_adaptive_variant(state, mode, variant)
+            if recovered and (token, mode, variant, filename) in self._adaptive_retry_failures:
+                state["retryRecoveries"] += 1
+
+    def adaptive_metrics(self, token: str) -> dict:
+        with self._adaptive_lock:
+            state = self._adaptive_state(token)
+            return {
+                key: sorted(value) if isinstance(value, set) else value
+                for key, value in state.items()
+                if key != "lastVariantByMode"
+            }
+
+    @staticmethod
+    def _record_adaptive_variant(state: dict, mode: str, variant: str) -> None:
+        # Only abr-ts advertises both representations in one master. Moving
+        # between separate one-variant URLs is a test phase change, not an ABR
+        # switch performed by the player.
+        if mode != "abr-ts":
+            return
+        previous = state["lastVariantByMode"].get(mode)
+        if previous not in {None, variant}:
+            state["variantTransitions"] += 1
+        state["lastVariantByMode"][mode] = variant
+
+    def complete_adaptive_run(self, token: str) -> dict:
+        with self._adaptive_lock:
+            state = self._adaptive_state(token)
+            state["clientCompleted"] = True
+            return {"clientCompleted": True}
 
     def trigger_stall(self, token: str) -> int:
         with self._stall_lock:

--- a/scripts/qualification/generate-fixtures.sh
+++ b/scripts/qualification/generate-fixtures.sh
@@ -25,6 +25,11 @@ fi
 mkdir -p "$OUTPUT_DIR/hls"
 fixture_tmp=$(mktemp -d "${TMPDIR:-/tmp}/swiftvlc-fixtures.XXXXXX")
 trap 'rm -rf "$fixture_tmp"' EXIT
+mkdir -p \
+  "$fixture_tmp/hls/soak/ts/low" \
+  "$fixture_tmp/hls/soak/ts/high" \
+  "$fixture_tmp/hls/soak/fmp4/low" \
+  "$fixture_tmp/hls/soak/fmp4/high"
 LIVE_DURATION_SECONDS="$DURATION_SECONDS"
 if [[ "$LIVE_DURATION_SECONDS" -lt 120 ]]; then
   LIVE_DURATION_SECONDS=120
@@ -51,6 +56,40 @@ ffmpeg_quiet=(ffmpeg -hide_banner -loglevel error -nostdin -y)
   -hls_segment_filename "$fixture_tmp/vod-%03d.ts" \
   "$fixture_tmp/vod.m3u8"
 
+# Two real representations and both HLS segment containers back the adaptive
+# soak origin. The server builds VOD, event, and sliding-live manifests from
+# these deterministic files at request time, so a long run never depends on a
+# third-party CDN or an expiring public stream.
+"${ffmpeg_quiet[@]}" \
+  -i "$fixture_tmp/vod.mp4" \
+  -vf "scale=320:180" -c:v libx264 -preset veryfast -pix_fmt yuv420p \
+  -g 60 -keyint_min 60 -sc_threshold 0 \
+  -c:a copy -movflags +faststart \
+  "$fixture_tmp/low.mp4"
+
+for variant in low high; do
+  source="$fixture_tmp/vod.mp4"
+  if [[ "$variant" == "low" ]]; then
+    source="$fixture_tmp/low.mp4"
+  fi
+
+  "${ffmpeg_quiet[@]}" \
+    -i "$source" -c copy \
+    -hls_time 2 -hls_playlist_type vod \
+    -hls_segment_filename "$fixture_tmp/hls/soak/ts/$variant/segment-%03d.ts" \
+    "$fixture_tmp/hls/soak/ts/$variant/media.m3u8"
+
+  (
+    cd "$fixture_tmp/hls/soak/fmp4/$variant"
+    "${ffmpeg_quiet[@]}" \
+      -i "$source" -c copy \
+      -hls_time 2 -hls_playlist_type vod -hls_segment_type fmp4 \
+      -hls_fmp4_init_filename init.mp4 \
+      -hls_segment_filename "segment-%03d.m4s" \
+      media.m3u8
+  )
+done
+
 "${ffmpeg_quiet[@]}" \
   -f lavfi -i "sine=frequency=440:sample_rate=48000" \
   -t "$DURATION_SECONDS" -c:a aac -b:a 128k \
@@ -63,6 +102,8 @@ mv "$fixture_tmp/vod.m3u8" "$OUTPUT_DIR/hls/vod.m3u8"
 for segment in "$fixture_tmp"/vod-*.ts; do
   mv "$segment" "$OUTPUT_DIR/hls/$(basename "$segment")"
 done
+rm -rf "$OUTPUT_DIR/hls/soak"
+mv "$fixture_tmp/hls/soak" "$OUTPUT_DIR/hls/soak"
 
 python3 - "$OUTPUT_DIR/vod.mp4" "$OUTPUT_DIR/unsupported-codec.mp4" <<'PY'
 import sys

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -14,6 +14,7 @@ OUTPUT_ROOT="${SWIFTVLC_DEVICE_RESULTS:-$ROOT_DIR/.qualification-results}"
 REQUIRE_STABLE=false
 SKIP_BUILD=false
 ONLY_SCENARIOS=()
+ADAPTIVE_SOAK_SECONDS="${SWIFTVLC_ADAPTIVE_SOAK_SECONDS:-7200}"
 
 usage() {
   cat <<'EOF'
@@ -36,6 +37,8 @@ Options:
                           continuity, capability-convergence,
                           vod-controls, long-stall, failed-start, dismissal,
                           interruptions,
+                          native-lifecycle, terminal-outcomes,
+                          adaptive-hls-soak,
                           deferred-pause-rejection,
                           accepted-start-delayed-failure, hls-seek,
                           harness-regressions, ui-failures, thumbnail-preview
@@ -48,6 +51,17 @@ operator steps. A beta OS can run exploratory tests, but never qualifies a
 release row.
 EOF
 }
+
+case "$ADAPTIVE_SOAK_SECONDS" in
+  ''|*[!0-9]*)
+    echo "Error: SWIFTVLC_ADAPTIVE_SOAK_SECONDS must be a positive integer." >&2
+    exit 2
+    ;;
+esac
+if [[ "$ADAPTIVE_SOAK_SECONDS" -le 0 ]]; then
+  echo "Error: SWIFTVLC_ADAPTIVE_SOAK_SECONDS must be positive." >&2
+  exit 2
+fi
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -66,7 +80,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-for command in git jq python3 shasum tar xcodebuild xcrun; do
+for command in curl git jq python3 shasum tar xcodebuild xcrun; do
   if ! command -v "$command" >/dev/null 2>&1; then
     echo "Error: required command is unavailable: $command" >&2
     exit 1
@@ -78,8 +92,27 @@ OUTPUT_DIR="$OUTPUT_ROOT/$run_id"
 mkdir -p "$OUTPUT_DIR"
 WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/swiftvlc-device-tests.XXXXXX")
 SERVER_PID=""
+ACTIVE_XCODEBUILD_PID=""
+ACTIVE_XCTRACE_PID=""
 
 cleanup() {
+  if [[ -n "$ACTIVE_XCTRACE_PID" ]] && kill -0 "$ACTIVE_XCTRACE_PID" 2>/dev/null; then
+    kill -INT "$ACTIVE_XCTRACE_PID" 2>/dev/null || true
+    for _ in {1..20}; do
+      if ! kill -0 "$ACTIVE_XCTRACE_PID" 2>/dev/null; then
+        break
+      fi
+      sleep 0.1
+    done
+    if kill -0 "$ACTIVE_XCTRACE_PID" 2>/dev/null; then
+      kill -KILL "$ACTIVE_XCTRACE_PID" 2>/dev/null || true
+    fi
+    wait "$ACTIVE_XCTRACE_PID" 2>/dev/null || true
+  fi
+  if [[ -n "$ACTIVE_XCODEBUILD_PID" ]] && kill -0 "$ACTIVE_XCODEBUILD_PID" 2>/dev/null; then
+    kill -TERM "$ACTIVE_XCODEBUILD_PID" 2>/dev/null || true
+    wait "$ACTIVE_XCODEBUILD_PID" 2>/dev/null || true
+  fi
   if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
     kill "$SERVER_PID" 2>/dev/null || true
     wait "$SERVER_PID" 2>/dev/null || true
@@ -113,7 +146,10 @@ DEVICE_ECID=$(jq -r '.selected.ecidHex' "$OUTPUT_DIR/device.json")
 RUN_MODE=$(jq -r '.mode' "$OUTPUT_DIR/device.json")
 echo "Selected $(jq -r '.selected.marketingName' "$OUTPUT_DIR/device.json") on $(jq -r '.selected.osVersion' "$OUTPUT_DIR/device.json") ($RUN_MODE)."
 
-if [[ ! -f "$FIXTURES/manifest.json" || ! -f "$FIXTURES/unsupported-codec.mp4" ]]; then
+if [[ ! -f "$FIXTURES/manifest.json" \
+  || ! -f "$FIXTURES/unsupported-codec.mp4" \
+  || ! -f "$FIXTURES/hls/soak/ts/low/segment-000.ts" \
+  || ! -f "$FIXTURES/hls/soak/fmp4/high/init.mp4" ]]; then
   "$SCRIPT_DIR/generate-fixtures.sh" "$FIXTURES"
 fi
 python3 "$SCRIPT_DIR/verify-fixtures.py" "$FIXTURES" > /dev/null
@@ -238,6 +274,8 @@ python3 "$SCRIPT_DIR/prepare-xctestrun.py" "$XCTESTRUN" "$DESTINATION_XCTESTRUN"
   --environment SWIFTVLC_PIP_INTERRUPTION_DEVICE=YES \
   --environment SWIFTVLC_PIP_NATIVE_LIFECYCLE_DEVICE=YES \
   --environment SWIFTVLC_TERMINAL_OUTCOMES_DEVICE=YES \
+  --environment SWIFTVLC_ADAPTIVE_HLS_SOAK_DEVICE=YES \
+  --environment SWIFTVLC_ADAPTIVE_SOAK_SECONDS="$ADAPTIVE_SOAK_SECONDS" \
   --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
   --environment SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE=YES \
   --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
@@ -291,7 +329,7 @@ xcrun devicectl device copy to \
   --destination Documents/streams.local.json \
   > "$OUTPUT_DIR/stage-streams.log"
 
-DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence vod-controls long-stall failed-start dismissal interruptions native-lifecycle terminal-outcomes deferred-pause-rejection accepted-start-delayed-failure hls-seek)
+DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence vod-controls long-stall failed-start dismissal interruptions native-lifecycle terminal-outcomes adaptive-hls-soak deferred-pause-rejection accepted-start-delayed-failure hls-seek)
 SCENARIOS_WERE_EXPLICIT=false
 if [[ ${#ONLY_SCENARIOS[@]} -eq 0 ]]; then
   ONLY_SCENARIOS=("${DEFAULT_SCENARIOS[@]}")
@@ -300,7 +338,7 @@ else
 fi
 for scenario in "${ONLY_SCENARIOS[@]}"; do
   case "$scenario" in
-    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|vod-controls|long-stall|failed-start|dismissal|interruptions|native-lifecycle|terminal-outcomes|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
+    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|vod-controls|long-stall|failed-start|dismissal|interruptions|native-lifecycle|terminal-outcomes|adaptive-hls-soak|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
     *) echo "Error: unknown scenario: $scenario" >&2; exit 2 ;;
   esac
 done
@@ -315,7 +353,7 @@ device_matches_hardware_row() {
 if ! device_matches_hardware_row "iphone-current"; then
   if [[ "$SCENARIOS_WERE_EXPLICIT" == true ]]; then
     for scenario in "${ONLY_SCENARIOS[@]}"; do
-      if [[ "$scenario" == "capability-convergence" || "$scenario" == "native-lifecycle" || "$scenario" == "terminal-outcomes" || "$scenario" == "deferred-pause-rejection" || "$scenario" == "accepted-start-delayed-failure" ]]; then
+      if [[ "$scenario" == "capability-convergence" || "$scenario" == "native-lifecycle" || "$scenario" == "terminal-outcomes" || "$scenario" == "adaptive-hls-soak" || "$scenario" == "deferred-pause-rejection" || "$scenario" == "accepted-start-delayed-failure" ]]; then
         echo "Error: $scenario requires the iphone-current hardware row." >&2
         exit 2
       fi
@@ -323,7 +361,7 @@ if ! device_matches_hardware_row "iphone-current"; then
   else
     FILTERED_SCENARIOS=()
     for scenario in "${ONLY_SCENARIOS[@]}"; do
-      if [[ "$scenario" != "capability-convergence" && "$scenario" != "native-lifecycle" && "$scenario" != "terminal-outcomes" && "$scenario" != "deferred-pause-rejection" && "$scenario" != "accepted-start-delayed-failure" ]]; then
+      if [[ "$scenario" != "capability-convergence" && "$scenario" != "native-lifecycle" && "$scenario" != "terminal-outcomes" && "$scenario" != "adaptive-hls-soak" && "$scenario" != "deferred-pause-rejection" && "$scenario" != "accepted-start-delayed-failure" ]]; then
         FILTERED_SCENARIOS+=("$scenario")
       fi
     done
@@ -456,6 +494,13 @@ run_scenario() {
       route="TerminalOutcomesValidation"
       selected_xctestrun="$DESTINATION_XCTESTRUN"
       ;;
+    adaptive-hls-soak)
+      test_identifiers=(
+        "iOSUITests/AdaptiveHLSSoakDeviceUITests/test_adaptiveHLSMatrixSoakRemainsBounded"
+      )
+      route="AdaptiveHLSSoakValidation"
+      selected_xctestrun="$DESTINATION_XCTESTRUN"
+      ;;
     deferred-pause-rejection)
       test_identifiers=(
         "iOSUITests/PiPDeferredPauseDeviceUITests/test_deferredPauseRejectionAndCancellationStayTruthful"
@@ -517,6 +562,8 @@ run_scenario() {
       --environment SWIFTVLC_PIP_INTERRUPTION_DEVICE=YES \
       --environment SWIFTVLC_PIP_NATIVE_LIFECYCLE_DEVICE=YES \
       --environment SWIFTVLC_TERMINAL_OUTCOMES_DEVICE=YES \
+      --environment SWIFTVLC_ADAPTIVE_HLS_SOAK_DEVICE=YES \
+      --environment SWIFTVLC_ADAPTIVE_SOAK_SECONDS="$ADAPTIVE_SOAK_SECONDS" \
       --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
       --environment SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE=YES \
       --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
@@ -532,6 +579,9 @@ run_scenario() {
   fi
 
   local started ended test_status result error_count log_status evidence_status
+  local allocation_trace_status="not-applicable"
+  local allocation_trace=""
+  local allocation_trace_toc=""
   local xcodebuild_log="$OUTPUT_DIR/$scenario-xcodebuild.log"
   local result_bundle="$OUTPUT_DIR/$scenario.xcresult"
   local test_selection_args=()
@@ -550,6 +600,7 @@ run_scenario() {
       -skip-testing:iOSUITests/PiPInterruptionDeviceUITests
       -skip-testing:iOSUITests/PiPNativeLifecycleDeviceUITests
       -skip-testing:iOSUITests/TerminalOutcomesDeviceUITests
+      -skip-testing:iOSUITests/AdaptiveHLSSoakDeviceUITests
       -skip-testing:iOSUITests/PiPDeferredPauseDeviceUITests
       -skip-testing:iOSUITests/PiPDelayedStartFailureDeviceUITests
       -skip-testing:iOSUITests/PiPOverlayDeviceUITests
@@ -564,26 +615,149 @@ run_scenario() {
     attempt_log="$OUTPUT_DIR/$scenario-xcodebuild-attempt$attempt.log"
     attempt_bundle="$OUTPUT_DIR/$scenario-attempt$attempt.xcresult"
     attempt_xctestrun="$selected_xctestrun"
+    local attempt_token=""
     if [[ "$scenario" != "analyzer" ]]; then
       final_log_prefix="$run_id-$scenario-attempt$attempt"
       attempt_xctestrun="$WORK_DIR/destination-$scenario-attempt$attempt.xctestrun"
-      python3 "$SCRIPT_DIR/prepare-xctestrun.py" \
-        "$selected_xctestrun" "$attempt_xctestrun" \
-        --environment SWIFTVLC_DEVICE_LOG_PREFIX="$final_log_prefix"
+      if [[ "$scenario" == "adaptive-hls-soak" ]]; then
+        attempt_token="$run_id-adaptive-$attempt"
+        python3 "$SCRIPT_DIR/prepare-xctestrun.py" \
+          "$selected_xctestrun" "$attempt_xctestrun" \
+          --environment SWIFTVLC_DEVICE_LOG_PREFIX="$final_log_prefix" \
+          --environment SWIFTVLC_ADAPTIVE_SOAK_TOKEN="$attempt_token"
+      else
+        python3 "$SCRIPT_DIR/prepare-xctestrun.py" \
+          "$selected_xctestrun" "$attempt_xctestrun" \
+          --environment SWIFTVLC_DEVICE_LOG_PREFIX="$final_log_prefix"
+      fi
       cp "$attempt_xctestrun" \
         "$OUTPUT_DIR/destination-$scenario-attempt$attempt.xctestrun"
     fi
+    if [[ "$scenario" == "adaptive-hls-soak" ]]; then
+      allocation_trace_status="missing"
+      allocation_trace="$OUTPUT_DIR/$scenario-allocations-attempt$attempt.trace"
+      allocation_trace_toc="$OUTPUT_DIR/$scenario-allocations-attempt$attempt-toc.xml"
+    fi
     set +e
-    xcodebuild test-without-building \
-      -xctestrun "$attempt_xctestrun" \
-      -destination "platform=iOS,id=$DEVICE_UDID" \
-      -collect-test-diagnostics never \
-      "${test_selection_args[@]}" \
-      -resultBundlePath "$attempt_bundle" \
-      > "$attempt_log" 2>&1
-    test_status=$?
+    if [[ "$scenario" == "adaptive-hls-soak" ]]; then
+      xcodebuild test-without-building \
+        -xctestrun "$attempt_xctestrun" \
+        -destination "platform=iOS,id=$DEVICE_UDID" \
+        -collect-test-diagnostics never \
+        -test-timeouts-enabled YES \
+        -default-test-execution-time-allowance "$((ADAPTIVE_SOAK_SECONDS + 300))" \
+        -maximum-test-execution-time-allowance "$((ADAPTIVE_SOAK_SECONDS + 300))" \
+        "${test_selection_args[@]}" \
+        -resultBundlePath "$attempt_bundle" \
+        > "$attempt_log" 2>&1 &
+      local xcodebuild_pid=$!
+      ACTIVE_XCODEBUILD_PID="$xcodebuild_pid"
+      local xctrace_pid=""
+      local trace_exited_early=false
+      for _ in {1..300}; do
+        if ! kill -0 "$xcodebuild_pid" 2>/dev/null; then
+          break
+        fi
+        if curl -fsS "$BASE_URL/adaptive/$attempt_token/metrics" 2>/dev/null \
+            | jq -e '.masterRequests > 0' >/dev/null 2>&1; then
+          xcrun xctrace record --quiet \
+            --template Allocations \
+            --device "$DEVICE_UDID" \
+            --attach iOS \
+            --time-limit "$((ADAPTIVE_SOAK_SECONDS + 300))s" \
+            --window 15m \
+            --output "$allocation_trace" \
+            --no-prompt \
+            > "$OUTPUT_DIR/$scenario-xctrace-attempt$attempt.log" 2>&1 &
+          xctrace_pid=$!
+          ACTIVE_XCTRACE_PID="$xctrace_pid"
+          break
+        fi
+        sleep 0.2
+      done
+      if [[ -n "$xctrace_pid" ]]; then
+        while kill -0 "$xcodebuild_pid" 2>/dev/null; do
+          if ! kill -0 "$xctrace_pid" 2>/dev/null; then
+            if curl -fsS "$BASE_URL/adaptive/$attempt_token/metrics" 2>/dev/null \
+                | jq -e '.clientCompleted == true' >/dev/null 2>&1; then
+              break
+            fi
+            trace_exited_early=true
+            echo "Error: allocation trace exited before the soak completed." >> "$attempt_log"
+            kill -TERM "$xcodebuild_pid" 2>/dev/null
+            break
+          fi
+          sleep 1
+        done
+      fi
+      wait "$xcodebuild_pid"
+      test_status=$?
+      ACTIVE_XCODEBUILD_PID=""
+      if [[ -n "$xctrace_pid" ]]; then
+        if kill -0 "$xctrace_pid" 2>/dev/null; then
+          kill -INT "$xctrace_pid" 2>/dev/null
+        fi
+        for _ in {1..100}; do
+          if ! kill -0 "$xctrace_pid" 2>/dev/null; then
+            break
+          fi
+          sleep 0.1
+        done
+        if kill -0 "$xctrace_pid" 2>/dev/null; then
+          kill -TERM "$xctrace_pid" 2>/dev/null
+        fi
+        for _ in {1..50}; do
+          if ! kill -0 "$xctrace_pid" 2>/dev/null; then
+            break
+          fi
+          sleep 0.1
+        done
+        if kill -0 "$xctrace_pid" 2>/dev/null; then
+          kill -KILL "$xctrace_pid" 2>/dev/null
+        fi
+        wait "$xctrace_pid" 2>/dev/null
+        ACTIVE_XCTRACE_PID=""
+      fi
+      if [[ "$trace_exited_early" == false ]] && [[ -d "$allocation_trace" ]]; then
+        python3 - "$allocation_trace" "$allocation_trace_toc" \
+            > "$OUTPUT_DIR/$scenario-xctrace-export-attempt$attempt.log" 2>&1 <<'PY'
+import subprocess
+import sys
+
+try:
+    result = subprocess.run(
+        [
+            "xcrun", "xctrace", "export", "--quiet",
+            "--input", sys.argv[1], "--toc", "--output", sys.argv[2],
+        ],
+        timeout=120,
+    )
+except subprocess.TimeoutExpired:
+    raise SystemExit(124)
+raise SystemExit(result.returncode)
+PY
+        local trace_export_status=$?
+        if [[ "$trace_export_status" -eq 0 ]] \
+          && [[ -s "$allocation_trace_toc" ]] \
+          && grep -qiE 'allocation|vm-tracker' "$allocation_trace_toc"; then
+          allocation_trace_status="captured"
+        fi
+      fi
+    else
+      xcodebuild test-without-building \
+        -xctestrun "$attempt_xctestrun" \
+        -destination "platform=iOS,id=$DEVICE_UDID" \
+        -collect-test-diagnostics never \
+        "${test_selection_args[@]}" \
+        -resultBundlePath "$attempt_bundle" \
+        > "$attempt_log" 2>&1
+      test_status=$?
+    fi
     set -e
     if [[ "$test_status" -eq 0 ]]; then
+      break
+    fi
+    if [[ "$scenario" == "adaptive-hls-soak" ]] && [[ "$trace_exited_early" == true ]]; then
       break
     fi
     if [[ "$attempt" -eq 3 ]] || ! grep -qE "$retryable_pattern" "$attempt_log"; then
@@ -694,12 +868,13 @@ PY
     fi
   fi
 
-  # This scenario deliberately drives six terminal engine failures. Preserve
-  # their raw error-level logs and report the count, but let the typed outcome
-  # assertions decide whether they are the expected failures. Every other
-  # scenario retains the strict zero-error gate.
+  # Terminal outcomes deliberately drives engine failures, while the adaptive
+  # soak deliberately injects recoverable HTTP failures. Preserve their raw
+  # logs, but let their typed assertions reject sanitizer signatures,
+  # unbounded recovery, or incorrect attribution. Other scenarios retain the
+  # strict zero-error gate.
   local log_errors_acceptable=false
-  if [[ "$error_count" -eq 0 || "$scenario" == "terminal-outcomes" ]]; then
+  if [[ "$error_count" -eq 0 || "$scenario" == "terminal-outcomes" || "$scenario" == "adaptive-hls-soak" ]]; then
     log_errors_acceptable=true
   fi
 
@@ -764,6 +939,10 @@ PY
       qualification_scenarios=("terminal-outcomes")
       qualification_attachments=("qualification-terminal-outcomes.json")
       ;;
+    adaptive-hls-soak)
+      qualification_scenarios=("adaptive-hls-soak")
+      qualification_attachments=("qualification-adaptive-hls-soak.json")
+      ;;
     deferred-pause-rejection)
       qualification_scenarios=("deferred-pause-rejection")
       qualification_attachments=("qualification-deferred-pause-rejection.json")
@@ -776,6 +955,7 @@ PY
   if [[ ${#qualification_scenarios[@]} -gt 0 ]]; then
     evidence_status="missing"
     if [[ "$test_status" -eq 0 ]] && [[ "$log_errors_acceptable" == true ]] \
+      && [[ "$allocation_trace_status" != "missing" ]] \
       && [[ "$log_status" == "captured" ]] && [[ -d "$result_bundle" ]]; then
       local attachments="$OUTPUT_DIR/$scenario-attachments"
       local hardware_id evidence_file evidence_relative export_status materialize_status
@@ -813,6 +993,25 @@ PY
           if [[ "$materialize_status" -ne 0 ]]; then
             continue
           fi
+          if [[ "$scenario" == "adaptive-hls-soak" ]]; then
+            set +e
+            python3 "$SCRIPT_DIR/augment-allocation-trace.py" \
+              --evidence "$evidence_file" \
+              --trace "$allocation_trace" \
+              --toc "$allocation_trace_toc" \
+              --digest-script "$ROOT_DIR/scripts/artifact-tree-digest.py"
+            local augment_trace_status=$?
+            set -e
+            if [[ "$augment_trace_status" -ne 0 ]]; then
+              continue
+            fi
+            if ! jq -e '
+                .durationSeconds
+                | type == "number" and . > 0 and floor == .
+              ' "$evidence_file" >/dev/null; then
+              continue
+            fi
+          fi
           materialized_count=$((materialized_count + 1))
           materialized_scenarios+=("$qualification_scenario")
           materialized_evidence+=("$evidence_relative")
@@ -820,10 +1019,15 @@ PY
         if [[ "$materialized_count" -eq "${#qualification_scenarios[@]}" ]]; then
           evidence_status="captured"
           for evidence_index in "${!materialized_scenarios[@]}"; do
+            local qualification_duration="$((ended - started))"
+            if [[ "${materialized_scenarios[$evidence_index]}" == "adaptive-hls-soak" ]]; then
+              qualification_duration=$(jq -r '.durationSeconds' \
+                "$OUTPUT_DIR/${materialized_evidence[$evidence_index]}")
+            fi
             python3 - \
                 "$OUTPUT_DIR/device.json" "$QUALIFICATION_ROWS" \
                 "${materialized_evidence[$evidence_index]}" \
-                "$FIXTURE_MANIFEST_CHECKSUM" "$((ended - started))" \
+                "$FIXTURE_MANIFEST_CHECKSUM" "$qualification_duration" \
                 "${materialized_scenarios[$evidence_index]}" <<'PY'
 import json
 import sys
@@ -856,6 +1060,7 @@ PY
 
   result="pass"
   if [[ "$test_status" -ne 0 ]] || [[ "$log_errors_acceptable" != true ]] || [[ "$log_status" == "missing" ]] \
+    || [[ "$allocation_trace_status" == "missing" ]] \
     || [[ "$evidence_status" == "missing" ]]; then
     result="fail"
   fi

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -32,6 +32,7 @@ prepare_xctestrun = load_script("prepare-xctestrun.py")
 verify_fixtures = load_script("verify-fixtures.py")
 candidate_metadata = load_script("candidate-metadata.py")
 materialize_evidence = load_script("materialize-evidence.py")
+augment_allocation_trace = load_script("augment-allocation-trace.py")
 assemble_record = load_script("assemble-record.py")
 
 
@@ -804,6 +805,97 @@ class QualificationEvidenceTests(unittest.TestCase):
             self.assertEqual(evidence["unattributedStopNaturalEndCount"], 0)
             self.assertTrue(evidence["subscriberPayloadsIdentical"])
 
+    def test_materializes_adaptive_hls_soak_evidence(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            payload = {
+                "formatVersion": 1,
+                "scenario": "adaptive-hls-soak",
+                "durationSeconds": 7200,
+                "playlistCoverage": {
+                    "playlistTypes": ["event", "live", "vod"],
+                    "containers": ["fmp4", "ts"],
+                    "variants": ["high", "low"],
+                    "variantTransitions": 4,
+                    "discontinuityManifests": 3,
+                    "expiredWindows": 2,
+                    "retryFailures": 1,
+                    "retryRecoveries": 1,
+                    "cancellations": 7,
+                },
+                "allocationProvenance": {
+                    "allocator": "Darwin default malloc zone",
+                    "sourceOwnershipRegression": "SegmentChunkOwnership_test",
+                    "expectedSourceReleaseCount": 1,
+                },
+                "memorySeries": [
+                    {"elapsedSeconds": 0, "residentBytes": 100},
+                    {"elapsedSeconds": 7200, "residentBytes": 101},
+                ],
+                "sanitizerFindings": 0,
+                "crashes": 0,
+                "unboundedRecoveries": 0,
+                "monotonicGrowth": False,
+                "upstreamCrossLink": "https://code.videolan.org/videolan/vlc/-/work_items/29845",
+            }
+            self.make_export(
+                root,
+                payload,
+                attachment_name="qualification-adaptive-hls-soak.json",
+                test_identifier="AdaptiveHLSSoakDeviceUITests/test_adaptiveHLSMatrixSoakRemainsBounded",
+            )
+            evidence = materialize_evidence.materialize(
+                root,
+                "qualification-adaptive-hls-soak.json",
+                "adaptive-hls-soak",
+                "iphone-current",
+                "a" * 64,
+                "b" * 64,
+            )
+            self.assertEqual(evidence["hardware"], "iphone-current")
+            self.assertEqual(evidence["sanitizerFindings"], 0)
+            self.assertFalse(evidence["monotonicGrowth"])
+            self.assertEqual(
+                evidence["allocationProvenance"]["expectedSourceReleaseCount"], 1
+            )
+
+    def test_host_binds_allocation_trace_digest_to_adaptive_evidence(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            evidence = root / "evidence.json"
+            evidence.write_text(
+                json.dumps(
+                    {
+                        "scenario": "adaptive-hls-soak",
+                        "allocationProvenance": {"allocator": "malloc"},
+                    }
+                )
+            )
+            trace = root / "adaptive.trace"
+            trace.mkdir()
+            (trace / "data.bin").write_bytes(b"candidate allocation stacks")
+            toc = root / "toc.xml"
+            toc.write_text('<table schema="allocations"/>')
+            digest_script = Path(__file__).resolve().parents[2] / "artifact-tree-digest.py"
+
+            augmented = augment_allocation_trace.augment(
+                evidence, trace, toc, digest_script
+            )
+            record = augmented["allocationProvenance"]["instrumentsTrace"]
+            self.assertRegex(record["treeDigest"], r"^[0-9a-f]{64}$")
+            self.assertEqual(record["template"], "Allocations")
+            self.assertEqual(
+                record["runArtifact"], "artifacts/evidence/adaptive.trace"
+            )
+            self.assertTrue((evidence.parent / record["runArtifact"]).is_dir())
+            self.assertTrue(
+                (evidence.parent / record["tableOfContents"]).is_file()
+            )
+
+            toc.write_text("<trace-toc/>")
+            with self.assertRaises(augment_allocation_trace.TraceEvidenceError):
+                augment_allocation_trace.augment(evidence, trace, toc, digest_script)
+
     def test_materializes_accepted_start_delayed_failure_evidence(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -1045,6 +1137,35 @@ class QualificationRecordAssemblyTests(unittest.TestCase):
         for row in record["rows"]:
             self.assertTrue((output.parent / row["evidence"]).is_file())
 
+    def test_assembles_digest_verified_allocation_trace_artifacts(self):
+        iphone = self.make_report("iphone")
+        ipad = self.make_report("ipad")
+        evidence_path = iphone.parent / "evidence" / "seek.json"
+        evidence = json.loads(evidence_path.read_text())
+        artifact_directory = evidence_path.parent / "artifacts" / "seek"
+        trace = artifact_directory / "allocations.trace"
+        trace.mkdir(parents=True)
+        (trace / "data.bin").write_bytes(b"allocation stacks")
+        toc = artifact_directory / "allocations-toc.xml"
+        toc.write_text('<table schema="allocations"/>')
+        evidence["allocationProvenance"] = {
+            "instrumentsTrace": {
+                "runArtifact": "artifacts/seek/allocations.trace",
+                "tableOfContents": "artifacts/seek/allocations-toc.xml",
+                "treeDigest": assemble_record.tree_digest(trace),
+            }
+        }
+        evidence_path.write_text(json.dumps(evidence))
+
+        output = self.root / "qualification" / "1.1.0.json"
+        assemble_record.assemble(
+            "1.1.0", self.candidate, self.matrix, [iphone, ipad], output
+        )
+
+        retained = output.parent / "evidence" / "1.1.0" / "artifacts" / "seek"
+        self.assertTrue((retained / "allocations.trace" / "data.bin").is_file())
+        self.assertTrue((retained / "allocations-toc.xml").is_file())
+
     def test_rejects_exploratory_and_duplicate_rows(self):
         output = self.root / "qualification" / "1.1.0.json"
         with self.assertRaises(assemble_record.AssemblyError):
@@ -1128,6 +1249,16 @@ class FixtureServerTests(unittest.TestCase):
         self.temporary = tempfile.TemporaryDirectory()
         self.root = Path(self.temporary.name)
         (self.root / "sample.bin").write_bytes(bytes(range(256)) * 64)
+        for container, suffix in (("ts", ".ts"), ("fmp4", ".m4s")):
+            for variant in ("low", "high"):
+                directory = self.root / "hls" / "soak" / container / variant
+                directory.mkdir(parents=True)
+                for index in range(4):
+                    (directory / f"segment-{index:03d}{suffix}").write_bytes(
+                        f"{container}-{variant}-{index}".encode()
+                    )
+                if container == "fmp4":
+                    (directory / "init.mp4").write_bytes(b"fixture-init")
         self.log = self.root / "requests.jsonl"
         self.server = fixture_server.FixtureHTTPServer(
             ("127.0.0.1", 0), self.root, self.log, 512, 0, False
@@ -1267,6 +1398,98 @@ class FixtureServerTests(unittest.TestCase):
             (self.root / "sample.bin").read_bytes()[:512],
         )
         retry_connection.close()
+
+    def test_adaptive_origin_serves_master_event_and_sliding_live_telemetry(self):
+        connection, response = self.request("/adaptive/run/vod-ts/master.m3u8")
+        master = response.read().decode()
+        connection.close()
+        self.assertEqual(response.status, 200)
+        self.assertIn("RESOLUTION=320x180", master)
+        self.assertIn("RESOLUTION=640x360", master)
+
+        connection, response = self.request("/adaptive/run/event-fmp4/low.m3u8")
+        event = response.read().decode()
+        connection.close()
+        self.assertIn("#EXT-X-PLAYLIST-TYPE:EVENT", event)
+        self.assertIn("#EXT-X-MAP", event)
+        self.assertIn("#EXT-X-DISCONTINUITY", event)
+
+        connection, response = self.request("/adaptive/run/live-ts/high.m3u8")
+        first_live = response.read().decode()
+        connection.close()
+        self.server._adaptive_started_at[("run", "live-ts", "high")] -= 4
+        connection, response = self.request("/adaptive/run/live-ts/high.m3u8")
+        second_live = response.read().decode()
+        connection.close()
+        self.assertIn("#EXT-X-MEDIA-SEQUENCE:0", first_live)
+        self.assertIn("#EXT-X-MEDIA-SEQUENCE:2", second_live)
+
+        connection, response = self.request("/adaptive/run/metrics")
+        metrics = json.loads(response.read())
+        connection.close()
+        self.assertEqual(metrics["playlistTypes"], ["event", "live", "vod"])
+        self.assertEqual(metrics["containers"], ["fmp4", "ts"])
+        self.assertGreater(metrics["expiredWindows"], 0)
+        self.assertGreater(metrics["discontinuityManifests"], 0)
+
+        connection, response = self.request("/adaptive/run/complete")
+        self.assertEqual(json.loads(response.read()), {"clientCompleted": True})
+        connection.close()
+        connection, response = self.request("/adaptive/run/metrics")
+        self.assertTrue(json.loads(response.read())["clientCompleted"])
+        connection.close()
+
+    def test_adaptive_retry_fails_once_then_recovers(self):
+        path = "/adaptive/retry/retry-ts/low/segment-000.ts"
+        connection, response = self.request(path)
+        self.assertEqual(response.status, 503)
+        response.read()
+        connection.close()
+
+        connection, response = self.request(path)
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.read(), b"ts-low-0")
+        connection.close()
+
+        connection, response = self.request("/adaptive/retry/metrics")
+        metrics = json.loads(response.read())
+        connection.close()
+        self.assertEqual(metrics["retryFailures"], 1)
+        self.assertEqual(metrics["retryRecoveries"], 1)
+
+    def test_adaptive_variant_transitions_require_one_multivariant_master(self):
+        for path in (
+            "/adaptive/transitions/abr-low-ts/low/segment-000.ts",
+            "/adaptive/transitions/abr-high-fmp4/high/segment-000.m4s",
+        ):
+            connection, response = self.request(path)
+            self.assertEqual(response.status, 200)
+            response.read()
+            connection.close()
+
+        connection, response = self.request("/adaptive/transitions/metrics")
+        self.assertEqual(json.loads(response.read())["variantTransitions"], 0)
+        connection.close()
+
+        for variant in ("low", "high"):
+            connection, response = self.request(
+                f"/adaptive/transitions/abr-ts/{variant}/segment-000.ts"
+            )
+            self.assertEqual(response.status, 200)
+            response.read()
+            connection.close()
+
+        connection, response = self.request("/adaptive/transitions/metrics")
+        self.assertEqual(json.loads(response.read())["variantTransitions"], 1)
+        connection.close()
+
+    def test_fmp4_generator_places_each_init_beside_its_variant(self):
+        script = (ROOT / "qualification" / "generate-fixtures.sh").read_text()
+        self.assertIn(
+            'cd "$fixture_tmp/hls/soak/fmp4/$variant"',
+            script,
+        )
+        self.assertIn("-hls_fmp4_init_filename init.mp4", script)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add an unattended, candidate-bound two-hour adaptive HLS soak on a physical current-generation iPhone
- cover VOD, event, and live playlists; TS/fMP4; both ABR variants; discontinuities; expired windows; injected retries/recovery; and repeated cancellation
- record resident/malloc trends, playback telemetry, library diagnostics, server coverage, and a digest-bound Instruments Allocations trace
- materialize the `adaptive-hls-soak` qualification row for issue #91 only when the full matrix minimum and evidence contract pass

The engine ownership fix for #91 is already on `main` from #116. This PR supplies the remaining repeatable candidate-bound qualification; it does not claim a device pass before the row is actually executed.

## Validation

- `bash -n scripts/qualification/run-device-tests.sh scripts/qualification/generate-fixtures.sh`
- `python3 -m unittest scripts.qualification.tests.test_qualification_harness` (41 passed)
- strict SwiftFormat and SwiftLint
- clean Release iOS Showcase `build-for-testing` against this local package branch
- `git diff --check origin/main...HEAD`

Closes #91 only after the physical qualification row is captured and accepted by the release gate; merging this harness alone does not close the issue.
