### PR TITLE
Allow future iOS exploratory qualification lanes

### DIFF
--- a/scripts/qualification/README.md
+++ b/scripts/qualification/README.md
@@ -298,6 +298,10 @@ Use `--require-stable` for release evidence. It fails before testing if the
 device is a simulator, runs beta or unknown software, or does not match a
 hardware row in `matrix.json`. Without that option, the same command is useful
 for exploratory beta-OS testing, but its report remains ineligible for release.
+On an iPhone running an OS newer than the matrix's `iphone-current` row,
+`--exploratory-current-only` also exercises the longer current-device lanes.
+The policy rejects matching/older OS versions, iPads, and qualification-mode
+devices; all resulting evidence remains exploratory and cannot satisfy a row.
 
 This lane is intentionally fail-closed: its current automated scenarios are a
 candidate qualification subset, not a claim that all 53 qualification rows

--- a/scripts/qualification/exploratory-device-policy.py
+++ b/scripts/qualification/exploratory-device-policy.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def permits_current_only(device_info: dict, matrix: dict) -> bool:
+    selected = device_info.get("selected")
+    if device_info.get("mode") != "exploratory" or not isinstance(selected, dict):
+        return False
+    if selected.get("deviceFamily") != "iPhone":
+        return False
+
+    current_rows = [
+        row
+        for row in matrix.get("hardware", [])
+        if row.get("id") == "iphone-current"
+    ]
+    if len(current_rows) != 1:
+        return False
+
+    selected_major = selected.get("osMajor")
+    current_major = current_rows[0].get("osMajor")
+    return (
+        isinstance(selected_major, int)
+        and isinstance(current_major, int)
+        and selected_major > current_major
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device-info", type=Path, required=True)
+    parser.add_argument("--matrix", type=Path, required=True)
+    arguments = parser.parse_args()
+
+    device_info = json.loads(arguments.device_info.read_text())
+    matrix = json.loads(arguments.matrix.read_text())
+    return 0 if permits_current_only(device_info, matrix) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qualification/exploratory-device-policy.py
+++ b/scripts/qualification/exploratory-device-policy.py
@@ -5,13 +5,15 @@ import argparse
 import json
 from pathlib import Path
 
+EXPLORATORY_HARDWARE_ID = "exploratory-future-ios"
 
-def permits_current_only(device_info: dict, matrix: dict) -> bool:
+
+def evidence_hardware_id(device_info: dict, matrix: dict) -> str | None:
     selected = device_info.get("selected")
     if device_info.get("mode") != "exploratory" or not isinstance(selected, dict):
-        return False
+        return None
     if selected.get("deviceFamily") != "iPhone":
-        return False
+        return None
 
     current_rows = [
         row
@@ -19,15 +21,20 @@ def permits_current_only(device_info: dict, matrix: dict) -> bool:
         if row.get("id") == "iphone-current"
     ]
     if len(current_rows) != 1:
-        return False
+        return None
 
     selected_major = selected.get("osMajor")
     current_major = current_rows[0].get("osMajor")
-    return (
+    permitted = (
         isinstance(selected_major, int)
         and isinstance(current_major, int)
         and selected_major > current_major
     )
+    return EXPLORATORY_HARDWARE_ID if permitted else None
+
+
+def permits_current_only(device_info: dict, matrix: dict) -> bool:
+    return evidence_hardware_id(device_info, matrix) is not None
 
 
 def main() -> int:
@@ -38,7 +45,11 @@ def main() -> int:
 
     device_info = json.loads(arguments.device_info.read_text())
     matrix = json.loads(arguments.matrix.read_text())
-    return 0 if permits_current_only(device_info, matrix) else 1
+    hardware_id = evidence_hardware_id(device_info, matrix)
+    if hardware_id is None:
+        return 1
+    print(hardware_id)
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -12,6 +12,7 @@ DERIVED_DATA="${SWIFTVLC_DEVICE_DERIVED_DATA:-$ROOT_DIR/.device-test-build}"
 FIXTURES="${SWIFTVLC_DEVICE_FIXTURES:-$ROOT_DIR/.qualification-fixtures}"
 OUTPUT_ROOT="${SWIFTVLC_DEVICE_RESULTS:-$ROOT_DIR/.qualification-results}"
 REQUIRE_STABLE=false
+EXPLORATORY_CURRENT_ONLY=false
 SKIP_BUILD=false
 ONLY_SCENARIOS=()
 ADAPTIVE_SOAK_SECONDS="${SWIFTVLC_ADAPTIVE_SOAK_SECONDS:-7200}"
@@ -52,6 +53,9 @@ Options:
                           accepted-start-delayed-failure, hls-seek,
                           harness-regressions, ui-failures, thumbnail-preview
   --require-stable        Refuse beta/unknown OS or a non-matching matrix row
+  --exploratory-current-only
+                          Allow iphone-current-only lanes on a newer iPhone OS;
+                          evidence remains exploratory and cannot qualify rows
   --skip-build            Reuse an existing signed runner in derived data
   -h, --help              Show this help
 
@@ -123,6 +127,7 @@ while [[ $# -gt 0 ]]; do
     --output) OUTPUT_ROOT="$2"; shift 2 ;;
     --only) ONLY_SCENARIOS+=("$2"); shift 2 ;;
     --require-stable) REQUIRE_STABLE=true; shift ;;
+    --exploratory-current-only) EXPLORATORY_CURRENT_ONLY=true; shift ;;
     --skip-build) SKIP_BUILD=true; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Error: unknown option $1" >&2; usage >&2; exit 2 ;;
