### PR TITLE
Automate native PiP subtitle qualification

### DIFF
--- a/Showcase/Shared/AccessibilityID.swift
+++ b/Showcase/Shared/AccessibilityID.swift
@@ -339,6 +339,18 @@ enum AccessibilityID {
     static let errorLabel = "pipCadence.error"
   }
 
+  enum NativeSubtitleMatrixValidation {
+    static let videoView = "nativeSubtitleMatrix.videoView"
+    static let stateLabel = "nativeSubtitleMatrix.state"
+    static let possibleLabel = "nativeSubtitleMatrix.possible"
+    static let activeLabel = "nativeSubtitleMatrix.active"
+    static let progressLabel = "nativeSubtitleMatrix.progress"
+    static let profileLabel = "nativeSubtitleMatrix.profile"
+    static let resultLabel = "nativeSubtitleMatrix.result"
+    static let runButton = "nativeSubtitleMatrix.run"
+    static let errorLabel = "nativeSubtitleMatrix.error"
+  }
+
   enum MatrixHValidation {
     static let stateLabel = "validation.matrixH.state"
     static let currentTimeLabel = "validation.matrixH.currentTime"

--- a/Showcase/Shared/LaunchArguments.swift
+++ b/Showcase/Shared/LaunchArguments.swift
@@ -65,6 +65,12 @@ enum LaunchArguments {
   static let pipCadenceBaseURLBase64 = "-UITestPiPCadenceBaseURLBase64"
   static let pipCadenceDuration = "-UITestPiPCadenceDuration"
 
+  /// Local origin, duration, and adaptive namespace for native subtitle/OSD
+  /// physical qualification.
+  static let nativeSubtitleBaseURLBase64 = "-UITestNativeSubtitleBaseURLBase64"
+  static let nativeSubtitleDuration = "-UITestNativeSubtitleDuration"
+  static let nativeSubtitleToken = "-UITestNativeSubtitleToken"
+
   /// Name of a showcase to deep-link to on launch (e.g. `"SimplePlayback"`).
   /// When unset, the showcase opens its normal navigation tree.
   static let route = "-UITestRoute"
@@ -158,6 +164,18 @@ enum LaunchArguments {
     UserDefaults.standard.string(forKey: key(pipCadenceDuration)).flatMap(Int.init)
   }
 
+  static var nativeSubtitleBaseURLValue: URL? {
+    encodedArgumentURL(named: nativeSubtitleBaseURLBase64)
+  }
+
+  static var nativeSubtitleDurationValue: Int? {
+    UserDefaults.standard.string(forKey: key(nativeSubtitleDuration)).flatMap(Int.init)
+  }
+
+  static var nativeSubtitleTokenValue: String? {
+    UserDefaults.standard.string(forKey: key(nativeSubtitleToken))
+  }
+
   static var routeValue: String? {
     UserDefaults.standard.string(forKey: key(route))
   }
@@ -246,6 +264,7 @@ enum UITestRoute: String, CaseIterable {
   case adaptiveHLSSoakValidation = "AdaptiveHLSSoakValidation"
   case pipRenderPerformanceValidation = "PiPRenderPerformanceValidation"
   case pipCadenceValidation = "PiPCadenceValidation"
+  case nativeSubtitleMatrixValidation = "NativeSubtitleMatrixValidation"
 
   static var current: UITestRoute? {
     LaunchArguments.routeValue.flatMap(UITestRoute.init(rawValue:))

--- a/Showcase/UITests/iOS/Support/ShowcaseIOSTestCase.swift
+++ b/Showcase/UITests/iOS/Support/ShowcaseIOSTestCase.swift
@@ -15,6 +15,18 @@ struct SystemPictureInPictureWindowRegion: Equatable {
   }
 }
 
+struct SystemPictureInPicturePixelSummary: Codable, Equatable {
+  let sampledPixels: Int
+  let brightPixelRatio: Double
+  let saturatedPixelRatio: Double
+  let yellowPixelRatio: Double
+  let greenPixelRatio: Double
+  let nonGrayPixelRatio: Double
+  let meanRed: Double
+  let meanGreen: Double
+  let meanBlue: Double
+}
+
 private struct SystemPictureInPictureInspectionFailure: Error, CustomStringConvertible {
   let description: String
 
@@ -375,6 +387,29 @@ class ShowcaseIOSTestCase: XCTestCase {
     return region
   }
 
+  /// Captures the detected system PiP window and reduces its pixels to stable,
+  /// numeric overlay/color evidence. Qualification tests compare these values
+  /// against the grayscale no-overlay phase instead of relying on a person to
+  /// inspect screenshots.
+  func captureSystemPictureInPicturePixelSummary(
+    in region: SystemPictureInPictureWindowRegion,
+    attachmentName: String
+  )
+    throws -> SystemPictureInPicturePixelSummary {
+    let screenshot = XCUIScreen.main.screenshot()
+    guard let crop = croppedSystemPictureInPictureRegion(screenshot.image, region: region) else {
+      throw SystemPictureInPictureInspectionFailure("Could not crop the system PiP window")
+    }
+    let attachment = XCTAttachment(image: crop)
+    attachment.name = attachmentName
+    attachment.lifetime = .keepAlways
+    add(attachment)
+    guard let summary = pictureInPicturePixelSummary(crop) else {
+      throw SystemPictureInPictureInspectionFailure("Could not rasterize the system PiP window")
+    }
+    return summary
+  }
+
   private func inspectSystemPictureInPictureMotion(
     samples: Int,
     interval: TimeInterval
@@ -623,6 +658,77 @@ private func croppedPiPMotionRegion(
   guard pixelRegion.width > 0, pixelRegion.height > 0 else { return nil }
   guard let cropped = cgImage.cropping(to: pixelRegion) else { return nil }
   return UIImage(cgImage: cropped, scale: image.scale, orientation: image.imageOrientation)
+}
+
+private func croppedSystemPictureInPictureRegion(
+  _ image: UIImage,
+  region: SystemPictureInPictureWindowRegion
+) -> UIImage? {
+  guard let cgImage = image.cgImage else { return nil }
+  let bounds = CGRect(x: 0, y: 0, width: cgImage.width, height: cgImage.height)
+  let crop = CGRect(
+    x: Double(cgImage.width) * region.normalizedX,
+    y: Double(cgImage.height) * region.normalizedY,
+    width: Double(cgImage.width) * region.normalizedWidth,
+    height: Double(cgImage.height) * region.normalizedHeight
+  ).integral.intersection(bounds)
+  guard crop.width > 0, crop.height > 0, let cropped = cgImage.cropping(to: crop) else {
+    return nil
+  }
+  return UIImage(cgImage: cropped, scale: image.scale, orientation: image.imageOrientation)
+}
+
+private func pictureInPicturePixelSummary(
+  _ image: UIImage
+) -> SystemPictureInPicturePixelSummary? {
+  guard let frame = makePiPMotionFrame(from: image) else { return nil }
+  let pixels = frame.pixels
+  guard !pixels.isEmpty else { return nil }
+  var bright = 0
+  var saturated = 0
+  var yellow = 0
+  var green = 0
+  var nonGray = 0
+  var redTotal: UInt64 = 0
+  var greenTotal: UInt64 = 0
+  var blueTotal: UInt64 = 0
+  for pixel in pixels {
+    let red = Int(pixel.red)
+    let greenValue = Int(pixel.green)
+    let blue = Int(pixel.blue)
+    let maximum = max(red, greenValue, blue)
+    let minimum = min(red, greenValue, blue)
+    if minimum >= 220 {
+      bright += 1
+    }
+    if maximum >= 150, maximum - minimum >= 80 {
+      saturated += 1
+    }
+    if red >= 180, greenValue >= 160, blue <= 140 {
+      yellow += 1
+    }
+    if greenValue >= 140, greenValue >= red + 35, greenValue >= blue + 20 {
+      green += 1
+    }
+    if maximum - minimum >= 30 {
+      nonGray += 1
+    }
+    redTotal += UInt64(pixel.red)
+    greenTotal += UInt64(pixel.green)
+    blueTotal += UInt64(pixel.blue)
+  }
+  let count = Double(pixels.count)
+  return SystemPictureInPicturePixelSummary(
+    sampledPixels: pixels.count,
+    brightPixelRatio: Double(bright) / count,
+    saturatedPixelRatio: Double(saturated) / count,
+    yellowPixelRatio: Double(yellow) / count,
+    greenPixelRatio: Double(green) / count,
+    nonGrayPixelRatio: Double(nonGray) / count,
+    meanRed: Double(redTotal) / count,
+    meanGreen: Double(greenTotal) / count,
+    meanBlue: Double(blueTotal) / count
+  )
 }
 
 private func systemPiPMotionDiagnostics(_ analysis: PiPMotionRegionAnalysis) -> String {

--- a/Showcase/UITests/iOS/Tests/NativeSubtitleMatrixDeviceUITests.swift
+++ b/Showcase/UITests/iOS/Tests/NativeSubtitleMatrixDeviceUITests.swift
@@ -1,0 +1,229 @@
+import XCTest
+
+/// Fully unattended native PiP subtitle/OSD qualification. The app performs
+/// media transitions and samples process state; this test proves the overlay
+/// pixels are present in the actual SpringBoard PiP window at both real sizes.
+final class NativeSubtitleMatrixDeviceUITests: ShowcaseIOSTestCase {
+  func test_nativeSubtitleMatrixIsVisibleAndBounded() throws {
+    #if targetEnvironment(simulator)
+    throw XCTSkip("Native subtitle qualification requires a physical iPhone")
+    #else
+    guard ProcessInfo.processInfo.environment["SWIFTVLC_NATIVE_SUBTITLE_DEVICE"] == "YES"
+    else {
+      throw XCTSkip("Set SWIFTVLC_NATIVE_SUBTITLE_DEVICE=YES for candidate-bound hardware runs")
+    }
+    addUIInterruptionMonitor(withDescription: "Local network permission") { alert in
+      let allow = alert.buttons["Allow"]
+      guard allow.exists else { return false }
+      allow.tap()
+      return true
+    }
+    let duration = max(
+      1,
+      Int(ProcessInfo.processInfo.environment["SWIFTVLC_NATIVE_SUBTITLE_SECONDS"] ?? "900")
+        ?? 900
+    )
+    let encodedBaseURL = try XCTUnwrap(
+      ProcessInfo.processInfo.environment["SWIFTVLC_NATIVE_SUBTITLE_BASE_URL_BASE64"]
+    )
+    let token = ProcessInfo.processInfo.environment["SWIFTVLC_NATIVE_SUBTITLE_TOKEN"]
+      ?? "subtitle-\(UUID().uuidString.lowercased())"
+    app.launchArguments += [
+      LaunchArguments.route, UITestRoute.nativeSubtitleMatrixValidation.rawValue,
+      LaunchArguments.nativeSubtitleBaseURLBase64, encodedBaseURL,
+      LaunchArguments.nativeSubtitleDuration, String(duration),
+      LaunchArguments.nativeSubtitleToken, token
+    ]
+    app.launch()
+    app.tap()
+
+    let possible = element(AccessibilityID.NativeSubtitleMatrixValidation.possibleLabel)
+    let active = element(AccessibilityID.NativeSubtitleMatrixValidation.activeLabel)
+    let profileLabel = element(AccessibilityID.NativeSubtitleMatrixValidation.profileLabel)
+    let result = element(AccessibilityID.NativeSubtitleMatrixValidation.resultLabel)
+    let run = app.buttons[AccessibilityID.NativeSubtitleMatrixValidation.runButton]
+    let error = element(AccessibilityID.NativeSubtitleMatrixValidation.errorLabel)
+    reveal(run)
+    XCTAssertTrue(run.isEnabled)
+    run.tap()
+    waitForLabel(possible, equals: "yes", timeout: 60)
+    waitForLabel(active, equals: "yes", timeout: 60)
+
+    let sequence = [
+      "baseline", "text", "styled", "bitmap", "forced", "live",
+      "adaptive-low", "adaptive-high", "hdr", "osd"
+    ]
+    var visual: [String: [String: Any]] = [:]
+    var baseline: SystemPictureInPicturePixelSummary?
+    var visualPasses: [String: Bool] = [:]
+    let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+
+    for profile in sequence {
+      app.activate()
+      waitForLabel(active, equals: "yes", timeout: 30)
+      waitForLabel(profileLabel, equals: profile, timeout: 120)
+      XCUIDevice.shared.press(.home)
+      RunLoop.current.run(until: Date().addingTimeInterval(profile == "baseline" ? 8 : 20))
+      var region = try locateSystemPictureInPictureWindow(samples: 5, interval: 0.5)
+      let initialRegion = region
+      let first = try bestSummary(profile: profile, region: region, suffix: "initial")
+
+      springboard.coordinate(
+        withNormalizedOffset: region.normalizedPoint(x: 0.5, y: 0.5)
+      ).doubleTap()
+      RunLoop.current.run(until: Date().addingTimeInterval(4))
+      region = try locateSystemPictureInPictureWindow(samples: 5, interval: 0.5)
+      let sizeChanged = abs(region.normalizedWidth - initialRegion.normalizedWidth) > 0.03
+        || abs(region.normalizedHeight - initialRegion.normalizedHeight) > 0.03
+      XCTAssertTrue(sizeChanged, "System PiP did not resize for \(profile)")
+      let resized = try bestSummary(profile: profile, region: region, suffix: "resized")
+      if profile == "baseline" {
+        baseline = first
+      }
+      let reference = try XCTUnwrap(baseline)
+      let passed = profile == "baseline"
+        || overlayIsVisible(profile: profile, samples: [first, resized], baseline: reference)
+      visualPasses[profile] = passed
+      XCTAssertTrue(passed, "No measurable \(profile) overlay appeared in system PiP")
+      visual[profile] = [
+        "initial": dictionary(first),
+        "resized": dictionary(resized),
+        "initialGeometry": geometry(region: initialRegion),
+        "resizedGeometry": geometry(region: region),
+        "visibleAtBothSizes": passed
+      ]
+    }
+
+    app.activate()
+    waitForPrefix(result, prefix: "pass:", timeout: TimeInterval(duration + 300))
+    XCTAssertFalse(error.exists, "Native subtitle matrix failed: \(error.label)")
+    var evidence = try decodeEvidence(result.label)
+    XCTAssertGreaterThanOrEqual(evidence["durationSeconds"] as? Int ?? 0, 900)
+    XCTAssertEqual(evidence["profileSequence"] as? [String], sequence)
+    XCTAssertEqual((evidence["timingTransitions"] as? [[String: Any]])?.count, sequence.count)
+    let adaptive = try XCTUnwrap(evidence["adaptiveResolution"] as? [String: Any])
+    XCTAssertEqual(try Set(XCTUnwrap(adaptive["variants"] as? [String])), ["low", "high"])
+    let successfulByVariant = try XCTUnwrap(
+      adaptive["successfulSegmentsByVariant"] as? [String: Int]
+    )
+    XCTAssertGreaterThan(successfulByVariant["low"] ?? 0, 0)
+    XCTAssertGreaterThan(successfulByVariant["high"] ?? 0, 0)
+
+    let supportProfiles = ["text", "styled", "bitmap", "forced", "live", "osd"]
+    var support: [String: String] = [:]
+    for profile in supportProfiles {
+      XCTAssertEqual(visualPasses[profile], true)
+      support[profile] = "supported"
+    }
+    evidence["supportMatrix"] = support
+    evidence["resizeGeometry"] = visual
+    var metrics = try XCTUnwrap(evidence["metrics"] as? [String: Any])
+    var color = try XCTUnwrap(metrics["colorHDRImpact"] as? [String: Any])
+    color["screenshotMeasurements"] = [
+      "baseline": visual["baseline"] as Any,
+      "hdrWithSubtitle": visual["hdr"] as Any,
+      "osd": visual["osd"] as Any,
+      "measurement": "SpringBoard system-PiP RGB pixel summary"
+    ]
+    metrics["colorHDRImpact"] = color
+    evidence["metrics"] = metrics
+    attachQualificationEvidence(evidence, scenario: "native-subtitle-matrix")
+    #endif
+  }
+
+  private func bestSummary(
+    profile: String,
+    region: SystemPictureInPictureWindowRegion,
+    suffix: String
+  )
+    throws -> SystemPictureInPicturePixelSummary {
+    var summaries: [SystemPictureInPicturePixelSummary] = []
+    for index in 0..<4 {
+      try summaries.append(
+        captureSystemPictureInPicturePixelSummary(
+          in: region,
+          attachmentName: "native-subtitle-\(profile)-\(suffix)-\(index)"
+        )
+      )
+      RunLoop.current.run(until: Date().addingTimeInterval(1))
+    }
+    return try XCTUnwrap(summaries.max(by: { signal(profile, $0) < signal(profile, $1) }))
+  }
+
+  private func overlayIsVisible(
+    profile: String,
+    samples: [SystemPictureInPicturePixelSummary],
+    baseline: SystemPictureInPicturePixelSummary
+  ) -> Bool {
+    samples.allSatisfy { sample in
+      switch profile {
+      case "text", "forced", "adaptive-low", "adaptive-high", "hdr":
+        sample.brightPixelRatio >= max(0.0004, baseline.brightPixelRatio + 0.00025)
+      case "styled", "osd":
+        sample.yellowPixelRatio >= max(0.0004, baseline.yellowPixelRatio + 0.00025)
+      case "bitmap", "live":
+        sample.greenPixelRatio >= max(0.0004, baseline.greenPixelRatio + 0.00025)
+      default:
+        false
+      }
+    }
+  }
+
+  private func signal(
+    _ profile: String,
+    _ summary: SystemPictureInPicturePixelSummary
+  ) -> Double {
+    switch profile {
+    case "styled", "osd": summary.yellowPixelRatio
+    case "bitmap", "live": summary.greenPixelRatio
+    default: summary.brightPixelRatio
+    }
+  }
+
+  private func dictionary(_ summary: SystemPictureInPicturePixelSummary) -> [String: Any] {
+    [
+      "sampledPixels": summary.sampledPixels,
+      "brightPixelRatio": summary.brightPixelRatio,
+      "saturatedPixelRatio": summary.saturatedPixelRatio,
+      "yellowPixelRatio": summary.yellowPixelRatio,
+      "greenPixelRatio": summary.greenPixelRatio,
+      "nonGrayPixelRatio": summary.nonGrayPixelRatio,
+      "meanRed": summary.meanRed,
+      "meanGreen": summary.meanGreen,
+      "meanBlue": summary.meanBlue
+    ]
+  }
+
+  private func geometry(region: SystemPictureInPictureWindowRegion) -> [String: Double] {
+    [
+      "x": region.normalizedX,
+      "y": region.normalizedY,
+      "width": region.normalizedWidth,
+      "height": region.normalizedHeight
+    ]
+  }
+
+  private func decodeEvidence(_ label: String) throws -> [String: Any] {
+    let prefix = "pass:"
+    XCTAssertTrue(label.hasPrefix(prefix))
+    let data = try XCTUnwrap(Data(base64Encoded: String(label.dropFirst(prefix.count))))
+    return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+  }
+
+  private func waitForPrefix(_ element: XCUIElement, prefix: String, timeout: TimeInterval) {
+    let predicate = NSPredicate { _, _ in element.exists && element.label.hasPrefix(prefix) }
+    let expectation = expectation(for: predicate, evaluatedWith: NSObject())
+    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: timeout), .completed)
+  }
+
+  private func reveal(_ element: XCUIElement) {
+    for _ in 0..<10 where !element.isHittable {
+      app.swipeUp()
+    }
+    XCTAssertTrue(element.isHittable)
+  }
+
+  private func element(_ identifier: String) -> XCUIElement {
+    app.descendants(matching: .any)[identifier]
+  }
+}

--- a/Showcase/iOS/Internal/UITestSupport.swift
+++ b/Showcase/iOS/Internal/UITestSupport.swift
@@ -138,6 +138,7 @@ extension UITestRoute {
     case .adaptiveHLSSoakValidation: AdaptiveHLSSoakValidationCase()
     case .pipRenderPerformanceValidation: PiPRenderPerformanceValidationCase()
     case .pipCadenceValidation: PiPCadenceValidationCase()
+    case .nativeSubtitleMatrixValidation: NativeSubtitleMatrixValidationCase()
     }
   }
 }

--- a/Showcase/iOS/ValidationHarness/NativeSubtitleMatrixValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/NativeSubtitleMatrixValidationCase.swift
@@ -1,0 +1,489 @@
+import Darwin
+import Foundation
+import SwiftUI
+import SwiftVLC
+
+/// Candidate-bound native PiP subtitle/OSD matrix. XCTest inspects the real
+/// SpringBoard pixels and drives resize gestures while this view owns media,
+/// subtitle, pause, seek, replacement, and adaptive-resolution transitions.
+struct NativeSubtitleMatrixValidationCase: View {
+  @State private var player = Player()
+  @State private var controller: PiPController?
+  @State private var result = "not-run"
+  @State private var progress = "0s"
+  @State private var profileName = "idle"
+  @State private var playbackError: String?
+  @State private var isRunning = false
+
+  private let baseURL = LaunchArguments.nativeSubtitleBaseURLValue
+  private let durationSeconds = max(1, LaunchArguments.nativeSubtitleDurationValue ?? 900)
+  private let token = LaunchArguments.nativeSubtitleTokenValue ?? "missing-token"
+
+  var body: some View {
+    _ = player.currentTime
+    return Form {
+      Section {
+        PiPVideoView(player, controller: $controller)
+          .frame(height: 220)
+          .listRowInsets(EdgeInsets())
+          .accessibilityIdentifier(AccessibilityID.NativeSubtitleMatrixValidation.videoView)
+      }
+      Section("Measured state") {
+        valueRow("Playback", value: String(describing: player.state), identifier: AccessibilityID.NativeSubtitleMatrixValidation.stateLabel)
+        valueRow("PiP possible", value: controller?.isPossible == true ? "yes" : "no", identifier: AccessibilityID.NativeSubtitleMatrixValidation.possibleLabel)
+        valueRow("PiP active", value: controller?.isActive == true ? "yes" : "no", identifier: AccessibilityID.NativeSubtitleMatrixValidation.activeLabel)
+        valueRow("Elapsed", value: progress, identifier: AccessibilityID.NativeSubtitleMatrixValidation.progressLabel)
+        valueRow("Profile", value: profileName, identifier: AccessibilityID.NativeSubtitleMatrixValidation.profileLabel)
+        valueRow("Qualification", value: result, identifier: AccessibilityID.NativeSubtitleMatrixValidation.resultLabel)
+      }
+      Section("Native subtitle matrix") {
+        Button("Run native subtitle matrix") { Task { await run() } }
+          .accessibilityIdentifier(AccessibilityID.NativeSubtitleMatrixValidation.runButton)
+          .disabled(isRunning || baseURL == nil || token == "missing-token")
+        if let playbackError {
+          Text(playbackError)
+            .foregroundStyle(.red)
+            .accessibilityIdentifier(AccessibilityID.NativeSubtitleMatrixValidation.errorLabel)
+        }
+      }
+    }
+    .showcaseFormStyle()
+    .navigationTitle("Native PiP subtitles")
+    .onDisappear {
+      player.withMarquee { $0.hide() }
+      controller?.stop()
+      player.stop()
+    }
+  }
+
+  private func run() async {
+    guard baseURL != nil, token != "missing-token" else { return }
+    isRunning = true
+    playbackError = nil
+    result = "running"
+    defer { isRunning = false }
+    do {
+      let started = ProcessInfo.processInfo.systemUptime
+      let phaseSeconds = max(55, (durationSeconds - 60) / SubtitleProfile.allCases.count)
+      var transitions: [SubtitleTransitionEvidence] = []
+      var samples: [SubtitleProcessSample] = []
+      let support = Dictionary(
+        uniqueKeysWithValues: SubtitleProfile.supportProfiles.map { ($0.supportKey, "app-played") }
+      )
+
+      try play(.baseline)
+      try await waitForPlayback(.baseline)
+      try await waitUntil("Native PiP did not become possible", timeout: .seconds(30)) {
+        controller?.isPossible == true
+      }
+      guard controller?.overlaySupport == .composited else {
+        throw SubtitleMatrixFailure("Linked native backend does not advertise overlay composition")
+      }
+      guard controller?.start() == .accepted else {
+        throw SubtitleMatrixFailure("Native PiP start was not accepted")
+      }
+      try await waitUntil("Native PiP did not become active", timeout: .seconds(30)) {
+        controller?.isActive == true
+      }
+
+      for (index, profile) in SubtitleProfile.allCases.enumerated() {
+        try Task.checkCancellation()
+        if index > 0 {
+          player.withMarquee { $0.hide() }
+          try play(profile)
+          try await waitForPlayback(profile)
+          try await waitUntil("PiP did not survive \(profile.rawValue) replacement", timeout: .seconds(30)) {
+            controller?.isActive == true
+          }
+        }
+        if profile == .osd {
+          player.withMarquee {
+            $0.show(
+              text: "SWIFTVLC OSD MATRIX  %H:%M:%S",
+              fontSize: 36,
+              color: 0xFFFF00,
+              position: OverlayPosition.bottomRight.rawValue
+            )
+          }
+        }
+        // The UI test treats this label as the readiness signal for its
+        // SpringBoard capture. Publish it only after replacement, subtitle
+        // selection, PiP survival, and OSD setup have all settled.
+        profileName = profile.rawValue
+
+        let phaseStarted = ProcessInfo.processInfo.systemUptime
+        var paused = false
+        var pausePassed = false
+        var seekAttempted = false
+        var seekAccepted: Bool?
+        var selectedSubtitle = profile == .baseline || profile == .osd
+        var previousStatistics = player.statistics
+        var displayedPictures: UInt64 = 0
+        var lostPictures: UInt64 = 0
+
+        while Int(ProcessInfo.processInfo.systemUptime - phaseStarted) < phaseSeconds {
+          try Task.checkCancellation()
+          let phaseElapsed = Int(ProcessInfo.processInfo.systemUptime - phaseStarted)
+          let totalElapsed = Int(ProcessInfo.processInfo.systemUptime - started)
+          progress = "\(totalElapsed)s / \(durationSeconds)s"
+          if profile.expectsSubtitle, !selectedSubtitle, let track = player.subtitleTracks.first {
+            player.selectedSubtitleTrack = track
+            selectedSubtitle = true
+          }
+          if phaseElapsed >= 15, !paused {
+            player.pause()
+            try await waitUntil("Pause did not settle", timeout: .seconds(10)) { !player.isActive }
+            try await Task.sleep(for: .seconds(2))
+            player.resume()
+            try await waitUntil("Resume did not settle", timeout: .seconds(10)) { player.isActive }
+            pausePassed = true
+            paused = true
+          }
+          if phaseElapsed >= 30, !seekAttempted {
+            seekAccepted = profile.isLive ? nil : player.jump(by: .seconds(8))
+            seekAttempted = true
+          }
+          if phaseElapsed.isMultiple(of: 5) {
+            samples.append(Self.processSample(elapsed: totalElapsed, profile: profile.rawValue))
+          }
+          if let current = player.statistics {
+            if let previousStatistics {
+              displayedPictures &+= Self.delta(current.displayedPictures, previousStatistics.displayedPictures)
+              lostPictures &+= Self.delta(current.lostPictures, previousStatistics.lostPictures)
+            }
+            previousStatistics = current
+          }
+          guard controller?.isActive == true else {
+            throw SubtitleMatrixFailure("Native PiP stopped during \(profile.rawValue)")
+          }
+          try await Task.sleep(for: .seconds(1))
+        }
+        guard pausePassed else {
+          throw SubtitleMatrixFailure("Pause/resume was not exercised for \(profile.rawValue)")
+        }
+        if !profile.isLive, seekAccepted != true {
+          throw SubtitleMatrixFailure("Seek was not accepted for \(profile.rawValue)")
+        }
+        if profile.expectsSubtitle, !selectedSubtitle {
+          throw SubtitleMatrixFailure("No subtitle track appeared for \(profile.rawValue)")
+        }
+        let pictureTotal = displayedPictures + lostPictures
+        let dropRate = pictureTotal > 0 ? Double(lostPictures) / Double(pictureTotal) : 1
+        guard displayedPictures > 0, dropRate <= 0.10 else {
+          throw SubtitleMatrixFailure("\(profile.rawValue) exceeded the presentation budget")
+        }
+        transitions.append(
+          SubtitleTransitionEvidence(
+            profile: profile.rawValue,
+            pauseResume: "pass",
+            seek: profile.isLive ? "not-applicable-live" : "pass",
+            replacement: index == 0 ? "initial" : "pass",
+            selectedSubtitle: selectedSubtitle,
+            displayedPictures: displayedPictures,
+            lostPictures: lostPictures,
+            dropRate: dropRate,
+            pipRemainedActive: true
+          )
+        )
+      }
+
+      let adaptive = try await adaptiveMetrics()
+      guard
+        Set(adaptive.variants) == ["low", "high"],
+        adaptive.successfulSegmentsByVariant["low", default: 0] > 0,
+        adaptive.successfulSegmentsByVariant["high", default: 0] > 0
+      else {
+        throw SubtitleMatrixFailure("Adaptive subtitle phases did not change resolution")
+      }
+      let elapsedBeforeMinimum = Int(ProcessInfo.processInfo.systemUptime - started)
+      if elapsedBeforeMinimum < durationSeconds {
+        try await Task.sleep(for: .seconds(durationSeconds - elapsedBeforeMinimum))
+      }
+      guard controller?.isActive == true else {
+        throw SubtitleMatrixFailure("Native PiP stopped before the minimum duration")
+      }
+      let completedDuration = Int(ProcessInfo.processInfo.systemUptime - started)
+      samples.append(Self.processSample(elapsed: completedDuration, profile: "complete"))
+      let cpuStart = samples.first?.cpuSeconds ?? 0
+      let cpuEnd = samples.last?.cpuSeconds ?? cpuStart
+      let evidence = NativeSubtitleEvidence(
+        durationSeconds: completedDuration,
+        phaseSeconds: phaseSeconds,
+        profileSequence: SubtitleProfile.allCases.map(\.rawValue),
+        supportMatrix: support,
+        timingTransitions: transitions,
+        adaptiveResolution: adaptive,
+        metrics: NativeSubtitleMetrics(
+          cpu: NativeSubtitleCPUMetric(
+            value: max(0, cpuEnd - cpuStart),
+            unit: "cpu-seconds",
+            source: "Mach task thread times",
+            hostTraceStatus: "required-host-augmentation"
+          ),
+          gpu: NativeSubtitleTraceMetric(
+            status: "required-host-augmentation",
+            source: "Instruments Game Performance"
+          ),
+          colorHDRImpact: NativeSubtitleColorMetric(
+            sourceCodec: "hevc",
+            sourcePixelFormat: "yuv420p10le",
+            colorPrimaries: "bt2020",
+            transferFunction: "smpte2084",
+            matrix: "bt2020nc",
+            screenshotMeasurements: "required-ui-augmentation",
+            hostTraceStatus: "required-host-augmentation"
+          ),
+          thermalStates: Array(Set(samples.map(\.thermalState))).sorted(),
+          samples: samples
+        ),
+        hostTraceRequirements: [
+          "cpu": "Time Profiler",
+          "gpu": "Game Performance",
+          "colorHDRImpact": "Metal System Trace"
+        ]
+      )
+      result = try "pass:\(JSONEncoder().encode(evidence).base64EncodedString())"
+      progress = "\(completedDuration)s / \(durationSeconds)s"
+      profileName = "complete"
+    } catch is CancellationError {
+      result = "cancelled"
+    } catch {
+      controller?.stop()
+      playbackError = String(describing: error)
+      result = "failed"
+    }
+  }
+
+  private func play(_ profile: SubtitleProfile) throws {
+    guard let baseURL else { throw SubtitleMatrixFailure("Missing fixture origin") }
+    let mediaURL: URL = switch profile {
+    case .live:
+      baseURL.appending(path: "live/subtitles/live.ts")
+    case .adaptiveLow:
+      baseURL.appending(path: "adaptive/\(token)/abr-low-ts/master.m3u8")
+    case .adaptiveHigh:
+      baseURL.appending(path: "adaptive/\(token)/abr-high-fmp4/master.m3u8")
+    default:
+      baseURL.appending(path: "files/subtitles/\(profile.fileName)")
+    }
+    let media = try Media(url: qualificationURL(mediaURL))
+    if profile.isAdaptive {
+      try media.addSlave(
+        from: baseURL.appending(path: "files/subtitles/text.srt"),
+        type: .subtitle
+      )
+    }
+    try player.play(media)
+  }
+
+  private func qualificationURL(_ url: URL) throws -> URL {
+    guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+      throw SubtitleMatrixFailure("Could not bind the fixture URL to this run")
+    }
+    var queryItems = components.queryItems ?? []
+    queryItems.append(URLQueryItem(name: "swiftvlcQualification", value: token))
+    components.queryItems = queryItems
+    guard let qualified = components.url else {
+      throw SubtitleMatrixFailure("Could not construct the candidate-bound fixture URL")
+    }
+    return qualified
+  }
+
+  private func waitForPlayback(_ profile: SubtitleProfile) async throws {
+    try await waitUntil("\(profile.rawValue) did not start", timeout: .seconds(30)) {
+      player.state == .playing
+    }
+    if profile.expectsSubtitle {
+      try await waitUntil("\(profile.rawValue) published no subtitle track", timeout: .seconds(30)) {
+        !player.subtitleTracks.isEmpty
+      }
+      if let track = player.subtitleTracks.first {
+        player.selectedSubtitleTrack = track
+      }
+      try await waitUntil("\(profile.rawValue) subtitle selection did not settle", timeout: .seconds(10)) {
+        player.selectedSubtitleTrack != nil
+      }
+    }
+  }
+
+  private func adaptiveMetrics() async throws -> AdaptiveSubtitleEvidence {
+    guard let url = baseURL?.appending(path: "adaptive/\(token)/metrics") else {
+      throw SubtitleMatrixFailure("Missing adaptive metrics endpoint")
+    }
+    let (data, response) = try await URLSession.shared.data(from: url)
+    guard
+      (response as? HTTPURLResponse)?.statusCode == 200,
+      let payload = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else { throw SubtitleMatrixFailure("Adaptive metrics request failed") }
+    return AdaptiveSubtitleEvidence(
+      variants: payload["variants"] as? [String] ?? [],
+      variantTransitions: payload["variantTransitions"] as? Int ?? 0,
+      successfulSegments: payload["successfulSegments"] as? Int ?? 0,
+      successfulSegmentsByVariant: payload["successfulSegmentsByVariant"]
+        as? [String: Int] ?? [:]
+    )
+  }
+
+  private func waitUntil(_ failure: String, timeout: Duration, condition: @escaping @MainActor () -> Bool) async throws {
+    let deadline = ContinuousClock.now.advanced(by: timeout)
+    while !condition() {
+      try Task.checkCancellation()
+      guard ContinuousClock.now < deadline else { throw SubtitleMatrixFailure(failure) }
+      try await Task.sleep(for: .milliseconds(100))
+    }
+  }
+
+  private func valueRow(_ title: String, value: String, identifier: String) -> some View {
+    HStack { Text(title); Spacer(); Text(value).foregroundStyle(.secondary).accessibilityIdentifier(identifier) }
+  }
+
+  private static func delta(_ current: UInt64, _ previous: UInt64) -> UInt64 {
+    current >= previous ? current - previous : current
+  }
+
+  private static func processSample(elapsed: Int, profile: String) -> SubtitleProcessSample {
+    var basic = mach_task_basic_info()
+    var basicCount = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size / MemoryLayout<natural_t>.size)
+    let basicStatus = withUnsafeMutablePointer(to: &basic) { pointer in
+      pointer.withMemoryRebound(to: integer_t.self, capacity: Int(basicCount)) {
+        task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &basicCount)
+      }
+    }
+    var times = task_thread_times_info()
+    var timesCount = mach_msg_type_number_t(MemoryLayout<task_thread_times_info>.size / MemoryLayout<natural_t>.size)
+    let timesStatus = withUnsafeMutablePointer(to: &times) { pointer in
+      pointer.withMemoryRebound(to: integer_t.self, capacity: Int(timesCount)) {
+        task_info(mach_task_self_, task_flavor_t(TASK_THREAD_TIMES_INFO), $0, &timesCount)
+      }
+    }
+    let cpu = timesStatus == KERN_SUCCESS
+      ? Double(times.user_time.seconds + times.system_time.seconds)
+      + Double(times.user_time.microseconds + times.system_time.microseconds) / 1_000_000
+      : 0
+    return SubtitleProcessSample(
+      elapsedSeconds: elapsed,
+      profile: profile,
+      residentBytes: basicStatus == KERN_SUCCESS ? basic.resident_size : 0,
+      cpuSeconds: cpu,
+      thermalState: ProcessInfo.processInfo.thermalState.subtitleQualificationName
+    )
+  }
+}
+
+private enum SubtitleProfile: String, CaseIterable {
+  case baseline, text, styled, bitmap, forced, live
+  case adaptiveLow = "adaptive-low"
+  case adaptiveHigh = "adaptive-high"
+  case hdr, osd
+
+  static let supportProfiles: [SubtitleProfile] = [.text, .styled, .bitmap, .forced, .live, .osd]
+  var supportKey: String {
+    rawValue
+  }
+
+  var isLive: Bool {
+    self == .live
+  }
+
+  var isAdaptive: Bool {
+    self == .adaptiveLow || self == .adaptiveHigh
+  }
+
+  var expectsSubtitle: Bool {
+    self != .baseline && self != .osd
+  }
+
+  var fileName: String {
+    switch self {
+    case .baseline, .osd: "base.mp4"
+    case .hdr: "hdr-text.mkv"
+    case .text, .styled, .bitmap, .forced: "\(rawValue).mkv"
+    case .live: "live.ts"
+    case .adaptiveLow, .adaptiveHigh: "text.srt"
+    }
+  }
+}
+
+private struct SubtitleProcessSample: Encodable {
+  let elapsedSeconds: Int
+  let profile: String
+  let residentBytes: UInt64
+  let cpuSeconds: Double
+  let thermalState: String
+}
+
+private struct SubtitleTransitionEvidence: Encodable {
+  let profile: String
+  let pauseResume: String
+  let seek: String
+  let replacement: String
+  let selectedSubtitle: Bool
+  let displayedPictures: UInt64
+  let lostPictures: UInt64
+  let dropRate: Double
+  let pipRemainedActive: Bool
+}
+
+private struct AdaptiveSubtitleEvidence: Encodable {
+  let variants: [String]
+  let variantTransitions: Int
+  let successfulSegments: Int
+  let successfulSegmentsByVariant: [String: Int]
+}
+
+private struct NativeSubtitleEvidence: Encodable {
+  let durationSeconds: Int
+  let phaseSeconds: Int
+  let profileSequence: [String]
+  let supportMatrix: [String: String]
+  let timingTransitions: [SubtitleTransitionEvidence]
+  let adaptiveResolution: AdaptiveSubtitleEvidence
+  let metrics: NativeSubtitleMetrics
+  let hostTraceRequirements: [String: String]
+}
+
+private struct NativeSubtitleMetrics: Encodable {
+  let cpu: NativeSubtitleCPUMetric
+  let gpu: NativeSubtitleTraceMetric
+  let colorHDRImpact: NativeSubtitleColorMetric
+  let thermalStates: [String]
+  let samples: [SubtitleProcessSample]
+}
+
+private struct NativeSubtitleCPUMetric: Encodable {
+  let value: Double
+  let unit: String
+  let source: String
+  let hostTraceStatus: String
+}
+
+private struct NativeSubtitleTraceMetric: Encodable { let status: String; let source: String }
+
+private struct NativeSubtitleColorMetric: Encodable {
+  let sourceCodec: String
+  let sourcePixelFormat: String
+  let colorPrimaries: String
+  let transferFunction: String
+  let matrix: String
+  let screenshotMeasurements: String
+  let hostTraceStatus: String
+}
+
+private struct SubtitleMatrixFailure: Error, CustomStringConvertible {
+  let description: String
+  init(_ description: String) {
+    self.description = description
+  }
+}
+
+extension ProcessInfo.ThermalState {
+  fileprivate var subtitleQualificationName: String {
+    switch self {
+    case .nominal: "nominal"
+    case .fair: "fair"
+    case .serious: "serious"
+    case .critical: "critical"
+    @unknown default: "unknown"
+    }
+  }
+}

