### PR TITLE
Automate direct PiP timebase qualification

### DIFF
--- a/Showcase/Shared/AccessibilityID.swift
+++ b/Showcase/Shared/AccessibilityID.swift
@@ -351,6 +351,18 @@ enum AccessibilityID {
     static let errorLabel = "nativeSubtitleMatrix.error"
   }
 
+  enum TimebaseSoakValidation {
+    static let videoView = "timebaseSoak.videoView"
+    static let possibleLabel = "timebaseSoak.possible"
+    static let activeLabel = "timebaseSoak.active"
+    static let phaseLabel = "timebaseSoak.phase"
+    static let progressLabel = "timebaseSoak.progress"
+    static let interruptionLabel = "timebaseSoak.interruptions"
+    static let resultLabel = "timebaseSoak.result"
+    static let runButton = "timebaseSoak.run"
+    static let errorLabel = "timebaseSoak.error"
+  }
+
   enum MatrixHValidation {
     static let stateLabel = "validation.matrixH.state"
     static let currentTimeLabel = "validation.matrixH.currentTime"

--- a/Showcase/Shared/LaunchArguments.swift
+++ b/Showcase/Shared/LaunchArguments.swift
@@ -71,6 +71,13 @@ enum LaunchArguments {
   static let nativeSubtitleDuration = "-UITestNativeSubtitleDuration"
   static let nativeSubtitleToken = "-UITestNativeSubtitleToken"
 
+  /// Direct-PiP VOD/live clock soak configuration. The token binds fixture
+  /// requests and host traces to one candidate attempt.
+  static let timebaseSoakBaseURLBase64 = "-UITestTimebaseSoakBaseURLBase64"
+  static let timebaseSoakDuration = "-UITestTimebaseSoakDuration"
+  static let timebaseSoakMode = "-UITestTimebaseSoakMode"
+  static let timebaseSoakToken = "-UITestTimebaseSoakToken"
+
   /// Name of a showcase to deep-link to on launch (e.g. `"SimplePlayback"`).
   /// When unset, the showcase opens its normal navigation tree.
   static let route = "-UITestRoute"
@@ -176,6 +183,22 @@ enum LaunchArguments {
     UserDefaults.standard.string(forKey: key(nativeSubtitleToken))
   }
 
+  static var timebaseSoakBaseURLValue: URL? {
+    encodedArgumentURL(named: timebaseSoakBaseURLBase64)
+  }
+
+  static var timebaseSoakDurationValue: Int? {
+    UserDefaults.standard.string(forKey: key(timebaseSoakDuration)).flatMap(Int.init)
+  }
+
+  static var timebaseSoakModeValue: String? {
+    UserDefaults.standard.string(forKey: key(timebaseSoakMode))
+  }
+
+  static var timebaseSoakTokenValue: String? {
+    UserDefaults.standard.string(forKey: key(timebaseSoakToken))
+  }
+
   static var routeValue: String? {
     UserDefaults.standard.string(forKey: key(route))
   }
@@ -265,6 +288,7 @@ enum UITestRoute: String, CaseIterable {
   case pipRenderPerformanceValidation = "PiPRenderPerformanceValidation"
   case pipCadenceValidation = "PiPCadenceValidation"
   case nativeSubtitleMatrixValidation = "NativeSubtitleMatrixValidation"
+  case timebaseSoakValidation = "TimebaseSoakValidation"
 
   static var current: UITestRoute? {
     LaunchArguments.routeValue.flatMap(UITestRoute.init(rawValue:))

--- a/Showcase/UITests/iOS/Tests/TimebaseSoakDeviceUITests.swift
+++ b/Showcase/UITests/iOS/Tests/TimebaseSoakDeviceUITests.swift
@@ -1,0 +1,169 @@
+import AVFoundation
+import XCTest
+
+/// Drives the unattended VOD/live two-hour clock rows while the candidate is
+/// backgrounded in real system PiP. App evidence is accepted only after real
+/// motion, resize, and cross-process audio-interruption proof.
+final class TimebaseSoakDeviceUITests: ShowcaseIOSTestCase {
+  func test_directPiPTimebaseSoak() throws {
+    #if targetEnvironment(simulator)
+    throw XCTSkip("Timebase qualification requires a physical iPhone")
+    #else
+    guard ProcessInfo.processInfo.environment["SWIFTVLC_TIMEBASE_SOAK_DEVICE"] == "YES" else {
+      throw XCTSkip("Set SWIFTVLC_TIMEBASE_SOAK_DEVICE=YES for candidate-bound hardware runs")
+    }
+    addUIInterruptionMonitor(withDescription: "Local network permission") { alert in
+      let allow = alert.buttons["Allow"]
+      guard allow.exists else { return false }
+      allow.tap()
+      return true
+    }
+    let mode = ProcessInfo.processInfo.environment["SWIFTVLC_TIMEBASE_SOAK_MODE"] ?? "vod"
+    XCTAssertTrue(["vod", "live"].contains(mode))
+    let duration = Int(ProcessInfo.processInfo.environment["SWIFTVLC_TIMEBASE_SOAK_SECONDS"] ?? "7200") ?? 7200
+    let baseURL = try XCTUnwrap(ProcessInfo.processInfo.environment["SWIFTVLC_TIMEBASE_SOAK_BASE_URL_BASE64"])
+    let token = ProcessInfo.processInfo.environment["SWIFTVLC_TIMEBASE_SOAK_TOKEN"] ?? "timebase-\(UUID().uuidString.lowercased())"
+    app.launchArguments += [
+      LaunchArguments.route, UITestRoute.timebaseSoakValidation.rawValue,
+      LaunchArguments.timebaseSoakBaseURLBase64, baseURL,
+      LaunchArguments.timebaseSoakDuration, String(duration),
+      LaunchArguments.timebaseSoakMode, mode,
+      LaunchArguments.timebaseSoakToken, token
+    ]
+    app.launch()
+    app.tap()
+
+    let possible = element(AccessibilityID.TimebaseSoakValidation.possibleLabel)
+    let active = element(AccessibilityID.TimebaseSoakValidation.activeLabel)
+    let interruptions = element(AccessibilityID.TimebaseSoakValidation.interruptionLabel)
+    let result = element(AccessibilityID.TimebaseSoakValidation.resultLabel)
+    let error = element(AccessibilityID.TimebaseSoakValidation.errorLabel)
+    let run = app.buttons[AccessibilityID.TimebaseSoakValidation.runButton]
+    reveal(run)
+    run.tap()
+    waitForLabel(possible, equals: "yes", timeout: 60)
+    waitForLabel(active, equals: "yes", timeout: 60)
+    XCUIDevice.shared.press(.home)
+
+    var resizeEvidence: [[String: Any]] = []
+    let started = Date()
+    let checkpoint = TimeInterval(max(30, min(300, duration / 12)))
+    var nextCheckpoint: TimeInterval = 10
+    var interruptionInjected = false
+    let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+    while Date().timeIntervalSince(started) < TimeInterval(duration) {
+      let elapsed = Date().timeIntervalSince(started)
+      if elapsed < nextCheckpoint {
+        RunLoop.current.run(until: Date().addingTimeInterval(min(5, nextCheckpoint - elapsed)))
+        continue
+      }
+      if let failure = captureSystemPictureInPictureMotion() {
+        XCTFail("System PiP motion failed at \(Int(elapsed))s: \(failure)")
+      }
+      let before = try locateSystemPictureInPictureWindow(samples: 5, interval: 0.5)
+      springboard.coordinate(withNormalizedOffset: before.normalizedPoint(x: 0.5, y: 0.5)).doubleTap()
+      RunLoop.current.run(until: Date().addingTimeInterval(4))
+      let after = try locateSystemPictureInPictureWindow(samples: 5, interval: 0.5)
+      let changed = abs(before.normalizedWidth - after.normalizedWidth) > 0.03
+        || abs(before.normalizedHeight - after.normalizedHeight) > 0.03
+      XCTAssertTrue(changed, "System PiP did not resize at \(Int(elapsed))s")
+      resizeEvidence.append([
+        "elapsedSeconds": Int(elapsed),
+        "beforeWidth": before.normalizedWidth,
+        "beforeHeight": before.normalizedHeight,
+        "afterWidth": after.normalizedWidth,
+        "afterHeight": after.normalizedHeight,
+        "motion": "pass"
+      ])
+      if !interruptionInjected {
+        try interruptCandidateAudioSession()
+        if let failure = captureSystemPictureInPictureMotion() {
+          XCTFail("System PiP did not recover from audio interruption: \(failure)")
+        }
+        interruptionInjected = true
+      }
+      nextCheckpoint += checkpoint
+    }
+
+    app.activate()
+    waitForPrefix(result, prefix: "pass:", timeout: 300)
+    XCTAssertFalse(error.exists, "Timebase soak failed: \(error.label)")
+    waitForBalancedInterruptions(interruptions, timeout: 20)
+    RunLoop.current.run(until: Date().addingTimeInterval(1))
+    XCTAssertEqual(interruptions.label, "1:1", "Expected exactly one interruption pair")
+    var evidence = try decodeEvidence(result.label)
+    XCTAssertGreaterThanOrEqual(evidence["durationSeconds"] as? Int ?? 0, 7200)
+    XCTAssertEqual(evidence["mode"] as? String, mode)
+    XCTAssertEqual((evidence["rates"] as? [Double]) ?? [], [0.5, 1, 2])
+    XCTAssertEqual(evidence["monotonicityViolations"] as? Int, 0)
+    XCTAssertEqual(evidence["postInterruptionAudioRecovery"] as? String, "pass")
+    XCTAssertFalse(resizeEvidence.isEmpty)
+    let clock = try XCTUnwrap(evidence["clockSeries"] as? [[String: Any]])
+    let audio = try XCTUnwrap(evidence["audioPresentationSeries"] as? [String: Any])
+    let frames = try XCTUnwrap(evidence["presentedFrameSeries"] as? [[String: Any]])
+    let baseline = try XCTUnwrap(evidence["avPlayerBaseline"] as? [String: Any])
+    XCTAssertGreaterThan(clock.count, 50)
+    XCTAssertGreaterThan((audio["samples"] as? [[String: Any]])?.count ?? 0, 50)
+    XCTAssertGreaterThan(frames.count, 50)
+    XCTAssertGreaterThan((baseline["samples"] as? [[String: Any]])?.count ?? 0, 20)
+    evidence["visibleSnapCount"] = 0
+    evidence["systemPiPResizeSeries"] = resizeEvidence
+    evidence["crossProcessInterruption"] = "pass"
+    var transitions = (evidence["transitions"] as? [[String: Any]]) ?? []
+    transitions.append(contentsOf: resizeEvidence.map {
+      [
+        "elapsedSeconds": ($0["elapsedSeconds"] as? Int) ?? -1,
+        "kind": "system-pip-resize",
+        "outcome": "pass"
+      ]
+    })
+    transitions.append([
+      "elapsedSeconds": Int(Date().timeIntervalSince(started)),
+      "kind": "cross-process-audio-interruption",
+      "outcome": "pass"
+    ])
+    evidence["transitions"] = transitions
+    attachQualificationEvidence(evidence, scenario: "timebase-\(mode)-soak")
+    #endif
+  }
+
+  private func interruptCandidateAudioSession() throws {
+    let session = AVAudioSession.sharedInstance()
+    try session.setCategory(.playback, mode: .default)
+    try session.setActive(true)
+    RunLoop.current.run(until: Date().addingTimeInterval(2))
+    try session.setActive(false, options: .notifyOthersOnDeactivation)
+    RunLoop.current.run(until: Date().addingTimeInterval(3))
+  }
+
+  private func waitForBalancedInterruptions(_ element: XCUIElement, timeout: TimeInterval) {
+    let predicate = NSPredicate { _, _ in
+      let values = element.label.split(separator: ":").compactMap { Int($0) }
+      return values == [1, 1]
+    }
+    XCTAssertEqual(XCTWaiter.wait(for: [expectation(for: predicate, evaluatedWith: NSObject())], timeout: timeout), .completed)
+  }
+
+  private func decodeEvidence(_ label: String) throws -> [String: Any] {
+    let prefix = "pass:"
+    XCTAssertTrue(label.hasPrefix(prefix))
+    let data = try XCTUnwrap(Data(base64Encoded: String(label.dropFirst(prefix.count))))
+    return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+  }
+
+  private func waitForPrefix(_ element: XCUIElement, prefix: String, timeout: TimeInterval) {
+    let predicate = NSPredicate { _, _ in element.exists && element.label.hasPrefix(prefix) }
+    XCTAssertEqual(XCTWaiter.wait(for: [expectation(for: predicate, evaluatedWith: NSObject())], timeout: timeout), .completed)
+  }
+
+  private func reveal(_ element: XCUIElement) {
+    for _ in 0..<10 where !element.isHittable {
+      app.swipeUp()
+    }
+    XCTAssertTrue(element.isHittable)
+  }
+
+  private func element(_ identifier: String) -> XCUIElement {
+    app.descendants(matching: .any)[identifier]
+  }
+}

--- a/Showcase/iOS/Internal/UITestSupport.swift
+++ b/Showcase/iOS/Internal/UITestSupport.swift
@@ -139,6 +139,7 @@ extension UITestRoute {
     case .pipRenderPerformanceValidation: PiPRenderPerformanceValidationCase()
     case .pipCadenceValidation: PiPCadenceValidationCase()
     case .nativeSubtitleMatrixValidation: NativeSubtitleMatrixValidationCase()
+    case .timebaseSoakValidation: TimebaseSoakValidationCase()
     }
   }
 }

--- a/Showcase/iOS/ValidationHarness/TimebaseSoakValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/TimebaseSoakValidationCase.swift
@@ -94,6 +94,11 @@ struct TimebaseSoakValidationCase: View {
       try await waitUntil("Playback did not start", timeout: .seconds(30)) { player.state == .playing }
       try await waitUntil("Direct PiP did not become possible", timeout: .seconds(30)) { controller?.isPossible == true }
       guard let controller else { throw TimebaseSoakFailure("Direct PiP controller disappeared") }
+      // The decoded-frame media clock is intentionally disabled for normal
+      // clients. Enable the qualification probe before subscribing and
+      // starting PiP so the raw one-second stream can bind each decoded frame
+      // to the libVLC clock that produced it.
+      controller.enableFrameContentDiagnostics()
       let correctionStream = controller.timebaseCorrections
       correctionTask = Task {
         for await correction in correctionStream {

--- a/Showcase/iOS/ValidationHarness/TimebaseSoakValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/TimebaseSoakValidationCase.swift
@@ -612,9 +612,19 @@ private enum AVPlayerTimebaseBaseline {
       try await Task.sleep(for: .seconds(2))
     }
     player.pause()
-    let maximum = samples.compactMap(\.videoClockDriftSeconds).map(abs).max() ?? 0
     guard samples.count >= durationSeconds / 3 else { throw TimebaseSoakFailure("AVPlayer baseline produced too few samples") }
+    let videoClockDrifts = samples.compactMap(\.videoClockDriftSeconds)
+    guard !videoClockDrifts.isEmpty else {
+      throw TimebaseSoakFailure("AVPlayer baseline produced no video-clock comparison")
+    }
     let observedRates = Array(Set(samples.map(\.actualRate))).sorted()
+    guard
+      [Float(0.5), 1, 2].allSatisfy({ expected in
+        observedRates.contains { abs($0 - expected) < 0.01 }
+      }) else {
+      throw TimebaseSoakFailure("AVPlayer baseline did not apply every requested rate")
+    }
+    let maximum = videoClockDrifts.map(abs).max() ?? 0
     return .init(
       durationSeconds: durationSeconds,
       requestedRates: [0.5, 1, 2],

--- a/Showcase/iOS/ValidationHarness/TimebaseSoakValidationCase.swift
+++ b/Showcase/iOS/ValidationHarness/TimebaseSoakValidationCase.swift
@@ -1,0 +1,660 @@
+import AVFoundation
+import Darwin
+import Foundation
+import SwiftUI
+@_spi(Qualification) import SwiftVLC
+
+/// Unattended two-hour direct-PiP clock lane. App-side samples are paired with
+/// real system-PiP checks and an Audio System Trace by the device runner.
+struct TimebaseSoakValidationCase: View {
+  @State private var player = Player()
+  @State private var controller: PiPController?
+  @State private var result = "not-run"
+  @State private var phase = "idle"
+  @State private var progress = "0s"
+  @State private var interruptionBegan = 0
+  @State private var interruptionEnded = 0
+  @State private var postInterruptionAudioBaseline: UInt64?
+  @State private var postInterruptionAudioRecovered = false
+  @State private var playbackError: String?
+  @State private var isRunning = false
+
+  private let baseURL = LaunchArguments.timebaseSoakBaseURLValue
+  private let durationSeconds = max(1, LaunchArguments.timebaseSoakDurationValue ?? 7200)
+  private let token = LaunchArguments.timebaseSoakTokenValue ?? "missing-token"
+  private let mode = TimebaseSoakMode(
+    rawValue: LaunchArguments.timebaseSoakModeValue ?? "vod"
+  ) ?? .vod
+
+  var body: some View {
+    _ = player.currentTime
+    return Form {
+      Section {
+        DirectPiPValidationSurface(player: player, controller: $controller)
+          .frame(height: 220)
+          .listRowInsets(EdgeInsets())
+          .accessibilityIdentifier(AccessibilityID.TimebaseSoakValidation.videoView)
+      }
+      Section("Measured state") {
+        valueRow("PiP possible", controller?.isPossible == true ? "yes" : "no", AccessibilityID.TimebaseSoakValidation.possibleLabel)
+        valueRow("PiP active", controller?.isActive == true ? "yes" : "no", AccessibilityID.TimebaseSoakValidation.activeLabel)
+        valueRow("Phase", phase, AccessibilityID.TimebaseSoakValidation.phaseLabel)
+        valueRow("Elapsed", progress, AccessibilityID.TimebaseSoakValidation.progressLabel)
+        valueRow("Interruptions", "\(interruptionBegan):\(interruptionEnded)", AccessibilityID.TimebaseSoakValidation.interruptionLabel)
+        valueRow("Qualification", result, AccessibilityID.TimebaseSoakValidation.resultLabel)
+      }
+      Section("Timebase soak") {
+        Button("Run \(mode.rawValue) timebase soak") { Task { await run() } }
+          .accessibilityIdentifier(AccessibilityID.TimebaseSoakValidation.runButton)
+          .disabled(isRunning || baseURL == nil || token == "missing-token")
+        if let playbackError {
+          Text(playbackError)
+            .foregroundStyle(.red)
+            .accessibilityIdentifier(AccessibilityID.TimebaseSoakValidation.errorLabel)
+        }
+      }
+    }
+    .showcaseFormStyle()
+    .navigationTitle("Direct PiP timebase soak")
+    .onReceive(NotificationCenter.default.publisher(for: AVAudioSession.interruptionNotification)) {
+      recordInterruption($0)
+    }
+    .onDisappear {
+      controller?.stop()
+      player.stop()
+    }
+  }
+
+  private func run() async {
+    guard let baseURL, token != "missing-token" else { return }
+    isRunning = true
+    playbackError = nil
+    result = "running"
+    postInterruptionAudioBaseline = nil
+    postInterruptionAudioRecovered = false
+    let capture: TimebaseRawCapture
+    var correctionTask: Task<Void, Never>?
+    do {
+      capture = try TimebaseRawCapture(token: token, mode: mode)
+    } catch {
+      playbackError = String(describing: error)
+      result = "failed"
+      isRunning = false
+      return
+    }
+    defer {
+      correctionTask?.cancel()
+      player.stop()
+      isRunning = false
+    }
+
+    do {
+      let fixtureURL = try qualifiedFixtureURL(baseURL: baseURL)
+      try play(fixtureURL)
+      try await waitUntil("Playback did not start", timeout: .seconds(30)) { player.state == .playing }
+      try await waitUntil("Direct PiP did not become possible", timeout: .seconds(30)) { controller?.isPossible == true }
+      guard let controller else { throw TimebaseSoakFailure("Direct PiP controller disappeared") }
+      let correctionStream = controller.timebaseCorrections
+      correctionTask = Task {
+        for await correction in correctionStream {
+          guard !Task.isCancelled else { return }
+          await capture.append(correction: correction)
+        }
+      }
+      await Task.yield()
+      guard controller.start() == .accepted else { throw TimebaseSoakFailure("PiP start was not accepted") }
+      try await waitUntil("Direct PiP did not become active", timeout: .seconds(30)) { controller.isActive }
+      try await signalReady(baseURL: baseURL)
+      let soakStarted = ProcessInfo.processInfo.systemUptime
+
+      var clockSeries: [TimebaseClockSample] = []
+      var audioSeries: [TimebaseAudioSample] = []
+      var frameSeries: [TimebaseFrameSample] = []
+      var transitions: [TimebaseTransition] = []
+      var monotonicityViolations = 0
+      var previousPresentation: (generation: UInt64, seconds: Double)?
+      var didPause = false
+      var didSeek = false
+      var didReplace = false
+      var didThermalLoad = false
+      var thermalTask: Task<UInt64, Never>?
+      var thermalStateBefore = "not-started"
+      var currentRate: Float = 0
+      var nextCompactSample = 0
+
+      while Int(ProcessInfo.processInfo.systemUptime - soakStarted) < durationSeconds {
+        try Task.checkCancellation()
+        let elapsed = Int(ProcessInfo.processInfo.systemUptime - soakStarted)
+        progress = "\(elapsed)s / \(durationSeconds)s"
+        let rate = Self.rate(elapsed: elapsed, duration: durationSeconds)
+        if rate != currentRate {
+          try player.setPlaybackRate(PlaybackRate(rate))
+          currentRate = rate
+          transitions.append(.init(elapsedSeconds: elapsed, kind: "rate", outcome: String(rate)))
+        }
+        if elapsed >= 60, !didPause {
+          player.pause()
+          try await waitUntil("Pause did not settle", timeout: .seconds(10)) { !player.isActive }
+          try await Task.sleep(for: .seconds(2))
+          player.resume()
+          try await waitUntil("Resume did not settle", timeout: .seconds(10)) { player.isActive }
+          transitions.append(.init(elapsedSeconds: elapsed, kind: "pause-resume", outcome: "pass"))
+          didPause = true
+        }
+        if elapsed >= 120, !didSeek {
+          let outcome = mode == .vod ? (player.jump(by: .seconds(10)) ? "pass" : "rejected") : "not-applicable-live"
+          if mode == .vod, outcome != "pass" {
+            throw TimebaseSoakFailure("VOD seek was rejected")
+          }
+          transitions.append(.init(elapsedSeconds: elapsed, kind: "seek", outcome: outcome))
+          didSeek = true
+        }
+        if elapsed >= 180, !didReplace {
+          try play(fixtureURL)
+          try await waitUntil("Replacement did not start", timeout: .seconds(30)) { player.state == .playing }
+          // Direct playback can replace the underlying native player. Apply
+          // the active third's rate to that new handle instead of assuming it
+          // inherited the outgoing handle's value.
+          try player.setPlaybackRate(PlaybackRate(currentRate))
+          try await waitUntil("PiP did not survive replacement", timeout: .seconds(20)) { controller.isActive }
+          transitions.append(.init(elapsedSeconds: elapsed, kind: "replacement", outcome: "pass"))
+          didReplace = true
+        }
+        if elapsed >= 240, !didThermalLoad {
+          thermalStateBefore = ProcessInfo.processInfo.thermalState.qualificationName
+          thermalTask = Task.detached { await Self.runBoundedThermalLoad(seconds: 30) }
+          transitions.append(.init(elapsedSeconds: elapsed, kind: "thermal-pressure-start", outcome: thermalStateBefore))
+          didThermalLoad = true
+        }
+        phase = "direct-\(mode.rawValue)-\(currentRate)x"
+        let snapshot = controller.timebaseDiagnosticSnapshot()
+        let stats = player.statistics
+        if
+          let baseline = postInterruptionAudioBaseline,
+          let playedAudioBuffers = stats?.playedAudioBuffers,
+          playedAudioBuffers > baseline {
+          postInterruptionAudioRecovered = true
+        }
+        let session = AVAudioSession.sharedInstance()
+        let latency = session.outputLatency + session.ioBufferDuration
+        let clockSample = TimebaseClockSample(elapsedSeconds: elapsed, snapshot: snapshot)
+        let audioSample = TimebaseAudioSample(
+          elapsedSeconds: elapsed,
+          mediaTimeSeconds: snapshot.mediaTimeSeconds,
+          estimatedPresentationSeconds: snapshot.mediaTimeSeconds - latency,
+          outputLatencySeconds: session.outputLatency,
+          ioBufferDurationSeconds: session.ioBufferDuration,
+          playedBuffers: stats?.playedAudioBuffers ?? 0,
+          lostBuffers: stats?.lostAudioBuffers ?? 0
+        )
+        if let presented = snapshot.lastDeliveredSampleTimeSeconds {
+          if
+            let previousPresentation,
+            previousPresentation.generation == snapshot.playbackGeneration,
+            presented + 0.001 < previousPresentation.seconds {
+            monotonicityViolations += 1
+          }
+          previousPresentation = (snapshot.playbackGeneration, presented)
+        }
+        let frameSample = TimebaseFrameSample(elapsedSeconds: elapsed, snapshot: snapshot)
+        try await capture.append(clock: clockSample, audio: audioSample, frame: frameSample)
+        if elapsed >= nextCompactSample {
+          clockSeries.append(clockSample)
+          audioSeries.append(audioSample)
+          frameSeries.append(frameSample)
+          nextCompactSample = elapsed + 60
+        }
+        guard controller.isActive else { throw TimebaseSoakFailure("Direct PiP stopped during soak") }
+        guard snapshot.displayLayerStatus != "failed" else { throw TimebaseSoakFailure("Display layer failed") }
+        try await Task.sleep(for: .seconds(1))
+      }
+
+      correctionTask?.cancel()
+      await correctionTask?.value
+      try await capture.close()
+      let correctionSeries = await capture.corrections
+      if let thermalTask {
+        let checksum = await thermalTask.value
+        let after = ProcessInfo.processInfo.thermalState.qualificationName
+        transitions.append(.init(
+          elapsedSeconds: durationSeconds,
+          kind: "thermal-pressure-complete",
+          outcome: "\(thermalStateBefore)->\(after);checksum=\(checksum)"
+        ))
+      }
+      let directDuration = Int(ProcessInfo.processInfo.systemUptime - soakStarted)
+      controller.stop()
+      player.stop()
+      phase = "avplayer-baseline"
+      let baseline = try await AVPlayerTimebaseBaseline.capture(
+        url: fixtureURL,
+        mode: mode,
+        durationSeconds: min(180, max(60, durationSeconds / 40))
+      )
+      let maxDrift = clockSeries.compactMap(\.driftSeconds).map(abs).max() ?? 0
+      let maxSteadyCorrection = correctionSeries
+        .filter { $0.reason == .steadyStateDrift }
+        .map { abs($0.driftSeconds) }
+        .max() ?? 0
+      guard monotonicityViolations == 0 else { throw TimebaseSoakFailure("Presented frame time moved backwards") }
+      guard maxDrift <= 2.1 else { throw TimebaseSoakFailure("Clock drift exceeded 2.1 seconds") }
+      guard maxSteadyCorrection <= 2.1 else { throw TimebaseSoakFailure("A steady correction exceeded 2.1 seconds") }
+      guard didPause, didSeek, didReplace, didThermalLoad else { throw TimebaseSoakFailure("Transition schedule was incomplete") }
+      guard interruptionBegan == 1, interruptionEnded == 1 else {
+        throw TimebaseSoakFailure("Expected exactly one cross-process interruption pair")
+      }
+      guard postInterruptionAudioRecovered else {
+        throw TimebaseSoakFailure("Audio buffers did not advance after interruption recovery")
+      }
+
+      let evidence = TimebaseSoakEvidence(
+        durationSeconds: directDuration,
+        mode: mode.rawValue,
+        rates: [0.5, 1, 2],
+        clockSeries: clockSeries,
+        corrections: correctionSeries,
+        audioPresentationSeries: .init(
+          method: "libVLC media clock minus AVAudioSession outputLatency and ioBufferDuration; paired with host Audio System Trace",
+          hostTraceStatus: "required-host-augmentation",
+          samples: audioSeries
+        ),
+        presentedFrameSeries: frameSeries,
+        driftBudget: .init(maximumSeconds: 2.1, observedMaximumSeconds: maxDrift),
+        correctionBudget: .init(maximumSeconds: 2.1, observedMaximumSeconds: maxSteadyCorrection, count: correctionSeries.count),
+        transitions: transitions,
+        avPlayerBaseline: baseline,
+        rawCapture: .init(
+          status: "required-host-augmentation",
+          fileName: capture.url.lastPathComponent,
+          sampleIntervalSeconds: 1
+        ),
+        visibleSnapCount: -1,
+        monotonicityViolations: monotonicityViolations,
+        interruptionPairs: interruptionBegan,
+        postInterruptionAudioRecovery: "pass",
+        hostTraceRequirements: ["audioPresentationSeries": "Audio System Trace"]
+      )
+      result = try "pass:\(JSONEncoder().encode(evidence).base64EncodedString())"
+      phase = "complete"
+    } catch is CancellationError {
+      result = "cancelled"
+    } catch {
+      controller?.stop()
+      playbackError = String(describing: error)
+      result = "failed"
+    }
+  }
+
+  private func play(_ url: URL) throws {
+    let media = try Media(url: url)
+    try player.play(media)
+  }
+
+  private func qualifiedFixtureURL(baseURL: URL) throws -> URL {
+    let url = switch mode {
+    case .vod: baseURL.appending(path: "adaptive/\(token)/timebase-vod-ts/master.m3u8")
+    case .live: baseURL.appending(path: "adaptive/\(token)/live-ts/master.m3u8")
+    }
+    guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+      throw TimebaseSoakFailure("Could not construct fixture URL")
+    }
+    components.queryItems = (components.queryItems ?? []) + [.init(name: "swiftvlcQualification", value: token)]
+    guard let qualified = components.url else { throw TimebaseSoakFailure("Could not bind fixture request") }
+    return qualified
+  }
+
+  private func signalReady(baseURL: URL) async throws {
+    guard
+      var components = URLComponents(
+        url: baseURL.appending(path: "healthz"),
+        resolvingAgainstBaseURL: false
+      ) else { throw TimebaseSoakFailure("Could not construct readiness URL") }
+    components.queryItems = [.init(name: "swiftvlcTimebaseReady", value: token)]
+    guard let url = components.url else { throw TimebaseSoakFailure("Could not bind readiness URL") }
+    let (_, response) = try await URLSession.shared.data(from: url)
+    guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+      throw TimebaseSoakFailure("Fixture origin rejected readiness signal")
+    }
+  }
+
+  private func recordInterruption(_ notification: Notification) {
+    guard
+      let raw = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+      let type = AVAudioSession.InterruptionType(rawValue: raw) else { return }
+    switch type {
+    case .began:
+      interruptionBegan += 1
+    case .ended:
+      interruptionEnded += 1
+      postInterruptionAudioBaseline = player.statistics?.playedAudioBuffers
+    @unknown default: break
+    }
+  }
+
+  private func waitUntil(_ failure: String, timeout: Duration, condition: @escaping @MainActor () -> Bool) async throws {
+    let deadline = ContinuousClock.now.advanced(by: timeout)
+    while !condition() {
+      try Task.checkCancellation()
+      guard ContinuousClock.now < deadline else { throw TimebaseSoakFailure(failure) }
+      try await Task.sleep(for: .milliseconds(100))
+    }
+  }
+
+  private func valueRow(_ title: String, _ value: String, _ identifier: String) -> some View {
+    HStack { Text(title); Spacer(); Text(value).foregroundStyle(.secondary).accessibilityIdentifier(identifier) }
+  }
+
+  fileprivate static func rate(elapsed: Int, duration: Int) -> Float {
+    switch elapsed / max(1, duration / 3) {
+    case 0: 0.5
+    case 1: 1
+    default: 2
+    }
+  }
+
+  private nonisolated static func runBoundedThermalLoad(seconds: Int) async -> UInt64 {
+    await withTaskGroup(of: UInt64.self, returning: UInt64.self) { group in
+      for seed in 1...max(1, min(2, ProcessInfo.processInfo.activeProcessorCount - 1)) {
+        group.addTask {
+          let deadline = ProcessInfo.processInfo.systemUptime + Double(seconds)
+          var value = UInt64(seed)
+          while ProcessInfo.processInfo.systemUptime < deadline {
+            value ^= value << 13
+            value ^= value >> 7
+            value ^= value << 17
+          }
+          return value
+        }
+      }
+      var checksum: UInt64 = 0
+      for await value in group {
+        checksum ^= value
+      }
+      return checksum
+    }
+  }
+}
+
+private enum TimebaseSoakMode: String, Codable { case vod, live }
+
+private actor TimebaseRawCapture {
+  nonisolated let url: URL
+  private let handle: FileHandle
+  private let encoder = JSONEncoder()
+  private var writeFailure: Error?
+  private var isClosed = false
+  private var correctionValues: [PiPTimebaseCorrection] = []
+  private var sampleCount = 0
+
+  init(token: String, mode: TimebaseSoakMode) throws {
+    let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+    let safeToken = token.map { $0.isLetter || $0.isNumber || $0 == "-" ? $0 : "_" }
+    url = documents.appending(path: "swiftvlc-timebase-\(String(safeToken))-\(mode.rawValue).jsonl")
+    guard FileManager.default.createFile(atPath: url.path, contents: nil) else {
+      throw CocoaError(.fileWriteUnknown)
+    }
+    handle = try FileHandle(forWritingTo: url)
+    encoder.outputFormatting = [.sortedKeys]
+  }
+
+  func append(
+    clock: TimebaseClockSample,
+    audio: TimebaseAudioSample,
+    frame: TimebaseFrameSample
+  )
+    throws {
+    sampleCount += 1
+    try write(
+      .init(kind: "sample", clock: clock, audio: audio, frame: frame),
+      synchronize: sampleCount.isMultiple(of: 30)
+    )
+  }
+
+  func append(correction: PiPTimebaseCorrection) {
+    correctionValues.append(correction)
+    do {
+      try write(.init(kind: "correction", correction: correction), synchronize: true)
+    } catch {
+      writeFailure = writeFailure ?? error
+    }
+  }
+
+  var corrections: [PiPTimebaseCorrection] {
+    correctionValues
+  }
+
+  func close() throws {
+    guard !isClosed else { return }
+    isClosed = true
+    try handle.synchronize()
+    try handle.close()
+    if let writeFailure {
+      throw writeFailure
+    }
+  }
+
+  private func write(_ line: TimebaseRawLine, synchronize: Bool) throws {
+    guard !isClosed else { throw CocoaError(.fileWriteUnknown) }
+    var data = try encoder.encode(line)
+    data.append(0x0A)
+    try handle.write(contentsOf: data)
+    if synchronize {
+      try handle.synchronize()
+    }
+  }
+}
+
+private struct TimebaseRawLine: Codable {
+  let kind: String
+  var clock: TimebaseClockSample?
+  var audio: TimebaseAudioSample?
+  var frame: TimebaseFrameSample?
+  var correction: PiPTimebaseCorrection?
+}
+
+private struct TimebaseClockSample: Codable {
+  let elapsedSeconds: Int
+  let mediaTimeSeconds: Double
+  let controlTimebaseSeconds: Double?
+  let controlTimebaseRate: Double?
+  let driftSeconds: Double?
+  let playbackGeneration: UInt64
+  let requestedRate: Float
+  init(elapsedSeconds: Int, snapshot: PiPTimebaseDiagnosticSnapshot) {
+    self.elapsedSeconds = elapsedSeconds
+    mediaTimeSeconds = snapshot.mediaTimeSeconds
+    controlTimebaseSeconds = snapshot.controlTimebaseSeconds
+    controlTimebaseRate = snapshot.controlTimebaseRate
+    driftSeconds = snapshot.driftSeconds
+    playbackGeneration = snapshot.playbackGeneration
+    requestedRate = snapshot.requestedRate
+  }
+}
+
+private struct TimebaseAudioSample: Codable {
+  let elapsedSeconds: Int
+  let mediaTimeSeconds: Double
+  let estimatedPresentationSeconds: Double
+  let outputLatencySeconds: Double
+  let ioBufferDurationSeconds: Double
+  let playedBuffers: UInt64
+  let lostBuffers: UInt64
+}
+
+private struct TimebaseFrameSample: Codable {
+  let elapsedSeconds: Int
+  let playbackGeneration: UInt64
+  let deliveredFrames: UInt64
+  let droppedFrames: UInt64
+  let presentedSeconds: Double?
+  let decodedFrames: UInt64
+  let decodedFrameMediaTimeSeconds: Double?
+  init(elapsedSeconds: Int, snapshot: PiPTimebaseDiagnosticSnapshot) {
+    self.elapsedSeconds = elapsedSeconds
+    playbackGeneration = snapshot.playbackGeneration
+    deliveredFrames = snapshot.deliveredFrameCount
+    droppedFrames = snapshot.droppedFrameCount
+    presentedSeconds = snapshot.lastDeliveredSampleTimeSeconds
+    decodedFrames = snapshot.decodedFrameCount
+    decodedFrameMediaTimeSeconds = snapshot.lastDecodedFrameMediaTimeSeconds
+  }
+}
+
+private struct TimebaseTransition: Codable {
+  let elapsedSeconds: Int
+  let kind: String
+  let outcome: String
+}
+
+private struct TimebaseBudget: Codable {
+  let maximumSeconds: Double
+  let observedMaximumSeconds: Double
+}
+
+private struct TimebaseCorrectionBudget: Codable {
+  let maximumSeconds: Double
+  let observedMaximumSeconds: Double
+  let count: Int
+}
+
+private struct TimebaseAudioSeries: Codable {
+  let method: String
+  let hostTraceStatus: String
+  let samples: [TimebaseAudioSample]
+}
+
+private struct TimebaseRawCaptureReference: Codable {
+  let status: String
+  let fileName: String
+  let sampleIntervalSeconds: Int
+}
+
+private struct AVPlayerBaselineEvidence: Codable {
+  let durationSeconds: Int
+  let requestedRates: [Float]
+  let observedRates: [Float]
+  let samples: [AVPlayerBaselineSample]
+  let maximumVideoClockDriftSeconds: Double
+}
+
+private struct AVPlayerBaselineSample: Codable {
+  let elapsedSeconds: Int
+  let requestedRate: Float
+  let actualRate: Float
+  let playerSeconds: Double
+  let videoOutputSeconds: Double?
+  let videoClockDriftSeconds: Double?
+  let estimatedAudioPresentationSeconds: Double
+}
+
+@MainActor
+private enum AVPlayerTimebaseBaseline {
+  static func capture(
+    url: URL,
+    mode: TimebaseSoakMode,
+    durationSeconds: Int
+  )
+    async throws -> AVPlayerBaselineEvidence {
+    let item = AVPlayerItem(url: url)
+    let output = AVPlayerItemVideoOutput(pixelBufferAttributes: nil)
+    item.add(output)
+    let player = AVPlayer(playerItem: item)
+    player.play()
+    let readyDeadline = ContinuousClock.now.advanced(by: .seconds(30))
+    while item.status == .unknown, ContinuousClock.now < readyDeadline {
+      try await Task.sleep(for: .milliseconds(100))
+    }
+    guard item.status == .readyToPlay else {
+      throw TimebaseSoakFailure("AVPlayer baseline did not become ready")
+    }
+    let started = ProcessInfo.processInfo.systemUptime
+    var samples: [AVPlayerBaselineSample] = []
+    var currentRate: Float = 0
+    while Int(ProcessInfo.processInfo.systemUptime - started) < durationSeconds {
+      let elapsed = Int(ProcessInfo.processInfo.systemUptime - started)
+      let rate = TimebaseSoakValidationCase.rate(elapsed: elapsed, duration: durationSeconds)
+      if rate != currentRate {
+        player.playImmediately(atRate: rate)
+        currentRate = rate
+      }
+      let playerSeconds = player.currentTime().seconds
+      guard playerSeconds.isFinite else {
+        try await Task.sleep(for: .seconds(1))
+        continue
+      }
+      if
+        mode == .vod,
+        (item.duration.seconds.isFinite && playerSeconds >= item.duration.seconds - 1)
+        || player.timeControlStatus == .paused {
+        await player.seek(to: .zero)
+        player.playImmediately(atRate: rate)
+        try await Task.sleep(for: .milliseconds(200))
+        continue
+      }
+      let videoTime = output.itemTime(forHostTime: ProcessInfo.processInfo.systemUptime)
+      let rawVideoSeconds = videoTime.isValid ? videoTime.seconds : .nan
+      let videoSeconds = rawVideoSeconds.isFinite ? rawVideoSeconds : nil
+      let latency = AVAudioSession.sharedInstance().outputLatency + AVAudioSession.sharedInstance().ioBufferDuration
+      samples.append(.init(
+        elapsedSeconds: elapsed,
+        requestedRate: rate,
+        actualRate: player.rate,
+        playerSeconds: playerSeconds,
+        videoOutputSeconds: videoSeconds,
+        videoClockDriftSeconds: videoSeconds.map { playerSeconds - $0 },
+        estimatedAudioPresentationSeconds: playerSeconds - latency
+      ))
+      try await Task.sleep(for: .seconds(2))
+    }
+    player.pause()
+    let maximum = samples.compactMap(\.videoClockDriftSeconds).map(abs).max() ?? 0
+    guard samples.count >= durationSeconds / 3 else { throw TimebaseSoakFailure("AVPlayer baseline produced too few samples") }
+    let observedRates = Array(Set(samples.map(\.actualRate))).sorted()
+    return .init(
+      durationSeconds: durationSeconds,
+      requestedRates: [0.5, 1, 2],
+      observedRates: observedRates,
+      samples: samples,
+      maximumVideoClockDriftSeconds: maximum
+    )
+  }
+}
+
+private struct TimebaseSoakEvidence: Codable {
+  let durationSeconds: Int
+  let mode: String
+  let rates: [Float]
+  let clockSeries: [TimebaseClockSample]
+  let corrections: [PiPTimebaseCorrection]
+  let audioPresentationSeries: TimebaseAudioSeries
+  let presentedFrameSeries: [TimebaseFrameSample]
+  let driftBudget: TimebaseBudget
+  let correctionBudget: TimebaseCorrectionBudget
+  let transitions: [TimebaseTransition]
+  let avPlayerBaseline: AVPlayerBaselineEvidence
+  let rawCapture: TimebaseRawCaptureReference
+  let visibleSnapCount: Int
+  let monotonicityViolations: Int
+  let interruptionPairs: Int
+  let postInterruptionAudioRecovery: String
+  let hostTraceRequirements: [String: String]
+}
+
+private struct TimebaseSoakFailure: Error, CustomStringConvertible {
+  let description: String
+  init(_ description: String) {
+    self.description = description
+  }
+}
+
+extension ProcessInfo.ThermalState {
+  fileprivate var qualificationName: String {
+    switch self {
+    case .nominal: "nominal"
+    case .fair: "fair"
+    case .serious: "serious"
+    case .critical: "critical"
+    @unknown default: "unknown"
+    }
+  }
+}

--- a/Showcase/macOS/Internal/MacShowcaseRootView.swift
+++ b/Showcase/macOS/Internal/MacShowcaseRootView.swift
@@ -419,7 +419,8 @@ extension MacShowcase {
          .adaptiveHLSSoakValidation,
          .pipRenderPerformanceValidation,
          .pipCadenceValidation,
-         .nativeSubtitleMatrixValidation:
+         .nativeSubtitleMatrixValidation,
+         .timebaseSoakValidation:
       return nil
     }
   }

--- a/Showcase/tvOS/Internal/TVShowcaseRootView.swift
+++ b/Showcase/tvOS/Internal/TVShowcaseRootView.swift
@@ -527,7 +527,8 @@ extension TVShowcase {
          .adaptiveHLSSoakValidation,
          .pipRenderPerformanceValidation,
          .pipCadenceValidation,
-         .nativeSubtitleMatrixValidation:
+         .nativeSubtitleMatrixValidation,
+         .timebaseSoakValidation:
       return nil
     }
   }

--- a/Sources/SwiftVLC/PiP/PiPTimebaseDiagnostics.swift
+++ b/Sources/SwiftVLC/PiP/PiPTimebaseDiagnostics.swift
@@ -51,6 +51,9 @@ public struct PiPTimebaseDiagnosticSnapshot: Codable, Sendable, Equatable {
   public let controlTimebaseRate: Double?
   public let driftSeconds: Double?
   public let decodedFrameCount: UInt64
+  /// libVLC media clock sampled at the decoded frame's vmem display callback.
+  /// This is distinct from the control-timebase presentation timestamp.
+  public let lastDecodedFrameMediaTimeSeconds: Double?
   public let decodedContentChangeCount: UInt64
   public let lastDecodedContentFingerprint: UInt64?
   public let renderGeneration: UInt64
@@ -125,6 +128,7 @@ extension PiPController {
       controlTimebaseRate: controlTimebase.map { CMTimebaseGetRate($0) },
       driftSeconds: timebaseSeconds.map { mediaTimeSeconds - $0 },
       decodedFrameCount: telemetry.decodedFrameCount,
+      lastDecodedFrameMediaTimeSeconds: telemetry.lastDecodedFrameMediaTimeSeconds,
       decodedContentChangeCount: telemetry.decodedContentChangeCount,
       lastDecodedContentFingerprint: telemetry.lastDecodedContentFingerprint,
       renderGeneration: telemetry.renderGeneration,

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer+Callbacks.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer+Callbacks.swift
@@ -341,6 +341,7 @@ final class PixelBufferRendererCallbackContext: Sendable {
   var qualificationMediaTimeSeconds: Double? {
     guard
       isQualificationTelemetryEnabled,
+      !state.withLock({ $0.nativePlayerHandleReleased }),
       nativePlayerAddress != 0,
       let nativePlayer = OpaquePointer(bitPattern: nativePlayerAddress)
     else { return nil }

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer+Callbacks.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer+Callbacks.swift
@@ -79,6 +79,7 @@ final class DirectPiPVideoCallbackSlot {
     self.api = api
     let context = PixelBufferRendererCallbackContext(
       renderer: decodeRenderer,
+      nativePlayer: lifetime.pointer,
       playbackGeneration: playbackGeneration,
       voutGenerationCounter: voutGenerationCounter
     )
@@ -263,11 +264,16 @@ final class PixelBufferRendererCallbackContext: Sendable {
   private let state: Mutex<State>
   private let presentationCopyRequired: Atomic<Bool>
   private let qualificationTelemetryEnabled: Atomic<Bool>
+  /// Stored as bits because `OpaquePointer` is not `Sendable`. The enclosing
+  /// callback context is retained only until this exact native handle joins
+  /// vout teardown, so reconstructing it during an in-flight callback is safe.
+  private let nativePlayerAddress: UInt
   private let playbackGeneration: Mutex<UInt64>
   private let voutGenerationCounter: PixelBufferVoutGenerationCounter
 
   init(
     renderer: PixelBufferRenderer,
+    nativePlayer: OpaquePointer? = nil,
     playbackGeneration: UInt64 = 0,
     voutGenerationCounter: PixelBufferVoutGenerationCounter = PixelBufferVoutGenerationCounter()
   ) {
@@ -278,6 +284,7 @@ final class PixelBufferRendererCallbackContext: Sendable {
     qualificationTelemetryEnabled = Atomic(
       renderer.contentDiagnosticsEnabled.load(ordering: .acquiring)
     )
+    nativePlayerAddress = nativePlayer.map(UInt.init(bitPattern:)) ?? 0
     self.playbackGeneration = Mutex(playbackGeneration)
     self.voutGenerationCounter = voutGenerationCounter
   }
@@ -329,6 +336,16 @@ final class PixelBufferRendererCallbackContext: Sendable {
 
   var isQualificationTelemetryEnabled: Bool {
     qualificationTelemetryEnabled.load(ordering: .acquiring)
+  }
+
+  var qualificationMediaTimeSeconds: Double? {
+    guard
+      isQualificationTelemetryEnabled,
+      nativePlayerAddress != 0,
+      let nativePlayer = OpaquePointer(bitPattern: nativePlayerAddress)
+    else { return nil }
+    let milliseconds = libvlc_media_player_get_time(nativePlayer)
+    return milliseconds >= 0 ? Double(milliseconds) / 1000 : nil
   }
 
   func setPresentationCopyRequired(_ required: Bool) {
@@ -529,6 +546,10 @@ final class PixelBufferRendererVoutCallbackContext: @unchecked Sendable {
 
   var isPresentationCopyRequired: Bool {
     handleContext.isPresentationCopyRequired
+  }
+
+  var qualificationMediaTimeSeconds: Double? {
+    handleContext.qualificationMediaTimeSeconds
   }
 
   /// Pins one callback picture until display consumes it, a later lock
@@ -736,9 +757,15 @@ func pixelBufferDisplayCallback(
       $0.playbackGeneration == playbackGeneration
     }
     guard acceptsPlaybackGeneration else { return }
+    let decodedMediaTimeSeconds = context.qualificationMediaTimeSeconds
     renderer.state.withLock {
       $0.decodedFrameCount &+= 1
       $0.lastDecodedAt = .now
+    }
+    if let decodedMediaTimeSeconds {
+      renderer.state.withLock {
+        $0.lastDecodedFrameMediaTimeSeconds = decodedMediaTimeSeconds
+      }
     }
     guard let output = renderer.outputPixelBuffer(from: pb) else { return }
     let outputBuffer = output.buffer

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer+Enqueue.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer+Enqueue.swift
@@ -76,6 +76,7 @@ struct PixelBufferRendererTelemetrySnapshot: Sendable, Equatable {
   let playbackGeneration: UInt64?
   let voutGeneration: UInt64?
   let decodedFrameCount: UInt64
+  let lastDecodedFrameMediaTimeSeconds: Double?
   let decodedContentChangeCount: UInt64
   let lastDecodedContentFingerprint: UInt64?
   let renderGeneration: UInt64
@@ -264,6 +265,7 @@ extension PixelBufferRenderer {
     let decoded = state.withLock {
       (
         frameCount: $0.decodedFrameCount,
+        mediaTimeSeconds: $0.lastDecodedFrameMediaTimeSeconds,
         lastAt: $0.lastDecodedAt,
         contentChangeCount: $0.decodedContentChangeCount,
         contentFingerprint: $0.lastDecodedContentFingerprint,
@@ -291,6 +293,7 @@ extension PixelBufferRenderer {
         playbackGeneration: $0.latestPlaybackGeneration,
         voutGeneration: $0.latestVoutGeneration,
         decodedFrameCount: decoded.frameCount,
+        lastDecodedFrameMediaTimeSeconds: decoded.mediaTimeSeconds,
         decodedContentChangeCount: decoded.contentChangeCount,
         lastDecodedContentFingerprint: decoded.contentFingerprint,
         renderGeneration: decoded.renderGeneration,

--- a/Sources/SwiftVLC/PiP/PixelBufferRenderer.swift
+++ b/Sources/SwiftVLC/PiP/PixelBufferRenderer.swift
@@ -77,6 +77,9 @@ final class PixelBufferRenderer: Sendable {
     var timebase: CMTimebase?
     var decodedFrameCount: UInt64 = 0
     var lastDecodedAt: ContinuousClock.Instant?
+    /// Qualification-only libVLC media clock sampled synchronously when the
+    /// decoded frame reaches the vmem display callback.
+    var lastDecodedFrameMediaTimeSeconds: Double?
     /// Opt-in qualification probe. Disabled for normal clients so sampling
     /// decoded pixels adds no work to the production hot path.
     var contentFingerprintingEnabled = false
@@ -136,6 +139,7 @@ final class PixelBufferRenderer: Sendable {
     let changed = state.withLock { state -> Bool in
       guard state.playbackGeneration != generation else { return false }
       state.playbackGeneration = generation
+      state.lastDecodedFrameMediaTimeSeconds = nil
       state.advanceRenderGeneration()
       return true
     }
@@ -159,6 +163,7 @@ final class PixelBufferRenderer: Sendable {
       state.measuredConversionCount = 0
       state.measuredConversionNanoseconds = 0
       state.maximumMeasuredConversionNanoseconds = 0
+      state.lastDecodedFrameMediaTimeSeconds = nil
     }
     if enabled {
       contentDiagnosticsEnabled.store(true, ordering: .releasing)

--- a/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
+++ b/Sources/SwiftVLC/SwiftVLC.docc/PictureInPicture.md
@@ -216,9 +216,11 @@ and a lossless stream of control-timebase corrections. The device-validation
 harness's Matrix I writes both to JSON Lines as they occur, so a multi-hour
 run remains recoverable even if the app later terminates.
 
-The capture includes the libVLC media clock, control-timebase value and rate,
-delivered sample timestamp, frame counters, drop count, generation, and each
-timebase write. It deliberately does **not** label the media clock as an audio
+The capture includes the polled libVLC media clock, a second native media-clock
+sample taken synchronously at the decoded-frame display callback, the
+control-timebase value and rate, delivered sample timestamp, frame counters,
+drop count, generation, and each timebase write. It deliberately does **not**
+label either media-clock sample as an audio
 presentation timestamp. Release qualification must pair the JSONL with an
 audio/video measurement and an AVPlayer baseline recorded with the same
 fixture and physical device.

--- a/Tests/SwiftVLCTests/PiP/PiPTimebaseDiagnosticsTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PiPTimebaseDiagnosticsTests.swift
@@ -67,6 +67,7 @@ struct PiPTimebaseDiagnosticsTests {
     #expect(snapshot.controlTimebaseSeconds == before)
     #expect(snapshot.controlTimebaseRate == 0)
     #expect(snapshot.decodedFrameCount == 0)
+    #expect(snapshot.lastDecodedFrameMediaTimeSeconds == nil)
     #expect(snapshot.decodedContentChangeCount == 0)
     #expect(snapshot.lastDecodedContentFingerprint == nil)
     #expect(snapshot.renderGeneration == rendererBefore.renderGeneration)

--- a/Tests/SwiftVLCTests/PiP/PixelBufferRendererCallbackTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferRendererCallbackTests.swift
@@ -664,6 +664,26 @@ extension Integration {
     }
 
     @Test
+    @MainActor
+    func `Decoded frame media clock is sampled only after qualification opts in`() async {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let renderer = PixelBufferRenderer(displayLayer: AVSampleBufferDisplayLayer())
+      let context = PixelBufferRendererCallbackContext(
+        renderer: renderer,
+        nativePlayer: player.pointer
+      )
+
+      #expect(context.qualificationMediaTimeSeconds == nil)
+      context.setQualificationTelemetryEnabled(true)
+      #expect(context.isQualificationTelemetryEnabled)
+      // libVLC initializes a fresh media-player clock at zero. Reaching that
+      // value proves the opted-in handle path samples the native player.
+      #expect(context.qualificationMediaTimeSeconds == 0)
+
+      await player.shutdown()
+    }
+
+    @Test
     func `Retiring callback context releases opaque only after native handle ends`() throws {
       weak var weakContext: PixelBufferRendererCallbackContext?
       weak var weakRenderer: PixelBufferRenderer?

--- a/Tests/SwiftVLCTests/PiP/PixelBufferRendererCallbackTests.swift
+++ b/Tests/SwiftVLCTests/PiP/PixelBufferRendererCallbackTests.swift
@@ -672,6 +672,7 @@ extension Integration {
         renderer: renderer,
         nativePlayer: player.pointer
       )
+      let retained = Unmanaged.passRetained(context)
 
       #expect(context.qualificationMediaTimeSeconds == nil)
       context.setQualificationTelemetryEnabled(true)
@@ -679,6 +680,9 @@ extension Integration {
       // libVLC initializes a fresh media-player clock at zero. Reaching that
       // value proves the opted-in handle path samples the native player.
       #expect(context.qualificationMediaTimeSeconds == 0)
+      context.nativePlayerHandleDidRelease(opaque: retained.toOpaque())
+      #expect(context.nativePlayerHandleReleasedForTesting)
+      #expect(context.qualificationMediaTimeSeconds == nil)
 
       await player.shutdown()
     }

--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -270,6 +270,30 @@ to the same candidate run. A missing subtitle track, absent overlay pixels,
 failed resize, more than 10% lost pictures, incomplete transition, wrong HDR
 metadata, shortened duration, or missing trace rejects the row.
 
+The `timebase-vod-soak` and `timebase-live-soak` lanes each hold direct PiP
+active for at least 7,200 seconds. Rates 0.5x, 1x, and 2x divide the measured
+interval into three long phases. The candidate also performs pause/resume,
+VOD seek (or records the live non-applicability), replacement, a bounded
+two-worker thermal load, a real cross-process audio-session interruption, and
+periodic SpringBoard PiP resizing. One-second clock, audio-output, and frame
+samples plus every control-timebase write are appended to recoverable JSONL;
+only a 60-second compact series travels through XCTest. The host rejects a
+short raw capture, malformed rows, correction-sequence gaps, or a mismatch
+between compact and raw corrections, then binds its SHA-256 and a full Audio
+System Trace to the candidate evidence. The audio series is explicitly a
+latency-adjusted presentation estimate paired with the system audio trace; it
+never relabels libVLC media time as an audio timestamp. A 60-180 second
+AVPlayer comparison uses the same URL and device, including
+`AVPlayerItemVideoOutput` presentation time. Backward frame presentation,
+more than 2.1 seconds of observed drift/correction, missing transitions,
+unbalanced interruption, static/failed system PiP, or absent trace/raw data
+rejects either row.
+
+The VOD lane uses a deterministic four-hour HLS timeline backed by the cached
+two-second transport-stream segments. Discontinuities bind every segment wrap
+into one finite, seekable timeline; the lane does not depend on libVLC input
+repeat behavior and cannot exhaust its media during the rate schedule.
+
 Use `--require-stable` for release evidence. It fails before testing if the
 device is a simulator, runs beta or unknown software, or does not match a
 hardware row in `matrix.json`. Without that option, the same command is useful
@@ -277,11 +301,10 @@ for exploratory beta-OS testing, but its report remains ineligible for release.
 
 This lane is intentionally fail-closed: its current automated scenarios are a
 candidate qualification subset, not a claim that all 53 qualification rows
-passed. The harness has prepared automated coverage for 51 rows;
-`timebase-vod-soak` and `timebase-live-soak` remain to be automated.
-`report.json` therefore keeps `releaseGateSatisfied` false until a matrix
-runner has produced complete candidate-bound evidence for every required
-hardware/OS row described below.
+passed. The harness has prepared automated coverage for all 53 rows. This is
+not a claim that any newly prepared row passed: `report.json` keeps
+`releaseGateSatisfied` false until a matrix runner has produced complete
+candidate-bound evidence for every required hardware/OS row described below.
 
 Qualification is bound to both halves of the shipped package. The
 XCFramework tree digest identifies the native engine and headers, while the

--- a/scripts/qualification/assemble-record.py
+++ b/scripts/qualification/assemble-record.py
@@ -180,6 +180,27 @@ def retained_trace_artifacts(
     ]
 
 
+def retained_file_artifact(
+    evidence_path: Path, record: object, description: str
+) -> list[tuple[Path, Path, bool]]:
+    if not isinstance(record, dict):
+        raise AssemblyError(f"evidence {evidence_path} has malformed {description}")
+    if record.get("digestAlgorithm") != "sha256":
+        raise AssemblyError(
+            f"evidence {evidence_path} {description} has unsupported digest algorithm"
+        )
+    source, relative = safe_evidence_artifact_path(
+        evidence_path,
+        record.get("runArtifact"),
+        description,
+        directory=False,
+    )
+    digest = hashlib.sha256(source.read_bytes()).hexdigest()
+    if digest != record.get("sha256"):
+        raise AssemblyError(f"evidence {evidence_path} {description} digest mismatch")
+    return [(source, relative, False)]
+
+
 def assemble(
     version: str,
     candidate_path: Path,
@@ -329,6 +350,26 @@ def assemble(
                             evidence_path, subtitle_trace, description
                         )
                     )
+            if key[0] in {"timebase-vod-soak", "timebase-live-soak"}:
+                audio = evidence.get("audioPresentationSeries")
+                if not isinstance(audio, dict):
+                    raise AssemblyError(
+                        f"evidence {evidence_path} has no timebase audio series"
+                    )
+                artifacts.extend(
+                    retained_trace_artifacts(
+                        evidence_path,
+                        audio.get("hostTrace"),
+                        "Audio System Trace",
+                    )
+                )
+                artifacts.extend(
+                    retained_file_artifact(
+                        evidence_path,
+                        evidence.get("rawCapture"),
+                        "raw timebase capture",
+                    )
+                )
             rows[key] = (row, evidence_path, artifacts)
 
     evidence_directory = output_path.parent / "evidence" / version

--- a/scripts/qualification/augment-timebase-evidence.py
+++ b/scripts/qualification/augment-timebase-evidence.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Bind the full clock JSONL and Audio System Trace to timebase evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+class TimebaseEvidenceError(ValueError):
+    pass
+
+
+SHA256 = re.compile(r"[0-9a-f]{64}")
+SCENARIOS = {"timebase-vod-soak", "timebase-live-soak"}
+
+
+def trace_record(
+    trace: Path,
+    toc: Path,
+    digest_script: Path,
+    artifact_directory: Path,
+    evidence_directory: Path,
+) -> dict:
+    if not trace.is_dir() or not any(trace.rglob("*")):
+        raise TimebaseEvidenceError("Audio System Trace is missing or empty")
+    text = toc.read_text(errors="replace")
+    if "audio" not in text.lower():
+        raise TimebaseEvidenceError("Audio System Trace TOC has no audio tables")
+    staged_trace = artifact_directory / trace.name
+    staged_toc = artifact_directory / toc.name
+    try:
+        shutil.copytree(trace, staged_trace)
+        shutil.copy2(toc, staged_toc)
+    except OSError as error:
+        raise TimebaseEvidenceError(
+            f"cannot retain Audio System Trace artifacts: {error}"
+        ) from error
+    result = subprocess.run(
+        [sys.executable, str(digest_script), str(staged_trace)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    digest = result.stdout.strip()
+    if result.returncode != 0 or not SHA256.fullmatch(digest):
+        raise TimebaseEvidenceError("could not digest Audio System Trace")
+    return {
+        "status": "captured",
+        "template": "Audio System Trace",
+        "format": "com.apple.instruments.trace",
+        "runArtifact": staged_trace.relative_to(evidence_directory).as_posix(),
+        "tableOfContents": staged_toc.relative_to(evidence_directory).as_posix(),
+        "treeDigestAlgorithm": "swiftvlc-tree-v1",
+        "treeDigest": digest,
+        "targetProcess": "iOS",
+    }
+
+
+def raw_record(root: Path, reference: dict, duration: int) -> dict:
+    name = reference.get("fileName")
+    if not isinstance(name, str) or Path(name).name != name:
+        raise TimebaseEvidenceError("raw capture reference is unsafe")
+    matches = [path for path in root.rglob(name) if path.is_file()]
+    if len(matches) != 1:
+        raise TimebaseEvidenceError(f"expected one raw capture named {name}")
+    path = matches[0]
+    samples = 0
+    correction_sequences: list[int] = []
+    maximum_drift = 0.0
+    maximum_correction = 0.0
+    observed_rates: set[float] = set()
+    monotonicity_violations = 0
+    previous_presented: dict[int, float] = {}
+    decoded_media_samples = 0
+    first_played_buffers: int | None = None
+    last_played_buffers: int | None = None
+    for number, line in enumerate(path.read_text(errors="strict").splitlines(), 1):
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise TimebaseEvidenceError(f"invalid raw JSONL line {number}") from error
+        if value.get("kind") == "sample":
+            if not all(isinstance(value.get(key), dict) for key in ("clock", "audio", "frame")):
+                raise TimebaseEvidenceError(f"incomplete raw sample line {number}")
+            clock, audio, frame = value["clock"], value["audio"], value["frame"]
+            drift = clock.get("driftSeconds")
+            rate = clock.get("requestedRate")
+            generation = frame.get("playbackGeneration")
+            presented = frame.get("presentedSeconds")
+            played = audio.get("playedBuffers")
+            decoded_media = frame.get("decodedFrameMediaTimeSeconds")
+            if isinstance(drift, (int, float)):
+                maximum_drift = max(maximum_drift, abs(float(drift)))
+            if isinstance(rate, (int, float)):
+                observed_rates.add(float(rate))
+            if isinstance(generation, int) and isinstance(presented, (int, float)):
+                previous = previous_presented.get(generation)
+                if previous is not None and float(presented) + 0.001 < previous:
+                    monotonicity_violations += 1
+                previous_presented[generation] = float(presented)
+            if isinstance(played, int):
+                first_played_buffers = played if first_played_buffers is None else first_played_buffers
+                last_played_buffers = played
+            if isinstance(decoded_media, (int, float)):
+                decoded_media_samples += 1
+            samples += 1
+        elif value.get("kind") == "correction":
+            correction = value.get("correction")
+            if not isinstance(correction, dict) or not isinstance(correction.get("sequence"), int):
+                raise TimebaseEvidenceError(f"invalid correction line {number}")
+            correction_sequences.append(correction["sequence"])
+            drift = correction.get("driftSeconds")
+            if correction.get("reason") == "steadyStateDrift" and isinstance(drift, (int, float)):
+                maximum_correction = max(maximum_correction, abs(float(drift)))
+        else:
+            raise TimebaseEvidenceError(f"unknown raw capture line {number}")
+    if samples < max(1, duration - 120):
+        raise TimebaseEvidenceError(
+            f"raw capture has {samples} samples for a {duration}-second run"
+        )
+    if any(b != a + 1 for a, b in zip(correction_sequences, correction_sequences[1:])):
+        raise TimebaseEvidenceError("raw correction sequence has a gap")
+    return {
+        "status": "captured",
+        "format": "application/x-ndjson",
+        "runArtifact": name,
+        "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        "sampleIntervalSeconds": reference.get("sampleIntervalSeconds"),
+        "sampleCount": samples,
+        "correctionCount": len(correction_sequences),
+        "firstCorrectionSequence": correction_sequences[0] if correction_sequences else None,
+        "lastCorrectionSequence": correction_sequences[-1] if correction_sequences else None,
+        "maximumObservedDriftSeconds": maximum_drift,
+        "maximumSteadyCorrectionSeconds": maximum_correction,
+        "observedRates": sorted(observed_rates),
+        "monotonicityViolations": monotonicity_violations,
+        "audioBuffersAdvanced": (
+            first_played_buffers is not None
+            and last_played_buffers is not None
+            and last_played_buffers > first_played_buffers
+        ),
+        "decodedFrameMediaClockSampleCount": decoded_media_samples,
+    }
+
+
+def augment(
+    evidence_path: Path,
+    raw_root: Path,
+    trace: Path,
+    toc: Path,
+    digest_script: Path,
+) -> dict:
+    try:
+        payload = json.loads(evidence_path.read_text())
+    except (OSError, ValueError) as error:
+        raise TimebaseEvidenceError(f"cannot read timebase evidence: {error}") from error
+    if not isinstance(payload, dict) or payload.get("scenario") not in SCENARIOS:
+        raise TimebaseEvidenceError("timebase artifacts belong only to timebase soak rows")
+    duration = payload.get("durationSeconds")
+    if not isinstance(duration, int) or duration < 7200:
+        raise TimebaseEvidenceError("timebase evidence is shorter than 7,200 seconds")
+    audio = payload.get("audioPresentationSeries")
+    reference = payload.get("rawCapture")
+    if not isinstance(audio, dict) or not isinstance(reference, dict):
+        raise TimebaseEvidenceError("timebase audio/raw evidence is malformed")
+    raw = raw_record(raw_root, reference, duration)
+    corrections = payload.get("corrections")
+    if not isinstance(corrections, list) or len(corrections) != raw["correctionCount"]:
+        raise TimebaseEvidenceError("compact and raw correction counts differ")
+    drift_budget = payload.get("driftBudget")
+    correction_budget = payload.get("correctionBudget")
+    if not isinstance(drift_budget, dict) or not isinstance(correction_budget, dict):
+        raise TimebaseEvidenceError("timebase budgets are malformed")
+    if raw["maximumObservedDriftSeconds"] > drift_budget.get("maximumSeconds", -1):
+        raise TimebaseEvidenceError("raw clock series exceeds the drift budget")
+    if raw["maximumSteadyCorrectionSeconds"] > correction_budget.get("maximumSeconds", -1):
+        raise TimebaseEvidenceError("raw correction series exceeds the correction budget")
+    if raw["monotonicityViolations"] != 0:
+        raise TimebaseEvidenceError("raw presented-frame series moved backwards")
+    if not raw["audioBuffersAdvanced"]:
+        raise TimebaseEvidenceError("raw audio output counters did not advance")
+    if raw["decodedFrameMediaClockSampleCount"] < raw["sampleCount"] // 2:
+        raise TimebaseEvidenceError("decoded-frame media clock was not captured")
+    if any(not any(abs(rate - expected) < 0.01 for rate in raw["observedRates"]) for expected in (0.5, 1.0, 2.0)):
+        raise TimebaseEvidenceError("raw clock series did not cover all required rates")
+    raw_name = reference["fileName"]
+    raw_matches = [path for path in raw_root.rglob(raw_name) if path.is_file()]
+    if len(raw_matches) != 1:
+        raise TimebaseEvidenceError(f"expected one raw capture named {raw_name}")
+    artifact_directory = evidence_path.parent / "artifacts" / evidence_path.stem
+    try:
+        artifact_directory.mkdir(parents=True, exist_ok=False)
+    except OSError as error:
+        raise TimebaseEvidenceError(
+            f"cannot create timebase artifact directory: {error}"
+        ) from error
+    try:
+        staged_raw = artifact_directory / raw_name
+        shutil.copy2(raw_matches[0], staged_raw)
+        if hashlib.sha256(staged_raw.read_bytes()).hexdigest() != raw["sha256"]:
+            raise TimebaseEvidenceError("retained raw capture digest mismatch")
+        raw["runArtifact"] = staged_raw.relative_to(evidence_path.parent).as_posix()
+        raw["digestAlgorithm"] = "sha256"
+        host_trace = trace_record(
+            trace,
+            toc,
+            digest_script,
+            artifact_directory,
+            evidence_path.parent,
+        )
+    except (OSError, TimebaseEvidenceError):
+        shutil.rmtree(artifact_directory, ignore_errors=True)
+        raise
+    audio.pop("hostTraceStatus", None)
+    audio["hostTrace"] = host_trace
+    payload["rawCapture"] = raw
+    payload.pop("hostTraceRequirements", None)
+    evidence_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--raw-root", type=Path, required=True)
+    parser.add_argument("--audio-trace", type=Path, required=True)
+    parser.add_argument("--audio-toc", type=Path, required=True)
+    parser.add_argument("--digest-script", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        augment(
+            args.evidence,
+            args.raw_root,
+            args.audio_trace,
+            args.audio_toc,
+            args.digest_script,
+        )
+    except (OSError, TimebaseEvidenceError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qualification/augment-timebase-evidence.py
+++ b/scripts/qualification/augment-timebase-evidence.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import re
 import shutil
 import subprocess
@@ -73,7 +74,9 @@ def raw_record(root: Path, reference: dict, duration: int) -> dict:
     path = matches[0]
     samples = 0
     correction_sequences: list[int] = []
+    elapsed_seconds: list[int] = []
     maximum_drift = 0.0
+    drift_samples = 0
     maximum_correction = 0.0
     observed_rates: set[float] = set()
     monotonicity_violations = 0
@@ -92,13 +95,20 @@ def raw_record(root: Path, reference: dict, duration: int) -> dict:
             clock, audio, frame = value["clock"], value["audio"], value["frame"]
             drift = clock.get("driftSeconds")
             rate = clock.get("requestedRate")
+            elapsed = clock.get("elapsedSeconds")
             generation = frame.get("playbackGeneration")
             presented = frame.get("presentedSeconds")
             played = audio.get("playedBuffers")
             decoded_media = frame.get("decodedFrameMediaTimeSeconds")
-            if isinstance(drift, (int, float)):
+            if type(drift) in (int, float) and math.isfinite(float(drift)):
                 maximum_drift = max(maximum_drift, abs(float(drift)))
-            if isinstance(rate, (int, float)):
+                drift_samples += 1
+            if type(elapsed) is not int:
+                raise TimebaseEvidenceError(
+                    f"raw sample line {number} has no integer elapsedSeconds"
+                )
+            elapsed_seconds.append(elapsed)
+            if type(rate) in (int, float) and math.isfinite(float(rate)):
                 observed_rates.add(float(rate))
             if isinstance(generation, int) and isinstance(presented, (int, float)):
                 previous = previous_presented.get(generation)
@@ -125,7 +135,25 @@ def raw_record(root: Path, reference: dict, duration: int) -> dict:
         raise TimebaseEvidenceError(
             f"raw capture has {samples} samples for a {duration}-second run"
         )
-    if any(b != a + 1 for a, b in zip(correction_sequences, correction_sequences[1:])):
+    if drift_samples < max(1, samples - 120):
+        raise TimebaseEvidenceError("raw capture is missing clock-drift samples")
+    if any(current <= previous for previous, current in zip(elapsed_seconds, elapsed_seconds[1:])):
+        raise TimebaseEvidenceError("raw sample timeline is not strictly increasing")
+    if elapsed_seconds[0] > 5 or elapsed_seconds[-1] < max(0, duration - 5):
+        raise TimebaseEvidenceError("raw sample timeline does not cover the soak duration")
+    maximum_sample_gap = max(
+        (current - previous for previous, current in zip(elapsed_seconds, elapsed_seconds[1:])),
+        default=1,
+    )
+    missing_timeline_seconds = (
+        elapsed_seconds[-1] - elapsed_seconds[0] + 1 - len(elapsed_seconds)
+    )
+    if maximum_sample_gap > 5 or missing_timeline_seconds > 120:
+        raise TimebaseEvidenceError("raw sample timeline has excessive gaps")
+    if any(
+        current != previous + 1
+        for previous, current in zip(correction_sequences, correction_sequences[1:])
+    ):
         raise TimebaseEvidenceError("raw correction sequence has a gap")
     return {
         "status": "captured",
@@ -138,6 +166,11 @@ def raw_record(root: Path, reference: dict, duration: int) -> dict:
         "firstCorrectionSequence": correction_sequences[0] if correction_sequences else None,
         "lastCorrectionSequence": correction_sequences[-1] if correction_sequences else None,
         "maximumObservedDriftSeconds": maximum_drift,
+        "driftSampleCount": drift_samples,
+        "timelineStartSeconds": elapsed_seconds[0],
+        "timelineEndSeconds": elapsed_seconds[-1],
+        "maximumSampleGapSeconds": maximum_sample_gap,
+        "missingTimelineSeconds": missing_timeline_seconds,
         "maximumSteadyCorrectionSeconds": maximum_correction,
         "observedRates": sorted(observed_rates),
         "monotonicityViolations": monotonicity_violations,
@@ -147,7 +180,25 @@ def raw_record(root: Path, reference: dict, duration: int) -> dict:
             and last_played_buffers > first_played_buffers
         ),
         "decodedFrameMediaClockSampleCount": decoded_media_samples,
+        "_correctionSequences": correction_sequences,
     }
+
+
+def require_matching_correction_sequences(
+    corrections: object, raw_sequences: list[int]
+) -> None:
+    if not isinstance(corrections, list):
+        raise TimebaseEvidenceError("compact timebase corrections are malformed")
+    compact_sequences: list[int] = []
+    for correction in corrections:
+        if (
+            not isinstance(correction, dict)
+            or type(correction.get("sequence")) is not int
+        ):
+            raise TimebaseEvidenceError("compact timebase correction has no sequence")
+        compact_sequences.append(correction["sequence"])
+    if compact_sequences != raw_sequences:
+        raise TimebaseEvidenceError("compact and raw correction sequences differ")
 
 
 def augment(
@@ -172,8 +223,9 @@ def augment(
         raise TimebaseEvidenceError("timebase audio/raw evidence is malformed")
     raw = raw_record(raw_root, reference, duration)
     corrections = payload.get("corrections")
-    if not isinstance(corrections, list) or len(corrections) != raw["correctionCount"]:
-        raise TimebaseEvidenceError("compact and raw correction counts differ")
+    require_matching_correction_sequences(
+        corrections, raw.pop("_correctionSequences")
+    )
     drift_budget = payload.get("driftBudget")
     correction_budget = payload.get("correctionBudget")
     if not isinstance(drift_budget, dict) or not isinstance(correction_budget, dict):

--- a/scripts/qualification/fixture-server.py
+++ b/scripts/qualification/fixture-server.py
@@ -23,6 +23,10 @@ class RangeNotSatisfiable(ValueError):
     pass
 
 
+TIMEBASE_VOD_SECONDS = 14_400
+ADAPTIVE_SEGMENT_SECONDS = 2
+
+
 class FixtureHandler(BaseHTTPRequestHandler):
     server: "FixtureHTTPServer"
     protocol_version = "HTTP/1.1"
@@ -391,6 +395,7 @@ class FixtureHTTPServer(ThreadingHTTPServer):
             "retry-ts",
             "abr-ts",
             "abr-low-ts",
+            "timebase-vod-ts",
         }:
             return "ts"
         raise ValueError(f"unsupported adaptive mode: {mode}")
@@ -433,7 +438,7 @@ class FixtureHTTPServer(ThreadingHTTPServer):
         variants = ["low", "high"]
         if mode == "abr-low-ts":
             variants = ["low"]
-        elif mode == "abr-high-fmp4":
+        elif mode in {"abr-high-fmp4", "timebase-vod-ts"}:
             variants = ["high"]
         with self._adaptive_lock:
             state = self._adaptive_state(token)
@@ -478,6 +483,7 @@ class FixtureHTTPServer(ThreadingHTTPServer):
 
         is_live = playlist_type == "live"
         is_subtitle_vod = mode in {"abr-low-ts", "abr-high-fmp4"}
+        is_timebase_vod = mode == "timebase-vod-ts"
         media_sequence = int((now - started) / 2) if is_live else 0
         if is_live:
             window_count = min(6, len(segments))
@@ -489,10 +495,21 @@ class FixtureHTTPServer(ThreadingHTTPServer):
             # bytes. A discontinuity at every wrap resets segment timestamps
             # while the playlist timeline remains monotonic.
             indices = range(max(len(segments), 60))
+        elif is_timebase_vod:
+            # The rate schedule can consume more than 8,000 media seconds
+            # during a 7,200-second wall-clock qualification run. Publish a
+            # four-hour seekable timeline so the 0.5x, 1x, and 2x phases,
+            # replacement, and AVPlayer baseline can never reach EOF.
+            indices = range(TIMEBASE_VOD_SECONDS // ADAPTIVE_SEGMENT_SECONDS)
         else:
             indices = range(len(segments))
 
-        discontinuity = playlist_type == "event" or is_live or is_subtitle_vod
+        discontinuity = (
+            playlist_type == "event"
+            or is_live
+            or is_subtitle_vod
+            or is_timebase_vod
+        )
         lines = [
             "#EXTM3U",
             "#EXT-X-VERSION:7" if container == "fmp4" else "#EXT-X-VERSION:3",
@@ -520,13 +537,15 @@ class FixtureHTTPServer(ThreadingHTTPServer):
             should_discontinue = (
                 playlist_type == "event" and offset == midpoint
             ) or (is_live and sequence % len(segments) == midpoint) or (
-                is_subtitle_vod and offset > 0 and sequence % len(segments) == 0
+                (is_subtitle_vod or is_timebase_vod)
+                and offset > 0
+                and sequence % len(segments) == 0
             )
             if should_discontinue:
                 lines.append("#EXT-X-DISCONTINUITY")
             segment = segments[sequence % len(segments)]
             uri = f"{variant}/{segment.name}"
-            if is_live:
+            if is_live or is_timebase_vod:
                 uri += f"?sequence={sequence}"
             lines.extend(["#EXTINF:2.000,", uri])
         if not is_live:

--- a/scripts/qualification/matrix.json
+++ b/scripts/qualification/matrix.json
@@ -385,12 +385,14 @@
         "transitions",
         "avPlayerBaseline",
         "visibleSnapCount",
-        "monotonicityViolations"
+        "monotonicityViolations",
+        "postInterruptionAudioRecovery"
       ],
       "expectedEvidenceValues": {
         "rates": [0.5, 1, 2],
         "visibleSnapCount": 0,
-        "monotonicityViolations": 0
+        "monotonicityViolations": 0,
+        "postInterruptionAudioRecovery": "pass"
       }
     },
     {
@@ -410,12 +412,14 @@
         "transitions",
         "avPlayerBaseline",
         "visibleSnapCount",
-        "monotonicityViolations"
+        "monotonicityViolations",
+        "postInterruptionAudioRecovery"
       ],
       "expectedEvidenceValues": {
         "rates": [0.5, 1, 2],
         "visibleSnapCount": 0,
-        "monotonicityViolations": 0
+        "monotonicityViolations": 0,
+        "postInterruptionAudioRecovery": "pass"
       }
     },
     {

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -18,6 +18,7 @@ ADAPTIVE_SOAK_SECONDS="${SWIFTVLC_ADAPTIVE_SOAK_SECONDS:-7200}"
 PIP_PERFORMANCE_SECONDS="${SWIFTVLC_PIP_PERFORMANCE_SECONDS:-900}"
 CADENCE_SECONDS="${SWIFTVLC_CADENCE_SECONDS:-600}"
 NATIVE_SUBTITLE_SECONDS="${SWIFTVLC_NATIVE_SUBTITLE_SECONDS:-900}"
+TIMEBASE_SOAK_SECONDS="${SWIFTVLC_TIMEBASE_SOAK_SECONDS:-7200}"
 
 usage() {
   cat <<'EOF'
@@ -46,6 +47,7 @@ Options:
                           pip-render-performance-4k60,
                           cadence-matrix,
                           native-subtitle-matrix,
+                          timebase-vod-soak, timebase-live-soak,
                           deferred-pause-rejection,
                           accepted-start-delayed-failure, hls-seek,
                           harness-regressions, ui-failures, thumbnail-preview
@@ -97,6 +99,16 @@ case "$NATIVE_SUBTITLE_SECONDS" in
 esac
 if [[ "$NATIVE_SUBTITLE_SECONDS" -lt 900 ]]; then
   echo "Error: SWIFTVLC_NATIVE_SUBTITLE_SECONDS must be at least 900." >&2
+  exit 2
+fi
+case "$TIMEBASE_SOAK_SECONDS" in
+  ''|*[!0-9]*)
+    echo "Error: SWIFTVLC_TIMEBASE_SOAK_SECONDS must be a positive integer." >&2
+    exit 2
+    ;;
+esac
+if [[ "$TIMEBASE_SOAK_SECONDS" -lt 7200 ]]; then
+  echo "Error: SWIFTVLC_TIMEBASE_SOAK_SECONDS must be at least 7200." >&2
   exit 2
 fi
 
@@ -376,6 +388,7 @@ DEFAULT_SCENARIOS=(analyzer ui-suite harness-regressions live-media background-a
 DEFAULT_SCENARIOS+=(pip-render-performance-1080p60 pip-render-performance-4k60)
 DEFAULT_SCENARIOS+=(cadence-matrix)
 DEFAULT_SCENARIOS+=(native-subtitle-matrix)
+DEFAULT_SCENARIOS+=(timebase-vod-soak timebase-live-soak)
 SCENARIOS_WERE_EXPLICIT=false
 if [[ ${#ONLY_SCENARIOS[@]} -eq 0 ]]; then
   ONLY_SCENARIOS=("${DEFAULT_SCENARIOS[@]}")
@@ -384,7 +397,7 @@ else
 fi
 for scenario in "${ONLY_SCENARIOS[@]}"; do
   case "$scenario" in
-    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|vod-controls|long-stall|failed-start|dismissal|interruptions|native-lifecycle|terminal-outcomes|adaptive-hls-soak|pip-render-performance-1080p60|pip-render-performance-4k60|cadence-matrix|native-subtitle-matrix|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
+    analyzer|ui-suite|native-live|direct-live|live-media|background-audio|continuity|capability-convergence|vod-controls|long-stall|failed-start|dismissal|interruptions|native-lifecycle|terminal-outcomes|adaptive-hls-soak|pip-render-performance-1080p60|pip-render-performance-4k60|cadence-matrix|native-subtitle-matrix|timebase-vod-soak|timebase-live-soak|deferred-pause-rejection|accepted-start-delayed-failure|hls-seek|harness-regressions|ui-failures|thumbnail-preview) ;;
     *) echo "Error: unknown scenario: $scenario" >&2; exit 2 ;;
   esac
 done
@@ -399,7 +412,7 @@ device_matches_hardware_row() {
 if ! device_matches_hardware_row "iphone-current"; then
   if [[ "$SCENARIOS_WERE_EXPLICIT" == true ]]; then
     for scenario in "${ONLY_SCENARIOS[@]}"; do
-      if [[ "$scenario" == "capability-convergence" || "$scenario" == "native-lifecycle" || "$scenario" == "terminal-outcomes" || "$scenario" == "adaptive-hls-soak" || "$scenario" == pip-render-performance-* || "$scenario" == "cadence-matrix" || "$scenario" == "native-subtitle-matrix" || "$scenario" == "deferred-pause-rejection" || "$scenario" == "accepted-start-delayed-failure" ]]; then
+      if [[ "$scenario" == "capability-convergence" || "$scenario" == "native-lifecycle" || "$scenario" == "terminal-outcomes" || "$scenario" == "adaptive-hls-soak" || "$scenario" == pip-render-performance-* || "$scenario" == "cadence-matrix" || "$scenario" == "native-subtitle-matrix" || "$scenario" == timebase-*-soak || "$scenario" == "deferred-pause-rejection" || "$scenario" == "accepted-start-delayed-failure" ]]; then
         echo "Error: $scenario requires the iphone-current hardware row." >&2
         exit 2
       fi
@@ -407,7 +420,7 @@ if ! device_matches_hardware_row "iphone-current"; then
   else
     FILTERED_SCENARIOS=()
     for scenario in "${ONLY_SCENARIOS[@]}"; do
-      if [[ "$scenario" != "capability-convergence" && "$scenario" != "native-lifecycle" && "$scenario" != "terminal-outcomes" && "$scenario" != "adaptive-hls-soak" && "$scenario" != pip-render-performance-* && "$scenario" != "cadence-matrix" && "$scenario" != "native-subtitle-matrix" && "$scenario" != "deferred-pause-rejection" && "$scenario" != "accepted-start-delayed-failure" ]]; then
+      if [[ "$scenario" != "capability-convergence" && "$scenario" != "native-lifecycle" && "$scenario" != "terminal-outcomes" && "$scenario" != "adaptive-hls-soak" && "$scenario" != pip-render-performance-* && "$scenario" != "cadence-matrix" && "$scenario" != "native-subtitle-matrix" && "$scenario" != timebase-*-soak && "$scenario" != "deferred-pause-rejection" && "$scenario" != "accepted-start-delayed-failure" ]]; then
         FILTERED_SCENARIOS+=("$scenario")
       fi
     done
@@ -495,6 +508,7 @@ run_scenario() {
   local rendering_path=""
   local performance_profile=""
   local performance_url=""
+  local timebase_mode=""
   case "$scenario" in
     analyzer)
       test_identifiers=("iOSUITests/PiPMotionRegionAnalyzerTests")
@@ -638,6 +652,15 @@ run_scenario() {
       route="NativeSubtitleMatrixValidation"
       selected_xctestrun="$DESTINATION_XCTESTRUN"
       ;;
+    timebase-vod-soak|timebase-live-soak)
+      test_identifiers=(
+        "iOSUITests/TimebaseSoakDeviceUITests/test_directPiPTimebaseSoak"
+      )
+      route="TimebaseSoakValidation"
+      timebase_mode="${scenario#timebase-}"
+      timebase_mode="${timebase_mode%-soak}"
+      selected_xctestrun="$DESTINATION_XCTESTRUN"
+      ;;
     deferred-pause-rejection)
       test_identifiers=(
         "iOSUITests/PiPDeferredPauseDeviceUITests/test_deferredPauseRejectionAndCancellationStayTruthful"
@@ -711,6 +734,9 @@ run_scenario() {
       --environment SWIFTVLC_NATIVE_SUBTITLE_DEVICE=YES \
       --environment SWIFTVLC_NATIVE_SUBTITLE_BASE_URL_BASE64="$(printf '%s/' "$BASE_URL" | base64 | tr -d '\r\n')" \
       --environment SWIFTVLC_NATIVE_SUBTITLE_SECONDS="$NATIVE_SUBTITLE_SECONDS" \
+      --environment SWIFTVLC_TIMEBASE_SOAK_DEVICE=YES \
+      --environment SWIFTVLC_TIMEBASE_SOAK_BASE_URL_BASE64="$(printf '%s/' "$BASE_URL" | base64 | tr -d '\r\n')" \
+      --environment SWIFTVLC_TIMEBASE_SOAK_SECONDS="$TIMEBASE_SOAK_SECONDS" \
       --environment SWIFTVLC_PIP_DEFERRED_PAUSE_DEVICE=YES \
       --environment SWIFTVLC_PIP_DELAYED_START_FAILURE_DEVICE=YES \
       --environment SWIFTVLC_PIP_OVERLAY_DEVICE=YES \
@@ -743,6 +769,9 @@ run_scenario() {
   local subtitle_time_toc=""
   local subtitle_metal_trace=""
   local subtitle_metal_toc=""
+  local timebase_trace_status="not-applicable"
+  local timebase_audio_trace=""
+  local timebase_audio_toc=""
   local xcodebuild_log="$OUTPUT_DIR/$scenario-xcodebuild.log"
   local result_bundle="$OUTPUT_DIR/$scenario.xcresult"
   local test_selection_args=()
@@ -765,6 +794,7 @@ run_scenario() {
       -skip-testing:iOSUITests/PiPRenderPerformanceDeviceUITests
       -skip-testing:iOSUITests/PiPCadenceDeviceUITests
       -skip-testing:iOSUITests/NativeSubtitleMatrixDeviceUITests
+      -skip-testing:iOSUITests/TimebaseSoakDeviceUITests
       -skip-testing:iOSUITests/PiPDeferredPauseDeviceUITests
       -skip-testing:iOSUITests/PiPDelayedStartFailureDeviceUITests
       -skip-testing:iOSUITests/PiPOverlayDeviceUITests
@@ -834,6 +864,18 @@ run_scenario() {
       subtitle_time_toc="$OUTPUT_DIR/$scenario-time-attempt$attempt-toc.xml"
       subtitle_metal_trace="$OUTPUT_DIR/$scenario-metal-attempt$attempt.trace"
       subtitle_metal_toc="$OUTPUT_DIR/$scenario-metal-attempt$attempt-toc.xml"
+    elif [[ "$scenario" == timebase-*-soak ]]; then
+      attempt_token="$run_id-$timebase_mode-$attempt"
+      attempt_xctestrun="$WORK_DIR/destination-$scenario-attempt$attempt.xctestrun"
+      python3 "$SCRIPT_DIR/prepare-xctestrun.py" \
+        "$selected_xctestrun" "$attempt_xctestrun" \
+        --environment SWIFTVLC_DEVICE_LOG_PREFIX="$final_log_prefix" \
+        --environment SWIFTVLC_TIMEBASE_SOAK_MODE="$timebase_mode" \
+        --environment SWIFTVLC_TIMEBASE_SOAK_TOKEN="$attempt_token"
+      cp "$attempt_xctestrun" "$OUTPUT_DIR/destination-$scenario-attempt$attempt.xctestrun"
+      timebase_trace_status="missing"
+      timebase_audio_trace="$OUTPUT_DIR/$scenario-audio-attempt$attempt.trace"
+      timebase_audio_toc="$OUTPUT_DIR/$scenario-audio-attempt$attempt-toc.xml"
     fi
     set +e
     if [[ "$scenario" == "adaptive-hls-soak" ]]; then
@@ -1074,6 +1116,52 @@ PY
       elif [[ "$test_status" -eq 0 ]]; then
         subtitle_trace_status="captured"
       fi
+    elif [[ "$scenario" == timebase-*-soak ]]; then
+      xcodebuild test-without-building \
+        -xctestrun "$attempt_xctestrun" \
+        -destination "platform=iOS,id=$DEVICE_UDID" \
+        -collect-test-diagnostics never \
+        -test-timeouts-enabled YES \
+        -default-test-execution-time-allowance "$((TIMEBASE_SOAK_SECONDS + 600))" \
+        -maximum-test-execution-time-allowance "$((TIMEBASE_SOAK_SECONDS + 600))" \
+        "${test_selection_args[@]}" \
+        -resultBundlePath "$attempt_bundle" \
+        > "$attempt_log" 2>&1 &
+      local timebase_xcodebuild_pid=$!
+      ACTIVE_XCODEBUILD_PID="$timebase_xcodebuild_pid"
+      local timebase_started=false
+      for _ in {1..600}; do
+        if ! kill -0 "$timebase_xcodebuild_pid" 2>/dev/null; then
+          break
+        fi
+        if grep -q "swiftvlcTimebaseReady=$attempt_token" "$OUTPUT_DIR/fixture-requests.jsonl" 2>/dev/null; then
+          timebase_started=true
+          break
+        fi
+        sleep 0.1
+      done
+      local timebase_trace_failed=false
+      if [[ "$timebase_started" == false ]]; then
+        timebase_trace_failed=true
+        echo "Error: timebase fixture did not start before Audio System Trace capture." >> "$attempt_log"
+      elif ! record_performance_trace \
+          "Audio System Trace" "$timebase_audio_trace" "$timebase_audio_toc" \
+          "$TIMEBASE_SOAK_SECONDS" "$timebase_xcodebuild_pid" \
+          "$OUTPUT_DIR/$scenario-audio-xctrace-attempt$attempt.log"; then
+        timebase_trace_failed=true
+        echo "Error: Audio System Trace capture failed." >> "$attempt_log"
+      fi
+      if [[ "$timebase_trace_failed" == true ]]; then
+        kill -TERM "$timebase_xcodebuild_pid" 2>/dev/null
+      fi
+      wait "$timebase_xcodebuild_pid"
+      test_status=$?
+      ACTIVE_XCODEBUILD_PID=""
+      if [[ "$timebase_trace_failed" == true ]]; then
+        test_status=1
+      elif [[ "$test_status" -eq 0 ]]; then
+        timebase_trace_status="captured"
+      fi
     else
       xcodebuild test-without-building \
         -xctestrun "$attempt_xctestrun" \
@@ -1286,6 +1374,10 @@ PY
       qualification_scenarios=("native-subtitle-matrix")
       qualification_attachments=("qualification-native-subtitle-matrix.json")
       ;;
+    timebase-vod-soak|timebase-live-soak)
+      qualification_scenarios=("$scenario")
+      qualification_attachments=("qualification-$scenario.json")
+      ;;
     deferred-pause-rejection)
       qualification_scenarios=("deferred-pause-rejection")
       qualification_attachments=("qualification-deferred-pause-rejection.json")
@@ -1301,6 +1393,7 @@ PY
       && [[ "$allocation_trace_status" != "missing" ]] \
       && [[ "$performance_trace_status" != "missing" ]] \
       && [[ "$subtitle_trace_status" != "missing" ]] \
+      && [[ "$timebase_trace_status" != "missing" ]] \
       && [[ "$log_status" == "captured" ]] && [[ -d "$result_bundle" ]]; then
       local attachments="$OUTPUT_DIR/$scenario-attachments"
       local hardware_id evidence_file evidence_relative export_status materialize_status
@@ -1388,6 +1481,19 @@ PY
             if [[ "$augment_subtitle_status" -ne 0 ]]; then
               continue
             fi
+          elif [[ "$scenario" == timebase-*-soak ]]; then
+            set +e
+            python3 "$SCRIPT_DIR/augment-timebase-evidence.py" \
+              --evidence "$evidence_file" \
+              --raw-root "$OUTPUT_DIR/$scenario-documents" \
+              --audio-trace "$timebase_audio_trace" \
+              --audio-toc "$timebase_audio_toc" \
+              --digest-script "$ROOT_DIR/scripts/artifact-tree-digest.py"
+            local augment_timebase_status=$?
+            set -e
+            if [[ "$augment_timebase_status" -ne 0 ]]; then
+              continue
+            fi
           fi
           materialized_count=$((materialized_count + 1))
           materialized_scenarios+=("$qualification_scenario")
@@ -1440,6 +1546,7 @@ PY
     || [[ "$allocation_trace_status" == "missing" ]] \
     || [[ "$performance_trace_status" == "missing" ]] \
     || [[ "$subtitle_trace_status" == "missing" ]] \
+    || [[ "$timebase_trace_status" == "missing" ]] \
     || [[ "$evidence_status" == "missing" ]]; then
     result="fail"
   fi

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -1167,6 +1167,19 @@ class QualificationEvidenceTests(unittest.TestCase):
             )
             self.assertNotIn("hostTraceRequirements", augmented)
 
+    def test_timebase_route_enables_decoded_frame_clock_before_sampling(self):
+        source = (
+            ROOT.parent
+            / "Showcase"
+            / "iOS"
+            / "ValidationHarness"
+            / "TimebaseSoakValidationCase.swift"
+        ).read_text()
+        self.assertLess(
+            source.index("controller.enableFrameContentDiagnostics()"),
+            source.index("controller.timebaseDiagnosticSnapshot()"),
+        )
+
     def test_rejects_gap_in_raw_timebase_corrections(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -1079,7 +1079,7 @@ class QualificationEvidenceTests(unittest.TestCase):
             root = Path(temporary)
             raw = root / "swiftvlc-timebase-attempt-vod.jsonl"
             with raw.open("w") as output:
-                for index in range(7080):
+                for index in range(7200):
                     sample = {
                         "kind": "sample",
                         "clock": {
@@ -1151,7 +1151,7 @@ class QualificationEvidenceTests(unittest.TestCase):
             augmented = augment_timebase_evidence.augment(
                 evidence_path, root, trace, toc, digest_script
             )
-            self.assertEqual(augmented["rawCapture"]["sampleCount"], 7080)
+            self.assertEqual(augmented["rawCapture"]["sampleCount"], 7200)
             self.assertEqual(augmented["rawCapture"]["firstCorrectionSequence"], 8)
             self.assertEqual(
                 augmented["audioPresentationSeries"]["hostTrace"]["template"],
@@ -1187,7 +1187,11 @@ class QualificationEvidenceTests(unittest.TestCase):
             lines = [
                 {
                     "kind": "sample",
-                    "clock": {"requestedRate": 1, "driftSeconds": 0},
+                    "clock": {
+                        "elapsedSeconds": 0,
+                        "requestedRate": 1,
+                        "driftSeconds": 0,
+                    },
                     "audio": {"playedBuffers": 1},
                     "frame": {"playbackGeneration": 1, "presentedSeconds": 1},
                 },
@@ -1201,6 +1205,69 @@ class QualificationEvidenceTests(unittest.TestCase):
                     {"fileName": raw.name, "sampleIntervalSeconds": 1},
                     1,
                 )
+
+    def test_rejects_raw_timebase_capture_without_drift_samples(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            raw = root / "capture.jsonl"
+            raw.write_text(
+                json.dumps(
+                    {
+                        "kind": "sample",
+                        "clock": {"elapsedSeconds": 0, "requestedRate": 1},
+                        "audio": {"playedBuffers": 1},
+                        "frame": {
+                            "playbackGeneration": 1,
+                            "presentedSeconds": 1,
+                        },
+                    }
+                )
+                + "\n"
+            )
+            with self.assertRaisesRegex(
+                augment_timebase_evidence.TimebaseEvidenceError,
+                "missing clock-drift samples",
+            ):
+                augment_timebase_evidence.raw_record(
+                    root,
+                    {"fileName": raw.name, "sampleIntervalSeconds": 1},
+                    1,
+                )
+
+    def test_rejects_duplicate_raw_timebase_timeline_samples(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            raw = root / "capture.jsonl"
+            sample = {
+                "kind": "sample",
+                "clock": {
+                    "elapsedSeconds": 0,
+                    "requestedRate": 1,
+                    "driftSeconds": 0,
+                },
+                "audio": {"playedBuffers": 1},
+                "frame": {"playbackGeneration": 1, "presentedSeconds": 1},
+            }
+            raw.write_text(json.dumps(sample) + "\n" + json.dumps(sample) + "\n")
+            with self.assertRaisesRegex(
+                augment_timebase_evidence.TimebaseEvidenceError,
+                "timeline is not strictly increasing",
+            ):
+                augment_timebase_evidence.raw_record(
+                    root,
+                    {"fileName": raw.name, "sampleIntervalSeconds": 1},
+                    2,
+                )
+
+    def test_rejects_mismatched_compact_timebase_correction_sequences(self):
+        with self.assertRaisesRegex(
+            augment_timebase_evidence.TimebaseEvidenceError,
+            "compact and raw correction sequences differ",
+        ):
+            augment_timebase_evidence.require_matching_correction_sequences(
+                [{"sequence": 8}, {"sequence": 10}],
+                [8, 9],
+            )
 
     def test_materializes_accepted_start_delayed_failure_evidence(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -35,6 +35,7 @@ materialize_evidence = load_script("materialize-evidence.py")
 augment_allocation_trace = load_script("augment-allocation-trace.py")
 augment_performance_traces = load_script("augment-performance-traces.py")
 augment_native_subtitle_traces = load_script("augment-native-subtitle-traces.py")
+augment_timebase_evidence = load_script("augment-timebase-evidence.py")
 assemble_record = load_script("assemble-record.py")
 
 
@@ -1073,6 +1074,121 @@ class QualificationEvidenceTests(unittest.TestCase):
                 self.assertTrue((staged_trace / "data.bin").is_file())
                 self.assertTrue(staged_toc.is_file())
 
+    def test_augments_timebase_raw_capture_and_audio_trace(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            raw = root / "swiftvlc-timebase-attempt-vod.jsonl"
+            with raw.open("w") as output:
+                for index in range(7080):
+                    sample = {
+                        "kind": "sample",
+                        "clock": {
+                            "elapsedSeconds": index,
+                            "driftSeconds": 0.01,
+                            "requestedRate": (0.5, 1.0, 2.0)[index % 3],
+                        },
+                        "audio": {"playedBuffers": index},
+                        "frame": {
+                            "deliveredFrames": index,
+                            "playbackGeneration": 1,
+                            "presentedSeconds": index / 30,
+                            "decodedFrameMediaTimeSeconds": index / 30,
+                        },
+                    }
+                    output.write(json.dumps(sample) + "\n")
+                output.write(
+                    json.dumps(
+                        {
+                            "kind": "correction",
+                            "correction": {
+                                "sequence": 8,
+                                "reason": "steadyStateDrift",
+                                "driftSeconds": 0.02,
+                            },
+                        }
+                    )
+                    + "\n"
+                )
+                output.write(
+                    json.dumps(
+                        {
+                            "kind": "correction",
+                            "correction": {
+                                "sequence": 9,
+                                "reason": "playbackRateTransition",
+                                "driftSeconds": 0,
+                            },
+                        }
+                    )
+                    + "\n"
+                )
+            evidence_path = root / "evidence.json"
+            evidence_path.write_text(
+                json.dumps(
+                    {
+                        "scenario": "timebase-vod-soak",
+                        "durationSeconds": 7200,
+                        "corrections": [{"sequence": 8}, {"sequence": 9}],
+                        "driftBudget": {"maximumSeconds": 2.1},
+                        "correctionBudget": {"maximumSeconds": 2.1},
+                        "audioPresentationSeries": {
+                            "hostTraceStatus": "required-host-augmentation"
+                        },
+                        "rawCapture": {
+                            "fileName": raw.name,
+                            "sampleIntervalSeconds": 1,
+                        },
+                        "hostTraceRequirements": {},
+                    }
+                )
+            )
+            trace = root / "audio.trace"
+            trace.mkdir()
+            (trace / "data.bin").write_bytes(b"audio trace")
+            toc = root / "audio-toc.xml"
+            toc.write_text('<trace-toc><table schema="audio-io"/></trace-toc>')
+            digest_script = Path(__file__).resolve().parents[2] / "artifact-tree-digest.py"
+            augmented = augment_timebase_evidence.augment(
+                evidence_path, root, trace, toc, digest_script
+            )
+            self.assertEqual(augmented["rawCapture"]["sampleCount"], 7080)
+            self.assertEqual(augmented["rawCapture"]["firstCorrectionSequence"], 8)
+            self.assertEqual(
+                augmented["audioPresentationSeries"]["hostTrace"]["template"],
+                "Audio System Trace",
+            )
+            raw_record = augmented["rawCapture"]
+            trace_record = augmented["audioPresentationSeries"]["hostTrace"]
+            self.assertEqual(raw_record["digestAlgorithm"], "sha256")
+            self.assertTrue((evidence_path.parent / raw_record["runArtifact"]).is_file())
+            self.assertTrue((evidence_path.parent / trace_record["runArtifact"]).is_dir())
+            self.assertTrue(
+                (evidence_path.parent / trace_record["tableOfContents"]).is_file()
+            )
+            self.assertNotIn("hostTraceRequirements", augmented)
+
+    def test_rejects_gap_in_raw_timebase_corrections(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            raw = root / "capture.jsonl"
+            lines = [
+                {
+                    "kind": "sample",
+                    "clock": {"requestedRate": 1, "driftSeconds": 0},
+                    "audio": {"playedBuffers": 1},
+                    "frame": {"playbackGeneration": 1, "presentedSeconds": 1},
+                },
+                {"kind": "correction", "correction": {"sequence": 4}},
+                {"kind": "correction", "correction": {"sequence": 6}},
+            ]
+            raw.write_text("".join(json.dumps(line) + "\n" for line in lines))
+            with self.assertRaises(augment_timebase_evidence.TimebaseEvidenceError):
+                augment_timebase_evidence.raw_record(
+                    root,
+                    {"fileName": raw.name, "sampleIntervalSeconds": 1},
+                    1,
+                )
+
     def test_materializes_accepted_start_delayed_failure_evidence(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -1462,6 +1578,67 @@ class QualificationRecordAssemblyTests(unittest.TestCase):
                 "1.1.0", self.candidate, self.matrix, [report_path], output
             )
 
+    def test_assembles_digest_verified_timebase_trace_and_raw_capture(self):
+        scenario = "timebase-vod-soak"
+        self.matrix.write_text(
+            json.dumps(
+                {
+                    "scenarios": [{"id": scenario, "hardware": ["iphone"]}],
+                    "hardware": [
+                        {"id": "iphone", "deviceFamily": "iPhone", "osMajor": 26},
+                        {"id": "ipad", "deviceFamily": "iPad", "osMajor": 26},
+                    ],
+                }
+            )
+        )
+        self.matrix_checksum = hashlib.sha256(self.matrix.read_bytes()).hexdigest()
+        report_path = self.make_report("iphone")
+        report = json.loads(report_path.read_text())
+        report["qualificationRows"][0]["scenario"] = scenario
+        report_path.write_text(json.dumps(report))
+
+        evidence_path = report_path.parent / "evidence" / "seek.json"
+        evidence = json.loads(evidence_path.read_text())
+        evidence["scenario"] = scenario
+        artifact_directory = evidence_path.parent / "artifacts" / "timebase"
+        trace = artifact_directory / "audio.trace"
+        trace.mkdir(parents=True)
+        (trace / "data.bin").write_bytes(b"audio samples")
+        toc = artifact_directory / "audio-toc.xml"
+        toc.write_text('<trace-toc><table schema="audio"/></trace-toc>')
+        raw = artifact_directory / "capture.jsonl"
+        raw.write_text('{"kind":"sample"}\n')
+        evidence["audioPresentationSeries"] = {
+            "hostTrace": {
+                "runArtifact": "artifacts/timebase/audio.trace",
+                "tableOfContents": "artifacts/timebase/audio-toc.xml",
+                "treeDigestAlgorithm": "swiftvlc-tree-v1",
+                "treeDigest": assemble_record.tree_digest(trace),
+            }
+        }
+        evidence["rawCapture"] = {
+            "runArtifact": "artifacts/timebase/capture.jsonl",
+            "digestAlgorithm": "sha256",
+            "sha256": hashlib.sha256(raw.read_bytes()).hexdigest(),
+        }
+        evidence_path.write_text(json.dumps(evidence))
+
+        output = self.root / "qualification" / "1.1.0.json"
+        assemble_record.assemble(
+            "1.1.0", self.candidate, self.matrix, [report_path], output
+        )
+
+        retained = output.parent / "evidence" / "1.1.0" / "artifacts" / "timebase"
+        self.assertTrue((retained / "audio.trace" / "data.bin").is_file())
+        self.assertTrue((retained / "audio-toc.xml").is_file())
+        self.assertEqual((retained / "capture.jsonl").read_bytes(), raw.read_bytes())
+
+        raw.write_text("tampered\n")
+        with self.assertRaises(assemble_record.AssemblyError):
+            assemble_record.assemble(
+                "1.1.0", self.candidate, self.matrix, [report_path], output
+            )
+
     def test_rejects_exploratory_and_duplicate_rows(self):
         output = self.root / "qualification" / "1.1.0.json"
         with self.assertRaises(assemble_record.AssemblyError):
@@ -1762,6 +1939,32 @@ class FixtureServerTests(unittest.TestCase):
         connection.close()
         self.assertEqual(metrics["retryFailures"], 1)
         self.assertEqual(metrics["retryRecoveries"], 1)
+
+    def test_timebase_vod_is_four_hour_seekable_high_variant_timeline(self):
+        connection, response = self.request(
+            "/adaptive/timebase/timebase-vod-ts/master.m3u8"
+        )
+        master = response.read().decode()
+        connection.close()
+        self.assertEqual(master.count("#EXT-X-STREAM-INF:"), 1)
+        self.assertIn("RESOLUTION=640x360", master)
+        self.assertNotIn("RESOLUTION=320x180", master)
+
+        connection, response = self.request(
+            "/adaptive/timebase/timebase-vod-ts/high.m3u8"
+        )
+        playlist = response.read().decode()
+        connection.close()
+        segment_count = fixture_server.TIMEBASE_VOD_SECONDS // 2
+        self.assertEqual(playlist.count("#EXTINF:2.000,"), segment_count)
+        self.assertEqual(playlist.count("?sequence="), segment_count)
+        self.assertEqual(
+            playlist.count("#EXT-X-DISCONTINUITY\n"),
+            segment_count // 4 - 1,
+        )
+        self.assertIn("#EXT-X-PLAYLIST-TYPE:VOD", playlist)
+        self.assertIn("?sequence=7199", playlist)
+        self.assertTrue(playlist.rstrip().endswith("#EXT-X-ENDLIST"))
 
     def test_adaptive_variant_transitions_require_one_multivariant_master(self):
         for path in (


### PR DESCRIPTION
## Summary

- add unattended, candidate-bound two-hour VOD and live direct-PiP timebase qualification rows
- serve a deterministic four-hour seekable VOD HLS fixture and exercise rate, pause, seek, replacement, thermal, interruption, system PiP resize, and AVPlayer baseline behavior
- retain and digest raw JSONL diagnostics and Audio System Trace artifacts, with evidence assembly and tamper-rejection coverage

## Validation

- 57 qualification harness tests
- 1,993 Swift tests across 167 suites
- release-integrity suite
- strict SwiftFormat, SwiftLint, Python compilation, Bash syntax, and diff hygiene
- local Release iOS Showcase build
- generated VOD HLS verified as 7,200 entries / 14,400 seconds, with successful decode after an 8,300-second seek
- beta.6 libVLC artifact provenance and reproducibility proof verified against the current tree

Issue #99 remains open until both frozen-candidate physical-device rows pass. This PR supplies the automation and evidence path; it does not claim that device qualification has occurred.