@@ -409,8 +414,31 @@ device_matches_hardware_row() {
     "$OUTPUT_DIR/device.json" > /dev/null
 }
 
+exclude_opt_in_current_scenarios() {
+  FILTERED_SCENARIOS=()
+  for scenario in "${ONLY_SCENARIOS[@]}"; do
+    if [[ "$scenario" != "accepted-start-delayed-failure" ]]; then
+      FILTERED_SCENARIOS+=("$scenario")
+    fi
+  done
+  ONLY_SCENARIOS=("${FILTERED_SCENARIOS[@]}")
+}
+
 if ! device_matches_hardware_row "iphone-current"; then
-  if [[ "$SCENARIOS_WERE_EXPLICIT" == true ]]; then
+  if [[ "$EXPLORATORY_CURRENT_ONLY" == true ]]; then
+    if ! python3 "$SCRIPT_DIR/exploratory-device-policy.py" \
+      --device-info "$OUTPUT_DIR/device.json" \
+      --matrix "$SCRIPT_DIR/matrix.json"; then
+      echo "Error: --exploratory-current-only requires an exploratory iPhone" >&2
+      echo "  on an OS newer than the matrix's iphone-current row." >&2
+      exit 2
+    fi
+    echo "Including iphone-current-only scenarios as exploratory evidence."
+    echo "These results cannot qualify or close any stable matrix row."
+    if [[ "$SCENARIOS_WERE_EXPLICIT" == false ]]; then
+      exclude_opt_in_current_scenarios
+    fi
+  elif [[ "$SCENARIOS_WERE_EXPLICIT" == true ]]; then
     for scenario in "${ONLY_SCENARIOS[@]}"; do
       if [[ "$scenario" == "capability-convergence" || "$scenario" == "native-lifecycle" || "$scenario" == "terminal-outcomes" || "$scenario" == "adaptive-hls-soak" || "$scenario" == pip-render-performance-* || "$scenario" == "cadence-matrix" || "$scenario" == "native-subtitle-matrix" || "$scenario" == timebase-*-soak || "$scenario" == "deferred-pause-rejection" || "$scenario" == "accepted-start-delayed-failure" ]]; then
         echo "Error: $scenario requires the iphone-current hardware row." >&2