--- a/Showcase/macOS/Internal/MacShowcaseRootView.swift
+++ b/Showcase/macOS/Internal/MacShowcaseRootView.swift
@@ -418,7 +418,8 @@ extension MacShowcase {
          .terminalOutcomesValidation,
          .adaptiveHLSSoakValidation,
          .pipRenderPerformanceValidation,
-         .pipCadenceValidation:
+         .pipCadenceValidation,
+         .nativeSubtitleMatrixValidation:
       return nil
     }
   }

--- a/Showcase/tvOS/Internal/TVShowcaseRootView.swift
+++ b/Showcase/tvOS/Internal/TVShowcaseRootView.swift
@@ -526,7 +526,8 @@ extension TVShowcase {
          .terminalOutcomesValidation,
          .adaptiveHLSSoakValidation,
          .pipRenderPerformanceValidation,
-         .pipCadenceValidation:
+         .pipCadenceValidation,
+         .nativeSubtitleMatrixValidation:
       return nil
     }
   }

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -253,6 +253,23 @@ so phase completion does not depend on media options unsupported by the pinned
 media-player API. `SWIFTVLC_CADENCE_SECONDS` may shorten exploratory runs, but the matrix
 rejects release evidence shorter than 600 seconds.
 
+The `native-subtitle-matrix` lane runs for at least 900 seconds on
+`iphone-current`. Deterministic grayscale fixtures exercise text, styled ASS,
+forced, DVB bitmap, repeated live DVB, adaptive-resolution text, 10-bit
+BT.2020/PQ HDR text, and marquee OSD composition. The bitmap stream is the
+exact SHA-256-pinned FFmpeg FATE filtered VideoLAN sample, so fixture drift
+fails generation. Every finite subtitle phase has a real 120-second seekable
+timeline; adaptive VOD reuses deterministic segments across explicit HLS
+discontinuities instead of relying on unsupported media repeat options. Native
+PiP remains active across media replacements,
+pause/resume, seek, and adaptive low/high transitions. XCTest measures the
+actual SpringBoard PiP pixels against the grayscale baseline and requires each
+supported overlay at both real PiP sizes. Host augmentation must also bind
+non-empty Time Profiler, Game Performance, and Metal System Trace recordings
+to the same candidate run. A missing subtitle track, absent overlay pixels,
+failed resize, more than 10% lost pictures, incomplete transition, wrong HDR
+metadata, shortened duration, or missing trace rejects the row.
+
 Use `--require-stable` for release evidence. It fails before testing if the
 device is a simulator, runs beta or unknown software, or does not match a
 hardware row in `matrix.json`. Without that option, the same command is useful