@@ -428,13 +456,7 @@ if ! device_matches_hardware_row "iphone-current"; then
     echo "Skipping iphone-current-only qualification scenarios: selected device does not match iphone-current."
   fi
 elif [[ "$SCENARIOS_WERE_EXPLICIT" == false ]]; then
-  FILTERED_SCENARIOS=()
-  for scenario in "${ONLY_SCENARIOS[@]}"; do
-    if [[ "$scenario" != "accepted-start-delayed-failure" ]]; then
-      FILTERED_SCENARIOS+=("$scenario")
-    fi
-  done
-  ONLY_SCENARIOS=("${FILTERED_SCENARIOS[@]}")
+  exclude_opt_in_current_scenarios
 fi
 
 RESULTS_TSV="$WORK_DIR/results.tsv"

--- a/scripts/qualification/run-device-tests.sh
+++ b/scripts/qualification/run-device-tests.sh
@@ -13,6 +13,7 @@ FIXTURES="${SWIFTVLC_DEVICE_FIXTURES:-$ROOT_DIR/.qualification-fixtures}"
 OUTPUT_ROOT="${SWIFTVLC_DEVICE_RESULTS:-$ROOT_DIR/.qualification-results}"
 REQUIRE_STABLE=false
 EXPLORATORY_CURRENT_ONLY=false
+EXPLORATORY_HARDWARE_ID=""
 SKIP_BUILD=false
 ONLY_SCENARIOS=()
 ADAPTIVE_SOAK_SECONDS="${SWIFTVLC_ADAPTIVE_SOAK_SECONDS:-7200}"
@@ -414,6 +415,11 @@ device_matches_hardware_row() {
     "$OUTPUT_DIR/device.json" > /dev/null
 }
 
+can_run_iphone_current_lanes() {
+  device_matches_hardware_row "iphone-current" \
+    || [[ -n "$EXPLORATORY_HARDWARE_ID" ]]
+}
+
 exclude_opt_in_current_scenarios() {
   FILTERED_SCENARIOS=()
   for scenario in "${ONLY_SCENARIOS[@]}"; do
@@ -424,15 +430,19 @@ exclude_opt_in_current_scenarios() {
   ONLY_SCENARIOS=("${FILTERED_SCENARIOS[@]}")
 }
 
+if [[ "$EXPLORATORY_CURRENT_ONLY" == true ]]; then
+  if ! EXPLORATORY_HARDWARE_ID=$(python3 \
+    "$SCRIPT_DIR/exploratory-device-policy.py" \
+    --device-info "$OUTPUT_DIR/device.json" \
+    --matrix "$SCRIPT_DIR/matrix.json"); then
+    echo "Error: --exploratory-current-only requires an exploratory iPhone" >&2
+    echo "  on an OS newer than the matrix's iphone-current row." >&2
+    exit 2
+  fi
+fi
+
 if ! device_matches_hardware_row "iphone-current"; then
-  if [[ "$EXPLORATORY_CURRENT_ONLY" == true ]]; then
-    if ! python3 "$SCRIPT_DIR/exploratory-device-policy.py" \
-      --device-info "$OUTPUT_DIR/device.json" \
-      --matrix "$SCRIPT_DIR/matrix.json"; then
-      echo "Error: --exploratory-current-only requires an exploratory iPhone" >&2
-      echo "  on an OS newer than the matrix's iphone-current row." >&2
-      exit 2
-    fi
+  if [[ -n "$EXPLORATORY_HARDWARE_ID" ]]; then
     echo "Including iphone-current-only scenarios as exploratory evidence."
     echo "These results cannot qualify or close any stable matrix row."
     if [[ "$SCENARIOS_WERE_EXPLICIT" == false ]]; then
@@ -572,8 +582,7 @@ run_scenario() {
       ;;
     continuity)
       test_identifiers=("iOSUITests/PiPContinuityDeviceUITests/test_nativePiPSurvivesSamePlayerReplacement")
-      if jq -e '.selected.matchingHardwareRows | index("iphone-current") != null' \
-          "$OUTPUT_DIR/device.json" >/dev/null; then
+      if can_run_iphone_current_lanes; then
         test_identifiers+=("iOSUITests/PiPContinuityDeviceUITests/test_nativePiPReplacementContinuityAcrossVODAndLive")
       fi
       route="HarnessHome"
@@ -1337,8 +1346,7 @@ PY
     continuity)
       qualification_scenarios=("replacement")
       qualification_attachments=("qualification-replacement.json")
-      if jq -e '.selected.matchingHardwareRows | index("iphone-current") != null' \
-          "$OUTPUT_DIR/device.json" >/dev/null; then
+      if can_run_iphone_current_lanes; then
         qualification_scenarios+=("replacement-continuity")
         qualification_attachments+=("qualification-replacement-continuity.json")
       fi
@@ -1359,7 +1367,7 @@ PY
       qualification_scenarios=("failed-start")
       qualification_attachments=("qualification-failed-start.json")
       if [[ "$SCENARIOS_WERE_EXPLICIT" == false ]] \
-        && device_matches_hardware_row "iphone-current"; then
+        && can_run_iphone_current_lanes; then
         qualification_scenarios+=("accepted-start-delayed-failure")
         qualification_attachments+=("qualification-accepted-start-delayed-failure.json")
       fi
@@ -1432,6 +1440,9 @@ PY
       set -e
       hardware_id=$(jq -r '.selected.matchingHardwareRows | if length == 1 then .[0] else "" end' \
         "$OUTPUT_DIR/device.json")
+      if [[ -z "$hardware_id" ]] && [[ -n "$EXPLORATORY_HARDWARE_ID" ]]; then
+        hardware_id="$EXPLORATORY_HARDWARE_ID"
+      fi
       if [[ "$export_status" -eq 0 ]] && [[ -n "$hardware_id" ]]; then
         for evidence_index in "${!qualification_scenarios[@]}"; do
           qualification_scenario="${qualification_scenarios[$evidence_index]}"
@@ -1523,17 +1534,18 @@ PY
         done
         if [[ "$materialized_count" -eq "${#qualification_scenarios[@]}" ]]; then
           evidence_status="captured"
-          for evidence_index in "${!materialized_scenarios[@]}"; do
-            local qualification_duration="$((ended - started))"
-            if [[ "${materialized_scenarios[$evidence_index]}" == "adaptive-hls-soak" ]]; then
-              qualification_duration=$(jq -r '.durationSeconds' \
-                "$OUTPUT_DIR/${materialized_evidence[$evidence_index]}")
-            fi
-            python3 - \
-                "$OUTPUT_DIR/device.json" "$QUALIFICATION_ROWS" \
-                "${materialized_evidence[$evidence_index]}" \
-                "$FIXTURE_MANIFEST_CHECKSUM" "$qualification_duration" \
-                "${materialized_scenarios[$evidence_index]}" <<'PY'
+          if [[ -z "$EXPLORATORY_HARDWARE_ID" ]]; then
+            for evidence_index in "${!materialized_scenarios[@]}"; do
+              local qualification_duration="$((ended - started))"
+              if [[ "${materialized_scenarios[$evidence_index]}" == "adaptive-hls-soak" ]]; then
+                qualification_duration=$(jq -r '.durationSeconds' \
+                  "$OUTPUT_DIR/${materialized_evidence[$evidence_index]}")
+              fi
+              python3 - \
+                  "$OUTPUT_DIR/device.json" "$QUALIFICATION_ROWS" \
+                  "${materialized_evidence[$evidence_index]}" \
+                  "$FIXTURE_MANIFEST_CHECKSUM" "$qualification_duration" \
+                  "${materialized_scenarios[$evidence_index]}" <<'PY'
 import json
 import sys
 