@@ -260,11 +277,11 @@ for exploratory beta-OS testing, but its report remains ineligible for release.
 
 This lane is intentionally fail-closed: its current automated scenarios are a
 candidate qualification subset, not a claim that all 53 qualification rows
-passed. `report.json` therefore keeps `releaseGateSatisfied` false until a
-matrix runner has produced the complete candidate-bound records described
-below. Remaining subtitle-format coverage, timebase soaks, and
-every required hardware/OS row must still be represented by
-automated evidence before the stable gate can open.
+passed. The harness has prepared automated coverage for 51 rows;
+`timebase-vod-soak` and `timebase-live-soak` remain to be automated.
+`report.json` therefore keeps `releaseGateSatisfied` false until a matrix
+runner has produced complete candidate-bound evidence for every required
+hardware/OS row described below.
 
 Qualification is bound to both halves of the shipped package. The
 XCFramework tree digest identifies the native engine and headers, while the

--- a/scripts/qualification/assemble-record.py
+++ b/scripts/qualification/assemble-record.py
@@ -156,6 +156,10 @@ def retained_trace_artifacts(
         raise AssemblyError(
             f"evidence {evidence_path} has malformed {description} provenance"
         )
+    if trace.get("treeDigestAlgorithm") != "swiftvlc-tree-v1":
+        raise AssemblyError(
+            f"evidence {evidence_path} {description} has unsupported digest algorithm"
+        )
     trace_source, trace_relative = safe_evidence_artifact_path(
         evidence_path,
         trace.get("runArtifact"),
@@ -301,6 +305,28 @@ def assemble(
                     artifacts.extend(
                         retained_trace_artifacts(
                             evidence_path, performance_trace, description
+                        )
+                    )
+            if key[0] == "native-subtitle-matrix":
+                metrics = evidence.get("metrics")
+                if not isinstance(metrics, dict):
+                    raise AssemblyError(
+                        f"evidence {evidence_path} has no native subtitle metrics"
+                    )
+                cpu = metrics.get("cpu")
+                color = metrics.get("colorHDRImpact")
+                if not isinstance(cpu, dict) or not isinstance(color, dict):
+                    raise AssemblyError(
+                        f"evidence {evidence_path} has malformed native subtitle metrics"
+                    )
+                for subtitle_trace, description in (
+                    (cpu.get("hostTrace"), "Time Profiler trace"),
+                    (metrics.get("gpu"), "Game Performance trace"),
+                    (color.get("hostTrace"), "Metal System Trace"),
+                ):
+                    artifacts.extend(
+                        retained_trace_artifacts(
+                            evidence_path, subtitle_trace, description
                         )
                     )
             rows[key] = (row, evidence_path, artifacts)

--- a/scripts/qualification/augment-native-subtitle-traces.py
+++ b/scripts/qualification/augment-native-subtitle-traces.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Bind CPU, GPU, and Metal/color traces to native subtitle evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+class NativeSubtitleTraceError(ValueError):
+    pass
+
+
+SHA256 = re.compile(r"[0-9a-f]{64}")
+TRACE_FIELDS = {
+    "time": ("cpu", "Time Profiler"),
+    "game": ("gpu", "Game Performance"),
+    "metal": ("colorHDRImpact", "Metal System Trace"),
+}
+
+
+def trace_record(
+    trace: Path,
+    toc: Path,
+    digest_script: Path,
+    template: str,
+    artifact_directory: Path,
+    evidence_directory: Path,
+) -> dict:
+    if not trace.is_dir() or not any(trace.rglob("*")):
+        raise NativeSubtitleTraceError(f"{template} trace is missing or empty")
+    try:
+        toc_text = toc.read_text(errors="replace")
+    except OSError as error:
+        raise NativeSubtitleTraceError(
+            f"cannot read {template} trace TOC: {error}"
+        ) from error
+    if "schema" not in toc_text.lower() and "table" not in toc_text.lower():
+        raise NativeSubtitleTraceError(f"{template} trace TOC has no recorded tables")
+    staged_trace = artifact_directory / trace.name
+    staged_toc = artifact_directory / toc.name
+    try:
+        shutil.copytree(trace, staged_trace)
+        shutil.copy2(toc, staged_toc)
+    except OSError as error:
+        raise NativeSubtitleTraceError(
+            f"cannot retain {template} trace artifacts: {error}"
+        ) from error
+    result = subprocess.run(
+        [sys.executable, str(digest_script), str(staged_trace)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    digest = result.stdout.strip()
+    if result.returncode != 0 or not SHA256.fullmatch(digest):
+        raise NativeSubtitleTraceError(f"could not digest {template} trace")
+    return {
+        "status": "captured",
+        "template": template,
+        "format": "com.apple.instruments.trace",
+        "runArtifact": staged_trace.relative_to(evidence_directory).as_posix(),
+        "tableOfContents": staged_toc.relative_to(evidence_directory).as_posix(),
+        "treeDigestAlgorithm": "swiftvlc-tree-v1",
+        "treeDigest": digest,
+        "targetProcess": "iOS",
+    }
+
+
+def augment(
+    evidence_path: Path,
+    traces: dict[str, tuple[Path, Path]],
+    digest_script: Path,
+) -> dict:
+    try:
+        payload = json.loads(evidence_path.read_text())
+    except (OSError, ValueError) as error:
+        raise NativeSubtitleTraceError(
+            f"cannot read native subtitle evidence: {error}"
+        ) from error
+    if not isinstance(payload, dict) or payload.get("scenario") != "native-subtitle-matrix":
+        raise NativeSubtitleTraceError(
+            "native subtitle traces belong only to native-subtitle-matrix"
+        )
+    metrics = payload.get("metrics")
+    if not isinstance(metrics, dict):
+        raise NativeSubtitleTraceError("native subtitle evidence has no metrics object")
+
+    artifact_directory = evidence_path.parent / "artifacts" / evidence_path.stem
+    try:
+        artifact_directory.mkdir(parents=True, exist_ok=False)
+    except OSError as error:
+        raise NativeSubtitleTraceError(
+            f"cannot create native subtitle trace artifact directory: {error}"
+        ) from error
+    try:
+        for key, (field, template) in TRACE_FIELDS.items():
+            trace, toc = traces[key]
+            record = trace_record(
+                trace,
+                toc,
+                digest_script,
+                template,
+                artifact_directory,
+                evidence_path.parent,
+            )
+            metric = metrics.get(field)
+            if not isinstance(metric, dict):
+                raise NativeSubtitleTraceError(f"{field} evidence is malformed")
+            metric.pop("hostTraceStatus", None)
+            if field == "gpu":
+                metrics[field] = record
+            else:
+                metric["hostTrace"] = record
+    except (OSError, NativeSubtitleTraceError):
+        shutil.rmtree(artifact_directory, ignore_errors=True)
+        raise
+    payload.pop("hostTraceRequirements", None)
+    evidence_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--time-trace", type=Path, required=True)
+    parser.add_argument("--time-toc", type=Path, required=True)
+    parser.add_argument("--game-trace", type=Path, required=True)
+    parser.add_argument("--game-toc", type=Path, required=True)
+    parser.add_argument("--metal-trace", type=Path, required=True)
+    parser.add_argument("--metal-toc", type=Path, required=True)
+    parser.add_argument("--digest-script", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        augment(
+            args.evidence,
+            {
+                "time": (args.time_trace, args.time_toc),
+                "game": (args.game_trace, args.game_toc),
+                "metal": (args.metal_trace, args.metal_toc),
+            },
+            args.digest_script,
+        )
+    except NativeSubtitleTraceError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qualification/fixture-server.py
+++ b/scripts/qualification/fixture-server.py
@@ -411,6 +411,7 @@ class FixtureHTTPServer(ThreadingHTTPServer):
                 "mediaPlaylistRequests": 0,
                 "segmentRequests": 0,
                 "successfulSegments": 0,
+                "successfulSegmentsByVariant": {"low": 0, "high": 0},
                 "retryFailures": 0,
                 "retryRecoveries": 0,
                 "expiredWindows": 0,
@@ -476,14 +477,22 @@ class FixtureHTTPServer(ThreadingHTTPServer):
             state["modes"].add(mode)
 
         is_live = playlist_type == "live"
+        is_subtitle_vod = mode in {"abr-low-ts", "abr-high-fmp4"}
         media_sequence = int((now - started) / 2) if is_live else 0
         if is_live:
             window_count = min(6, len(segments))
             indices = range(media_sequence, media_sequence + window_count)
+        elif is_subtitle_vod:
+            # The subtitle matrix owns each ABR profile for about 84 seconds.
+            # Reuse the deterministic two-second media segments to publish a
+            # real 120-second seekable timeline without duplicating fixture
+            # bytes. A discontinuity at every wrap resets segment timestamps
+            # while the playlist timeline remains monotonic.
+            indices = range(max(len(segments), 60))
         else:
             indices = range(len(segments))
 
-        discontinuity = playlist_type == "event" or is_live
+        discontinuity = playlist_type == "event" or is_live or is_subtitle_vod
         lines = [
             "#EXTM3U",
             "#EXT-X-VERSION:7" if container == "fmp4" else "#EXT-X-VERSION:3",
@@ -510,7 +519,9 @@ class FixtureHTTPServer(ThreadingHTTPServer):
         for offset, sequence in enumerate(indices):
             should_discontinue = (
                 playlist_type == "event" and offset == midpoint
-            ) or (is_live and sequence % len(segments) == midpoint)
+            ) or (is_live and sequence % len(segments) == midpoint) or (
+                is_subtitle_vod and offset > 0 and sequence % len(segments) == 0
+            )
             if should_discontinue:
                 lines.append("#EXT-X-DISCONTINUITY")
             segment = segments[sequence % len(segments)]
@@ -557,6 +568,7 @@ class FixtureHTTPServer(ThreadingHTTPServer):
             if mode != "retry-ts" or (token, mode, variant, filename) not in self._adaptive_retry_failures:
                 state["segmentRequests"] += 1
             state["successfulSegments"] += 1
+            state["successfulSegmentsByVariant"][variant] += 1
             state["variants"].add(variant)
             self._record_adaptive_variant(state, mode, variant)
             if recovered and (token, mode, variant, filename) in self._adaptive_retry_failures:

--- a/scripts/qualification/generate-fixtures.sh
+++ b/scripts/qualification/generate-fixtures.sh
@@ -14,6 +14,10 @@ if ! command -v ffprobe >/dev/null 2>&1; then
   echo "Error: ffprobe is required to verify qualification fixtures." >&2
   exit 1
 fi
+if ! command -v curl >/dev/null 2>&1; then
+  echo "Error: curl is required to fetch the pinned FFmpeg bitmap-subtitle sample." >&2
+  exit 1
+fi
 
 case "$DURATION_SECONDS" in
   ''|*[!0-9]*)
@@ -35,13 +39,153 @@ mkdir -p \
   "$fixture_tmp/hls/soak/fmp4/low" \
   "$fixture_tmp/hls/soak/fmp4/high" \
   "$fixture_tmp/performance" \
-  "$fixture_tmp/cadence"
+  "$fixture_tmp/cadence" \
+  "$fixture_tmp/subtitles"
 LIVE_DURATION_SECONDS="$DURATION_SECONDS"
 if [[ "$LIVE_DURATION_SECONDS" -lt 120 ]]; then
   LIVE_DURATION_SECONDS=120
 fi
 
 ffmpeg_quiet=(ffmpeg -hide_banner -loglevel error -nostdin -y)
+
+# A deliberately grayscale moving source makes the subtitle/OSD pixels
+# measurable in SpringBoard screenshots. No saturated source color can be
+# mistaken for a composited overlay.
+"${ffmpeg_quiet[@]}" \
+  -f lavfi -i "testsrc2=size=640x360:rate=30" \
+  -f lavfi -i "sine=frequency=700:sample_rate=48000" \
+  -vf "hue=s=0,eq=contrast=0.55:brightness=-0.15,format=yuv420p" \
+  -t "$LIVE_DURATION_SECONDS" -shortest \
+  -c:v libx264 -preset ultrafast -crf 28 -g 60 -keyint_min 60 -sc_threshold 0 \
+  -c:a aac -b:a 96k -movflags +faststart \
+  "$fixture_tmp/subtitles/base.mp4"
+
+python3 - "$fixture_tmp/subtitles" "$LIVE_DURATION_SECONDS" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+duration = int(sys.argv[2])
+
+def stamp(seconds: int, separator: str = ",") -> str:
+    hours, remainder = divmod(seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}{separator}000"
+
+cues = []
+events = []
+for index, start in enumerate(range(0, duration, 8), 1):
+    end = min(duration, start + 6)
+    cues.append(
+        f'{index}\n{stamp(start)} --> {stamp(end)}\n'
+        f'<font color="#FFFFFF">SWIFTVLC TEXT {index:02d}</font>\n'
+    )
+    events.append(
+        f'Dialogue: 0,{stamp(start, ".")[:-1]},{stamp(end, ".")[:-1]},Matrix,,0,0,0,,'
+        f'{{\\an2\\bord3\\c&H0000FFFF&}}STYLED MATRIX {index:02d}'
+    )
+(root / "text.srt").write_text("\n".join(cues))
+(root / "forced.srt").write_text("\n".join(cue.replace("TEXT", "FORCED") for cue in cues))
+(root / "styled.ass").write_text(
+    "[Script Info]\nScriptType: v4.00+\nPlayResX: 640\nPlayResY: 360\n\n"
+    "[V4+ Styles]\n"
+    "Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColour,BackColour,"
+    "Bold,Italic,Underline,StrikeOut,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,"
+    "Alignment,MarginL,MarginR,MarginV,Encoding\n"
+    "Style: Matrix,Helvetica,38,&H0000FFFF,&H000000FF,&H00000000,&H80000000,"
+    "-1,0,0,0,100,100,0,0,1,3,1,2,20,20,28,1\n\n"
+    "[Events]\n"
+    "Format: Layer,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text\n"
+    + "\n".join(events)
+    + "\n"
+)
+PY
+
+for subtitle_profile in text styled forced; do
+  subtitle_input="$fixture_tmp/subtitles/$subtitle_profile.srt"
+  subtitle_codec="srt"
+  if [[ "$subtitle_profile" == "styled" ]]; then
+    subtitle_input="$fixture_tmp/subtitles/styled.ass"
+    subtitle_codec="ass"
+  fi
+  subtitle_disposition="default"
+  if [[ "$subtitle_profile" == "forced" ]]; then
+    subtitle_disposition="forced+default"
+  fi
+  "${ffmpeg_quiet[@]}" \
+    -i "$fixture_tmp/subtitles/base.mp4" -i "$subtitle_input" \
+    -map 0:v -map 0:a -map 1:0 -c:v copy -c:a copy -c:s "$subtitle_codec" \
+    -metadata:s:s:0 language=eng -metadata:s:s:0 title="$subtitle_profile" \
+    -disposition:s:0 "$subtitle_disposition" \
+    "$fixture_tmp/subtitles/$subtitle_profile.mkv"
+done
+
+# FFmpeg's 77 KiB FATE sample is a filtered VideoLAN DVB-subtitle stream. Pin
+# the exact bytes: an upstream change, redirect, or unavailable source fails
+# fixture generation instead of silently changing release evidence.
+bitmap_source="$fixture_tmp/subtitles/dvbsubtest_filter.ts"
+curl -fsSL https://fate-suite.ffmpeg.org/sub/dvbsubtest_filter.ts -o "$bitmap_source"
+bitmap_digest=$(shasum -a 256 "$bitmap_source" | cut -d' ' -f1)
+if [[ "$bitmap_digest" != "93ad6d0be649bb29697275ff522a983d475a1e58ab070271f912b86799e04a86" ]]; then
+  echo "Error: pinned FFmpeg DVB-subtitle fixture digest changed: $bitmap_digest" >&2
+  exit 1
+fi
+"${ffmpeg_quiet[@]}" -copyts -start_at_zero -i "$bitmap_source" \
+  -map 0:s:0 -c copy "$fixture_tmp/subtitles/bitmap-only.mkv"
+"${ffmpeg_quiet[@]}" \
+  -i "$fixture_tmp/subtitles/base.mp4" \
+  -stream_loop -1 -i "$fixture_tmp/subtitles/bitmap-only.mkv" \
+  -map 0:v -map 0:a -map 1:s:0 -c copy -metadata:s:s:0 title=bitmap \
+  -disposition:s:0 default -t "$LIVE_DURATION_SECONDS" \
+  "$fixture_tmp/subtitles/bitmap.mkv"
+"${ffmpeg_quiet[@]}" \
+  -stream_loop -1 -i "$fixture_tmp/subtitles/bitmap.mkv" \
+  -t "$LIVE_DURATION_SECONDS" -map 0:v -map 0:a -map 0:s:0 -c copy -f mpegts \
+  "$fixture_tmp/subtitles/live.ts"
+
+# A real 10-bit BT.2020/PQ source measures HDR/color impact with and without
+# native PiP composition. The expensive HEVC source is encoded once, then
+# remuxed into a real continuous timeline long enough for the physical phase.
+"${ffmpeg_quiet[@]}" \
+  -f lavfi -i "testsrc2=size=640x360:rate=30" \
+  -f lavfi -i "sine=frequency=740:sample_rate=48000" \
+  -t 6 -shortest \
+  -vf "hue=s=0,eq=contrast=0.55:brightness=-0.15,format=yuv420p10le" \
+  -c:v libx265 -preset ultrafast \
+  -x265-params "hdr10=1:repeat-headers=1:colorprim=bt2020:transfer=smpte2084:colormatrix=bt2020nc" \
+  -tag:v hvc1 -c:a aac -b:a 96k -movflags +faststart \
+  "$fixture_tmp/subtitles/hdr-base.mp4"
+"${ffmpeg_quiet[@]}" \
+  -stream_loop -1 -i "$fixture_tmp/subtitles/hdr-base.mp4" \
+  -i "$fixture_tmp/subtitles/text.srt" \
+  -map 0:v -map 0:a -map 1:0 -c:v copy -c:a copy -c:s srt \
+  -metadata:s:s:0 title=hdr-text -disposition:s:0 default \
+  -t "$LIVE_DURATION_SECONDS" "$fixture_tmp/subtitles/hdr-text.mkv"
+ffprobe -v error -select_streams v:0 \
+  -show_entries stream=codec_name,pix_fmt,color_space,color_transfer,color_primaries \
+  -of json "$fixture_tmp/subtitles/hdr-text.mkv" \
+  > "$fixture_tmp/subtitles/hdr-probe.json"
+python3 - "$fixture_tmp/subtitles/hdr-probe.json" <<'PY'
+import json
+import sys
+
+streams = json.load(open(sys.argv[1])).get("streams", [])
+expected = {
+    "codec_name": "hevc",
+    "pix_fmt": "yuv420p10le",
+    "color_space": "bt2020nc",
+    "color_transfer": "smpte2084",
+    "color_primaries": "bt2020",
+}
+if len(streams) != 1 or any(streams[0].get(key) != value for key, value in expected.items()):
+    raise SystemExit(
+        f"generated HDR subtitle fixture metadata mismatch: {streams!r} != {expected!r}"
+    )
+PY
+rm "$fixture_tmp/subtitles/bitmap-only.mkv" \
+  "$fixture_tmp/subtitles/dvbsubtest_filter.ts" \
+  "$fixture_tmp/subtitles/hdr-base.mp4" \
+  "$fixture_tmp/subtitles/hdr-probe.json"
 
 "${ffmpeg_quiet[@]}" \
   -f lavfi -i "testsrc2=size=640x360:rate=30" \
@@ -193,6 +337,8 @@ rm -rf "$OUTPUT_DIR/performance"
 mv "$fixture_tmp/performance" "$OUTPUT_DIR/performance"
 rm -rf "$OUTPUT_DIR/cadence"
 mv "$fixture_tmp/cadence" "$OUTPUT_DIR/cadence"
+rm -rf "$OUTPUT_DIR/subtitles"
+mv "$fixture_tmp/subtitles" "$OUTPUT_DIR/subtitles"
 mv "$fixture_tmp/vod.m3u8" "$OUTPUT_DIR/hls/vod.m3u8"
 for segment in "$fixture_tmp"/vod-*.ts; do
   mv "$segment" "$OUTPUT_DIR/hls/$(basename "$segment")"
@@ -247,6 +393,21 @@ manifest = {
         "rates": [23.976, 24, 25, 29.97, 30, 50, 59.94, 60],
         "vfr": True,
         "durationSeconds": live_duration,
+    },
+    "subtitles": {
+        "profiles": ["text", "styled", "bitmap", "forced", "live", "adaptive", "hdr", "osd"],
+        "bitmapSource": {
+            "origin": "FFmpeg FATE filtered VideoLAN DVB subtitle sample",
+            "sha256": "93ad6d0be649bb29697275ff522a983d475a1e58ab070271f912b86799e04a86",
+        },
+        "hdr": {
+            "codec": "hevc",
+            "pixelFormat": "yuv420p10le",
+            "colorPrimaries": "bt2020",
+            "transfer": "smpte2084",
+            "colorSpace": "bt2020nc",
+            "durationSeconds": live_duration,
+        },
     },
     "files": files,
 }

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -17,6 +17,7 @@ ONLY_SCENARIOS=()
 ADAPTIVE_SOAK_SECONDS="${SWIFTVLC_ADAPTIVE_SOAK_SECONDS:-7200}"
 PIP_PERFORMANCE_SECONDS="${SWIFTVLC_PIP_PERFORMANCE_SECONDS:-900}"
 CADENCE_SECONDS="${SWIFTVLC_CADENCE_SECONDS:-600}"
+NATIVE_SUBTITLE_SECONDS="${SWIFTVLC_NATIVE_SUBTITLE_SECONDS:-900}"
 
 usage() {
   cat <<'EOF'
@@ -44,6 +45,7 @@ Options:
                           pip-render-performance-1080p60,
                           pip-render-performance-4k60,
                           cadence-matrix,
+                          native-subtitle-matrix,
                           deferred-pause-rejection,
                           accepted-start-delayed-failure, hls-seek,
                           harness-regressions, ui-failures, thumbnail-preview
@@ -85,6 +87,16 @@ case "$CADENCE_SECONDS" in
 esac
 if [[ "$CADENCE_SECONDS" -le 0 ]]; then
   echo "Error: SWIFTVLC_CADENCE_SECONDS must be positive." >&2
+  exit 2
+fi
+case "$NATIVE_SUBTITLE_SECONDS" in
+  ''|*[!0-9]*)
+    echo "Error: SWIFTVLC_NATIVE_SUBTITLE_SECONDS must be a positive integer." >&2
+    exit 2
+    ;;
+esac
+if [[ "$NATIVE_SUBTITLE_SECONDS" -lt 900 ]]; then
+  echo "Error: SWIFTVLC_NATIVE_SUBTITLE_SECONDS must be at least 900." >&2
   exit 2
 fi
 
@@ -178,7 +190,9 @@ if [[ ! -f "$FIXTURES/manifest.json" \
   || ! -f "$FIXTURES/performance/1080p60.mp4" \
   || ! -f "$FIXTURES/performance/4k60.mp4" \
   || ! -f "$FIXTURES/cadence/23_976.mp4" \
-  || ! -f "$FIXTURES/cadence/vfr.mp4" ]]; then
+  || ! -f "$FIXTURES/cadence/vfr.mp4" \
+  || ! -f "$FIXTURES/subtitles/bitmap.mkv" \
+  || ! -f "$FIXTURES/subtitles/hdr-text.mkv" ]]; then
   "$SCRIPT_DIR/generate-fixtures.sh" "$FIXTURES"
 fi
 python3 "$SCRIPT_DIR/verify-fixtures.py" "$FIXTURES" > /dev/null
@@ -361,6 +375,7 @@ xcrun devicectl device copy to \
 DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-audio continuity capability-convergence vod-controls long-stall failed-start dismissal interruptions native-lifecycle terminal-outcomes adaptive-hls-soak deferred-pause-rejection accepted-start-delayed-failure hls-seek)
 DEFAULT_SCENARIOS+=(pip-render-performance-1080p60 pip-render-performance-4k60)
 DEFAULT_SCENARIOS+=(cadence-matrix)
+DEFAULT_SCENARIOS+=(native-subtitle-matrix)
 SCENARIOS_WERE_EXPLICIT=false
 if [[ ${#ONLY_SCENARIOS[@]} -eq 0 ]]; then
   ONLY_SCENARIOS=("${DEFAULT_SCENARIOS[@]}")
@@ -369,7 +384,7 @@ else
 fi
 for scenario in "${ONLY_SCENARIOS[@]}"; do
   case "$scenario" in
-    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|vod-controls|long-stall|failed-start|dismissal|interruptions|native-lifecycle|terminal-outcomes|adaptive-hls-soak|pip-render-performance-1080p60|pip-render-performance-4k60|cadence-matrix|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
+    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|vod-controls|long-stall|failed-start|dismissal|interruptions|native-lifecycle|terminal-outcomes|adaptive-hls-soak|pip-render-performance-1080p60|pip-render-performance-4k60|cadence-matrix|native-subtitle-matrix|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
     *) echo "Error: unknown scenario: $scenario" >&2; exit 2 ;;
   esac
 done
@@ -384,7 +399,7 @@ device_matches_hardware_row() {
 if ! device_matches_hardware_row "iphone-current"; then
   if [[ "$SCENARIOS_WERE_EXPLICIT" == true ]]; then
     for scenario in "${ONLY_SCENARIOS[@]}"; do
-      if [[ "$scenario" == "capability-convergence" || "$scenario" == "native-lifecycle" || "$scenario" == "terminal-outcomes" || "$scenario" == "adaptive-hls-soak" || "$scenario" == pip-render-performance-* || "$scenario" == "cadence-matrix" || "$scenario" == "deferred-pause-rejection" || "$scenario" == "accepted-start-delayed-failure" ]]; then
+      if [[ "$scenario" == "capability-convergence" || "$scenario" == "native-lifecycle" || "$scenario" == "terminal-outcomes" || "$scenario" == "adaptive-hls-soak" || "$scenario" == pip-render-performance-* || "$scenario" == "cadence-matrix" || "$scenario" == "native-subtitle-matrix" || "$scenario" == "deferred-pause-rejection" || "$scenario" == "accepted-start-delayed-failure" ]]; then
         echo "Error: $scenario requires the iphone-current hardware row." >&2
         exit 2
       fi
@@ -392,7 +407,7 @@ if ! device_matches_hardware_row "iphone-current"; then
   else
     FILTERED_SCENARIOS=()
     for scenario in "${ONLY_SCENARIOS[@]}"; do
-      if [[ "$scenario" != "capability-convergence" && "$scenario" != "native-lifecycle" && "$scenario" != "terminal-outcomes" && "$scenario" != "adaptive-hls-soak" && "$scenario" != pip-render-performance-* && "$scenario" != "cadence-matrix" && "$scenario" != "deferred-pause-rejection" && "$scenario" != "accepted-start-delayed-failure" ]]; then
+      if [[ "$scenario" != "capability-convergence" && "$scenario" != "native-lifecycle" && "$scenario" != "terminal-outcomes" && "$scenario" != "adaptive-hls-soak" && "$scenario" != pip-render-performance-* && "$scenario" != "cadence-matrix" && "$scenario" != "native-subtitle-matrix" && "$scenario" != "deferred-pause-rejection" && "$scenario" != "accepted-start-delayed-failure" ]]; then
         FILTERED_SCENARIOS+=("$scenario")
       fi
     done
@@ -616,6 +631,13 @@ run_scenario() {
       route="PiPCadenceValidation"
       selected_xctestrun="$DESTINATION_XCTESTRUN"
       ;;
+    native-subtitle-matrix)
+      test_identifiers=(
+        "iOSUITests/NativeSubtitleMatrixDeviceUITests/test_nativeSubtitleMatrixIsVisibleAndBounded"
+      )
+      route="NativeSubtitleMatrixValidation"
+      selected_xctestrun="$DESTINATION_XCTESTRUN"
+      ;;
     deferred-pause-rejection)
       test_identifiers=(
         "iOSUITests/PiPDeferredPauseDeviceUITests/test_deferredPauseRejectionAndCancellationStayTruthful"
@@ -686,6 +708,9 @@ run_scenario() {
       --environment SWIFTVLC_PIP_CADENCE_DEVICE=YES \
       --environment SWIFTVLC_PIP_CADENCE_BASE_URL_BASE64="$(printf '%s/' "$BASE_URL" | base64 | tr -d '\r\n')" \
       --environment SWIFTVLC_CADENCE_SECONDS="$CADENCE_SECONDS" \
+      --environment SWIFTVLC_NATIVE_SUBTITLE_DEVICE=YES \
+      --environment SWIFTVLC_NATIVE_SUBTITLE_BASE_URL_BASE64="$(printf '%s/' "$BASE_URL" | base64 | tr -d '\r\n')" \
+      --environment SWIFTVLC_NATIVE_SUBTITLE_SECONDS="$NATIVE_SUBTITLE_SECONDS" \
       --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
       --environment SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE=YES \
       --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
@@ -711,6 +736,13 @@ run_scenario() {
   local perf_power_toc=""
   local perf_time_trace=""
   local perf_time_toc=""
+  local subtitle_trace_status="not-applicable"
+  local subtitle_game_trace=""
+  local subtitle_game_toc=""
+  local subtitle_time_trace=""
+  local subtitle_time_toc=""
+  local subtitle_metal_trace=""
+  local subtitle_metal_toc=""
   local xcodebuild_log="$OUTPUT_DIR/$scenario-xcodebuild.log"
   local result_bundle="$OUTPUT_DIR/$scenario.xcresult"
   local test_selection_args=()
@@ -732,6 +764,7 @@ run_scenario() {
       -skip-testing:iOSUITests/AdaptiveHLSSoakDeviceUITests
       -skip-testing:iOSUITests/PiPRenderPerformanceDeviceUITests
       -skip-testing:iOSUITests/PiPCadenceDeviceUITests
+      -skip-testing:iOSUITests/NativeSubtitleMatrixDeviceUITests
       -skip-testing:iOSUITests/PiPDeferredPauseDeviceUITests
       -skip-testing:iOSUITests/PiPDelayedStartFailureDeviceUITests
       -skip-testing:iOSUITests/PiPOverlayDeviceUITests
@@ -786,6 +819,21 @@ run_scenario() {
       perf_power_toc="$OUTPUT_DIR/$scenario-power-attempt$attempt-toc.xml"
       perf_time_trace="$OUTPUT_DIR/$scenario-time-attempt$attempt.trace"
       perf_time_toc="$OUTPUT_DIR/$scenario-time-attempt$attempt-toc.xml"
+    elif [[ "$scenario" == "native-subtitle-matrix" ]]; then
+      attempt_token="$run_id-subtitle-$attempt"
+      attempt_xctestrun="$WORK_DIR/destination-$scenario-attempt$attempt.xctestrun"
+      python3 "$SCRIPT_DIR/prepare-xctestrun.py" \
+        "$selected_xctestrun" "$attempt_xctestrun" \
+        --environment SWIFTVLC_DEVICE_LOG_PREFIX="$final_log_prefix" \
+        --environment SWIFTVLC_NATIVE_SUBTITLE_TOKEN="$attempt_token"
+      cp "$attempt_xctestrun" "$OUTPUT_DIR/destination-$scenario-attempt$attempt.xctestrun"
+      subtitle_trace_status="missing"
+      subtitle_game_trace="$OUTPUT_DIR/$scenario-game-attempt$attempt.trace"
+      subtitle_game_toc="$OUTPUT_DIR/$scenario-game-attempt$attempt-toc.xml"
+      subtitle_time_trace="$OUTPUT_DIR/$scenario-time-attempt$attempt.trace"
+      subtitle_time_toc="$OUTPUT_DIR/$scenario-time-attempt$attempt-toc.xml"
+      subtitle_metal_trace="$OUTPUT_DIR/$scenario-metal-attempt$attempt.trace"
+      subtitle_metal_toc="$OUTPUT_DIR/$scenario-metal-attempt$attempt-toc.xml"
     fi
     set +e
     if [[ "$scenario" == "adaptive-hls-soak" ]]; then
@@ -965,6 +1013,67 @@ PY
         -resultBundlePath "$attempt_bundle" \
         > "$attempt_log" 2>&1
       test_status=$?
+    elif [[ "$scenario" == "native-subtitle-matrix" ]]; then
+      xcodebuild test-without-building \
+        -xctestrun "$attempt_xctestrun" \
+        -destination "platform=iOS,id=$DEVICE_UDID" \
+        -collect-test-diagnostics never \
+        -test-timeouts-enabled YES \
+        -default-test-execution-time-allowance "$((NATIVE_SUBTITLE_SECONDS + 300))" \
+        -maximum-test-execution-time-allowance "$((NATIVE_SUBTITLE_SECONDS + 300))" \
+        "${test_selection_args[@]}" \
+        -resultBundlePath "$attempt_bundle" \
+        > "$attempt_log" 2>&1 &
+      local subtitle_xcodebuild_pid=$!
+      ACTIVE_XCODEBUILD_PID="$subtitle_xcodebuild_pid"
+      local subtitle_started=false
+      for _ in {1..600}; do
+        if ! kill -0 "$subtitle_xcodebuild_pid" 2>/dev/null; then
+          break
+        fi
+        if grep -q "$attempt_token" "$OUTPUT_DIR/fixture-requests.jsonl" 2>/dev/null; then
+          subtitle_started=true
+          break
+        fi
+        sleep 0.1
+      done
+      local subtitle_trace_failed=false
+      local subtitle_phase_seconds=$(((NATIVE_SUBTITLE_SECONDS - 120) / 3))
+      if [[ "$subtitle_phase_seconds" -lt 60 ]]; then
+        subtitle_phase_seconds=60
+      fi
+      if [[ "$subtitle_started" == false ]]; then
+        subtitle_trace_failed=true
+        echo "Error: subtitle fixture did not start before trace capture." >> "$attempt_log"
+      else
+        local subtitle_spec subtitle_key subtitle_template subtitle_trace subtitle_toc
+        for subtitle_spec in \
+          "time|Time Profiler|$subtitle_time_trace|$subtitle_time_toc" \
+          "game|Game Performance|$subtitle_game_trace|$subtitle_game_toc" \
+          "metal|Metal System Trace|$subtitle_metal_trace|$subtitle_metal_toc"; do
+          IFS='|' read -r subtitle_key subtitle_template subtitle_trace subtitle_toc \
+            <<< "$subtitle_spec"
+          if ! record_performance_trace \
+              "$subtitle_template" "$subtitle_trace" "$subtitle_toc" \
+              "$subtitle_phase_seconds" "$subtitle_xcodebuild_pid" \
+              "$OUTPUT_DIR/$scenario-$subtitle_key-xctrace-attempt$attempt.log"; then
+            subtitle_trace_failed=true
+            echo "Error: $subtitle_template trace capture failed." >> "$attempt_log"
+            break
+          fi
+        done
+      fi
+      if [[ "$subtitle_trace_failed" == true ]]; then
+        kill -TERM "$subtitle_xcodebuild_pid" 2>/dev/null
+      fi
+      wait "$subtitle_xcodebuild_pid"
+      test_status=$?
+      ACTIVE_XCODEBUILD_PID=""
+      if [[ "$subtitle_trace_failed" == true ]]; then
+        test_status=1
+      elif [[ "$test_status" -eq 0 ]]; then
+        subtitle_trace_status="captured"
+      fi
     else
       xcodebuild test-without-building \
         -xctestrun "$attempt_xctestrun" \
@@ -1173,6 +1282,10 @@ PY
       qualification_scenarios=("cadence-matrix")
       qualification_attachments=("qualification-cadence-matrix.json")
       ;;
+    native-subtitle-matrix)
+      qualification_scenarios=("native-subtitle-matrix")
+      qualification_attachments=("qualification-native-subtitle-matrix.json")
+      ;;
     deferred-pause-rejection)
       qualification_scenarios=("deferred-pause-rejection")
       qualification_attachments=("qualification-deferred-pause-rejection.json")
@@ -1187,6 +1300,7 @@ PY
     if [[ "$test_status" -eq 0 ]] && [[ "$log_errors_acceptable" == true ]] \
       && [[ "$allocation_trace_status" != "missing" ]] \
       && [[ "$performance_trace_status" != "missing" ]] \
+      && [[ "$subtitle_trace_status" != "missing" ]] \
       && [[ "$log_status" == "captured" ]] && [[ -d "$result_bundle" ]]; then
       local attachments="$OUTPUT_DIR/$scenario-attachments"
       local hardware_id evidence_file evidence_relative export_status materialize_status
@@ -1258,6 +1372,22 @@ PY
             if [[ "$augment_performance_status" -ne 0 ]]; then
               continue
             fi
+          elif [[ "$scenario" == "native-subtitle-matrix" ]]; then
+            set +e
+            python3 "$SCRIPT_DIR/augment-native-subtitle-traces.py" \
+              --evidence "$evidence_file" \
+              --time-trace "$subtitle_time_trace" \
+              --time-toc "$subtitle_time_toc" \
+              --game-trace "$subtitle_game_trace" \
+              --game-toc "$subtitle_game_toc" \
+              --metal-trace "$subtitle_metal_trace" \
+              --metal-toc "$subtitle_metal_toc" \
+              --digest-script "$ROOT_DIR/scripts/artifact-tree-digest.py"
+            local augment_subtitle_status=$?
+            set -e
+            if [[ "$augment_subtitle_status" -ne 0 ]]; then
+              continue
+            fi
           fi
           materialized_count=$((materialized_count + 1))
           materialized_scenarios+=("$qualification_scenario")
@@ -1309,6 +1439,7 @@ PY
   if [[ "$test_status" -ne 0 ]] || [[ "$log_errors_acceptable" != true ]] || [[ "$log_status" == "missing" ]] \
     || [[ "$allocation_trace_status" == "missing" ]] \
     || [[ "$performance_trace_status" == "missing" ]] \
+    || [[ "$subtitle_trace_status" == "missing" ]] \
     || [[ "$evidence_status" == "missing" ]]; then
     result="fail"
   fi

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -34,6 +34,7 @@ candidate_metadata = load_script("candidate-metadata.py")
 materialize_evidence = load_script("materialize-evidence.py")
 augment_allocation_trace = load_script("augment-allocation-trace.py")
 augment_performance_traces = load_script("augment-performance-traces.py")
+augment_native_subtitle_traces = load_script("augment-native-subtitle-traces.py")
 assemble_record = load_script("assemble-record.py")
 
 
@@ -995,6 +996,83 @@ class QualificationEvidenceTests(unittest.TestCase):
             with self.assertRaises(augment_performance_traces.PerformanceTraceError):
                 augment_performance_traces.augment(evidence, traces, digest_script)
 
+    def test_materializes_and_augments_native_subtitle_matrix(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            support = {
+                key: "supported"
+                for key in ("text", "styled", "bitmap", "forced", "live", "osd")
+            }
+            payload = {
+                "formatVersion": 1,
+                "scenario": "native-subtitle-matrix",
+                "supportMatrix": support,
+                "timingTransitions": [{"profile": "text", "pauseResume": "pass"}],
+                "metrics": {
+                    "cpu": {"value": 10, "hostTraceStatus": "required-host-augmentation"},
+                    "gpu": {"status": "required-host-augmentation"},
+                    "colorHDRImpact": {
+                        "sourcePixelFormat": "yuv420p10le",
+                        "screenshotMeasurements": {"baseline": {}, "hdrWithSubtitle": {}},
+                        "hostTraceStatus": "required-host-augmentation",
+                    },
+                },
+                "hostTraceRequirements": {},
+            }
+            self.make_export(
+                root,
+                payload,
+                attachment_name="qualification-native-subtitle-matrix.json",
+                test_identifier="NativeSubtitleMatrixDeviceUITests/test_nativeSubtitleMatrixIsVisibleAndBounded",
+            )
+            evidence = materialize_evidence.materialize(
+                root,
+                "qualification-native-subtitle-matrix.json",
+                "native-subtitle-matrix",
+                "iphone-current",
+                "a" * 64,
+                "b" * 64,
+            )
+            evidence_path = root / "evidence.json"
+            evidence_path.write_text(json.dumps(evidence))
+            traces = {}
+            for key in ("time", "game", "metal"):
+                trace = root / f"{key}.trace"
+                trace.mkdir()
+                (trace / "data.bin").write_bytes(f"{key} trace".encode())
+                toc = root / f"{key}-toc.xml"
+                toc.write_text('<trace-toc><table schema="samples"/></trace-toc>')
+                traces[key] = (trace, toc)
+            digest_script = Path(__file__).resolve().parents[2] / "artifact-tree-digest.py"
+            augmented = augment_native_subtitle_traces.augment(
+                evidence_path, traces, digest_script
+            )
+            self.assertEqual(augmented["supportMatrix"], support)
+            self.assertNotIn("hostTraceRequirements", augmented)
+            self.assertEqual(
+                augmented["metrics"]["cpu"]["hostTrace"]["template"],
+                "Time Profiler",
+            )
+            self.assertEqual(augmented["metrics"]["gpu"]["template"], "Game Performance")
+            self.assertEqual(
+                augmented["metrics"]["colorHDRImpact"]["hostTrace"]["template"],
+                "Metal System Trace",
+            )
+            records = (
+                augmented["metrics"]["cpu"]["hostTrace"],
+                augmented["metrics"]["gpu"],
+                augmented["metrics"]["colorHDRImpact"]["hostTrace"],
+            )
+            for record in records:
+                self.assertEqual(record["treeDigestAlgorithm"], "swiftvlc-tree-v1")
+                self.assertFalse(Path(record["runArtifact"]).is_absolute())
+                self.assertFalse(Path(record["tableOfContents"]).is_absolute())
+                staged_trace = evidence_path.parent / record["runArtifact"]
+                staged_toc = evidence_path.parent / record["tableOfContents"]
+                self.assertTrue(staged_trace.is_dir())
+                self.assertTrue((staged_trace / "data.bin").is_file())
+                self.assertTrue(staged_toc.is_file())
+
     def test_materializes_accepted_start_delayed_failure_evidence(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -1251,6 +1329,7 @@ class QualificationRecordAssemblyTests(unittest.TestCase):
             "instrumentsTrace": {
                 "runArtifact": "artifacts/seek/allocations.trace",
                 "tableOfContents": "artifacts/seek/allocations-toc.xml",
+                "treeDigestAlgorithm": "swiftvlc-tree-v1",
                 "treeDigest": assemble_record.tree_digest(trace),
             }
         }
@@ -1298,6 +1377,7 @@ class QualificationRecordAssemblyTests(unittest.TestCase):
             trace_records[name] = {
                 "runArtifact": f"artifacts/performance/{name}.trace",
                 "tableOfContents": f"artifacts/performance/{name}-toc.xml",
+                "treeDigestAlgorithm": "swiftvlc-tree-v1",
                 "treeDigest": assemble_record.tree_digest(trace),
             }
         evidence["metrics"] = {
@@ -1318,6 +1398,65 @@ class QualificationRecordAssemblyTests(unittest.TestCase):
             self.assertTrue((retained / f"{name}-toc.xml").is_file())
 
         (retained / "game.trace" / "data.bin").write_bytes(b"tampered")
+        with self.assertRaises(assemble_record.AssemblyError):
+            assemble_record.assemble(
+                "1.1.0", self.candidate, self.matrix, [report_path], output
+            )
+
+    def test_assembles_digest_verified_native_subtitle_trace_artifacts(self):
+        scenario = "native-subtitle-matrix"
+        self.matrix.write_text(
+            json.dumps(
+                {
+                    "scenarios": [{"id": scenario, "hardware": ["iphone"]}],
+                    "hardware": [
+                        {"id": "iphone", "deviceFamily": "iPhone", "osMajor": 26},
+                        {"id": "ipad", "deviceFamily": "iPad", "osMajor": 26},
+                    ],
+                }
+            )
+        )
+        self.matrix_checksum = hashlib.sha256(self.matrix.read_bytes()).hexdigest()
+        report_path = self.make_report("iphone")
+        report = json.loads(report_path.read_text())
+        report["qualificationRows"][0]["scenario"] = scenario
+        report_path.write_text(json.dumps(report))
+
+        evidence_path = report_path.parent / "evidence" / "seek.json"
+        evidence = json.loads(evidence_path.read_text())
+        evidence["scenario"] = scenario
+        artifact_directory = evidence_path.parent / "artifacts" / "subtitles"
+        trace_records = {}
+        for name in ("time", "game", "metal"):
+            trace = artifact_directory / f"{name}.trace"
+            trace.mkdir(parents=True)
+            (trace / "data.bin").write_bytes(f"{name} samples".encode())
+            toc = artifact_directory / f"{name}-toc.xml"
+            toc.write_text('<trace-toc><table schema="samples"/></trace-toc>')
+            trace_records[name] = {
+                "runArtifact": f"artifacts/subtitles/{name}.trace",
+                "tableOfContents": f"artifacts/subtitles/{name}-toc.xml",
+                "treeDigestAlgorithm": "swiftvlc-tree-v1",
+                "treeDigest": assemble_record.tree_digest(trace),
+            }
+        evidence["metrics"] = {
+            "cpu": {"hostTrace": trace_records["time"]},
+            "gpu": trace_records["game"],
+            "colorHDRImpact": {"hostTrace": trace_records["metal"]},
+        }
+        evidence_path.write_text(json.dumps(evidence))
+
+        output = self.root / "qualification" / "1.1.0.json"
+        assemble_record.assemble(
+            "1.1.0", self.candidate, self.matrix, [report_path], output
+        )
+
+        retained = output.parent / "evidence" / "1.1.0" / "artifacts" / "subtitles"
+        for name in ("time", "game", "metal"):
+            self.assertTrue((retained / f"{name}.trace" / "data.bin").is_file())
+            self.assertTrue((retained / f"{name}-toc.xml").is_file())
+
+        (retained / "metal.trace" / "data.bin").write_bytes(b"tampered")
         with self.assertRaises(assemble_record.AssemblyError):
             assemble_record.assemble(
                 "1.1.0", self.candidate, self.matrix, [report_path], output
@@ -1581,6 +1720,16 @@ class FixtureServerTests(unittest.TestCase):
         self.assertIn("#EXT-X-MEDIA-SEQUENCE:0", first_live)
         self.assertIn("#EXT-X-MEDIA-SEQUENCE:2", second_live)
 
+        connection, response = self.request(
+            "/adaptive/run/abr-low-ts/low.m3u8"
+        )
+        subtitle_vod = response.read().decode()
+        connection.close()
+        self.assertEqual(subtitle_vod.count("#EXTINF:2.000,"), 60)
+        self.assertIn("#EXT-X-PLAYLIST-TYPE:VOD", subtitle_vod)
+        self.assertIn("#EXT-X-DISCONTINUITY", subtitle_vod)
+        self.assertTrue(subtitle_vod.rstrip().endswith("#EXT-X-ENDLIST"))
+
         connection, response = self.request("/adaptive/run/metrics")
         metrics = json.loads(response.read())
         connection.close()
@@ -1625,7 +1774,12 @@ class FixtureServerTests(unittest.TestCase):
             connection.close()
 
         connection, response = self.request("/adaptive/transitions/metrics")
-        self.assertEqual(json.loads(response.read())["variantTransitions"], 0)
+        forced_metrics = json.loads(response.read())
+        self.assertEqual(forced_metrics["variantTransitions"], 0)
+        self.assertEqual(
+            forced_metrics["successfulSegmentsByVariant"],
+            {"low": 1, "high": 1},
+        )
         connection.close()
 
         for variant in ("low", "high"):


### PR DESCRIPTION
## Summary
- add deterministic text, styled, bitmap, forced, adaptive, live, HDR, and OSD subtitle fixtures
- add an automated on-device native PiP subtitle matrix with timing, visibility, bounded-render, CPU/GPU, and HDR/color evidence
- retain and digest-bind Time Profiler, Game Performance, and Metal System Trace artifacts in the final qualification record
- add harness coverage for fixture behavior, evidence materialization, trace retention, and tamper rejection

## Validation
- `python3 -m unittest scripts/qualification/tests/test_qualification_harness.py` (49 tests)
- `swift test --parallel` (1,992 tests / 167 suites)
- SwiftFormat lint, SwiftLint strict, Python compile, and `git diff --check`
- local Release iOS Showcase `build-for-testing` against this checkout

Closes no milestone issue by itself: issue #95 remains open until the candidate-bound physical-device row passes.