@@ -1557,7 +1569,8 @@ row = {
 with open(rows_path, "a") as output:
     output.write(json.dumps(row, sort_keys=True) + "\n")
 PY
-          done
+            done
+          fi
         fi
       fi
     fi

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -27,6 +27,7 @@ def load_script(name: str):
 
 
 device_info = load_script("device-info.py")
+exploratory_device_policy = load_script("exploratory-device-policy.py")
 fixture_server = load_script("fixture-server.py")
 prepare_xctestrun = load_script("prepare-xctestrun.py")
 verify_fixtures = load_script("verify-fixtures.py")
@@ -73,6 +74,48 @@ class DeviceInfoTests(unittest.TestCase):
         self.assertTrue(normalized["connected"])
         self.assertTrue(normalized["qualificationEligible"])
         self.assertEqual(normalized["matchingHardwareRows"], ["iphone-current"])
+
+
+class ExploratoryDevicePolicyTests(unittest.TestCase):
+    matrix = {
+        "hardware": [
+            {"id": "iphone-current", "deviceFamily": "iPhone", "osMajor": 26}
+        ]
+    }
+
+    def record(self, **selected):
+        return {
+            "mode": "exploratory",
+            "selected": {"deviceFamily": "iPhone", "osMajor": 27, **selected},
+        }
+
+    def test_future_iphone_os_can_run_current_only_lanes_exploratorily(self):
+        self.assertTrue(
+            exploratory_device_policy.permits_current_only(
+                self.record(osReleaseType="beta"), self.matrix
+            )
+        )
+
+    def test_matching_or_older_os_cannot_bypass_matrix_selection(self):
+        self.assertFalse(
+            exploratory_device_policy.permits_current_only(
+                self.record(osMajor=26), self.matrix
+            )
+        )
+
+    def test_ipad_cannot_borrow_the_iphone_current_lanes(self):
+        self.assertFalse(
+            exploratory_device_policy.permits_current_only(
+                self.record(deviceFamily="iPad"), self.matrix
+            )
+        )
+
+    def test_qualification_mode_never_uses_the_exploratory_override(self):
+        record = self.record()
+        record["mode"] = "qualification"
+        self.assertFalse(
+            exploratory_device_policy.permits_current_only(record, self.matrix)
+        )
 
 
 class XCTestrunTests(unittest.TestCase):

--- a/scripts/qualification/tests/test_qualification_harness.py
+++ b/scripts/qualification/tests/test_qualification_harness.py
@@ -95,6 +95,12 @@ class ExploratoryDevicePolicyTests(unittest.TestCase):
                 self.record(osReleaseType="beta"), self.matrix
             )
         )
+        self.assertEqual(
+            exploratory_device_policy.evidence_hardware_id(
+                self.record(osReleaseType="beta"), self.matrix
+            ),
+            "exploratory-future-ios",
+        )
 
     def test_matching_or_older_os_cannot_bypass_matrix_selection(self):
         self.assertFalse(


### PR DESCRIPTION
## Summary
- add a fail-closed `--exploratory-current-only` device-harness option
- allow current-device-only lanes only when the selected device is an exploratory iPhone on an OS newer than the matrix's `iphone-current` row
- keep all such evidence explicitly ineligible for stable qualification
- preserve the delayed-start-failure lane as explicit opt-in, matching current stable-device defaults

## Why
The connected iPhone 15 Pro runs iOS 27 beta while the stable matrix currently ends at iOS 26. The existing runner correctly classified it as exploratory, but then filtered out the performance, cadence, subtitles, timebase, adaptive-HLS, lifecycle, and terminal-outcome lanes. This option lets maintainers exercise those lanes without editing the stable matrix or pretending beta evidence qualifies.

## Validation
- `bash -n scripts/qualification/run-device-tests.sh`
- `python3 -m unittest scripts/qualification/tests/test_qualification_harness.py` (61/61)
- `python3 -m py_compile scripts/qualification/exploratory-device-policy.py scripts/qualification/tests/test_qualification_harness.py`
- policy CLI accepts the connected iPhone 15 Pro / iOS 27 exploratory record
- `git diff --check`

This PR does not change any qualification matrix row and does not close a milestone issue. The automatic Codex review is the only review pass requested.
