### PR TITLE
Make native release builds path-stable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,9 +77,12 @@ jobs:
           SWIFTVLC_ALLOW_DRAFT_RELEASE: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}
         run: ./scripts/tests/release-integrity.sh
 
-      - name: Test native artifact path gate
+      - name: Test native filesystem safety helpers
         timeout-minutes: 1
-        run: python3 -B -m unittest scripts/tests/test_verify_libvlc_build_paths.py
+        run: |
+          python3 -B -m unittest \
+            scripts/tests/test_verify_libvlc_build_paths.py \
+            scripts/tests/test_detach_managed_build_directory.py
 
       - name: Test native build-root safety
         timeout-minutes: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,14 @@ jobs:
           SWIFTVLC_ALLOW_DRAFT_RELEASE: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}
         run: ./scripts/tests/release-integrity.sh
 
+      - name: Test native artifact path gate
+        timeout-minutes: 1
+        run: python3 -B -m unittest scripts/tests/test_verify_libvlc_build_paths.py
+
+      - name: Test native build-root safety
+        timeout-minutes: 1
+        run: ./scripts/tests/build-libvlc-build-root.sh
+
       # Reports engine patches that are in the tree but not in the exact binary
       # release declared by the checkout. Warns rather
       # than fails: patches legitimately land before the release carrying them,

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ Package.resolved
 
 # libVLC build artifacts (21GB+ — rebuild with ./scripts/build-libvlc.sh)
 .build-libvlc/
+/scripts/.build-libvlc.removing-*/
+/scripts/.swiftvlc-managed-build.initializing-*/
 
 # Pre-built xcframework (1.2GB — rebuild with ./scripts/build-libvlc.sh)
 Vendor/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -796,6 +796,7 @@ blocked until `check-qualification.sh` accepts that record.
 |---|---|
 | `scripts/setup-dev.sh` | First step for local repo work. Downloads the last-released xcframework into `Vendor/`, flips `Package.swift` to the local-path form, and points the Showcase app at the repo-local Swift package. Flags: `--force` (re-download), `--skip-download` (only flip local references). |
 | `scripts/build-libvlc.sh` | Compiles libVLC from VideoLAN source (pinned via `VLC_HASH`) into `Vendor/libvlc.xcframework`. Applies the local VLC source patches described in README. |
+| `scripts/detach-managed-build-directory.py` | Implements no-follow, descriptor-relative initialization, handoff, quarantine cleanup, and publication primitives for native build/output directories. It rejects identity changes and device/filesystem crossings instead of falling back to pathname-recursive deletion. |
 | `scripts/validate-native-patch-series-source.sh` | Replays the complete hash-locked VLC patch stack in a disposable external work root and runs its fast source/mutation contracts, including libaom/NASM consumer compatibility. |
 | `scripts/validate-headless-vout-teardown.sh` | Verifies patch 0040's started-vout lifecycle ordering and, when given an XCFramework, runs bounded headless H.264 stop/release and natural-EOF/release regressions against its macOS archive. |
 | `scripts/validate-native-extension-contract.sh` | Binds the ordered native patch intent to exact extension v9 source/header semantics, the inherited v8 audio-session lease refinement, a fail-closed weak compatibility path, and one strong required symbol in every XCFramework architecture. |
@@ -941,6 +942,7 @@ SwiftVLC/
 │
 ├── scripts/
 │   ├── build-libvlc.sh                   # Compile libvlc from source
+│   ├── detach-managed-build-directory.py # Descriptor-safe native filesystem operations
 │   ├── setup-dev.sh                      # Download xcframework for local dev
 │   ├── release.sh                        # Cut a versioned release and advance main
 │   ├── fix-duplicate-symbols.sh          # Localize duplicate json symbols

--- a/README.md
+++ b/README.md
@@ -266,10 +266,25 @@ mkdir -p /Volumes/ExternalSSD/SwiftVLC-Native
   --clean-build --all
 ```
 
-The managed child carries an ownership marker, and an atomic lock prevents two
-builds from using the root concurrently. The script refuses to remove an
-unmarked directory and never automatically clears a stale lock; verify its
-recorded owner first.
+The managed child carries an ownership marker, and an atomic generation-bound
+lock prevents two builds from using the root concurrently. The script refuses
+to remove an unmarked directory and never automatically clears a stale lock;
+verify that no build is active before inspecting or removing that exact lock
+directory and its `.swiftvlc-lock-generation-v1` token.
+Cleanup detaches the marked child atomically and walks it through no-follow
+directory descriptors, refusing filesystem boundaries or replacement races.
+Any interrupted quarantine or publication staging is preserved and reported
+for inspection instead of being silently reused or recursively deleted.
+
+Source mutation, output assembly, and final `Vendor/` publication each use a
+one-use directory binding before entering an anchored working directory. The
+XCFramework is built and fully validated in the stable external path, copied
+to a private Vendor staging directory, and checked against its recorded tree
+identity before it replaces the previous artifact. Publication uses atomic
+no-replace moves and writes provenance last as the completion marker, so a
+partial handoff cannot masquerade as a releasable native artifact. These
+constraints are part of the release reproducibility and data-safety contract,
+not coverage-only tests.
 
 The inexpensive source-contract lane replays the complete ordered patch stack
 and exercises its mutation/behavior proofs without compiling VLC:

--- a/README.md
+++ b/README.md
@@ -241,16 +241,35 @@ Needed only when bumping `VLC_HASH`, modifying build patches, or preparing a rel
 
 ```bash
 brew install autoconf automake libtool cmake pkg-config gettext
-./scripts/build-libvlc.sh --clean-build --all
+mkdir -p /Volumes/ExternalSSD/SwiftVLC-Native
+./scripts/build-libvlc.sh \
+  --build-root=/Volumes/ExternalSSD/SwiftVLC-Native \
+  --clean-build --all
 ```
 
-Expect a full `--all` build to take tens of minutes on Apple Silicon. The script clones VLC at a pinned commit into `scripts/.build-libvlc/`, applies the hash-locked patch manifest, builds every contrib (FFmpeg, dav1d, x264, libass, …) per slice, and assembles the result into `Vendor/libvlc.xcframework`.
+Expect a full `--all` build to take tens of minutes on Apple Silicon. By
+default, the script clones VLC at a pinned commit into
+`scripts/.build-libvlc/`. It applies the hash-locked patch manifest, builds
+every contrib (FFmpeg, dav1d, x264, libass, …) per slice, and assembles the
+result into `Vendor/libvlc.xcframework`.
 
 A clean all-platform build needs roughly 100 GiB of working space. The script
-checks the volume that contains the repository before compiling and fails early
-when it is too small. Keep the checkout on an external SSD when internal disk
-space is constrained: the VLC source, contrib trees, architecture builds, and
-assembled libraries all remain under `scripts/.build-libvlc/` on that volume.
+checks the volume that contains its working directory before compiling and
+fails early when it is too small. For an external SSD, create a dedicated root
+and pass its canonical physical path; the script owns and may remove only the
+`swiftvlc-libvlc-build` child beneath it:
+
+```bash
+mkdir -p /Volumes/ExternalSSD/SwiftVLC-Native
+./scripts/build-libvlc.sh \
+  --build-root=/Volumes/ExternalSSD/SwiftVLC-Native \
+  --clean-build --all
+```
+
+The managed child carries an ownership marker, and an atomic lock prevents two
+builds from using the root concurrently. The script refuses to remove an
+unmarked directory and never automatically clears a stale lock; verify its
+recorded owner first.
 
 The inexpensive source-contract lane replays the complete ordered patch stack
 and exercises its mutation/behavior proofs without compiling VLC:
@@ -279,7 +298,8 @@ a bounded build failure instead of letting a release build hang indefinitely.
 | `--all` | iOS, tvOS, visionOS, macOS, Mac Catalyst (eight slices) |
 | `--ios-only` / `--tvos-only` / `--visionos-only` / `--macos-only` / `--catalyst-only` | Replaces `Vendor/` with that single platform |
 | `--tvos` / `--visionos` / `--macos` / `--catalyst` | Adds a platform to the default set |
-| `--clean` / `--clean-build` | Wipe `scripts/.build-libvlc/` (the latter rebuilds afterwards) |
+| `--clean` / `--clean-build` | Wipe the managed build directory (the latter rebuilds afterwards) |
+| `--build-root=<absolute-dir>` | Use `<absolute-dir>/swiftvlc-libvlc-build`; the root must already exist outside the checkout |
 | `--hash=<sha>` | Override the pinned VLC commit |
 
 > `*-only` flags **replace** the xcframework; any slices already in `Vendor/` are lost.
@@ -288,9 +308,22 @@ a bounded build failure instead of letting a release build hang indefinitely.
 
 A release needs two complete `--clean-build --all` invocations from the same
 committed SwiftVLC revision, on the same unchanged host toolchain and with the
-same `MAKEFLAGS`. Use separate checkouts on the external SSD: each build keeps
-its VLC source under that checkout, and a second build in the first checkout
-would replace both `Vendor/libvlc.xcframework` and its provenance.
+same `MAKEFLAGS`. Use separate checkouts, but pass both sequential invocations
+the exact same canonical external `--build-root`. VLC and some contribs retain
+configure/source paths in live string data, so different working roots are
+different build inputs even after debug symbols are stripped. The shared root
+is locked against concurrent use; each `--clean-build` still removes the entire
+managed child before cloning and compiling from scratch.
+
+For example, prepare the shared root once, then use the identical option in
+both checkouts:
+
+```bash
+mkdir -p /Volumes/ExternalSSD/SwiftVLC-Repro
+./scripts/build-libvlc.sh \
+  --build-root=/Volumes/ExternalSSD/SwiftVLC-Repro \
+  --clean-build --all
+```
 
 After build A completes, preserve and validate its actual artifact rather than
 copying only its JSON record:
@@ -305,9 +338,10 @@ cp Vendor/libvlc-provenance.json \
   /absolute/path/to/repro/run-a/libvlc-provenance.json
 ```
 
-Run build B in a different clean checkout at the same commit. From build B's
-checkout, compare both retained artifacts and records, then retain A's record
-beside B's selected artifact:
+Run build B in a different clean checkout at the same commit, with the same
+`--build-root` command shown above. From build B's checkout, compare both
+retained artifacts and records, then retain A's record beside B's selected
+artifact:
 
 ```bash
 python3 scripts/libvlc-provenance.py compare \
@@ -376,7 +410,9 @@ eligible candidate; the published beta.8 archive remains usable through the
 fail-closed weak compatibility path but cannot pass the current release gate.
 
 ```bash
-./scripts/build-libvlc.sh --clean-build --all  # run twice; retain proof above
+./scripts/build-libvlc.sh \
+  --build-root=/absolute/path/to/shared-native-root \
+  --clean-build --all                    # run twice; retain proof above
 ./scripts/release.sh X.Y.Z --dry-run     # strip + zip + checksum, no push
 ./scripts/release.sh X.Y.Z --prepare /absolute/path/to/candidate
 ./scripts/check-qualification.sh X.Y.Z /absolute/path/to/candidate/libvlc.xcframework

--- a/Tests/SwiftVLCTests/Player/PlayerDormantSuccessorControlTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerDormantSuccessorControlTests.swift
@@ -386,7 +386,7 @@ extension Integration {
     @Test
     func `Fresh-handle play publication yields to nested load and play`() throws {
       let player = try makeActiveDrawablePlayer(nativeState: .paused)
-      let retiringPointer = player.pointer
+      let retiringNativeHandleGeneration = player.eventBridge.currentNativeHandleGeneration
       let generationBeforePlays = player.sessionGeneration
       var nestedMRL: String?
       var nestedLoadRan = false
@@ -417,7 +417,13 @@ extension Integration {
       #expect(player.sessionGenerationMedia == player.currentMedia?.pointer)
       #expect(player.mediaPublicationGeneration == nil)
       #expect(player.nativeHandleRepresentsCurrentMedia)
-      #expect(player.pointer != retiringPointer)
+      // A can finish releasing before C is allocated, so C may reuse A's
+      // address. The monotonic attachment generation is the non-aliasing
+      // identity for the two committed A -> B -> C replacements.
+      #expect(
+        player.eventBridge.currentNativeHandleGeneration
+          == retiringNativeHandleGeneration &+ 2
+      )
       #expect(playDispatchCount == 1)
     }
 

--- a/scripts/build-libvlc.sh
+++ b/scripts/build-libvlc.sh
@@ -15,14 +15,26 @@
 #   ./build-libvlc.sh --macos-only # macOS only (fastest for dev)
 #   ./build-libvlc.sh --catalyst   # Add Mac Catalyst (arm64 + x86_64)
 #   ./build-libvlc.sh --clean      # Remove build directory
-#   ./build-libvlc.sh --clean-build --all # Required when patch 0038 is selected
+#   ./build-libvlc.sh --build-root=/absolute/path --clean-build --all
+#   ./build-libvlc.sh --build-root=/absolute/path # Canonical external work root
 #   ./build-libvlc.sh --hash=abc   # Pin to a specific VLC commit
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BUILD_DIR="${SCRIPT_DIR}/.build-libvlc"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+DEFAULT_BUILD_DIR="${SCRIPT_DIR}/.build-libvlc"
+BUILD_ROOT="${SCRIPT_DIR}"
+BUILD_DIR="${DEFAULT_BUILD_DIR}"
+EXTERNAL_BUILD_ROOT=no
+BUILD_ROOT_OVERRIDE=""
+BUILD_ROOT_OVERRIDE_SET=no
+BUILD_LOCK_DIR=""
+BUILD_LOCK_HELD=no
+OUTPUT_LOCK_DIR=""
+OUTPUT_LOCK_HELD=no
+BUILD_DIRECTORY_MARKER=".swiftvlc-managed-libvlc-build-v1"
+BUILD_DIRECTORY_MARKER_CONTENT="SwiftVLC managed libVLC build directory v1"
 OUTPUT_DIR="${REPO_ROOT}/Vendor"
 VLC_REPO="https://code.videolan.org/videolan/vlc.git"
 VLC_BRANCH="master"
@@ -57,6 +69,7 @@ BUILD_CATALYST=no
 # restore the asserts with --with-asserts.
 WITH_ASSERTS=no
 CLEAN_BUILD=no
+CLEAN_ONLY=no
 
 # Keep these deployment targets in sync with Package.swift.
 SWIFTVLC_MIN_IOS="18.0"
@@ -113,6 +126,178 @@ error() {
     echo "[${COLOR_RED}error${COLOR_RESET}] [$(elapsed)] $1" >&2
     exit 1
 }
+
+# A release reproducibility proof uses two different SwiftVLC checkouts, but
+# VLC and several contribs retain their absolute source/configure paths in live
+# string data. Giving both sequential builds the same external working root
+# makes that otherwise-hidden input explicit and stable. BUILD_DIR is always a
+# fixed child of the user-selected root so cleanup never targets the root
+# itself. Existing children must carry our ownership marker before deletion.
+configure_external_build_root() {
+    local requested_root="$1"
+    local canonical_root
+
+    if [ -z "${requested_root}" ]; then
+        error "--build-root requires an absolute directory path."
+    fi
+    case "${requested_root}" in
+        /*) ;;
+        *) error "--build-root must be an absolute directory path: ${requested_root}" ;;
+    esac
+    while [ "${requested_root}" != "/" ] &&
+          [ "${requested_root%/}" != "${requested_root}" ]; do
+        requested_root="${requested_root%/}"
+    done
+    if [ ! -d "${requested_root}" ]; then
+        error "External build root does not exist: ${requested_root}"
+    fi
+    canonical_root=$(cd "${requested_root}" && pwd -P)
+    if [ "${canonical_root}" != "${requested_root}" ]; then
+        error "--build-root must use its canonical physical path: ${canonical_root}"
+    fi
+    if [ "${canonical_root}" = "/" ]; then
+        error "Refusing to use the filesystem root as --build-root."
+    fi
+    case "${canonical_root}/" in
+        "${REPO_ROOT}/"*)
+            error "--build-root must be outside the SwiftVLC checkout so separate checkouts share one path."
+            ;;
+    esac
+    case "${REPO_ROOT}/" in
+        "${canonical_root}/swiftvlc-libvlc-build/"*)
+            error "Refusing an external build directory that contains the SwiftVLC checkout."
+            ;;
+    esac
+
+    BUILD_ROOT="${canonical_root}"
+    BUILD_DIR="${BUILD_ROOT}/swiftvlc-libvlc-build"
+    BUILD_LOCK_DIR="${BUILD_ROOT}/.swiftvlc-libvlc-build.lock"
+    EXTERNAL_BUILD_ROOT=yes
+}
+
+verify_managed_build_directory() {
+    if [ "${EXTERNAL_BUILD_ROOT}" != yes ]; then
+        return
+    fi
+    if [ -L "${BUILD_DIR}" ]; then
+        error "Refusing symlinked managed build directory: ${BUILD_DIR}"
+    fi
+    if [ ! -e "${BUILD_DIR}" ]; then
+        return
+    fi
+    if [ ! -d "${BUILD_DIR}" ]; then
+        error "Managed build path is not a directory: ${BUILD_DIR}"
+    fi
+    if [ -L "${BUILD_DIR}/${BUILD_DIRECTORY_MARKER}" ] ||
+       [ ! -f "${BUILD_DIR}/${BUILD_DIRECTORY_MARKER}" ]; then
+        error "Refusing unowned external build directory: ${BUILD_DIR}"
+    fi
+    if ! printf '%s\n' "${BUILD_DIRECTORY_MARKER_CONTENT}" | \
+         cmp -s - "${BUILD_DIR}/${BUILD_DIRECTORY_MARKER}"; then
+        error "Refusing unowned external build directory: ${BUILD_DIR}"
+    fi
+}
+
+release_build_root_lock() {
+    if [ "${BUILD_LOCK_HELD}" != yes ]; then
+        return
+    fi
+    if [ ! -f "${BUILD_LOCK_DIR}/owner" ] ||
+       ! grep -Fqx "invocationId=${BUILD_INVOCATION_ID}" "${BUILD_LOCK_DIR}/owner"; then
+        warn "External build-root lock ownership changed; leaving it untouched: ${BUILD_LOCK_DIR}"
+        BUILD_LOCK_HELD=no
+        return
+    fi
+    rm -f "${BUILD_LOCK_DIR}/owner"
+    if ! rmdir "${BUILD_LOCK_DIR}" 2>/dev/null; then
+        warn "Could not remove external build-root lock: ${BUILD_LOCK_DIR}"
+    fi
+    BUILD_LOCK_HELD=no
+}
+
+acquire_build_root_lock() {
+    local lock_owner=""
+    if [ "${EXTERNAL_BUILD_ROOT}" != yes ]; then
+        return
+    fi
+    if ! mkdir "${BUILD_LOCK_DIR}" 2>/dev/null; then
+        if [ -f "${BUILD_LOCK_DIR}/owner" ]; then
+            lock_owner=$(tr '\n' ' ' < "${BUILD_LOCK_DIR}/owner")
+        fi
+        error "External build root is locked; verify the owner before removing the lock: ${BUILD_LOCK_DIR}${lock_owner:+ (${lock_owner})}"
+    fi
+    BUILD_LOCK_HELD=yes
+    printf 'invocationId=%s\npid=%s\nhost=%s\nrevision=%s\nstartedAt=%s\n' \
+        "${BUILD_INVOCATION_ID}" "$$" "$(hostname)" \
+        "$(git -C "${REPO_ROOT}" rev-parse HEAD 2>/dev/null || echo unknown)" \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "${BUILD_LOCK_DIR}/owner"
+}
+
+release_output_lock() {
+    if [ "${OUTPUT_LOCK_HELD}" != yes ]; then
+        return
+    fi
+    if [ ! -f "${OUTPUT_LOCK_DIR}/owner" ] ||
+       ! grep -Fqx "invocationId=${BUILD_INVOCATION_ID}" "${OUTPUT_LOCK_DIR}/owner"; then
+        warn "Checkout artifact lock ownership changed; leaving it untouched: ${OUTPUT_LOCK_DIR}"
+        OUTPUT_LOCK_HELD=no
+        return
+    fi
+    rm -f "${OUTPUT_LOCK_DIR}/owner"
+    if ! rmdir "${OUTPUT_LOCK_DIR}" 2>/dev/null; then
+        warn "Could not remove checkout artifact lock: ${OUTPUT_LOCK_DIR}"
+    fi
+    OUTPUT_LOCK_HELD=no
+}
+
+release_build_locks() {
+    release_output_lock
+    release_build_root_lock
+}
+
+acquire_output_lock() {
+    local raw_lock_path
+    local lock_parent
+    local lock_owner=""
+    raw_lock_path=$(git -C "${REPO_ROOT}" rev-parse --git-path swiftvlc-libvlc-output.lock)
+    case "${raw_lock_path}" in
+        /*) ;;
+        *) raw_lock_path="${REPO_ROOT}/${raw_lock_path}" ;;
+    esac
+    lock_parent=$(cd "$(dirname "${raw_lock_path}")" && pwd -P)
+    OUTPUT_LOCK_DIR="${lock_parent}/$(basename "${raw_lock_path}")"
+    if ! mkdir "${OUTPUT_LOCK_DIR}" 2>/dev/null; then
+        if [ -f "${OUTPUT_LOCK_DIR}/owner" ]; then
+            lock_owner=$(tr '\n' ' ' < "${OUTPUT_LOCK_DIR}/owner")
+        fi
+        error "This checkout already has a native build or cleanup in progress: ${OUTPUT_LOCK_DIR}${lock_owner:+ (${lock_owner})}"
+    fi
+    OUTPUT_LOCK_HELD=yes
+    printf 'invocationId=%s\npid=%s\nhost=%s\nrevision=%s\nstartedAt=%s\n' \
+        "${BUILD_INVOCATION_ID}" "$$" "$(hostname)" \
+        "$(git -C "${REPO_ROOT}" rev-parse HEAD 2>/dev/null || echo unknown)" \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "${OUTPUT_LOCK_DIR}/owner"
+}
+
+initialize_managed_build_directory() {
+    mkdir -p "${BUILD_DIR}"
+    if [ "${EXTERNAL_BUILD_ROOT}" = yes ]; then
+        printf '%s\n' "${BUILD_DIRECTORY_MARKER_CONTENT}" > \
+            "${BUILD_DIR}/${BUILD_DIRECTORY_MARKER}"
+    fi
+}
+
+verify_checkout_path_not_embedded() {
+    if [ "${EXTERNAL_BUILD_ROOT}" != yes ]; then
+        return
+    fi
+    PYTHONDONTWRITEBYTECODE=1 python3 \
+        "${SCRIPT_DIR}/verify-libvlc-build-paths.py" \
+        --xcframework "${OUTPUT_DIR}/libvlc.xcframework" \
+        --forbidden-path "${REPO_ROOT}"
+}
+
+trap release_build_locks EXIT
 
 # --- Error trap for better failure reporting ---
 # Install only after `error` and its formatting dependencies are defined so a
@@ -204,7 +389,7 @@ check_disk_space() {
         required_gb=40
     fi
     local available_kb
-    available_kb=$(df -k "$SCRIPT_DIR" | awk 'NR==2 {print $4}')
+    available_kb=$(df -k "$BUILD_ROOT" | awk 'NR==2 {print $4}')
     local available_gb=$((available_kb / 1024 / 1024))
 
     if [ "$available_gb" -lt "$required_gb" ]; then
@@ -219,7 +404,12 @@ check_disk_space() {
 # fail closed if any writer keeps repopulating it.
 remove_build_directory() {
     local attempt
+    verify_managed_build_directory
     for attempt in 1 2 3 4 5; do
+        # An external directory is deletion-authorized only while the exact
+        # marker remains present. If another process recreates or swaps the
+        # child between attempts, fail closed instead of deleting new data.
+        verify_managed_build_directory
         if rm -rf "${BUILD_DIR}" && [ ! -e "${BUILD_DIR}" ]; then
             return
         fi
@@ -228,6 +418,28 @@ remove_build_directory() {
     done
     error "Could not completely remove build directory after 5 attempts: ${BUILD_DIR}"
 }
+
+# Resolve this before processing --clean/--clean-build: cleanup must never
+# depend on option order. Reject duplicates rather than silently selecting one
+# root and deleting another caller's managed directory.
+for arg in "$@"; do
+    case $arg in
+        --build-root=*)
+            if [ "${BUILD_ROOT_OVERRIDE_SET}" = yes ]; then
+                error "--build-root may be specified only once."
+            fi
+            BUILD_ROOT_OVERRIDE="${arg#--build-root=}"
+            BUILD_ROOT_OVERRIDE_SET=yes
+            ;;
+    esac
+done
+if [ "${BUILD_ROOT_OVERRIDE_SET}" = yes ]; then
+    configure_external_build_root "${BUILD_ROOT_OVERRIDE}"
+    acquire_build_root_lock
+    verify_managed_build_directory
+    info "Canonical external build root: ${BUILD_ROOT}"
+    info "Managed native build directory: ${BUILD_DIR}"
+fi
 
 # --- Parse arguments ---
 for arg in "$@"; do
@@ -287,16 +499,10 @@ for arg in "$@"; do
             BUILD_CATALYST=yes
             ;;
         --clean)
-            echo "Removing build directory: ${BUILD_DIR}"
-            remove_build_directory
-            echo "Done."
-            exit 0
+            CLEAN_ONLY=yes
             ;;
         --clean-build)
-            echo "Removing build directory: ${BUILD_DIR}"
-            remove_build_directory
             CLEAN_BUILD=yes
-            echo "Continuing with fresh build..."
             ;;
         --with-asserts)
             WITH_ASSERTS=yes
@@ -314,6 +520,10 @@ for arg in "$@"; do
                 echo "Error: Patches directory not found: ${PATCHES_DIR}" >&2
                 exit 1
             fi
+            ;;
+        --build-root=*)
+            # Resolved before this loop so --clean is safe regardless of
+            # argument order.
             ;;
         --help)
             cat <<HELPEOF
@@ -334,6 +544,9 @@ Platform selection:
 Build options:
   --clean            Remove the build directory and exit
   --clean-build      Remove the build directory, then build
+  --build-root=DIR   Use DIR/swiftvlc-libvlc-build as the canonical external
+                     working directory. DIR must already exist, be outside
+                     this checkout, and be identical for both release builds.
   --hash=COMMIT      Pin to a specific VLC commit (default: ${VLC_HASH})
   --patches-dir=DIR  Directory containing .patch files to apply
   --with-asserts     Enable libVLC run-time assertions (debugging only; these
@@ -348,7 +561,7 @@ Examples:
   $0 --macos-only             # Quick macOS build for development
   $0 --all                    # Full build for all platforms
   $0 --hash=abc123 --all      # Build all platforms from a specific commit
-  $0 --clean-build --all      # Fresh build for all platforms
+  $0 --build-root=/Volumes/Builds --clean-build --all
 HELPEOF
             exit 0
             ;;
@@ -359,6 +572,24 @@ HELPEOF
             ;;
     esac
 done
+
+if [ "${CLEAN_ONLY}" = yes ] && [ "${CLEAN_BUILD}" = yes ]; then
+    error "--clean and --clean-build cannot be used together."
+fi
+if [ "${CLEAN_BUILD}" = yes ] && [ "${EXTERNAL_BUILD_ROOT}" != yes ]; then
+    error "--clean-build requires a canonical external --build-root so release builds cannot depend on a checkout-local path."
+fi
+
+# Every native invocation that can delete its work tree or replace Vendor must
+# own this checkout's artifact lock. Git keeps the lock outside the tracked
+# tree and gives linked worktrees independent paths.
+acquire_output_lock
+if [ "${CLEAN_ONLY}" = yes ]; then
+    echo "Removing build directory: ${BUILD_DIR}"
+    remove_build_directory
+    echo "Done."
+    exit 0
+fi
 
 # Record the exact SwiftVLC commit whose build logic and vendored headers are
 # producing this artifact. A short or symbolic revision would allow a stale
@@ -389,6 +620,9 @@ verify_clean_swiftvlc_checkout() {
 # appear in this check.
 if [ "${CLEAN_BUILD}" = yes ]; then
     verify_clean_swiftvlc_checkout
+    echo "Removing build directory: ${BUILD_DIR}"
+    remove_build_directory
+    echo "Continuing with fresh build..."
 fi
 
 # --- Run startup checks ---
@@ -701,7 +935,7 @@ PYEOF
 
 # --- Step 1: Clone VLC source ---
 info "Setting up VLC source..."
-mkdir -p "${BUILD_DIR}"
+initialize_managed_build_directory
 cd "${BUILD_DIR}"
 
 if [ ! -d "vlc" ]; then
@@ -1971,6 +2205,15 @@ find "${OUTPUT_DIR}/libvlc.xcframework" -name '*.a' -exec strip -S {} \;
 info "Normalizing archive indexes after stripping..."
 find "${OUTPUT_DIR}/libvlc.xcframework" -name '*.a' -exec xcrun ranlib -D {} \;
 
+# The external working root is intentionally stable across clean builds, but
+# the two SwiftVLC checkout paths must remain independent. Reject any future
+# build-system change that copies a checkout-local absolute path into a shipped
+# library or header; such a leak would make the proof location-dependent again.
+if [ "${EXTERNAL_BUILD_ROOT}" = yes ]; then
+    info "Verifying that the release artifact contains no checkout-local paths..."
+    verify_checkout_path_not_embedded
+fi
+
 # Re-evaluate the manifest-owned identity across every exact archive after the
 # final archive mutation. The central gate inspects every declared architecture
 # and additionally executes its probe when a host-runnable macOS slice exists.
@@ -2034,6 +2277,7 @@ provenance_args=(
     --build-configuration-file "build-libvlc.sh=${SCRIPT_DIR}/build-libvlc.sh"
     --build-configuration-file "fix-duplicate-symbols.sh=${SCRIPT_DIR}/fix-duplicate-symbols.sh"
     --build-configuration-file "validate-libvlc-macho-metadata.py=${SCRIPT_DIR}/validate-libvlc-macho-metadata.py"
+    --build-configuration-file "verify-libvlc-build-paths.py=${SCRIPT_DIR}/verify-libvlc-build-paths.py"
     --build-configuration-file "validate-apple-assembly-metadata-patch.sh=${SCRIPT_DIR}/validate-apple-assembly-metadata-patch.sh"
     --build-configuration-file "validate-aom-nasm3-detection.sh=${SCRIPT_DIR}/validate-aom-nasm3-detection.sh"
     --build-configuration-file "validate-headless-vout-teardown.sh=${SCRIPT_DIR}/validate-headless-vout-teardown.sh"

--- a/scripts/build-libvlc.sh
+++ b/scripts/build-libvlc.sh
@@ -21,20 +21,58 @@
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && /bin/pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && /bin/pwd -P)"
+INVOCATION_DIRECTORY="$(/bin/pwd -P)"
+# Keep the lock-owning parent shell inside the exact scripts directory it
+# resolved. This gives checkout-local cleanup the same stable top-level anchor
+# as an external --build-root: renaming or replacing the checkout pathname
+# cannot redirect a later helper open into a different marker-bearing tree.
+cd "${SCRIPT_DIR}"
 DEFAULT_BUILD_DIR="${SCRIPT_DIR}/.build-libvlc"
-BUILD_ROOT="${SCRIPT_DIR}"
-BUILD_DIR="${DEFAULT_BUILD_DIR}"
+BUILD_ROOT="."
+BUILD_ROOT_HELPER="."
+BUILD_ROOT_DISPLAY="${SCRIPT_DIR}"
+BUILD_DIR=".build-libvlc"
+BUILD_DIR_DISPLAY="${DEFAULT_BUILD_DIR}"
 EXTERNAL_BUILD_ROOT=no
 BUILD_ROOT_OVERRIDE=""
 BUILD_ROOT_OVERRIDE_SET=no
 BUILD_LOCK_DIR=""
+BUILD_LOCK_DISPLAY=""
+BUILD_LOCK_PARENT_FD=8
+BUILD_LOCK_PARENT_FD_OPEN=no
 BUILD_LOCK_HELD=no
 OUTPUT_LOCK_DIR=""
+OUTPUT_LOCK_NAME=""
+OUTPUT_LOCK_DISPLAY=""
+OUTPUT_LOCK_PARENT_FD=9
+OUTPUT_LOCK_PARENT_FD_OPEN=no
 OUTPUT_LOCK_HELD=no
+LOCK_TOKEN_NAME=".swiftvlc-lock-generation-v1"
+BUILD_LOCK_TOKEN_CONTENT=""
+OUTPUT_LOCK_TOKEN_CONTENT=""
+OUTPUT_BINDING_HELD=no
 BUILD_DIRECTORY_MARKER=".swiftvlc-managed-libvlc-build-v1"
 BUILD_DIRECTORY_MARKER_CONTENT="SwiftVLC managed libVLC build directory v1"
+BUILD_DIRECTORY_CHILD=".build-libvlc"
+STAGED_OUTPUT_MARKER=".swiftvlc-managed-native-output-v1"
+STAGED_OUTPUT_MARKER_CONTENT="SwiftVLC managed native output directory v1"
+BUILD_QUARANTINE_NAME=""
+BUILD_QUARANTINE_DIR=""
+BUILD_QUARANTINE_PAYLOAD=""
+BUILD_BINDING_NAME=""
+BUILD_BINDING_CONTENT=""
+VLC_SOURCE_BINDING_NAME=""
+VLC_SOURCE_BINDING_CONTENT=""
+OUTPUT_BINDING_NAME=""
+OUTPUT_BINDING_CONTENT=""
+STAGED_OUTPUT_BINDING_NAME=""
+STAGED_OUTPUT_BINDING_CONTENT=""
+PUBLISHED_ARTIFACT_REMOVAL_BINDING_NAME=".swiftvlc-managed-artifact-removal-v1"
+PUBLISHED_ARTIFACT_REMOVAL_BINDING_CONTENT=""
+PUBLISHING_BINDING_NAME=".swiftvlc-managed-publication-binding-v1"
+PUBLISHING_BINDING_CONTENT=""
 OUTPUT_DIR="${REPO_ROOT}/Vendor"
 VLC_REPO="https://code.videolan.org/videolan/vlc.git"
 VLC_BRANCH="master"
@@ -80,6 +118,21 @@ SWIFTVLC_MIN_CATALYST="18.0"
 
 BUILD_START_TIME=$(date +%s)
 BUILD_INVOCATION_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+BUILD_QUARANTINE_NAME=".build-libvlc.removing-${BUILD_INVOCATION_ID}"
+BUILD_QUARANTINE_DIR="${SCRIPT_DIR}/${BUILD_QUARANTINE_NAME}"
+BUILD_QUARANTINE_PAYLOAD="${BUILD_QUARANTINE_DIR}/payload"
+BUILD_BINDING_NAME=".swiftvlc-managed-build-binding-v1"
+BUILD_BINDING_CONTENT="SwiftVLC managed build binding ${BUILD_INVOCATION_ID}"
+VLC_SOURCE_BINDING_NAME=".swiftvlc-managed-vlc-binding-v1"
+VLC_SOURCE_BINDING_CONTENT="SwiftVLC managed VLC binding ${BUILD_INVOCATION_ID}"
+OUTPUT_BINDING_NAME=".swiftvlc-managed-output-binding-v1"
+OUTPUT_BINDING_CONTENT="SwiftVLC managed output binding ${BUILD_INVOCATION_ID}"
+STAGED_OUTPUT_BINDING_NAME=".swiftvlc-managed-native-output-binding-v1"
+STAGED_OUTPUT_BINDING_CONTENT="SwiftVLC managed native output binding ${BUILD_INVOCATION_ID}"
+PUBLISHED_ARTIFACT_REMOVAL_BINDING_CONTENT="SwiftVLC managed artifact removal ${BUILD_INVOCATION_ID}"
+PUBLISHING_BINDING_CONTENT="SwiftVLC managed publication binding ${BUILD_INVOCATION_ID}"
+BUILD_LOCK_TOKEN_CONTENT="SwiftVLC external build-root lock ${BUILD_INVOCATION_ID}"
+OUTPUT_LOCK_TOKEN_CONTENT="SwiftVLC checkout output lock ${BUILD_INVOCATION_ID}"
 
 if [ -z "$MAKEFLAGS" ]; then
     MAKEFLAGS="-j$(sysctl -n machdep.cpu.core_count || nproc)"
@@ -151,7 +204,11 @@ configure_external_build_root() {
     if [ ! -d "${requested_root}" ]; then
         error "External build root does not exist: ${requested_root}"
     fi
-    canonical_root=$(cd "${requested_root}" && pwd -P)
+    # Stay inside the directory we canonicalize. The shell's live CWD anchors
+    # this exact inode even if a non-cooperating process later renames or
+    # replaces the absolute root pathname.
+    cd "${requested_root}"
+    canonical_root=$(/bin/pwd -P)
     if [ "${canonical_root}" != "${requested_root}" ]; then
         error "--build-root must use its canonical physical path: ${canonical_root}"
     fi
@@ -169,10 +226,102 @@ configure_external_build_root() {
             ;;
     esac
 
-    BUILD_ROOT="${canonical_root}"
-    BUILD_DIR="${BUILD_ROOT}/swiftvlc-libvlc-build"
-    BUILD_LOCK_DIR="${BUILD_ROOT}/.swiftvlc-libvlc-build.lock"
+    BUILD_DIRECTORY_CHILD="swiftvlc-libvlc-build"
+    BUILD_QUARANTINE_NAME=".swiftvlc-libvlc-build.removing-${BUILD_INVOCATION_ID}"
+    BUILD_ROOT="."
+    BUILD_ROOT_HELPER="."
+    BUILD_ROOT_DISPLAY="${canonical_root}"
+    BUILD_DIR="${BUILD_DIRECTORY_CHILD}"
+    BUILD_DIR_DISPLAY="${canonical_root}/${BUILD_DIRECTORY_CHILD}"
+    BUILD_LOCK_DIR=".swiftvlc-libvlc-build.lock"
+    BUILD_LOCK_DISPLAY="${canonical_root}/.swiftvlc-libvlc-build.lock"
+    BUILD_QUARANTINE_DIR="${canonical_root}/${BUILD_QUARANTINE_NAME}"
+    BUILD_QUARANTINE_PAYLOAD="${BUILD_QUARANTINE_DIR}/payload"
     EXTERNAL_BUILD_ROOT=yes
+}
+
+managed_build_directory_helper() {
+    local operation="$1"
+    shift
+    PYTHONDONTWRITEBYTECODE=1 python3 \
+        "${SCRIPT_DIR}/detach-managed-build-directory.py" \
+        "${operation}" \
+        --root "${BUILD_ROOT_HELPER}" \
+        --child "${BUILD_DIRECTORY_CHILD}" \
+        --marker-name "${BUILD_DIRECTORY_MARKER}" \
+        --marker-content "${BUILD_DIRECTORY_MARKER_CONTENT}" \
+        "$@"
+}
+
+bind_directory_for_handoff() {
+    local root="$1"
+    local child="$2"
+    local binding_name="$3"
+    local binding_content="$4"
+    shift 4
+    PYTHONDONTWRITEBYTECODE=1 python3 \
+        "${SCRIPT_DIR}/detach-managed-build-directory.py" \
+        bind \
+        --root "${root}" \
+        --child "${child}" \
+        --marker-name "${BUILD_DIRECTORY_MARKER}" \
+        --marker-content "${BUILD_DIRECTORY_MARKER_CONTENT}" \
+        --binding-name "${binding_name}" \
+        --binding-content "${binding_content}" \
+        "$@"
+}
+
+verify_directory_binding() {
+    local binding_name="$1"
+    local binding_content="$2"
+    local description="$3"
+    if [ -L "${binding_name}" ] || \
+       [ ! -f "${binding_name}" ] || \
+       ! printf '%s\n' "${binding_content}" | cmp -s - "${binding_name}"; then
+        error "${description} changed before it could be anchored."
+    fi
+}
+
+retire_directory_binding() {
+    local binding_name="$1"
+    local binding_content="$2"
+    local description="$3"
+    verify_directory_binding \
+        "${binding_name}" "${binding_content}" "${description}"
+    rm -f -- "${binding_name}"
+    if [ -e "${binding_name}" ] || [ -L "${binding_name}" ]; then
+        error "Could not retire ${description} binding: ${binding_name}"
+    fi
+}
+
+release_output_binding() {
+    if [ "${OUTPUT_BINDING_HELD}" != yes ]; then
+        return 0
+    fi
+    # Enter the current public Vendor path but remove a file only when it still
+    # carries this invocation's exact continuity token. If Vendor or an
+    # ancestor was replaced, leave both directories untouched for inspection.
+    (
+    if ! cd "${REPO_ROOT}/Vendor" 2>/dev/null; then
+        return 0
+    fi
+    if [ ! -e "${OUTPUT_BINDING_NAME}" ] && \
+       [ ! -L "${OUTPUT_BINDING_NAME}" ]; then
+        return 0
+    fi
+    if [ -L "${OUTPUT_BINDING_NAME}" ] || \
+       [ ! -f "${OUTPUT_BINDING_NAME}" ] || \
+       ! printf '%s\n' "${OUTPUT_BINDING_CONTENT}" | \
+         cmp -s - "${OUTPUT_BINDING_NAME}"; then
+        warn "Vendor output binding changed; leaving it untouched: ${REPO_ROOT}/Vendor/${OUTPUT_BINDING_NAME}"
+        return 0
+    fi
+    if ! rm -f -- "${OUTPUT_BINDING_NAME}"; then
+        warn "Could not remove Vendor output binding: ${REPO_ROOT}/Vendor/${OUTPUT_BINDING_NAME}"
+    fi
+    ) || true
+    OUTPUT_BINDING_HELD=no
+    return 0
 }
 
 verify_managed_build_directory() {
@@ -180,110 +329,174 @@ verify_managed_build_directory() {
         return
     fi
     if [ -L "${BUILD_DIR}" ]; then
-        error "Refusing symlinked managed build directory: ${BUILD_DIR}"
+        error "Refusing symlinked managed build directory: ${BUILD_DIR_DISPLAY}"
     fi
     if [ ! -e "${BUILD_DIR}" ]; then
         return
     fi
     if [ ! -d "${BUILD_DIR}" ]; then
-        error "Managed build path is not a directory: ${BUILD_DIR}"
+        error "Managed build path is not a directory: ${BUILD_DIR_DISPLAY}"
     fi
     if [ -L "${BUILD_DIR}/${BUILD_DIRECTORY_MARKER}" ] ||
        [ ! -f "${BUILD_DIR}/${BUILD_DIRECTORY_MARKER}" ]; then
-        error "Refusing unowned external build directory: ${BUILD_DIR}"
+        error "Refusing unowned external build directory: ${BUILD_DIR_DISPLAY}"
     fi
     if ! printf '%s\n' "${BUILD_DIRECTORY_MARKER_CONTENT}" | \
          cmp -s - "${BUILD_DIR}/${BUILD_DIRECTORY_MARKER}"; then
-        error "Refusing unowned external build directory: ${BUILD_DIR}"
+        error "Refusing unowned external build directory: ${BUILD_DIR_DISPLAY}"
     fi
 }
 
 release_build_root_lock() {
     if [ "${BUILD_LOCK_HELD}" != yes ]; then
-        return
+        return 0
     fi
-    if [ ! -f "${BUILD_LOCK_DIR}/owner" ] ||
-       ! grep -Fqx "invocationId=${BUILD_INVOCATION_ID}" "${BUILD_LOCK_DIR}/owner"; then
-        warn "External build-root lock ownership changed; leaving it untouched: ${BUILD_LOCK_DIR}"
-        BUILD_LOCK_HELD=no
-        return
-    fi
-    rm -f "${BUILD_LOCK_DIR}/owner"
-    if ! rmdir "${BUILD_LOCK_DIR}" 2>/dev/null; then
-        warn "Could not remove external build-root lock: ${BUILD_LOCK_DIR}"
+    # Release only the exact generation acquired by this invocation. The
+    # helper retains and validates both the anchored parent descriptor and the
+    # opened lock directory, so path replacement cannot retire a successor.
+    if ! PYTHONDONTWRITEBYTECODE=1 python3 \
+        "${SCRIPT_DIR}/detach-managed-build-directory.py" lock-release \
+        --root-fd "${BUILD_LOCK_PARENT_FD}" \
+        --child "${BUILD_LOCK_DIR}" \
+        --token-name "${LOCK_TOKEN_NAME}" \
+        --token-content "${BUILD_LOCK_TOKEN_CONTENT}"; then
+        warn "Could not remove external build-root lock: ${BUILD_LOCK_DISPLAY}"
     fi
     BUILD_LOCK_HELD=no
+    return 0
+}
+
+close_build_lock_parent() {
+    if [ "${BUILD_LOCK_PARENT_FD_OPEN}" != yes ]; then
+        return 0
+    fi
+    exec 8<&-
+    BUILD_LOCK_PARENT_FD_OPEN=no
+    return 0
 }
 
 acquire_build_root_lock() {
-    local lock_owner=""
     if [ "${EXTERNAL_BUILD_ROOT}" != yes ]; then
         return
     fi
-    if ! mkdir "${BUILD_LOCK_DIR}" 2>/dev/null; then
-        if [ -f "${BUILD_LOCK_DIR}/owner" ]; then
-            lock_owner=$(tr '\n' ' ' < "${BUILD_LOCK_DIR}/owner")
-        fi
-        error "External build root is locked; verify the owner before removing the lock: ${BUILD_LOCK_DIR}${lock_owner:+ (${lock_owner})}"
+    if ! exec 8<.; then
+        error "Could not anchor external build-root lock parent: ${BUILD_ROOT_DISPLAY}"
+    fi
+    BUILD_LOCK_PARENT_FD_OPEN=yes
+    if ! PYTHONDONTWRITEBYTECODE=1 python3 \
+        "${SCRIPT_DIR}/detach-managed-build-directory.py" lock-acquire \
+        --root-fd "${BUILD_LOCK_PARENT_FD}" \
+        --child "${BUILD_LOCK_DIR}" \
+        --token-name "${LOCK_TOKEN_NAME}" \
+        --token-content "${BUILD_LOCK_TOKEN_CONTENT}"; then
+        error "External build root is locked or has preserved lock state; verify no build is active and inspect this exact managed lock: ${BUILD_LOCK_DISPLAY}"
     fi
     BUILD_LOCK_HELD=yes
-    printf 'invocationId=%s\npid=%s\nhost=%s\nrevision=%s\nstartedAt=%s\n' \
-        "${BUILD_INVOCATION_ID}" "$$" "$(hostname)" \
-        "$(git -C "${REPO_ROOT}" rev-parse HEAD 2>/dev/null || echo unknown)" \
-        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "${BUILD_LOCK_DIR}/owner"
+}
+
+reject_stale_managed_build_state() {
+    local candidate
+    local candidate_name
+    local quarantine_pattern
+    if [ "${EXTERNAL_BUILD_ROOT}" = yes ]; then
+        quarantine_pattern=./.swiftvlc-libvlc-build.removing-\*
+    else
+        quarantine_pattern=./.build-libvlc.removing-\*
+    fi
+    (
+    cd "${BUILD_ROOT_HELPER}"
+    for candidate in \
+        ${quarantine_pattern} \
+        ./.swiftvlc-lock.initializing-* \
+        ./.swiftvlc-managed-build.initializing-*; do
+        if [ ! -e "${candidate}" ] && [ ! -L "${candidate}" ]; then
+            continue
+        fi
+        candidate_name=${candidate#./}
+        error "Found preserved managed-build state: ${BUILD_ROOT_DISPLAY}/${candidate_name}. Inspect and recover or remove this exact path before retrying; it is never deleted automatically."
+    done
+    )
+    return 0
 }
 
 release_output_lock() {
     if [ "${OUTPUT_LOCK_HELD}" != yes ]; then
-        return
+        return 0
     fi
-    if [ ! -f "${OUTPUT_LOCK_DIR}/owner" ] ||
-       ! grep -Fqx "invocationId=${BUILD_INVOCATION_ID}" "${OUTPUT_LOCK_DIR}/owner"; then
-        warn "Checkout artifact lock ownership changed; leaving it untouched: ${OUTPUT_LOCK_DIR}"
-        OUTPUT_LOCK_HELD=no
-        return
-    fi
-    rm -f "${OUTPUT_LOCK_DIR}/owner"
-    if ! rmdir "${OUTPUT_LOCK_DIR}" 2>/dev/null; then
-        warn "Could not remove checkout artifact lock: ${OUTPUT_LOCK_DIR}"
+    # Keep the Git lock-parent descriptor opened before an external build
+    # re-anchors the shell elsewhere. Descriptor-relative removal cannot be
+    # redirected into a replacement checkout or linked-worktree metadata path.
+    if ! PYTHONDONTWRITEBYTECODE=1 python3 \
+        "${SCRIPT_DIR}/detach-managed-build-directory.py" lock-release \
+        --root-fd "${OUTPUT_LOCK_PARENT_FD}" \
+        --child "${OUTPUT_LOCK_NAME}" \
+        --token-name "${LOCK_TOKEN_NAME}" \
+        --token-content "${OUTPUT_LOCK_TOKEN_CONTENT}"; then
+        warn "Could not remove checkout artifact lock: ${OUTPUT_LOCK_DISPLAY}"
     fi
     OUTPUT_LOCK_HELD=no
+    return 0
+}
+
+close_output_lock_parent() {
+    if [ "${OUTPUT_LOCK_PARENT_FD_OPEN}" != yes ]; then
+        return 0
+    fi
+    exec 9<&-
+    OUTPUT_LOCK_PARENT_FD_OPEN=no
+    return 0
 }
 
 release_build_locks() {
-    release_output_lock
-    release_build_root_lock
+    release_output_binding || true
+    release_output_lock || true
+    release_build_root_lock || true
+    close_build_lock_parent || true
+    close_output_lock_parent || true
+    return 0
 }
 
 acquire_output_lock() {
     local raw_lock_path
     local lock_parent
-    local lock_owner=""
-    raw_lock_path=$(git -C "${REPO_ROOT}" rev-parse --git-path swiftvlc-libvlc-output.lock)
+    if [ "$(/bin/pwd -P)" != "${SCRIPT_DIR}" ]; then
+        error "Checkout output lock must be anchored before leaving the scripts directory."
+    fi
+    raw_lock_path=$(git -C . rev-parse --git-path swiftvlc-libvlc-output.lock)
     case "${raw_lock_path}" in
         /*) ;;
-        *) raw_lock_path="${REPO_ROOT}/${raw_lock_path}" ;;
+        *) raw_lock_path="${SCRIPT_DIR}/${raw_lock_path}" ;;
     esac
-    lock_parent=$(cd "$(dirname "${raw_lock_path}")" && pwd -P)
-    OUTPUT_LOCK_DIR="${lock_parent}/$(basename "${raw_lock_path}")"
-    if ! mkdir "${OUTPUT_LOCK_DIR}" 2>/dev/null; then
-        if [ -f "${OUTPUT_LOCK_DIR}/owner" ]; then
-            lock_owner=$(tr '\n' ' ' < "${OUTPUT_LOCK_DIR}/owner")
-        fi
-        error "This checkout already has a native build or cleanup in progress: ${OUTPUT_LOCK_DIR}${lock_owner:+ (${lock_owner})}"
+    lock_parent=$(cd "$(dirname "${raw_lock_path}")" && /bin/pwd -P)
+    OUTPUT_LOCK_NAME=$(basename "${raw_lock_path}")
+    OUTPUT_LOCK_DISPLAY="${lock_parent}/${OUTPUT_LOCK_NAME}"
+    OUTPUT_LOCK_DIR="${OUTPUT_LOCK_DISPLAY}"
+    if ! exec 9<"${lock_parent}"; then
+        error "Could not anchor checkout artifact-lock parent: ${lock_parent}"
+    fi
+    OUTPUT_LOCK_PARENT_FD_OPEN=yes
+    if ! PYTHONDONTWRITEBYTECODE=1 python3 \
+        "${SCRIPT_DIR}/detach-managed-build-directory.py" lock-acquire \
+        --root-fd "${OUTPUT_LOCK_PARENT_FD}" \
+        --child "${OUTPUT_LOCK_NAME}" \
+        --token-name "${LOCK_TOKEN_NAME}" \
+        --token-content "${OUTPUT_LOCK_TOKEN_CONTENT}"; then
+        error "This checkout already has a native build or cleanup in progress, or preserved lock state; verify no build is active and inspect this exact managed lock: ${OUTPUT_LOCK_DISPLAY}"
     fi
     OUTPUT_LOCK_HELD=yes
-    printf 'invocationId=%s\npid=%s\nhost=%s\nrevision=%s\nstartedAt=%s\n' \
-        "${BUILD_INVOCATION_ID}" "$$" "$(hostname)" \
-        "$(git -C "${REPO_ROOT}" rev-parse HEAD 2>/dev/null || echo unknown)" \
-        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "${OUTPUT_LOCK_DIR}/owner"
 }
 
 initialize_managed_build_directory() {
-    mkdir -p "${BUILD_DIR}"
-    if [ "${EXTERNAL_BUILD_ROOT}" = yes ]; then
-        printf '%s\n' "${BUILD_DIRECTORY_MARKER_CONTENT}" > \
-            "${BUILD_DIR}/${BUILD_DIRECTORY_MARKER}"
+    if [ "${CLEAN_BUILD}" = yes ]; then
+        if ! managed_build_directory_helper initialize --require-new \
+            --binding-name "${BUILD_BINDING_NAME}" \
+            --binding-content "${BUILD_BINDING_CONTENT}"; then
+            error "Could not exclusively initialize a fresh managed build directory: ${BUILD_DIR_DISPLAY}"
+        fi
+    elif ! managed_build_directory_helper initialize \
+        --binding-name "${BUILD_BINDING_NAME}" \
+        --binding-content "${BUILD_BINDING_CONTENT}"; then
+        error "Could not safely initialize managed build directory: ${BUILD_DIR_DISPLAY}"
     fi
 }
 
@@ -403,20 +616,33 @@ check_disk_space() {
 # Clean builds must start from an absent tree, so retry the whole removal and
 # fail closed if any writer keeps repopulating it.
 remove_build_directory() {
-    local attempt
-    verify_managed_build_directory
-    for attempt in 1 2 3 4 5; do
-        # An external directory is deletion-authorized only while the exact
-        # marker remains present. If another process recreates or swaps the
-        # child between attempts, fail closed instead of deleting new data.
-        verify_managed_build_directory
-        if rm -rf "${BUILD_DIR}" && [ ! -e "${BUILD_DIR}" ]; then
-            return
+    local cleanup_status
+
+    # Verification and deletion cannot safely share the public pathname. The
+    # helper opens and verifies the exact directory, atomically renames it
+    # beneath a private quarantine, then keeps that original descriptor live
+    # while walking and unlinking entries relative to directory FDs. Use this
+    # for both external and legacy checkout-local roots; neither path gets a
+    # recursive shell fallback.
+    if managed_build_directory_helper clean \
+        --quarantine "${BUILD_QUARANTINE_NAME}"; then
+        cleanup_status=0
+    else
+        cleanup_status=$?
+    fi
+    if [ "${cleanup_status}" -eq 3 ]; then
+        if [ -e "${BUILD_DIR}" ] || [ -L "${BUILD_DIR}" ]; then
+            error "Managed build path appeared during cleanup and was left untouched: ${BUILD_DIR_DISPLAY}"
         fi
-        warn "Build directory cleanup did not settle (attempt ${attempt}/5); retrying..."
-        sleep 1
-    done
-    error "Could not completely remove build directory after 5 attempts: ${BUILD_DIR}"
+        return 0
+    fi
+    if [ "${cleanup_status}" -ne 0 ]; then
+        error "Could not safely clean managed build directory; any detached data was preserved for inspection: ${BUILD_QUARANTINE_DIR}"
+    fi
+    if [ -e "${BUILD_DIR}" ] || [ -L "${BUILD_DIR}" ]; then
+        error "Managed build path reappeared during cleanup and was left untouched: ${BUILD_DIR_DISPLAY}"
+    fi
+    return 0
 }
 
 # Resolve this before processing --clean/--clean-build: cleanup must never
@@ -433,13 +659,6 @@ for arg in "$@"; do
             ;;
     esac
 done
-if [ "${BUILD_ROOT_OVERRIDE_SET}" = yes ]; then
-    configure_external_build_root "${BUILD_ROOT_OVERRIDE}"
-    acquire_build_root_lock
-    verify_managed_build_directory
-    info "Canonical external build root: ${BUILD_ROOT}"
-    info "Managed native build directory: ${BUILD_DIR}"
-fi
 
 # --- Parse arguments ---
 for arg in "$@"; do
@@ -516,6 +735,10 @@ for arg in "$@"; do
             ;;
         --patches-dir=*)
             PATCHES_DIR="${arg#--patches-dir=}"
+            case "${PATCHES_DIR}" in
+                /*) ;;
+                *) PATCHES_DIR="${INVOCATION_DIRECTORY}/${PATCHES_DIR}" ;;
+            esac
             if [ ! -d "$PATCHES_DIR" ]; then
                 echo "Error: Patches directory not found: ${PATCHES_DIR}" >&2
                 exit 1
@@ -576,16 +799,61 @@ done
 if [ "${CLEAN_ONLY}" = yes ] && [ "${CLEAN_BUILD}" = yes ]; then
     error "--clean and --clean-build cannot be used together."
 fi
-if [ "${CLEAN_BUILD}" = yes ] && [ "${EXTERNAL_BUILD_ROOT}" != yes ]; then
+if [ "${CLEAN_BUILD}" = yes ] && [ "${BUILD_ROOT_OVERRIDE_SET}" != yes ]; then
     error "--clean-build requires a canonical external --build-root so release builds cannot depend on a checkout-local path."
 fi
 
 # Every native invocation that can delete its work tree or replace Vendor must
-# own this checkout's artifact lock. Git keeps the lock outside the tracked
-# tree and gives linked worktrees independent paths.
+# own this checkout's artifact lock. Acquire it while the shell is still in its
+# original scripts-directory CWD, and retain the Git lock-parent descriptor so
+# linked-worktree or checkout path replacement cannot redirect its release.
 acquire_output_lock
+
+# Bind the original checkout's Vendor generation before an external build root
+# changes the parent shell's CWD. Later absolute-path entry must present this
+# exact invocation token; a renamed/replaced checkout therefore fails closed
+# instead of minting authority in the replacement tree.
+if [ "${CLEAN_ONLY}" != yes ]; then
+    if ! (
+        cd -P ..
+        if [ "$(/bin/pwd -P)" != "${REPO_ROOT}" ]; then
+            error "SwiftVLC checkout path changed before Vendor could be anchored."
+        fi
+        for preserved_checkout_state in \
+            ./.swiftvlc-managed-build.initializing-*; do
+            if [ -e "${preserved_checkout_state}" ] || \
+               [ -L "${preserved_checkout_state}" ]; then
+                error "Found preserved checkout publication state: ${preserved_checkout_state}. Inspect and recover or remove it before retrying."
+            fi
+        done
+        if ! bind_directory_for_handoff \
+            . Vendor \
+            "${OUTPUT_BINDING_NAME}" "${OUTPUT_BINDING_CONTENT}" \
+            --create; then
+            error "Could not safely anchor the original checkout Vendor output directory."
+        fi
+    ); then
+        error "Could not establish original checkout continuity for native output."
+    fi
+    OUTPUT_BINDING_HELD=yes
+fi
+
+# Only now may external mode re-anchor the parent at its canonical build root.
+# The checkout output lock and Vendor token above remain tied to the original
+# checkout while the build-root lock remains tied to this new live CWD.
+if [ "${BUILD_ROOT_OVERRIDE_SET}" = yes ]; then
+    configure_external_build_root "${BUILD_ROOT_OVERRIDE}"
+    acquire_build_root_lock
+    reject_stale_managed_build_state
+    verify_managed_build_directory
+    info "Canonical external build root: ${BUILD_ROOT_DISPLAY}"
+    info "Managed native build directory: ${BUILD_DIR_DISPLAY}"
+else
+    reject_stale_managed_build_state
+fi
+
 if [ "${CLEAN_ONLY}" = yes ]; then
-    echo "Removing build directory: ${BUILD_DIR}"
+    echo "Removing build directory: ${BUILD_DIR_DISPLAY}"
     remove_build_directory
     echo "Done."
     exit 0
@@ -620,7 +888,7 @@ verify_clean_swiftvlc_checkout() {
 # appear in this check.
 if [ "${CLEAN_BUILD}" = yes ]; then
     verify_clean_swiftvlc_checkout
-    echo "Removing build directory: ${BUILD_DIR}"
+    echo "Removing build directory: ${BUILD_DIR_DISPLAY}"
     remove_build_directory
     echo "Continuing with fresh build..."
 fi
@@ -634,13 +902,29 @@ fi
 check_disk_space
 
 # Any new native build invalidates the previous two-build evidence immediately.
+# Re-enter the public Vendor path only after the early original-checkout bind:
+# a checkout replacement cannot present this invocation's continuity token.
 # Do this before source setup/compilation so an interrupted replacement cannot
 # leave an older A record or proof looking current beside the prior artifact.
-mkdir -p "${OUTPUT_DIR}"
-rm -f "${OUTPUT_DIR}/libvlc-provenance-a.json" \
-    "${OUTPUT_DIR}/libvlc-provenance.json" \
-    "${OUTPUT_DIR}/libvlc-reproducibility.json" \
-    "${OUTPUT_DIR}/libvlc-macho-metadata.json"
+(
+cd "${OUTPUT_DIR}"
+verify_directory_binding \
+    "${OUTPUT_BINDING_NAME}" "${OUTPUT_BINDING_CONTENT}" \
+    "Checkout Vendor output directory"
+for preserved_output_state in \
+    ./.swiftvlc-native-output-publishing-* \
+    ./.swiftvlc-published-artifact.removing-* \
+    ./.swiftvlc-managed-build.initializing-* \
+    "./libvlc.xcframework/${PUBLISHED_ARTIFACT_REMOVAL_BINDING_NAME}"; do
+    if [ -e "${preserved_output_state}" ] || [ -L "${preserved_output_state}" ]; then
+        error "Found preserved Vendor publication state: ${preserved_output_state}. Inspect and recover or remove it before retrying."
+    fi
+done
+rm -f ./libvlc-provenance-a.json \
+    ./libvlc-provenance.json \
+    ./libvlc-reproducibility.json \
+    ./libvlc-macho-metadata.json
+)
 
 # Normalize architecture name for directory naming
 # VLC's build.sh accepts "aarch64" but creates "arm64" directories internally
@@ -933,19 +1217,87 @@ PYEOF
     info "VLC build system patched for Mac Catalyst"
 }
 
+# Keep the lock-owning parent shell anchored at the external root. The native
+# body runs in a child shell whose CWD becomes the exact managed directory;
+# its path and CWD changes therefore cannot redirect the parent's EXIT cleanup.
+(
+trap - EXIT
+trap 'error "Native build body failed at line $LINENO (exit code $?)"' ERR
+
 # --- Step 1: Clone VLC source ---
 info "Setting up VLC source..."
 initialize_managed_build_directory
+# Enter the exact child initialized through a no-follow root descriptor, then
+# require its one-use binding. This protects both external release roots and
+# the legacy checkout-local developer root; neither path relies on a bare
+# mkdir/marker check before native mutations begin.
 cd "${BUILD_DIR}"
+if [ -L "${BUILD_DIRECTORY_MARKER}" ] || \
+   [ ! -f "${BUILD_DIRECTORY_MARKER}" ] || \
+   ! printf '%s\n' "${BUILD_DIRECTORY_MARKER_CONTENT}" | \
+     cmp -s - "${BUILD_DIRECTORY_MARKER}"; then
+    error "Managed build directory changed before it could be anchored: ${BUILD_DIR_DISPLAY}"
+fi
+retire_directory_binding \
+    "${BUILD_BINDING_NAME}" "${BUILD_BINDING_CONTENT}" \
+    "Managed build directory"
+BUILD_DIR="."
 
-if [ ! -d "vlc" ]; then
+# A managed root authorizes its own files, but never a symlink or filesystem
+# mounted beneath its `vlc` entry. The helper creates a one-use binding in the
+# exact no-follow directory it opened; validating that binding after `cd`
+# bridges the remaining pathname race. All subsequent source mutations stay
+# relative to this live source-directory CWD.
+VLC_SOURCE_WAS_CLONED=no
+if [ -L vlc ]; then
+    error "Refusing a symlinked VLC source directory: ${BUILD_DIR_DISPLAY}/vlc"
+elif [ ! -e vlc ]; then
     info "Cloning VLC from ${VLC_REPO}..."
     git clone "${VLC_REPO}" --branch "${VLC_BRANCH}" --single-branch vlc
-    cd vlc
+    VLC_SOURCE_WAS_CLONED=yes
+elif [ ! -d vlc ]; then
+    error "VLC source path is not a directory: ${BUILD_DIR_DISPLAY}/vlc"
+fi
+if ! bind_directory_for_handoff \
+    . vlc "${VLC_SOURCE_BINDING_NAME}" "${VLC_SOURCE_BINDING_CONTENT}"; then
+    error "Could not safely anchor the managed VLC source directory."
+fi
+cd vlc
+retire_directory_binding \
+    "${VLC_SOURCE_BINDING_NAME}" "${VLC_SOURCE_BINDING_CONTENT}" \
+    "Managed VLC source directory"
+VLC_SOURCE_DIRECTORY=$(/bin/pwd -P)
+NATIVE_BUILD_PARENT=$(cd -P .. && /bin/pwd -P)
+if [ "${EXTERNAL_BUILD_ROOT}" = yes ]; then
+    if [ "${NATIVE_BUILD_PARENT}" != "${BUILD_DIR_DISPLAY}" ] || \
+       [ "${VLC_SOURCE_DIRECTORY}" != "${BUILD_DIR_DISPLAY}/vlc" ]; then
+        error "Managed native paths changed after they were anchored."
+    fi
+fi
+# Keep generated libraries, validators, and release staging beneath this same
+# anchored source CWD. Nothing later relies on `..`, whose parent relation
+# could change if a non-cooperating process renamed the source directory.
+BUILD_DIR="."
+VLC_SRC="."
+NATIVE_BUILD_DIRECTORY="${VLC_SOURCE_DIRECTORY}"
+
+# A killed helper deliberately preserves state instead of guessing whether a
+# pathname still identifies its original directory. Surface those exact
+# source-root remnants before any new output stage can hide them among a
+# multi-gigabyte VLC tree.
+for preserved_source_state in \
+    ./.swiftvlc-native-output \
+    ./.swiftvlc-native-output.removing-* \
+    ./.swiftvlc-managed-build.initializing-*; do
+    if [ -e "${preserved_source_state}" ] || \
+       [ -L "${preserved_source_state}" ]; then
+        error "Found preserved native output state: ${preserved_source_state}. Inspect and recover or remove it before retrying."
+    fi
+done
+
+if [ "${VLC_SOURCE_WAS_CLONED}" = yes ]; then
     git checkout -B build "${VLC_HASH}"
-    cd ..
 else
-    cd vlc
     # Only reset the whole checkout if HEAD isn't already at the pinned commit.
     # Step 1b verifies the exact ordered patch result and restores only
     # mismatching patch-owned paths, preserving source mtimes, unrelated
@@ -965,10 +1317,7 @@ else
     else
         info "VLC source already at ${VLC_HASH}"
     fi
-    cd ..
 fi
-
-VLC_SRC="${BUILD_DIR}/vlc"
 
 # Resolve the requested revision to a full commit ID before applying any
 # uncommitted source patches. This keeps build logs auditable even when VLC_HASH
@@ -1087,8 +1436,6 @@ if [ -n "${PATCHES_DIR}" ] && [ -d "${PATCHES_DIR}" ]; then
        [ "$CLEAN_BUILD" != yes ]; then
         error "Patch 0039 requires --clean-build; cached libaom configuration or objects cannot be reused."
     fi
-    cd "${VLC_SRC}"
-
     # Ordered patches can intentionally overlap (0003 refines code introduced
     # by 0002), which makes a per-patch reverse-check ambiguous on a subsequent
     # run. Build the expected final tree in a temporary Git index first. If the
@@ -1250,7 +1597,6 @@ if [ -n "${PATCHES_DIR}" ] && [ -d "${PATCHES_DIR}" ]; then
         info "Validating Chromecast music metadata and one-shot warnings..."
         "${SCRIPT_DIR}/validate-chromecast-metadata-warning.sh" "${VLC_SRC}"
     fi
-    cd "${BUILD_DIR}"
 fi
 
 # The ordered manifest, rather than whichever checked-in header happens to be
@@ -1785,11 +2131,16 @@ patch_vlc_disable_rust
 
 # --- Step 2: Build tools ---
 info "Building VLC build tools..."
-export PATH="${VLC_SRC}/extras/tools/build/bin:$PATH"
+HOST_BUILD_PATH="$PATH"
+(
 cd "${VLC_SRC}/extras/tools"
+TOOLS_SOURCE_DIRECTORY=$(/bin/pwd -P)
+export PATH="${TOOLS_SOURCE_DIRECTORY}/build/bin:${HOST_BUILD_PATH}"
 ./bootstrap
 make ${MAKEFLAGS}
-cd "${BUILD_DIR}"
+)
+VLC_TOOLS_BIN=$(cd "${VLC_SRC}/extras/tools/build/bin" && /bin/pwd -P)
+export PATH="${VLC_TOOLS_BIN}:${HOST_BUILD_PATH}"
 
 # Patches 0028/0034's linked gates use the tools produced above. Run them
 # before any platform compile so malformed Cast JSON handling, unreachable
@@ -1849,15 +2200,16 @@ compile_libvlc() {
     # This matches what VLC's build.sh creates internally
     local BUILDDIR="${VLC_SRC}/build-${PLATFORM}-${ACTUAL_ARCH}"
     mkdir -p "${BUILDDIR}"
+    (
     cd "${BUILDDIR}"
 
-    "${VLC_SRC}/extras/package/apple/build.sh" \
+    PATH="${VLC_TOOLS_BIN}:${HOST_BUILD_PATH}" \
+    "../extras/package/apple/build.sh" \
         --arch="${ARCH}" \
         --sdk="${PLATFORM}${SDK_VERSION}" \
         "${VLC_DEBUG_ARGS[@]}" \
         ${MAKEFLAGS}
-
-    cd "${BUILD_DIR}"
+    )
 
     local platform_end=$(date +%s)
     local platform_secs=$((platform_end - platform_start))
@@ -1881,16 +2233,17 @@ compile_libvlc_catalyst() {
     # Use a separate build directory to avoid colliding with native macOS builds
     local BUILDDIR="${VLC_SRC}/build-maccatalyst-${ACTUAL_ARCH}"
     mkdir -p "${BUILDDIR}"
+    (
     cd "${BUILDDIR}"
 
-    "${VLC_SRC}/extras/package/apple/build.sh" \
+    PATH="${VLC_TOOLS_BIN}:${HOST_BUILD_PATH}" \
+    "../extras/package/apple/build.sh" \
         --arch="${ARCH}" \
         --sdk="macosx${SDK_VERSION}" \
         --catalyst \
         "${VLC_DEBUG_ARGS[@]}" \
         ${MAKEFLAGS}
-
-    cd "${BUILD_DIR}"
+    )
 
     local platform_end=$(date +%s)
     local platform_secs=$((platform_end - platform_start))
@@ -1934,8 +2287,8 @@ if [ "$BUILD_IOS" = "yes" ]; then
     cp "${VLC_SRC}/build-iphoneos-arm64/static-lib/libvlc-full-static.a" \
        "${BUILD_DIR}/libs/ios-device/libvlc.a"
 
-    XCFRAMEWORK_ARGS+=(-library "${BUILD_DIR}/libs/ios-device/libvlc.a" -headers "${REPO_ROOT}/Sources/CLibVLC/include")
-    XCFRAMEWORK_ARGS+=(-library "${BUILD_DIR}/libs/ios-simulator/libvlc.a" -headers "${REPO_ROOT}/Sources/CLibVLC/include")
+    XCFRAMEWORK_ARGS+=(-library "${NATIVE_BUILD_DIRECTORY}/libs/ios-device/libvlc.a" -headers "${REPO_ROOT}/Sources/CLibVLC/include")
+    XCFRAMEWORK_ARGS+=(-library "${NATIVE_BUILD_DIRECTORY}/libs/ios-simulator/libvlc.a" -headers "${REPO_ROOT}/Sources/CLibVLC/include")
 fi
 
 if [ "$BUILD_TVOS" = "yes" ]; then
@@ -1953,8 +2306,8 @@ if [ "$BUILD_TVOS" = "yes" ]; then
     cp "${VLC_SRC}/build-appletvos-arm64/static-lib/libvlc-full-static.a" \
        "${BUILD_DIR}/libs/tvos-device/libvlc.a"
 
-    XCFRAMEWORK_ARGS+=(-library "${BUILD_DIR}/libs/tvos-device/libvlc.a" -headers "${REPO_ROOT}/Sources/CLibVLC/include")
-    XCFRAMEWORK_ARGS+=(-library "${BUILD_DIR}/libs/tvos-simulator/libvlc.a" -headers "${REPO_ROOT}/Sources/CLibVLC/include")
+    XCFRAMEWORK_ARGS+=(-library "${NATIVE_BUILD_DIRECTORY}/libs/tvos-device/libvlc.a" -headers "${REPO_ROOT}/Sources/CLibVLC/include")
+    XCFRAMEWORK_ARGS+=(-library "${NATIVE_BUILD_DIRECTORY}/libs/tvos-simulator/libvlc.a" -headers "${REPO_ROOT}/Sources/CLibVLC/include")
 fi
 
 if [ "$BUILD_VISIONOS" = "yes" ]; then
@@ -1972,8 +2325,8 @@ if [ "$BUILD_VISIONOS" = "yes" ]; then
     cp "${VLC_SRC}/build-xros-arm64/static-lib/libvlc-full-static.a" \
        "${BUILD_DIR}/libs/visionos-device/libvlc.a"
 
-    XCFRAMEWORK_ARGS+=(-library "${BUILD_DIR}/libs/visionos-device/libvlc.a" -headers "${REPO_ROOT}/Sources/CLibVLC/include")
-    XCFRAMEWORK_ARGS+=(-library "${BUILD_DIR}/libs/visionos-simulator/libvlc.a" -headers "${REPO_ROOT}/Sources/CLibVLC/include")
+    XCFRAMEWORK_ARGS+=(-library "${NATIVE_BUILD_DIRECTORY}/libs/visionos-device/libvlc.a" -headers "${REPO_ROOT}/Sources/CLibVLC/include")
+    XCFRAMEWORK_ARGS+=(-library "${NATIVE_BUILD_DIRECTORY}/libs/visionos-simulator/libvlc.a" -headers "${REPO_ROOT}/Sources/CLibVLC/include")
 fi
 
 if [ "$BUILD_MACOS" = "yes" ]; then
@@ -1986,7 +2339,7 @@ if [ "$BUILD_MACOS" = "yes" ]; then
         "${VLC_SRC}/build-macosx-x86_64/static-lib/libvlc-full-static.a" \
         -create -output "${BUILD_DIR}/libs/macos/libvlc.a"
 
-    XCFRAMEWORK_ARGS+=(-library "${BUILD_DIR}/libs/macos/libvlc.a" -headers "${REPO_ROOT}/Sources/CLibVLC/include")
+    XCFRAMEWORK_ARGS+=(-library "${NATIVE_BUILD_DIRECTORY}/libs/macos/libvlc.a" -headers "${REPO_ROOT}/Sources/CLibVLC/include")
 fi
 
 if [ "$BUILD_CATALYST" = "yes" ]; then
@@ -2002,7 +2355,7 @@ if [ "$BUILD_CATALYST" = "yes" ]; then
         "${VLC_SRC}/build-maccatalyst-x86_64/static-lib/libvlc-full-static.a" \
         -create -output "${BUILD_DIR}/libs/maccatalyst/libvlc.a"
 
-    XCFRAMEWORK_ARGS+=(-library "${BUILD_DIR}/libs/maccatalyst/libvlc.a" -headers "${REPO_ROOT}/Sources/CLibVLC/include")
+    XCFRAMEWORK_ARGS+=(-library "${NATIVE_BUILD_DIRECTORY}/libs/maccatalyst/libvlc.a" -headers "${REPO_ROOT}/Sources/CLibVLC/include")
 fi
 
 # --- Step 4: Create XCFramework ---
@@ -2010,14 +2363,44 @@ if [ ${#XCFRAMEWORK_ARGS[@]} -eq 0 ]; then
     error "No platforms were built. Use --macos, --ios-only, --tvos-only, --visionos-only, --catalyst-only, --tvos, --visionos, --macos, --catalyst, or --all"
 fi
 
+# Build and validate the complete release payload beneath the already-anchored
+# VLC source CWD. Vendor is touched again only during the final bound publish,
+# so replacing the checkout path during a long native build cannot redirect
+# any intermediate deletion or mutation.
+STAGED_OUTPUT_CHILD=".swiftvlc-native-output"
+if [ -e "${STAGED_OUTPUT_CHILD}" ] || [ -L "${STAGED_OUTPUT_CHILD}" ]; then
+    error "Stable native output staging path already exists; inspect or clean the managed build before retrying: ${STAGED_OUTPUT_CHILD}"
+fi
+if ! PYTHONDONTWRITEBYTECODE=1 python3 \
+    "${SCRIPT_DIR}/detach-managed-build-directory.py" initialize \
+    --root . \
+    --child "${STAGED_OUTPUT_CHILD}" \
+    --marker-name "${STAGED_OUTPUT_MARKER}" \
+    --marker-content "${STAGED_OUTPUT_MARKER_CONTENT}" \
+    --binding-name "${STAGED_OUTPUT_BINDING_NAME}" \
+    --binding-content "${STAGED_OUTPUT_BINDING_CONTENT}" \
+    --require-new; then
+    error "Could not create stable native output staging directory."
+fi
+PUBLISHED_OUTPUT_DIR="${REPO_ROOT}/Vendor"
+(
+cd "${STAGED_OUTPUT_CHILD}"
+verify_directory_binding \
+    "${STAGED_OUTPUT_BINDING_NAME}" "${STAGED_OUTPUT_BINDING_CONTENT}" \
+    "Native output staging directory"
+STAGED_OUTPUT_DIRECTORY=$(/bin/pwd -P)
+if [ "${STAGED_OUTPUT_DIRECTORY}" != \
+     "${VLC_SOURCE_DIRECTORY}/${STAGED_OUTPUT_CHILD}" ]; then
+    error "Native output staging path changed before it was anchored."
+fi
+OUTPUT_DIR="."
+# The output phase remains in its own anchored CWD. Source inputs use the
+# physical path captured while the parent shell was still anchored in VLC.
+VLC_SRC="${VLC_SOURCE_DIRECTORY}"
+BUILD_DIR="${NATIVE_BUILD_DIRECTORY}"
+
 info "Creating libvlc.xcframework..."
-mkdir -p "${OUTPUT_DIR}"
 MACHO_METADATA_REPORT="${OUTPUT_DIR}/libvlc-macho-metadata.json"
-rm -f "${OUTPUT_DIR}/libvlc-provenance-a.json" \
-    "${OUTPUT_DIR}/libvlc-provenance.json" \
-    "${OUTPUT_DIR}/libvlc-reproducibility.json" \
-    "${MACHO_METADATA_REPORT}"
-rm -rf "${OUTPUT_DIR}/libvlc.xcframework"
 
 xcodebuild -create-xcframework \
     "${XCFRAMEWORK_ARGS[@]}" \
@@ -2256,8 +2639,9 @@ info "Verified every Mach-O object; report: ${MACHO_METADATA_REPORT}"
 #
 # Provenance is deliberately written only after the complete per-object metadata
 # gate passes. The artifact is also stripped above, before hashing, so the two-
-# clean-build proof covers the exact tree release.sh packages; no post-proof
-# rebind is permitted.
+# clean-build proof covers the exact tree release.sh packages. Final publication
+# copies that immutable tree into an invocation-private Vendor staging directory
+# and verifies the provenance tree digest again before replacing the old output.
 if [ "${CLEAN_BUILD}" = yes ]; then
     # Recheck after compilation so a checkout edit or branch move during the
     # long build cannot be attributed to the revision captured at startup.
@@ -2275,6 +2659,7 @@ provenance_args=(
     --source-date-epoch "${SOURCE_DATE_EPOCH}"
     --build-invocation-id "${BUILD_INVOCATION_ID}"
     --build-configuration-file "build-libvlc.sh=${SCRIPT_DIR}/build-libvlc.sh"
+    --build-configuration-file "detach-managed-build-directory.py=${SCRIPT_DIR}/detach-managed-build-directory.py"
     --build-configuration-file "fix-duplicate-symbols.sh=${SCRIPT_DIR}/fix-duplicate-symbols.sh"
     --build-configuration-file "validate-libvlc-macho-metadata.py=${SCRIPT_DIR}/validate-libvlc-macho-metadata.py"
     --build-configuration-file "verify-libvlc-build-paths.py=${SCRIPT_DIR}/verify-libvlc-build-paths.py"
@@ -2307,11 +2692,156 @@ fi
 "${provenance_args[@]}"
 info "Recorded verified build provenance: ${PROVENANCE_FILE}"
 
+# Publish only the fully validated payload. The helper binds the exact Vendor
+# directory without following a symlink; the publishing shell then stays in
+# that directory and uses only direct relative destinations. A checkout-path
+# replacement therefore cannot redirect deletion into unrelated data.
+if [ "$(/bin/pwd -P)" != "${STAGED_OUTPUT_DIRECTORY}" ]; then
+    error "Native output staging path changed before artifact publication."
+fi
+verify_directory_binding \
+    "${STAGED_OUTPUT_BINDING_NAME}" "${STAGED_OUTPUT_BINDING_CONTENT}" \
+    "Native output staging directory"
+STAGED_OUTPUT_DIRECTORY=$(cd "${OUTPUT_DIR}" && /bin/pwd -P)
+if [ "${STAGED_OUTPUT_DIRECTORY}" != \
+     "${VLC_SOURCE_DIRECTORY}/${STAGED_OUTPUT_CHILD}" ]; then
+    error "Invocation output path changed before publication."
+fi
+STAGED_PROVENANCE_SHA256=$(shasum -a 256 \
+    "${STAGED_OUTPUT_DIRECTORY}/libvlc-provenance.json" | awk '{print $1}')
+STAGED_MACHO_REPORT_SHA256=$(shasum -a 256 \
+    "${STAGED_OUTPUT_DIRECTORY}/libvlc-macho-metadata.json" | awk '{print $1}')
+if ! [[ "${STAGED_PROVENANCE_SHA256}" =~ ^[0-9a-f]{64}$ ]] || \
+   ! [[ "${STAGED_MACHO_REPORT_SHA256}" =~ ^[0-9a-f]{64}$ ]]; then
+    error "Could not capture exact staged-output identities before publication."
+fi
+(
+cd "${REPO_ROOT}/Vendor"
+retire_directory_binding \
+    "${OUTPUT_BINDING_NAME}" "${OUTPUT_BINDING_CONTENT}" \
+    "Checkout Vendor output directory"
+
+PUBLISHING_CHILD=".swiftvlc-native-output-publishing-${BUILD_INVOCATION_ID}"
+if ! bind_directory_for_handoff \
+    . "${PUBLISHING_CHILD}" \
+    "${PUBLISHING_BINDING_NAME}" "${PUBLISHING_BINDING_CONTENT}" \
+    --create; then
+    error "Could not safely initialize the Vendor publication staging directory."
+fi
+(
+cd "${PUBLISHING_CHILD}"
+verify_directory_binding \
+    "${PUBLISHING_BINDING_NAME}" "${PUBLISHING_BINDING_CONTENT}" \
+    "Vendor publication staging directory"
+/usr/bin/ditto \
+    "${STAGED_OUTPUT_DIRECTORY}/libvlc.xcframework" \
+    ./libvlc.xcframework
+cp -p "${STAGED_OUTPUT_DIRECTORY}/libvlc-provenance.json" \
+    ./libvlc-provenance.json
+cp -p "${STAGED_OUTPUT_DIRECTORY}/libvlc-macho-metadata.json" \
+    ./libvlc-macho-metadata.json
+
+# libvlc-provenance.py's tree identity includes entry kinds, permissions,
+# symlink targets, and file bytes. First bind the copied provenance/report to
+# hashes captured while the source CWD was still anchored, then verify the copy
+# against that immutable provenance record. Re-reading a replaceable source
+# pathname can therefore never make two attacker substitutions compare equal.
+PUBLISHED_PROVENANCE_SHA256=$(shasum -a 256 \
+    ./libvlc-provenance.json | awk '{print $1}')
+PUBLISHED_MACHO_REPORT_SHA256=$(shasum -a 256 \
+    ./libvlc-macho-metadata.json | awk '{print $1}')
+if [ "${PUBLISHED_PROVENANCE_SHA256}" != "${STAGED_PROVENANCE_SHA256}" ]; then
+    error "Published provenance record differs from its validated staging input."
+fi
+if [ "${PUBLISHED_MACHO_REPORT_SHA256}" != "${STAGED_MACHO_REPORT_SHA256}" ]; then
+    error "Published Mach-O report differs from its validated staging input."
+fi
+PYTHONDONTWRITEBYTECODE=1 python3 - \
+    "${SCRIPT_DIR}/libvlc-provenance.py" \
+    ./libvlc-provenance.json \
+    ./libvlc.xcframework <<'PYEOF'
+import importlib.util
+import sys
+from pathlib import Path
+
+module_path, provenance_path, published_path = map(Path, sys.argv[1:])
+spec = importlib.util.spec_from_file_location("swiftvlc_provenance", module_path)
+if spec is None or spec.loader is None:
+    raise SystemExit("could not load libVLC provenance implementation")
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+record = module.load_record(provenance_path)
+module.verify_recorded_artifact(record, published_path, "published XCFramework")
+PYEOF
+)
+
+if [ -L ./libvlc.xcframework ]; then
+    # rm of a final symlink removes that one Vendor entry and never follows it.
+    rm -f ./libvlc.xcframework
+elif [ -e ./libvlc.xcframework ]; then
+    if [ ! -d ./libvlc.xcframework ]; then
+        error "Existing Vendor/libvlc.xcframework is not a directory or symlink."
+    fi
+    if ! bind_directory_for_handoff \
+        . libvlc.xcframework \
+        "${PUBLISHED_ARTIFACT_REMOVAL_BINDING_NAME}" \
+        "${PUBLISHED_ARTIFACT_REMOVAL_BINDING_CONTENT}"; then
+        error "Could not safely authorize replacement of the existing XCFramework."
+    fi
+    if ! PYTHONDONTWRITEBYTECODE=1 python3 \
+        "${SCRIPT_DIR}/detach-managed-build-directory.py" clean \
+        --root . \
+        --child libvlc.xcframework \
+        --quarantine ".swiftvlc-published-artifact.removing-${BUILD_INVOCATION_ID}" \
+        --marker-name "${PUBLISHED_ARTIFACT_REMOVAL_BINDING_NAME}" \
+        --marker-content "${PUBLISHED_ARTIFACT_REMOVAL_BINDING_CONTENT}"; then
+        error "Existing XCFramework replacement stopped safely; inspect the preserved Vendor quarantine."
+    fi
+fi
+rm -f ./libvlc-provenance-a.json \
+    ./libvlc-provenance.json \
+    ./libvlc-reproducibility.json \
+    ./libvlc-macho-metadata.json
+# Publish in commit order with atomic no-replace renames. Provenance is last:
+# if any earlier move fails, release.sh cannot mistake a partial handoff for a
+# complete artifact, and the helper leaves all state in place for inspection.
+if ! PYTHONDONTWRITEBYTECODE=1 python3 \
+    "${SCRIPT_DIR}/detach-managed-build-directory.py" publish \
+    --root . \
+    --child "${PUBLISHING_CHILD}" \
+    --marker-name "${BUILD_DIRECTORY_MARKER}" \
+    --marker-content "${BUILD_DIRECTORY_MARKER_CONTENT}" \
+    --binding-name "${PUBLISHING_BINDING_NAME}" \
+    --binding-content "${PUBLISHING_BINDING_CONTENT}" \
+    --entry libvlc.xcframework \
+    --entry libvlc-macho-metadata.json \
+    --entry libvlc-provenance.json; then
+    error "Verified native artifact publication stopped safely; inspect the preserved Vendor publication state."
+fi
+)
+info "Published verified native artifact: ${PUBLISHED_OUTPUT_DIR}/libvlc.xcframework"
+)
+# The published copy has already passed the exact tree-digest comparison.
+# Retire the source staging tree through the same fd-relative cleanup used for
+# the main external build directory. Its invocation-unique binding stays live
+# for the entire output phase and authorizes this exact generation; a static
+# ownership marker alone must never authorize a replacement at the public path.
+if ! PYTHONDONTWRITEBYTECODE=1 python3 \
+    "${SCRIPT_DIR}/detach-managed-build-directory.py" clean \
+    --root . \
+    --child "${STAGED_OUTPUT_CHILD}" \
+    --quarantine ".swiftvlc-native-output.removing-${BUILD_INVOCATION_ID}" \
+    --marker-name "${STAGED_OUTPUT_BINDING_NAME}" \
+    --marker-content "${STAGED_OUTPUT_BINDING_CONTENT}"; then
+    error "Published successfully, but could not safely retire native output staging."
+fi
+
 echo ""
 info "Build complete!"
-echo "  XCFramework: ${OUTPUT_DIR}/libvlc.xcframework"
+echo "  XCFramework: ${PUBLISHED_OUTPUT_DIR}/libvlc.xcframework"
 echo "  Architectures:"
-find "${OUTPUT_DIR}/libvlc.xcframework" -name "*.a" -exec lipo -info {} \;
+find "${PUBLISHED_OUTPUT_DIR}/libvlc.xcframework" -name "*.a" -exec lipo -info {} \;
 
 local_end=$(date +%s)
 local_total=$((local_end - BUILD_START_TIME))
@@ -2320,3 +2850,4 @@ echo ""
 echo "  Total time: ${local_mins}m$((local_total % 60))s"
 echo ""
 echo "To use: run 'swift build' in the SwiftVLC directory"
+)

--- a/scripts/detach-managed-build-directory.py
+++ b/scripts/detach-managed-build-directory.py
@@ -1,0 +1,2289 @@
+#!/usr/bin/env python3
+"""Safely initialize, detach, and revalidate a managed build directory."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import errno
+import hashlib
+import json
+import os
+import secrets
+import stat
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+PAYLOAD_NAME = "payload"
+IDENTITY_NAME = "identity.json"
+IDENTITY_SCHEMA = "org.harflabs.swiftvlc.detached-managed-build-directory"
+IDENTITY_VERSION = 1
+MAX_IDENTITY_BYTES = 4096
+REMOVE_ATTEMPTS = 5
+REMOVE_RETRY_DELAY_SECONDS = 1
+STAGING_PREFIX = ".swiftvlc-managed-build.initializing-"
+LOCK_STAGING_PREFIX = ".swiftvlc-lock.initializing-"
+
+
+class SafetyError(Exception):
+    """A filesystem state failed a safety invariant."""
+
+
+class ChildAbsentError(Exception):
+    """The public managed child did not exist when detachment began."""
+
+
+@dataclass
+class DetachedContext:
+    root: str
+    child: str
+    quarantine: str
+    marker_name: str
+    marker_bytes: bytes
+    root_fd: int
+    root_metadata: os.stat_result
+    quarantine_fd: int
+    quarantine_metadata: os.stat_result
+    payload_fd: int
+    payload_metadata: os.stat_result
+
+    @property
+    def recovery_path(self) -> str:
+        return os.path.join(self.root, self.quarantine, PAYLOAD_NAME)
+
+    def close(self) -> None:
+        for descriptor_name in ("payload_fd", "quarantine_fd", "root_fd"):
+            descriptor = getattr(self, descriptor_name)
+            if descriptor >= 0:
+                try:
+                    os.close(descriptor)
+                finally:
+                    setattr(self, descriptor_name, -1)
+
+
+def required_flag(name: str) -> int:
+    value = getattr(os, name, None)
+    if value is None:
+        raise SafetyError(f"this platform does not provide required {name} support")
+    return int(value)
+
+
+def directory_open_flags() -> int:
+    return (
+        os.O_RDONLY
+        | required_flag("O_DIRECTORY")
+        | required_flag("O_NOFOLLOW")
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+
+
+def regular_read_flags() -> int:
+    return (
+        os.O_RDONLY
+        | required_flag("O_NOFOLLOW")
+        | required_flag("O_NONBLOCK")
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+
+
+def regular_create_flags() -> int:
+    return (
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | required_flag("O_NOFOLLOW")
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+
+
+def rename_noreplace(
+    source_parent_fd: int,
+    source_name: str,
+    destination_parent_fd: int,
+    destination_name: str,
+) -> None:
+    """Atomically rename a single component without replacing a destination."""
+
+    source = os.fsencode(source_name)
+    destination = os.fsencode(destination_name)
+    library = ctypes.CDLL(None, use_errno=True)
+    function: Any
+    flags: int
+    if sys.platform == "darwin":
+        function = getattr(library, "renameatx_np", None)
+        flags = 0x00000004  # RENAME_EXCL
+    elif sys.platform.startswith("linux"):
+        function = getattr(library, "renameat2", None)
+        flags = 0x00000001  # RENAME_NOREPLACE
+    else:
+        function = None
+        flags = 0
+    if function is None:
+        raise SafetyError(
+            "this platform has no supported atomic no-replace rename primitive"
+        )
+    function.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    ]
+    function.restype = ctypes.c_int
+    ctypes.set_errno(0)
+    result = function(
+        source_parent_fd,
+        source,
+        destination_parent_fd,
+        destination,
+        flags,
+    )
+    if result != 0:
+        error_number = ctypes.get_errno()
+        raise OSError(
+            error_number,
+            os.strerror(error_number),
+            f"{source_name} -> {destination_name}",
+        )
+
+
+def validate_component(value: str, description: str) -> None:
+    if not value or value in (".", "..") or "/" in value or "\0" in value:
+        raise SafetyError(
+            f"{description} must be one non-special path component: {value!r}"
+        )
+
+
+def validate_root(root: str) -> None:
+    if root == ".":
+        return
+    if not os.path.isabs(root):
+        raise SafetyError(f"root must be an absolute path or exactly '.': {root}")
+    if os.path.normpath(root) != root:
+        raise SafetyError(f"root must be a normalized absolute path: {root}")
+
+
+def expected_utf8_line(content: str, description: str) -> bytes:
+    try:
+        return content.encode("utf-8") + b"\n"
+    except UnicodeEncodeError as error:
+        raise SafetyError(f"{description} is not valid UTF-8 text: {error}")
+
+
+def expected_marker_bytes(marker_content: str) -> bytes:
+    return expected_utf8_line(marker_content, "marker content")
+
+
+def binding_specification(
+    binding_name: Optional[str],
+    binding_content: Optional[str],
+    marker_name: str,
+) -> Optional[Tuple[str, bytes]]:
+    if (binding_name is None) != (binding_content is None):
+        raise SafetyError(
+            "--binding-name and --binding-content must be provided together"
+        )
+    if binding_name is None or binding_content is None:
+        return None
+    validate_component(binding_name, "binding name")
+    if binding_name == marker_name:
+        raise SafetyError("binding and marker names must differ")
+    return binding_name, expected_utf8_line(binding_content, "binding content")
+
+
+def same_identity(left: os.stat_result, right: os.stat_result) -> bool:
+    return left.st_dev == right.st_dev and left.st_ino == right.st_ino
+
+
+def describe_identity(metadata: os.stat_result) -> str:
+    return f"device={metadata.st_dev}, inode={metadata.st_ino}"
+
+
+def filesystem_identifier(directory_fd: int, description: str) -> Optional[int]:
+    """Return an opened directory's filesystem ID when the platform exposes it."""
+
+    fstatvfs = getattr(os, "fstatvfs", None)
+    if fstatvfs is None:
+        if sys.platform == "darwin":
+            raise SafetyError(
+                f"cannot verify filesystem identity for {description}: "
+                "os.fstatvfs is unavailable"
+            )
+        return None
+    try:
+        filesystem_metadata = fstatvfs(directory_fd)
+    except OSError as error:
+        raise SafetyError(
+            f"cannot inspect filesystem identity for {description}: {error}"
+        )
+    identifier = getattr(filesystem_metadata, "f_fsid", None)
+    if identifier is None:
+        if sys.platform == "darwin":
+            raise SafetyError(
+                f"cannot verify filesystem identity for {description}: "
+                "f_fsid is unavailable"
+            )
+        return None
+    try:
+        return int(identifier)
+    except (TypeError, ValueError) as error:
+        raise SafetyError(f"filesystem identity for {description} is invalid: {error}")
+
+
+def require_opened_directory_containment(
+    parent_fd: int,
+    parent_metadata: os.stat_result,
+    directory_fd: int,
+    directory_metadata: os.stat_result,
+    description: str,
+) -> None:
+    """Reject a child opened across either a device or filesystem boundary."""
+
+    if parent_metadata.st_dev != directory_metadata.st_dev:
+        raise SafetyError(
+            f"refusing {description} across a device/filesystem identity boundary "
+            f"(parent device={parent_metadata.st_dev}; "
+            f"child device={directory_metadata.st_dev})"
+        )
+    parent_filesystem = filesystem_identifier(parent_fd, "parent directory")
+    child_filesystem = filesystem_identifier(directory_fd, description)
+    if parent_filesystem is None and child_filesystem is None:
+        return
+    if parent_filesystem is None or child_filesystem is None:
+        raise SafetyError(
+            f"cannot consistently verify device/filesystem identity for {description}"
+        )
+    if parent_filesystem != child_filesystem:
+        raise SafetyError(
+            f"refusing {description} across a device/filesystem identity boundary "
+            f"(parent filesystem={parent_filesystem}; "
+            f"child filesystem={child_filesystem})"
+        )
+
+
+def require_directory(metadata: os.stat_result, description: str) -> None:
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise SafetyError(f"{description} is not a directory")
+
+
+def require_regular(metadata: os.stat_result, description: str) -> None:
+    if not stat.S_ISREG(metadata.st_mode):
+        raise SafetyError(f"{description} is not a regular file")
+
+
+def stat_at(parent_fd: int, name: str, description: str) -> os.stat_result:
+    try:
+        return os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except OSError as error:
+        raise SafetyError(f"cannot inspect {description}: {error}")
+
+
+def require_named_directory_identity(
+    parent_fd: int,
+    name: str,
+    opened_metadata: os.stat_result,
+    description: str,
+) -> None:
+    named_metadata = stat_at(parent_fd, name, description)
+    require_directory(named_metadata, description)
+    if not same_identity(named_metadata, opened_metadata):
+        raise SafetyError(
+            f"{description} identity changed (opened {describe_identity(opened_metadata)}; "
+            f"named entry {describe_identity(named_metadata)})"
+        )
+
+
+def require_root_identity(root: str, opened_metadata: os.stat_result) -> None:
+    try:
+        named_metadata = os.stat(root, follow_symlinks=False)
+    except OSError as error:
+        raise SafetyError(f"cannot revalidate root {root}: {error}")
+    require_directory(named_metadata, f"root {root}")
+    if not same_identity(named_metadata, opened_metadata):
+        raise SafetyError(
+            f"root identity changed (opened {describe_identity(opened_metadata)}; "
+            f"named path {describe_identity(named_metadata)})"
+        )
+
+
+def open_root(root: str) -> Tuple[int, os.stat_result]:
+    validate_root(root)
+    try:
+        named_metadata = os.stat(root, follow_symlinks=False)
+    except OSError as error:
+        raise SafetyError(f"cannot inspect root {root}: {error}")
+    require_directory(named_metadata, f"root {root}")
+    try:
+        root_fd = os.open(root, directory_open_flags())
+    except OSError as error:
+        raise SafetyError(
+            f"cannot open root without following symlinks {root}: {error}"
+        )
+    try:
+        opened_metadata = os.fstat(root_fd)
+        require_directory(opened_metadata, f"root {root}")
+        if not same_identity(named_metadata, opened_metadata):
+            raise SafetyError(
+                f"root identity changed while opening {root} "
+                f"({describe_identity(named_metadata)} -> "
+                f"{describe_identity(opened_metadata)})"
+            )
+        filesystem_identifier(root_fd, f"root {root}")
+        require_root_identity(root, opened_metadata)
+        return root_fd, opened_metadata
+    except Exception:
+        os.close(root_fd)
+        raise
+
+
+def open_inherited_directory(
+    descriptor_number: int, description: str
+) -> Tuple[int, os.stat_result]:
+    """Duplicate a caller-retained directory FD for descriptor-relative work."""
+
+    if descriptor_number < 0:
+        raise SafetyError(f"{description} descriptor must be non-negative")
+    try:
+        directory_fd = os.dup(descriptor_number)
+    except OSError as error:
+        raise SafetyError(f"cannot duplicate {description} descriptor: {error}")
+    try:
+        metadata = os.fstat(directory_fd)
+        require_directory(metadata, description)
+        filesystem_identifier(directory_fd, description)
+        require_open_directory_identity(directory_fd, metadata, description)
+        return directory_fd, metadata
+    except Exception:
+        os.close(directory_fd)
+        raise
+
+
+def reject_preserved_lock_state(root_fd: int, child: str) -> None:
+    preserved = [
+        name
+        for name in list_directory(root_fd, "lock parent")
+        if name.startswith(LOCK_STAGING_PREFIX)
+    ]
+    if preserved:
+        raise SafetyError(
+            "preserved lock handoff state requires inspection before retrying: "
+            + ", ".join(preserved)
+        )
+
+
+def acquire_generation_lock(
+    root_descriptor: int,
+    child: str,
+    token_name: str,
+    token_content: str,
+) -> None:
+    """Atomically publish a generation-bound lock below an anchored root FD."""
+
+    validate_component(child, "lock name")
+    validate_component(token_name, "lock token name")
+    if token_name == child:
+        raise SafetyError("lock token name must differ from lock name")
+    token_bytes = expected_utf8_line(token_content, "lock token content")
+    root_fd, root_metadata = open_inherited_directory(
+        root_descriptor, "lock parent"
+    )
+    staging_fd = -1
+    staging_name = ""
+    try:
+        reject_preserved_lock_state(root_fd, child)
+        staging_name, staging_fd, staging_metadata = create_private_staging_directory(
+            root_fd, LOCK_STAGING_PREFIX
+        )
+        create_regular_exclusive(
+            staging_fd,
+            token_name,
+            token_bytes,
+            0o600,
+            f"private lock token {token_name}",
+        )
+        require_named_directory_identity(
+            root_fd,
+            staging_name,
+            staging_metadata,
+            f"private lock staging directory {staging_name}",
+        )
+        try:
+            rename_noreplace(root_fd, staging_name, root_fd, child)
+        except (OSError, SafetyError) as publish_error:
+            try:
+                cleanup_binding_staging_directory(
+                    root_fd,
+                    staging_name,
+                    staging_fd,
+                    staging_metadata,
+                    token_name,
+                    token_bytes,
+                    0o600,
+                )
+            except SafetyError as cleanup_error:
+                raise SafetyError(
+                    f"cannot acquire generation lock {child}: {publish_error}; "
+                    f"staging cleanup also failed: {cleanup_error}"
+                )
+            if isinstance(publish_error, OSError) and publish_error.errno == errno.EEXIST:
+                raise SafetyError(f"lock already exists: {child}")
+            raise SafetyError(
+                f"cannot acquire generation lock {child}: {publish_error}"
+            )
+
+        require_absent(root_fd, staging_name, f"published lock staging {staging_name}")
+        require_named_directory_identity(
+            root_fd, child, staging_metadata, f"generation lock {child}"
+        )
+        actual_token = read_named_regular(
+            staging_fd,
+            token_name,
+            f"generation lock token {token_name}",
+            len(token_bytes),
+        )
+        if actual_token != token_bytes:
+            raise SafetyError(f"generation lock token {token_name} changed")
+        if list_directory(staging_fd, f"generation lock {child}") != [token_name]:
+            raise SafetyError(f"generation lock {child} was unexpectedly populated")
+        require_open_directory_identity(root_fd, root_metadata, "lock parent")
+    finally:
+        if staging_fd >= 0:
+            os.close(staging_fd)
+        os.close(root_fd)
+
+
+def release_generation_lock(
+    root_descriptor: int,
+    child: str,
+    token_name: str,
+    token_content: str,
+) -> None:
+    """Retire only the caller's exact generation-bound lock."""
+
+    validate_component(child, "lock name")
+    validate_component(token_name, "lock token name")
+    token_bytes = expected_utf8_line(token_content, "lock token content")
+    root_fd, root_metadata = open_inherited_directory(
+        root_descriptor, "lock parent"
+    )
+    lock_fd = -1
+    token_removed = False
+    lock_removed = False
+    try:
+        lock_fd, lock_metadata = open_named_directory(
+            root_fd, child, f"generation lock {child}"
+        )
+        actual_token = read_named_regular(
+            lock_fd,
+            token_name,
+            f"generation lock token {token_name}",
+            len(token_bytes),
+        )
+        if actual_token != token_bytes:
+            raise SafetyError(
+                f"generation lock {child} belongs to a different invocation"
+            )
+        if list_directory(lock_fd, f"generation lock {child}") != [token_name]:
+            raise SafetyError(f"generation lock {child} is unexpectedly populated")
+        require_named_directory_identity(
+            root_fd, child, lock_metadata, f"generation lock {child}"
+        )
+        require_open_directory_identity(root_fd, root_metadata, "lock parent")
+        unlink_verified_regular(
+            lock_fd,
+            token_name,
+            token_bytes,
+            f"generation lock token {token_name}",
+        )
+        token_removed = True
+        require_named_directory_identity(
+            root_fd, child, lock_metadata, f"generation lock {child}"
+        )
+        if list_directory(lock_fd, f"generation lock {child}"):
+            raise SafetyError(f"generation lock {child} was repopulated")
+        try:
+            os.rmdir(child, dir_fd=root_fd)
+        except OSError as error:
+            raise SafetyError(f"cannot retire generation lock {child}: {error}")
+        lock_removed = True
+        require_open_directory_identity(root_fd, root_metadata, "lock parent")
+    except (OSError, SafetyError) as error:
+        if token_removed and not lock_removed:
+            try:
+                ensure_exact_regular(
+                    lock_fd,
+                    token_name,
+                    token_bytes,
+                    0o600,
+                    f"generation lock token {token_name}",
+                )
+            except SafetyError as restore_error:
+                raise SafetyError(
+                    f"{error}; lock token restoration also failed: {restore_error}"
+                )
+        raise
+    finally:
+        if lock_fd >= 0:
+            os.close(lock_fd)
+        os.close(root_fd)
+
+
+def open_named_directory(
+    parent_fd: int, name: str, description: str
+) -> Tuple[int, os.stat_result]:
+    named_metadata = stat_at(parent_fd, name, description)
+    require_directory(named_metadata, description)
+    try:
+        directory_fd = os.open(name, directory_open_flags(), dir_fd=parent_fd)
+    except OSError as error:
+        raise SafetyError(
+            f"cannot open {description} without following symlinks: {error}"
+        )
+    try:
+        opened_metadata = os.fstat(directory_fd)
+        require_directory(opened_metadata, description)
+        if not same_identity(named_metadata, opened_metadata):
+            raise SafetyError(
+                f"{description} identity changed while opening "
+                f"({describe_identity(named_metadata)} -> "
+                f"{describe_identity(opened_metadata)})"
+            )
+        try:
+            parent_metadata = os.fstat(parent_fd)
+        except OSError as error:
+            raise SafetyError(
+                f"cannot inspect parent directory for {description}: {error}"
+            )
+        require_directory(parent_metadata, f"parent directory for {description}")
+        require_opened_directory_containment(
+            parent_fd,
+            parent_metadata,
+            directory_fd,
+            opened_metadata,
+            description,
+        )
+        require_named_directory_identity(parent_fd, name, opened_metadata, description)
+        return directory_fd, opened_metadata
+    except Exception:
+        os.close(directory_fd)
+        raise
+
+
+def regular_stability_signature(metadata: os.stat_result) -> Tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_nlink,
+        metadata.st_uid,
+        metadata.st_gid,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def read_all_bounded(file_fd: int, maximum_bytes: int, description: str) -> bytes:
+    chunks: List[bytes] = []
+    total = 0
+    while True:
+        try:
+            chunk = os.read(file_fd, min(65536, maximum_bytes + 1 - total))
+        except InterruptedError:
+            continue
+        except OSError as error:
+            raise SafetyError(f"cannot read {description}: {error}")
+        if not chunk:
+            return b"".join(chunks)
+        chunks.append(chunk)
+        total += len(chunk)
+        if total > maximum_bytes:
+            raise SafetyError(
+                f"{description} exceeds the {maximum_bytes}-byte safety limit"
+            )
+
+
+def read_named_regular(
+    parent_fd: int,
+    name: str,
+    description: str,
+    maximum_bytes: int,
+) -> bytes:
+    named_before = stat_at(parent_fd, name, description)
+    require_regular(named_before, description)
+    if named_before.st_size > maximum_bytes:
+        raise SafetyError(
+            f"{description} exceeds the {maximum_bytes}-byte safety limit"
+        )
+    try:
+        file_fd = os.open(name, regular_read_flags(), dir_fd=parent_fd)
+    except OSError as error:
+        raise SafetyError(
+            f"cannot open {description} without following symlinks: {error}"
+        )
+    try:
+        opened_before = os.fstat(file_fd)
+        require_regular(opened_before, description)
+        if not same_identity(named_before, opened_before):
+            raise SafetyError(f"{description} identity changed while opening")
+        payload = read_all_bounded(file_fd, maximum_bytes, description)
+        opened_after = os.fstat(file_fd)
+        if regular_stability_signature(opened_before) != regular_stability_signature(
+            opened_after
+        ):
+            raise SafetyError(f"{description} changed while it was being read")
+        named_after = stat_at(parent_fd, name, description)
+        require_regular(named_after, description)
+        if not same_identity(opened_after, named_after):
+            raise SafetyError(f"{description} identity changed while validating")
+        return payload
+    finally:
+        os.close(file_fd)
+
+
+def verify_marker(
+    directory_fd: int, marker_name: str, marker_bytes: bytes, description: str
+) -> None:
+    actual = read_named_regular(
+        directory_fd,
+        marker_name,
+        f"{description} marker {marker_name}",
+        len(marker_bytes),
+    )
+    if actual != marker_bytes:
+        raise SafetyError(f"{description} marker contents do not match exactly")
+
+
+def write_all(file_fd: int, payload: bytes, description: str) -> None:
+    offset = 0
+    while offset < len(payload):
+        try:
+            written = os.write(file_fd, payload[offset:])
+        except InterruptedError:
+            continue
+        except OSError as error:
+            raise SafetyError(f"cannot write {description}: {error}")
+        if written <= 0:
+            raise SafetyError(f"short write while creating {description}")
+        offset += written
+
+
+def create_regular_exclusive(
+    parent_fd: int, name: str, payload: bytes, mode: int, description: str
+) -> None:
+    try:
+        file_fd = os.open(name, regular_create_flags(), mode, dir_fd=parent_fd)
+    except OSError as error:
+        raise SafetyError(f"cannot exclusively create {description}: {error}")
+    try:
+        write_all(file_fd, payload, description)
+        metadata = os.fstat(file_fd)
+        require_regular(metadata, description)
+    finally:
+        os.close(file_fd)
+    actual = read_named_regular(parent_fd, name, description, len(payload))
+    if actual != payload:
+        raise SafetyError(f"{description} did not retain its exact contents")
+
+
+def identity_document(
+    child: str,
+    marker_name: str,
+    marker_bytes: bytes,
+    payload_metadata: os.stat_result,
+) -> Dict[str, Any]:
+    return {
+        "schema": IDENTITY_SCHEMA,
+        "version": IDENTITY_VERSION,
+        "device": payload_metadata.st_dev,
+        "inode": payload_metadata.st_ino,
+        "child": child,
+        "payload": PAYLOAD_NAME,
+        "markerName": marker_name,
+        "markerSHA256": hashlib.sha256(marker_bytes).hexdigest(),
+    }
+
+
+def encode_identity(document: Dict[str, Any]) -> bytes:
+    return (json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n").encode(
+        "utf-8"
+    )
+
+
+def reject_duplicate_json_keys(pairs: List[Tuple[str, Any]]) -> Dict[str, Any]:
+    result: Dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise SafetyError(f"identity metadata repeats key {key!r}")
+        result[key] = value
+    return result
+
+
+def decode_identity(payload: bytes) -> Dict[str, Any]:
+    try:
+        text = payload.decode("utf-8")
+        document = json.loads(text, object_pairs_hook=reject_duplicate_json_keys)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise SafetyError(f"identity metadata is not valid UTF-8 JSON: {error}")
+    if not isinstance(document, dict):
+        raise SafetyError("identity metadata must be a JSON object")
+    expected_keys = {
+        "schema",
+        "version",
+        "device",
+        "inode",
+        "child",
+        "payload",
+        "markerName",
+        "markerSHA256",
+    }
+    if set(document.keys()) != expected_keys:
+        missing = sorted(expected_keys - set(document.keys()))
+        extra = sorted(set(document.keys()) - expected_keys)
+        raise SafetyError(
+            f"identity metadata has unexpected fields (missing={missing}, extra={extra})"
+        )
+    for key in ("schema", "child", "payload", "markerName", "markerSHA256"):
+        if type(document[key]) is not str:
+            raise SafetyError(f"identity metadata field {key!r} must be a string")
+    for key in ("version", "device", "inode"):
+        if type(document[key]) is not int or document[key] < 0:
+            raise SafetyError(
+                f"identity metadata field {key!r} must be a nonnegative integer"
+            )
+    return document
+
+
+def require_identity_matches(
+    document: Dict[str, Any],
+    child: str,
+    marker_name: str,
+    marker_bytes: bytes,
+    payload_metadata: os.stat_result,
+) -> None:
+    expected = identity_document(child, marker_name, marker_bytes, payload_metadata)
+    if document != expected:
+        raise SafetyError(
+            "identity metadata does not match the detached payload, marker, or names"
+        )
+
+
+def require_absent(parent_fd: int, name: str, description: str) -> None:
+    try:
+        os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return
+    except OSError as error:
+        raise SafetyError(f"cannot inspect {description}: {error}")
+    raise SafetyError(f"{description} exists unexpectedly")
+
+
+def list_directory(directory_fd: int, description: str) -> List[str]:
+    try:
+        with os.scandir(directory_fd) as entries:
+            # DirEntry metadata is intentionally ignored. Every destructive
+            # decision below obtains a fresh fd-relative, no-follow stat.
+            return sorted(entry.name for entry in entries)
+    except OSError as error:
+        raise SafetyError(f"cannot enumerate {description}: {error}")
+
+
+def unlink_verified_regular(
+    parent_fd: int,
+    name: str,
+    expected_payload: bytes,
+    description: str,
+) -> None:
+    actual = read_named_regular(parent_fd, name, description, len(expected_payload))
+    if actual != expected_payload:
+        raise SafetyError(f"{description} contents do not match exactly")
+    before = stat_at(parent_fd, name, description)
+    require_regular(before, description)
+    current = stat_at(parent_fd, name, description)
+    require_regular(current, description)
+    if not same_identity(before, current):
+        raise SafetyError(f"{description} identity changed before unlink")
+    try:
+        os.unlink(name, dir_fd=parent_fd)
+    except OSError as error:
+        raise SafetyError(f"cannot unlink {description}: {error}")
+
+
+def ensure_exact_regular(
+    parent_fd: int,
+    name: str,
+    payload: bytes,
+    mode: int,
+    description: str,
+) -> None:
+    try:
+        os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        create_regular_exclusive(parent_fd, name, payload, mode, description)
+        return
+    except OSError as error:
+        raise SafetyError(f"cannot inspect {description}: {error}")
+    actual = read_named_regular(parent_fd, name, description, len(payload))
+    if actual != payload:
+        raise SafetyError(f"{description} exists but does not match exactly")
+
+
+def cleanup_staging_directory(
+    root_fd: int,
+    staging_name: str,
+    staging_fd: int,
+    staging_metadata: os.stat_result,
+    marker_name: str,
+    marker_bytes: bytes,
+    binding_name: Optional[str] = None,
+    binding_bytes: Optional[bytes] = None,
+) -> None:
+    if (binding_name is None) != (binding_bytes is None):
+        raise SafetyError("internal staging cleanup received an incomplete binding")
+    description = f"private staging directory {staging_name}"
+    require_named_directory_identity(
+        root_fd, staging_name, staging_metadata, description
+    )
+    entries = list_directory(staging_fd, description)
+    expected_entries = [marker_name]
+    if binding_name is not None:
+        expected_entries.append(binding_name)
+    expected_entries.sort()
+    if entries != expected_entries:
+        raise SafetyError(
+            f"{description} contains unexpected entries and was preserved: {entries}"
+        )
+
+    file_specs: List[Tuple[str, bytes, int, str]] = []
+    if binding_name is not None and binding_bytes is not None:
+        file_specs.append(
+            (
+                binding_name,
+                binding_bytes,
+                0o644,
+                f"private staging binding {binding_name}",
+            )
+        )
+    file_specs.append(
+        (
+            marker_name,
+            marker_bytes,
+            0o644,
+            f"private staging marker {marker_name}",
+        )
+    )
+
+    for name, payload, _, file_description in file_specs:
+        actual = read_named_regular(staging_fd, name, file_description, len(payload))
+        if actual != payload:
+            raise SafetyError(
+                f"{file_description} contents do not match exactly; "
+                f"{description} was preserved"
+            )
+
+    removed_files: List[Tuple[str, bytes, int, str]] = []
+    try:
+        for name, payload, mode, file_description in file_specs:
+            unlink_verified_regular(staging_fd, name, payload, file_description)
+            removed_files.append((name, payload, mode, file_description))
+    except SafetyError as deletion_error:
+        restore_errors: List[str] = []
+        for name, payload, mode, file_description in reversed(removed_files):
+            try:
+                ensure_exact_regular(staging_fd, name, payload, mode, file_description)
+            except SafetyError as restore_error:
+                restore_errors.append(str(restore_error))
+        if restore_errors:
+            raise SafetyError(
+                f"could not retire staged files safely: {deletion_error}; "
+                f"restoration also failed: {'; '.join(restore_errors)}"
+            )
+        raise SafetyError(
+            f"could not retire staged files safely: {deletion_error}; removed "
+            "files were restored"
+        )
+    require_named_directory_identity(
+        root_fd, staging_name, staging_metadata, description
+    )
+    try:
+        os.rmdir(staging_name, dir_fd=root_fd)
+    except OSError as error:
+        restore_errors: List[str] = []
+        for name, payload, mode, file_description in reversed(removed_files):
+            try:
+                ensure_exact_regular(
+                    staging_fd,
+                    name,
+                    payload,
+                    mode,
+                    file_description,
+                )
+            except SafetyError as restore_error:
+                restore_errors.append(str(restore_error))
+        if restore_errors:
+            raise SafetyError(
+                f"cannot remove {description}: {error}; staged files could not "
+                f"all be restored: {'; '.join(restore_errors)}"
+            )
+        raise SafetyError(f"cannot remove {description}: {error}")
+
+
+def create_private_staging_directory(
+    root_fd: int,
+    prefix: str = STAGING_PREFIX,
+) -> Tuple[str, int, os.stat_result]:
+    for _ in range(8):
+        staging_name = prefix + secrets.token_hex(16)
+        try:
+            os.mkdir(staging_name, 0o700, dir_fd=root_fd)
+        except FileExistsError:
+            continue
+        except OSError as error:
+            raise SafetyError(f"cannot create private staging directory: {error}")
+        staging_fd, staging_metadata = open_named_directory(
+            root_fd,
+            staging_name,
+            f"private staging directory {staging_name}",
+        )
+        try:
+            os.fchmod(staging_fd, 0o700)
+        except OSError as error:
+            os.close(staging_fd)
+            raise SafetyError(f"cannot secure private staging directory: {error}")
+        staging_metadata = os.fstat(staging_fd)
+        require_named_directory_identity(
+            root_fd,
+            staging_name,
+            staging_metadata,
+            f"private staging directory {staging_name}",
+        )
+        if stat.S_IMODE(staging_metadata.st_mode) != 0o700:
+            os.close(staging_fd)
+            raise SafetyError("private staging directory does not have mode 0700")
+        return staging_name, staging_fd, staging_metadata
+    raise SafetyError("could not allocate a unique private staging directory")
+
+
+def cleanup_binding_staging_directory(
+    root_fd: int,
+    staging_name: str,
+    staging_fd: int,
+    staging_metadata: os.stat_result,
+    binding_name: str,
+    binding_bytes: bytes,
+    binding_mode: int = 0o644,
+) -> None:
+    description = f"private binding staging directory {staging_name}"
+    require_named_directory_identity(
+        root_fd, staging_name, staging_metadata, description
+    )
+    entries = list_directory(staging_fd, description)
+    if entries != [binding_name]:
+        raise SafetyError(
+            f"{description} contains unexpected entries and was preserved: {entries}"
+        )
+    unlink_verified_regular(
+        staging_fd,
+        binding_name,
+        binding_bytes,
+        f"private staged binding {binding_name}",
+    )
+    require_named_directory_identity(
+        root_fd, staging_name, staging_metadata, description
+    )
+    try:
+        os.rmdir(staging_name, dir_fd=root_fd)
+    except OSError as error:
+        try:
+            ensure_exact_regular(
+                staging_fd,
+                binding_name,
+                binding_bytes,
+                binding_mode,
+                f"private staged binding {binding_name}",
+            )
+        except SafetyError as restore_error:
+            raise SafetyError(
+                f"cannot remove {description}: {error}; its binding could not "
+                f"be restored: {restore_error}"
+            )
+        raise SafetyError(
+            f"cannot remove {description}: {error}; its binding was restored"
+        )
+
+
+def initialize(
+    root: str,
+    child: str,
+    marker_name: str,
+    marker_content: str,
+    require_new: bool = False,
+    binding_name: Optional[str] = None,
+    binding_content: Optional[str] = None,
+) -> None:
+    validate_component(child, "child")
+    validate_component(marker_name, "marker name")
+    marker_bytes = expected_marker_bytes(marker_content)
+    binding = binding_specification(binding_name, binding_content, marker_name)
+    binding_bytes = binding[1] if binding is not None else None
+    root_fd, root_metadata = open_root(root)
+    managed_fd = -1
+    staging_fd = -1
+    staging_name = ""
+    published = False
+    try:
+        staging_name, staging_fd, staging_metadata = create_private_staging_directory(
+            root_fd
+        )
+        try:
+            create_regular_exclusive(
+                staging_fd,
+                marker_name,
+                marker_bytes,
+                0o644,
+                f"private staging marker {marker_name}",
+            )
+            if binding is not None:
+                create_regular_exclusive(
+                    staging_fd,
+                    binding[0],
+                    binding[1],
+                    0o644,
+                    f"private staging binding {binding[0]}",
+                )
+            require_named_directory_identity(
+                root_fd,
+                staging_name,
+                staging_metadata,
+                f"private staging directory {staging_name}",
+            )
+            rename_noreplace(root_fd, staging_name, root_fd, child)
+            published = True
+        except OSError as error:
+            if error.errno != errno.EEXIST:
+                try:
+                    cleanup_staging_directory(
+                        root_fd,
+                        staging_name,
+                        staging_fd,
+                        staging_metadata,
+                        marker_name,
+                        marker_bytes,
+                        binding_name,
+                        binding_bytes,
+                    )
+                except SafetyError as cleanup_error:
+                    raise SafetyError(
+                        f"cannot atomically publish managed child {child}: {error}; "
+                        f"staging cleanup also failed: {cleanup_error}"
+                    )
+                raise SafetyError(
+                    f"cannot atomically publish managed child {child}: {error}"
+                )
+            cleanup_staging_directory(
+                root_fd,
+                staging_name,
+                staging_fd,
+                staging_metadata,
+                marker_name,
+                marker_bytes,
+                binding_name,
+                binding_bytes,
+            )
+            if require_new:
+                raise SafetyError(
+                    f"managed child {child} already exists but a new directory "
+                    "was required"
+                )
+
+        if published:
+            require_absent(
+                root_fd,
+                staging_name,
+                f"published staging name {staging_name}",
+            )
+            require_named_directory_identity(
+                root_fd, child, staging_metadata, f"managed child {child}"
+            )
+            verify_marker(
+                staging_fd, marker_name, marker_bytes, f"managed child {child}"
+            )
+            if binding is not None:
+                actual_binding = read_named_regular(
+                    staging_fd,
+                    binding[0],
+                    f"managed child binding {binding[0]}",
+                    len(binding[1]),
+                )
+                if actual_binding != binding[1]:
+                    raise SafetyError(
+                        f"managed child binding {binding[0]} contents do not "
+                        "match exactly"
+                    )
+            require_named_directory_identity(
+                root_fd, child, staging_metadata, f"managed child {child}"
+            )
+        else:
+            managed_fd, managed_metadata = open_named_directory(
+                root_fd, child, f"managed child {child}"
+            )
+            verify_marker(
+                managed_fd, marker_name, marker_bytes, f"managed child {child}"
+            )
+            require_named_directory_identity(
+                root_fd, child, managed_metadata, f"managed child {child}"
+            )
+            if binding is not None:
+                create_regular_exclusive(
+                    managed_fd,
+                    binding[0],
+                    binding[1],
+                    0o644,
+                    f"managed child binding {binding[0]}",
+                )
+                require_named_directory_identity(
+                    root_fd, child, managed_metadata, f"managed child {child}"
+                )
+
+        require_root_identity(root, root_metadata)
+    except (OSError, SafetyError):
+        if staging_fd >= 0 and staging_name and not published:
+            try:
+                os.stat(staging_name, dir_fd=root_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                pass
+            except OSError:
+                pass
+            else:
+                # Most paths already cleaned staging explicitly. Preserve it
+                # here rather than risk a second cleanup after interference.
+                pass
+        raise
+    finally:
+        if managed_fd >= 0:
+            os.close(managed_fd)
+        if staging_fd >= 0:
+            os.close(staging_fd)
+        os.close(root_fd)
+
+
+def bind(
+    root: str,
+    child: str,
+    binding_name: str,
+    binding_content: str,
+    create: bool = False,
+) -> None:
+    """Bind an opened directory, optionally publishing an absent binding-only child."""
+
+    validate_component(child, "child")
+    validate_component(binding_name, "binding name")
+    binding_bytes = expected_utf8_line(binding_content, "binding content")
+    root_fd, root_metadata = open_root(root)
+    child_fd = -1
+    staging_fd = -1
+    try:
+        try:
+            child_fd, child_metadata = open_named_directory(
+                root_fd, child, f"binding child {child}"
+            )
+        except SafetyError as child_error:
+            try:
+                os.stat(child, dir_fd=root_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                if not create:
+                    raise SafetyError(f"binding child {child} is absent")
+            except OSError:
+                raise child_error
+            else:
+                raise child_error
+
+            staging_name, staging_fd, staging_metadata = (
+                create_private_staging_directory(root_fd)
+            )
+            try:
+                create_regular_exclusive(
+                    staging_fd,
+                    binding_name,
+                    binding_bytes,
+                    0o644,
+                    f"private staged binding {binding_name}",
+                )
+                require_named_directory_identity(
+                    root_fd,
+                    staging_name,
+                    staging_metadata,
+                    f"private binding staging directory {staging_name}",
+                )
+                rename_noreplace(root_fd, staging_name, root_fd, child)
+            except (OSError, SafetyError) as publish_error:
+                try:
+                    cleanup_binding_staging_directory(
+                        root_fd,
+                        staging_name,
+                        staging_fd,
+                        staging_metadata,
+                        binding_name,
+                        binding_bytes,
+                    )
+                except SafetyError as cleanup_error:
+                    raise SafetyError(
+                        f"cannot atomically publish binding child {child}: "
+                        f"{publish_error}; staging cleanup also failed: "
+                        f"{cleanup_error}"
+                    )
+                raise SafetyError(
+                    f"cannot atomically publish binding child {child}: "
+                    f"{publish_error}"
+                )
+
+            require_absent(
+                root_fd,
+                staging_name,
+                f"published binding staging name {staging_name}",
+            )
+            require_named_directory_identity(
+                root_fd, child, staging_metadata, f"binding child {child}"
+            )
+            actual_binding = read_named_regular(
+                staging_fd,
+                binding_name,
+                f"child binding {binding_name}",
+                len(binding_bytes),
+            )
+            if actual_binding != binding_bytes:
+                raise SafetyError(
+                    f"child binding {binding_name} contents do not match exactly"
+                )
+            require_named_directory_identity(
+                root_fd, child, staging_metadata, f"binding child {child}"
+            )
+            require_root_identity(root, root_metadata)
+            return
+
+        require_named_directory_identity(
+            root_fd, child, child_metadata, f"binding child {child}"
+        )
+        create_regular_exclusive(
+            child_fd,
+            binding_name,
+            binding_bytes,
+            0o644,
+            f"child binding {binding_name}",
+        )
+        require_named_directory_identity(
+            root_fd, child, child_metadata, f"binding child {child}"
+        )
+        require_root_identity(root, root_metadata)
+    finally:
+        if staging_fd >= 0:
+            os.close(staging_fd)
+        if child_fd >= 0:
+            os.close(child_fd)
+        os.close(root_fd)
+
+
+def validate_publication_entries(
+    child: str, binding_name: str, entries: List[str]
+) -> None:
+    if not entries:
+        raise SafetyError("publish requires at least one --entry")
+    seen = set()
+    for entry in entries:
+        validate_component(entry, "publication entry")
+        if entry in seen:
+            raise SafetyError(f"duplicate publication entry: {entry}")
+        seen.add(entry)
+        if entry == binding_name:
+            raise SafetyError(
+                f"publication entry must differ from binding name: {entry}"
+            )
+        if entry == child:
+            raise SafetyError(
+                f"publication entry must differ from containing child: {entry}"
+            )
+
+
+def require_publication_context(
+    root: str,
+    child: str,
+    root_fd: int,
+    root_metadata: os.stat_result,
+    child_fd: int,
+    child_metadata: os.stat_result,
+) -> None:
+    require_open_directory_identity(root_fd, root_metadata, f"root {root}")
+    require_open_directory_identity(
+        child_fd, child_metadata, f"publication child {child}"
+    )
+    require_opened_directory_containment(
+        root_fd,
+        root_metadata,
+        child_fd,
+        child_metadata,
+        f"publication child {child}",
+    )
+    require_named_directory_identity(
+        root_fd, child, child_metadata, f"publication child {child}"
+    )
+    require_root_identity(root, root_metadata)
+
+
+def publish(
+    root: str,
+    child: str,
+    binding_name: str,
+    binding_content: str,
+    entries: List[str],
+) -> None:
+    """Publish an ordered set of bound child entries without unsafe rollback."""
+
+    validate_component(child, "child")
+    validate_component(binding_name, "binding name")
+    validate_publication_entries(child, binding_name, entries)
+    binding_bytes = expected_utf8_line(binding_content, "binding content")
+    root_fd, root_metadata = open_root(root)
+    child_fd = -1
+    published: List[Tuple[str, os.stat_result]] = []
+    moved_names: List[str] = []
+    try:
+        child_fd, child_metadata = open_named_directory(
+            root_fd, child, f"publication child {child}"
+        )
+        require_publication_context(
+            root,
+            child,
+            root_fd,
+            root_metadata,
+            child_fd,
+            child_metadata,
+        )
+        actual_binding = read_named_regular(
+            child_fd,
+            binding_name,
+            f"publication binding {binding_name}",
+            len(binding_bytes),
+        )
+        if actual_binding != binding_bytes:
+            raise SafetyError(
+                f"publication binding {binding_name} contents do not match exactly"
+            )
+
+        expected_child_entries = sorted([binding_name] + entries)
+        actual_child_entries = list_directory(child_fd, f"publication child {child}")
+        if actual_child_entries != expected_child_entries:
+            raise SafetyError(
+                f"publication child contains unexpected or missing entries; "
+                f"expected {expected_child_entries}, found {actual_child_entries}"
+            )
+        for entry in entries:
+            require_absent(root_fd, entry, f"publication destination {entry}")
+
+        for entry in entries:
+            require_publication_context(
+                root,
+                child,
+                root_fd,
+                root_metadata,
+                child_fd,
+                child_metadata,
+            )
+            require_absent(root_fd, entry, f"publication destination {entry}")
+            source_metadata = stat_at(child_fd, entry, f"publication source {entry}")
+            try:
+                rename_noreplace(child_fd, entry, root_fd, entry)
+            except OSError as error:
+                raise SafetyError(f"cannot atomically publish entry {entry}: {error}")
+            moved_names.append(entry)
+            destination_metadata = stat_at(
+                root_fd, entry, f"published destination {entry}"
+            )
+            if not same_identity(source_metadata, destination_metadata):
+                raise SafetyError(
+                    f"published destination {entry} is not the source entry "
+                    f"({describe_identity(source_metadata)} -> "
+                    f"{describe_identity(destination_metadata)})"
+                )
+            require_absent(child_fd, entry, f"moved publication source {entry}")
+            published.append((entry, destination_metadata))
+            require_publication_context(
+                root,
+                child,
+                root_fd,
+                root_metadata,
+                child_fd,
+                child_metadata,
+            )
+
+        for entry, expected_metadata in published:
+            destination_metadata = stat_at(
+                root_fd, entry, f"published destination {entry}"
+            )
+            if not same_identity(expected_metadata, destination_metadata):
+                raise SafetyError(
+                    f"published destination {entry} identity changed before "
+                    "publication completed"
+                )
+        remaining = list_directory(child_fd, f"publication child {child}")
+        if remaining != [binding_name]:
+            raise SafetyError(
+                f"publication child gained unexpected entries after handoff: "
+                f"{remaining}"
+            )
+
+        unlink_verified_regular(
+            child_fd,
+            binding_name,
+            binding_bytes,
+            f"publication binding {binding_name}",
+        )
+        require_publication_context(
+            root,
+            child,
+            root_fd,
+            root_metadata,
+            child_fd,
+            child_metadata,
+        )
+        if list_directory(child_fd, f"publication child {child}"):
+            ensure_exact_regular(
+                child_fd,
+                binding_name,
+                binding_bytes,
+                0o644,
+                f"publication binding {binding_name}",
+            )
+            raise SafetyError(
+                "publication child was repopulated; its exact binding was restored"
+            )
+        try:
+            os.rmdir(child, dir_fd=root_fd)
+        except OSError as error:
+            try:
+                ensure_exact_regular(
+                    child_fd,
+                    binding_name,
+                    binding_bytes,
+                    0o644,
+                    f"publication binding {binding_name}",
+                )
+            except SafetyError as restore_error:
+                raise SafetyError(
+                    f"cannot retire publication child ({error}) and could not "
+                    f"restore its binding: {restore_error}"
+                )
+            raise SafetyError(
+                f"cannot retire publication child ({error}); its exact binding "
+                "was restored"
+            )
+        require_absent(root_fd, child, f"retired publication child {child}")
+        require_root_identity(root, root_metadata)
+    except (OSError, SafetyError) as error:
+        if moved_names:
+            published_names = ", ".join(moved_names)
+            raise SafetyError(
+                f"{error}; publication stopped after moving: {published_names}. "
+                "Published destinations were left in place and no rollback was "
+                "attempted; no recursive cleanup targeted remaining child state"
+            )
+        raise
+    finally:
+        if child_fd >= 0:
+            os.close(child_fd)
+        os.close(root_fd)
+
+
+def detach_open(
+    root: str,
+    child: str,
+    quarantine: str,
+    marker_name: str,
+    marker_content: str,
+) -> DetachedContext:
+    validate_component(child, "child")
+    validate_component(quarantine, "quarantine")
+    validate_component(marker_name, "marker name")
+    if quarantine == child:
+        raise SafetyError("child and quarantine names must differ")
+    marker_bytes = expected_marker_bytes(marker_content)
+    recovery_path = os.path.join(root, quarantine, PAYLOAD_NAME)
+    root_fd, root_metadata = open_root(root)
+    child_fd = -1
+    quarantine_fd = -1
+    renamed = False
+    succeeded = False
+    try:
+        try:
+            child_fd, child_metadata = open_named_directory(
+                root_fd, child, f"managed child {child}"
+            )
+        except SafetyError as error:
+            try:
+                os.stat(child, dir_fd=root_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                raise ChildAbsentError(
+                    f"managed child is absent: {os.path.join(root, child)}"
+                )
+            except OSError:
+                pass
+            raise error
+
+        verify_marker(child_fd, marker_name, marker_bytes, f"managed child {child}")
+        require_named_directory_identity(
+            root_fd, child, child_metadata, f"managed child {child}"
+        )
+
+        try:
+            os.mkdir(quarantine, 0o700, dir_fd=root_fd)
+        except OSError as error:
+            raise SafetyError(
+                f"cannot exclusively create quarantine {quarantine}: {error}"
+            )
+        quarantine_fd, quarantine_metadata = open_named_directory(
+            root_fd, quarantine, f"quarantine {quarantine}"
+        )
+        try:
+            os.fchmod(quarantine_fd, 0o700)
+        except OSError as error:
+            raise SafetyError(f"cannot secure quarantine {quarantine}: {error}")
+        quarantine_metadata = os.fstat(quarantine_fd)
+        require_named_directory_identity(
+            root_fd,
+            quarantine,
+            quarantine_metadata,
+            f"quarantine {quarantine}",
+        )
+        if stat.S_IMODE(quarantine_metadata.st_mode) != 0o700:
+            raise SafetyError(f"quarantine {quarantine} does not have mode 0700")
+        require_absent(quarantine_fd, PAYLOAD_NAME, "quarantine payload")
+        require_absent(quarantine_fd, IDENTITY_NAME, "quarantine identity metadata")
+
+        # This is the authorization boundary: the final public-name identity
+        # check and the rename are followed by proof that the detached entry is
+        # the exact directory that was opened and verified above.
+        require_named_directory_identity(
+            root_fd, child, child_metadata, f"managed child {child}"
+        )
+        try:
+            rename_noreplace(root_fd, child, quarantine_fd, PAYLOAD_NAME)
+        except OSError as error:
+            raise SafetyError(
+                f"cannot atomically detach managed child {child}: {error}"
+            )
+        renamed = True
+
+        require_named_directory_identity(
+            root_fd,
+            quarantine,
+            quarantine_metadata,
+            f"quarantine {quarantine}",
+        )
+
+        detached_fd, payload_metadata = open_named_directory(
+            quarantine_fd, PAYLOAD_NAME, "detached payload"
+        )
+        try:
+            if not same_identity(child_metadata, payload_metadata):
+                raise SafetyError(
+                    "detached payload is not the verified managed child "
+                    f"(expected {describe_identity(child_metadata)}; found "
+                    f"{describe_identity(payload_metadata)})"
+                )
+            verify_marker(detached_fd, marker_name, marker_bytes, "detached payload")
+            require_named_directory_identity(
+                quarantine_fd,
+                PAYLOAD_NAME,
+                payload_metadata,
+                "detached payload",
+            )
+        finally:
+            os.close(detached_fd)
+
+        require_absent(root_fd, child, f"public managed child {child}")
+        require_named_directory_identity(
+            root_fd,
+            quarantine,
+            quarantine_metadata,
+            f"quarantine {quarantine}",
+        )
+        require_root_identity(root, root_metadata)
+
+        document = identity_document(child, marker_name, marker_bytes, payload_metadata)
+        encoded_document = encode_identity(document)
+        create_regular_exclusive(
+            quarantine_fd,
+            IDENTITY_NAME,
+            encoded_document,
+            0o600,
+            "quarantine identity metadata",
+        )
+        decoded_document = decode_identity(
+            read_named_regular(
+                quarantine_fd,
+                IDENTITY_NAME,
+                "quarantine identity metadata",
+                MAX_IDENTITY_BYTES,
+            )
+        )
+        require_identity_matches(
+            decoded_document, child, marker_name, marker_bytes, payload_metadata
+        )
+
+        require_named_directory_identity(
+            quarantine_fd, PAYLOAD_NAME, payload_metadata, "detached payload"
+        )
+        require_absent(root_fd, child, f"public managed child {child}")
+        require_named_directory_identity(
+            root_fd,
+            quarantine,
+            quarantine_metadata,
+            f"quarantine {quarantine}",
+        )
+        require_root_identity(root, root_metadata)
+        succeeded = True
+        return DetachedContext(
+            root=root,
+            child=child,
+            quarantine=quarantine,
+            marker_name=marker_name,
+            marker_bytes=marker_bytes,
+            root_fd=root_fd,
+            root_metadata=root_metadata,
+            quarantine_fd=quarantine_fd,
+            quarantine_metadata=quarantine_metadata,
+            payload_fd=child_fd,
+            payload_metadata=child_metadata,
+        )
+    except ChildAbsentError:
+        raise
+    except (OSError, SafetyError) as error:
+        if renamed:
+            raise SafetyError(
+                f"{error}; detached payload was not deleted and is preserved at "
+                f"{recovery_path}"
+            )
+        raise
+    finally:
+        if not succeeded:
+            if quarantine_fd >= 0:
+                os.close(quarantine_fd)
+            if child_fd >= 0:
+                os.close(child_fd)
+            os.close(root_fd)
+
+
+def detach(
+    root: str,
+    child: str,
+    quarantine: str,
+    marker_name: str,
+    marker_content: str,
+) -> None:
+    context = detach_open(root, child, quarantine, marker_name, marker_content)
+    context.close()
+
+
+def require_open_directory_identity(
+    directory_fd: int,
+    expected_metadata: os.stat_result,
+    description: str,
+) -> None:
+    try:
+        current = os.fstat(directory_fd)
+    except OSError as error:
+        raise SafetyError(f"cannot inspect opened {description}: {error}")
+    require_directory(current, description)
+    if not same_identity(current, expected_metadata):
+        raise SafetyError(f"opened {description} identity changed unexpectedly")
+
+
+def verify_detached_context(context: DetachedContext) -> None:
+    require_open_directory_identity(
+        context.root_fd, context.root_metadata, f"root {context.root}"
+    )
+    require_open_directory_identity(
+        context.quarantine_fd,
+        context.quarantine_metadata,
+        f"quarantine {context.quarantine}",
+    )
+    require_open_directory_identity(
+        context.payload_fd, context.payload_metadata, "detached payload"
+    )
+    require_opened_directory_containment(
+        context.root_fd,
+        context.root_metadata,
+        context.quarantine_fd,
+        context.quarantine_metadata,
+        f"quarantine {context.quarantine}",
+    )
+    require_opened_directory_containment(
+        context.quarantine_fd,
+        context.quarantine_metadata,
+        context.payload_fd,
+        context.payload_metadata,
+        "detached payload",
+    )
+    if stat.S_IMODE(os.fstat(context.quarantine_fd).st_mode) != 0o700:
+        raise SafetyError(f"quarantine {context.quarantine} does not have mode 0700")
+    require_named_directory_identity(
+        context.root_fd,
+        context.quarantine,
+        context.quarantine_metadata,
+        f"quarantine {context.quarantine}",
+    )
+    require_named_directory_identity(
+        context.quarantine_fd,
+        PAYLOAD_NAME,
+        context.payload_metadata,
+        "detached payload",
+    )
+    identity_payload = read_named_regular(
+        context.quarantine_fd,
+        IDENTITY_NAME,
+        "quarantine identity metadata",
+        MAX_IDENTITY_BYTES,
+    )
+    document = decode_identity(identity_payload)
+    require_identity_matches(
+        document,
+        context.child,
+        context.marker_name,
+        context.marker_bytes,
+        context.payload_metadata,
+    )
+    verify_marker(
+        context.payload_fd,
+        context.marker_name,
+        context.marker_bytes,
+        "detached payload",
+    )
+    require_absent(
+        context.root_fd,
+        context.child,
+        f"public managed child {context.child}",
+    )
+    require_root_identity(context.root, context.root_metadata)
+
+
+def open_detached_context(
+    root: str,
+    child: str,
+    quarantine: str,
+    marker_name: str,
+    marker_content: str,
+) -> DetachedContext:
+    validate_component(child, "child")
+    validate_component(quarantine, "quarantine")
+    validate_component(marker_name, "marker name")
+    if quarantine == child:
+        raise SafetyError("child and quarantine names must differ")
+    marker_bytes = expected_marker_bytes(marker_content)
+    root_fd, root_metadata = open_root(root)
+    quarantine_fd = -1
+    payload_fd = -1
+    succeeded = False
+    try:
+        quarantine_fd, quarantine_metadata = open_named_directory(
+            root_fd, quarantine, f"quarantine {quarantine}"
+        )
+        if stat.S_IMODE(quarantine_metadata.st_mode) != 0o700:
+            raise SafetyError(f"quarantine {quarantine} does not have mode 0700")
+        payload_fd, payload_metadata = open_named_directory(
+            quarantine_fd, PAYLOAD_NAME, "detached payload"
+        )
+        context = DetachedContext(
+            root=root,
+            child=child,
+            quarantine=quarantine,
+            marker_name=marker_name,
+            marker_bytes=marker_bytes,
+            root_fd=root_fd,
+            root_metadata=root_metadata,
+            quarantine_fd=quarantine_fd,
+            quarantine_metadata=quarantine_metadata,
+            payload_fd=payload_fd,
+            payload_metadata=payload_metadata,
+        )
+        verify_detached_context(context)
+        succeeded = True
+        return context
+    finally:
+        if not succeeded:
+            if payload_fd >= 0:
+                os.close(payload_fd)
+            if quarantine_fd >= 0:
+                os.close(quarantine_fd)
+            os.close(root_fd)
+
+
+def verify(
+    root: str,
+    child: str,
+    quarantine: str,
+    marker_name: str,
+    marker_content: str,
+) -> None:
+    context = open_detached_context(
+        root, child, quarantine, marker_name, marker_content
+    )
+    context.close()
+
+
+def remove_entry(
+    parent_fd: int,
+    name: str,
+    expected_device: int,
+    description: str,
+) -> bool:
+    """Remove one fd-relative entry; reject device/filesystem boundary crossings."""
+
+    try:
+        named_metadata = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return True
+    except OSError as error:
+        raise SafetyError(f"cannot inspect {description}: {error}")
+    if named_metadata.st_dev != expected_device:
+        raise SafetyError(
+            f"refusing to cross a device/filesystem identity boundary at "
+            f"{description}"
+        )
+
+    if stat.S_ISDIR(named_metadata.st_mode):
+        directory_fd = -1
+        try:
+            directory_fd, opened_metadata = open_named_directory(
+                parent_fd, name, description
+            )
+            if not same_identity(named_metadata, opened_metadata):
+                raise SafetyError(
+                    f"{description} identity changed before recursive descent"
+                )
+            if opened_metadata.st_dev != expected_device:
+                raise SafetyError(
+                    f"refusing to cross a device/filesystem identity boundary at "
+                    f"{description}"
+                )
+            for child_name in list_directory(directory_fd, description):
+                remove_entry(
+                    directory_fd,
+                    child_name,
+                    expected_device,
+                    f"{description}/{child_name}",
+                )
+            require_named_directory_identity(
+                parent_fd, name, opened_metadata, description
+            )
+            if list_directory(directory_fd, description):
+                return False
+            try:
+                os.rmdir(name, dir_fd=parent_fd)
+            except OSError as error:
+                if error.errno in (errno.ENOTEMPTY, errno.EEXIST):
+                    return False
+                raise SafetyError(f"cannot remove directory {description}: {error}")
+            return True
+        finally:
+            if directory_fd >= 0:
+                os.close(directory_fd)
+
+    current = stat_at(parent_fd, name, description)
+    if current.st_dev != expected_device or not same_identity(named_metadata, current):
+        raise SafetyError(f"{description} identity changed before unlink")
+    if stat.S_ISDIR(current.st_mode):
+        raise SafetyError(f"{description} became a directory before unlink")
+    try:
+        os.unlink(name, dir_fd=parent_fd)
+    except FileNotFoundError:
+        return True
+    except OSError as error:
+        raise SafetyError(f"cannot unlink {description}: {error}")
+    return True
+
+
+def restore_marker_after_failed_payload_rmdir(
+    context: DetachedContext, original_error: OSError
+) -> None:
+    try:
+        ensure_exact_regular(
+            context.payload_fd,
+            context.marker_name,
+            context.marker_bytes,
+            0o644,
+            f"detached payload marker {context.marker_name}",
+        )
+        require_named_directory_identity(
+            context.quarantine_fd,
+            PAYLOAD_NAME,
+            context.payload_metadata,
+            "detached payload",
+        )
+    except SafetyError as restore_error:
+        raise SafetyError(
+            f"payload removal failed ({original_error}) and its ownership marker "
+            f"could not be safely restored: {restore_error}; preserved at "
+            f"{context.recovery_path}"
+        )
+
+
+def remove_detached_context(context: DetachedContext) -> None:
+    expected_device = context.payload_metadata.st_dev
+    identity_bytes = encode_identity(
+        identity_document(
+            context.child,
+            context.marker_name,
+            context.marker_bytes,
+            context.payload_metadata,
+        )
+    )
+
+    payload_removed = False
+    for attempt in range(1, REMOVE_ATTEMPTS + 1):
+        verify_detached_context(context)
+        settled = True
+        for name in list_directory(context.payload_fd, "detached payload"):
+            if name == context.marker_name:
+                continue
+            if not remove_entry(
+                context.payload_fd,
+                name,
+                expected_device,
+                f"detached payload/{name}",
+            ):
+                settled = False
+
+        verify_detached_context(context)
+        remaining = [
+            name
+            for name in list_directory(context.payload_fd, "detached payload")
+            if name != context.marker_name
+        ]
+        if remaining or not settled:
+            if attempt < REMOVE_ATTEMPTS:
+                print(
+                    "Notice: detached build directory was repopulated during "
+                    f"cleanup (attempt {attempt}/{REMOVE_ATTEMPTS}); retrying",
+                    file=sys.stderr,
+                )
+                time.sleep(REMOVE_RETRY_DELAY_SECONDS)
+                continue
+            break
+
+        unlink_verified_regular(
+            context.payload_fd,
+            context.marker_name,
+            context.marker_bytes,
+            f"detached payload marker {context.marker_name}",
+        )
+        require_named_directory_identity(
+            context.quarantine_fd,
+            PAYLOAD_NAME,
+            context.payload_metadata,
+            "detached payload",
+        )
+        try:
+            os.rmdir(PAYLOAD_NAME, dir_fd=context.quarantine_fd)
+        except OSError as error:
+            restore_marker_after_failed_payload_rmdir(context, error)
+            if (
+                error.errno in (errno.ENOTEMPTY, errno.EEXIST)
+                and attempt < REMOVE_ATTEMPTS
+            ):
+                print(
+                    "Notice: detached build directory was repopulated during "
+                    f"final removal (attempt {attempt}/{REMOVE_ATTEMPTS}); retrying",
+                    file=sys.stderr,
+                )
+                time.sleep(REMOVE_RETRY_DELAY_SECONDS)
+                continue
+            raise SafetyError(
+                f"cannot remove detached payload after restoring its marker: {error}; "
+                f"preserved at {context.recovery_path}"
+            )
+        payload_removed = True
+        break
+
+    if not payload_removed:
+        verify_detached_context(context)
+        raise SafetyError(
+            f"detached payload did not settle after {REMOVE_ATTEMPTS} attempts; "
+            f"preserved at {context.recovery_path}"
+        )
+
+    require_absent(context.quarantine_fd, PAYLOAD_NAME, "removed detached payload")
+    require_named_directory_identity(
+        context.root_fd,
+        context.quarantine,
+        context.quarantine_metadata,
+        f"quarantine {context.quarantine}",
+    )
+    require_root_identity(context.root, context.root_metadata)
+    require_absent(
+        context.root_fd,
+        context.child,
+        f"public managed child {context.child}",
+    )
+
+    actual_identity = read_named_regular(
+        context.quarantine_fd,
+        IDENTITY_NAME,
+        "quarantine identity metadata",
+        MAX_IDENTITY_BYTES,
+    )
+    if actual_identity != identity_bytes:
+        raise SafetyError(
+            f"identity metadata changed after payload removal; preserving quarantine "
+            f"{os.path.join(context.root, context.quarantine)}"
+        )
+    entries = list_directory(context.quarantine_fd, f"quarantine {context.quarantine}")
+    if entries != [IDENTITY_NAME]:
+        raise SafetyError(
+            f"quarantine contains unexpected entries after payload removal and was "
+            f"preserved: {entries}"
+        )
+    unlink_verified_regular(
+        context.quarantine_fd,
+        IDENTITY_NAME,
+        identity_bytes,
+        "quarantine identity metadata",
+    )
+    require_named_directory_identity(
+        context.root_fd,
+        context.quarantine,
+        context.quarantine_metadata,
+        f"quarantine {context.quarantine}",
+    )
+    try:
+        os.rmdir(context.quarantine, dir_fd=context.root_fd)
+    except OSError as error:
+        try:
+            ensure_exact_regular(
+                context.quarantine_fd,
+                IDENTITY_NAME,
+                identity_bytes,
+                0o600,
+                "quarantine identity metadata",
+            )
+        except SafetyError as restore_error:
+            raise SafetyError(
+                f"cannot retire quarantine ({error}) and could not restore its "
+                f"identity metadata: {restore_error}"
+            )
+        raise SafetyError(
+            f"cannot retire quarantine after restoring its identity metadata: {error}"
+        )
+    require_absent(
+        context.root_fd,
+        context.quarantine,
+        f"retired quarantine {context.quarantine}",
+    )
+    require_root_identity(context.root, context.root_metadata)
+
+
+def remove(
+    root: str,
+    child: str,
+    quarantine: str,
+    marker_name: str,
+    marker_content: str,
+) -> None:
+    context = open_detached_context(
+        root, child, quarantine, marker_name, marker_content
+    )
+    try:
+        remove_detached_context(context)
+    finally:
+        context.close()
+
+
+def clean(
+    root: str,
+    child: str,
+    quarantine: str,
+    marker_name: str,
+    marker_content: str,
+) -> None:
+    context = detach_open(root, child, quarantine, marker_name, marker_content)
+    try:
+        remove_detached_context(context)
+    except (OSError, SafetyError) as error:
+        raise SafetyError(f"{error}; clean stopped without pathname-recursive fallback")
+    finally:
+        context.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Initialize, bind, publish, or atomically quarantine a managed "
+            "external directory without following entries through symlinks."
+        )
+    )
+    subparsers = parser.add_subparsers(dest="operation", required=True)
+
+    def add_common(subparser: argparse.ArgumentParser) -> None:
+        subparser.add_argument("--root", required=True)
+        subparser.add_argument("--child", required=True)
+        subparser.add_argument("--marker-name", required=True)
+        subparser.add_argument(
+            "--marker-content",
+            required=True,
+            help="UTF-8 marker text; exactly one trailing LF is added",
+        )
+
+    initialize_parser = subparsers.add_parser(
+        "initialize", help="exclusively create or verify the managed child"
+    )
+    add_common(initialize_parser)
+    initialize_parser.add_argument(
+        "--require-new",
+        action="store_true",
+        help="fail if the public managed child already exists",
+    )
+    initialize_parser.add_argument(
+        "--binding-name",
+        help="unique file to bind this initialization to its caller",
+    )
+    initialize_parser.add_argument(
+        "--binding-content",
+        help="UTF-8 binding text; exactly one trailing LF is added",
+    )
+
+    bind_parser = subparsers.add_parser(
+        "bind", help="exclusively bind an existing opened child directory"
+    )
+    add_common(bind_parser)
+    bind_parser.add_argument("--binding-name", required=True)
+    bind_parser.add_argument("--binding-content", required=True)
+    bind_parser.add_argument(
+        "--create",
+        action="store_true",
+        help="atomically publish a binding-only child when it is absent",
+    )
+
+    publish_parser = subparsers.add_parser(
+        "publish", help="atomically publish ordered entries from a bound child"
+    )
+    add_common(publish_parser)
+    publish_parser.add_argument("--binding-name", required=True)
+    publish_parser.add_argument("--binding-content", required=True)
+    publish_parser.add_argument(
+        "--entry",
+        action="append",
+        required=True,
+        help="direct child component to publish; repeat in publication order",
+    )
+
+    for operation in ("lock-acquire", "lock-release"):
+        lock_parser = subparsers.add_parser(
+            operation,
+            help="operate on a generation-bound lock below an inherited directory FD",
+        )
+        lock_parser.add_argument("--root-fd", type=int, required=True)
+        lock_parser.add_argument("--child", required=True)
+        lock_parser.add_argument("--token-name", required=True)
+        lock_parser.add_argument("--token-content", required=True)
+
+    for operation in ("detach", "verify", "remove", "clean"):
+        operation_parser = subparsers.add_parser(operation)
+        add_common(operation_parser)
+        operation_parser.add_argument("--quarantine", required=True)
+
+    return parser
+
+
+def main() -> int:
+    arguments = build_parser().parse_args()
+    try:
+        if arguments.operation == "initialize":
+            initialize(
+                arguments.root,
+                arguments.child,
+                arguments.marker_name,
+                arguments.marker_content,
+                arguments.require_new,
+                arguments.binding_name,
+                arguments.binding_content,
+            )
+        elif arguments.operation == "bind":
+            bind(
+                arguments.root,
+                arguments.child,
+                arguments.binding_name,
+                arguments.binding_content,
+                arguments.create,
+            )
+        elif arguments.operation == "publish":
+            publish(
+                arguments.root,
+                arguments.child,
+                arguments.binding_name,
+                arguments.binding_content,
+                arguments.entry,
+            )
+        elif arguments.operation == "lock-acquire":
+            acquire_generation_lock(
+                arguments.root_fd,
+                arguments.child,
+                arguments.token_name,
+                arguments.token_content,
+            )
+        elif arguments.operation == "lock-release":
+            release_generation_lock(
+                arguments.root_fd,
+                arguments.child,
+                arguments.token_name,
+                arguments.token_content,
+            )
+        elif arguments.operation == "detach":
+            detach(
+                arguments.root,
+                arguments.child,
+                arguments.quarantine,
+                arguments.marker_name,
+                arguments.marker_content,
+            )
+        elif arguments.operation == "verify":
+            verify(
+                arguments.root,
+                arguments.child,
+                arguments.quarantine,
+                arguments.marker_name,
+                arguments.marker_content,
+            )
+        elif arguments.operation == "remove":
+            remove(
+                arguments.root,
+                arguments.child,
+                arguments.quarantine,
+                arguments.marker_name,
+                arguments.marker_content,
+            )
+        else:
+            clean(
+                arguments.root,
+                arguments.child,
+                arguments.quarantine,
+                arguments.marker_name,
+                arguments.marker_content,
+            )
+    except ChildAbsentError as error:
+        print(f"Notice: {error}", file=sys.stderr)
+        return 3
+    except (OSError, SafetyError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+    except RecursionError:
+        print(
+            "Error: managed build tree exceeds the safe traversal depth; "
+            "cleanup stopped without a pathname-recursive fallback",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -900,6 +900,7 @@ verify_artifact_provenance() {
     --pinned-revision "$current_pin" \
     --patch-manifest "$SCRIPT_DIR/patches/manifest.sha256" \
     --build-configuration-file "build-libvlc.sh=$SCRIPT_DIR/build-libvlc.sh" \
+    --build-configuration-file "detach-managed-build-directory.py=$SCRIPT_DIR/detach-managed-build-directory.py" \
     --build-configuration-file "fix-duplicate-symbols.sh=$SCRIPT_DIR/fix-duplicate-symbols.sh" \
     --build-configuration-file "validate-libvlc-macho-metadata.py=$SCRIPT_DIR/validate-libvlc-macho-metadata.py" \
     --build-configuration-file "verify-libvlc-build-paths.py=$SCRIPT_DIR/verify-libvlc-build-paths.py" \

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,7 +3,8 @@
 # release.sh — Strip, zip, checksum, and publish the libVLC xcframework.
 #
 # Prerequisites:
-#   - Two ./scripts/build-libvlc.sh --clean-build --all invocations, compared
+#   - Two canonical-root ./scripts/build-libvlc.sh --clean-build --all
+#     invocations, compared byte-for-byte
 #     with both provenance records retained beside Vendor/libvlc.xcframework
 #   - gh authed (gh auth login)
 #   - A completely clean, up-to-date main checkout
@@ -384,7 +385,7 @@ snapshot_release_inputs() {
 
   if [[ ! -d "$source_xcframework" ]]; then
     echo "Error: $source_xcframework not found." >&2
-    echo "  Build it first: ./scripts/build-libvlc.sh --clean-build --all" >&2
+    echo "  Build it first: ./scripts/build-libvlc.sh --build-root=/absolute/path/to/shared-native-root --clean-build --all" >&2
     exit 1
   fi
   if [[ -n "$CANDIDATE_DIR" ]]; then
@@ -729,7 +730,7 @@ assert_hits=$(strings -a "$XCFW_PATH"/*/libvlc.a 2>/dev/null \
 if [[ "${assert_hits:-0}" -gt 0 ]]; then
   echo "Error: libVLC slices were built with run-time assertions enabled." >&2
   echo "  Shipping them would re-introduce the issue #30 abort() crash." >&2
-  echo "  Rebuild without --with-asserts: ./scripts/build-libvlc.sh --clean-build --all" >&2
+  echo "  Rebuild without --with-asserts: ./scripts/build-libvlc.sh --build-root=/absolute/path/to/shared-native-root --clean-build --all" >&2
   exit 1
 fi
 
@@ -884,7 +885,7 @@ verify_artifact_provenance() {
     echo "  Required: $reproducibility" >&2
     echo "  $XCFW_PATH was built before provenance was recorded, so its inputs" >&2
     echo "  cannot be established. Rebuild with:" >&2
-    echo "    ./scripts/build-libvlc.sh --clean-build --all" >&2
+    echo "    ./scripts/build-libvlc.sh --build-root=/absolute/path/to/shared-native-root --clean-build --all" >&2
     return 1
   fi
 
@@ -901,6 +902,7 @@ verify_artifact_provenance() {
     --build-configuration-file "build-libvlc.sh=$SCRIPT_DIR/build-libvlc.sh" \
     --build-configuration-file "fix-duplicate-symbols.sh=$SCRIPT_DIR/fix-duplicate-symbols.sh" \
     --build-configuration-file "validate-libvlc-macho-metadata.py=$SCRIPT_DIR/validate-libvlc-macho-metadata.py" \
+    --build-configuration-file "verify-libvlc-build-paths.py=$SCRIPT_DIR/verify-libvlc-build-paths.py" \
     --build-configuration-file "validate-apple-assembly-metadata-patch.sh=$SCRIPT_DIR/validate-apple-assembly-metadata-patch.sh" \
     --build-configuration-file "validate-aom-nasm3-detection.sh=$SCRIPT_DIR/validate-aom-nasm3-detection.sh" \
     --build-configuration-file "validate-headless-vout-teardown.sh=$SCRIPT_DIR/validate-headless-vout-teardown.sh" \
@@ -912,7 +914,7 @@ verify_artifact_provenance() {
     --build-configuration-file "native-validator-assets.sha256=$SCRIPT_DIR/native-validator-assets.sha256" \
     --build-configuration-file "verify-native-validator-assets.py=$SCRIPT_DIR/verify-native-validator-assets.py"; then
     echo "  Rebuild so every shipped slice and input has current provenance:" >&2
-    echo "    ./scripts/build-libvlc.sh --clean-build --all" >&2
+    echo "    ./scripts/build-libvlc.sh --build-root=/absolute/path/to/shared-native-root --clean-build --all" >&2
     return 1
   fi
   if ! python3 "$SCRIPT_DIR/libvlc-provenance.py" verify-proof \

--- a/scripts/tests/build-libvlc-build-root.sh
+++ b/scripts/tests/build-libvlc-build-root.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+temporary_root=$(mktemp -d "${TMPDIR:-/tmp}/swiftvlc-build-root-tests.XXXXXX")
+trap 'rm -rf "$temporary_root"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+expect_failure() {
+  local description="$1"
+  local expected="$2"
+  shift 2
+  if "$BUILD_SCRIPT" "$@" > "$temporary_root/failure.log" 2>&1; then
+    fail "$description was accepted"
+  fi
+  grep -Fq -- "$expected" "$temporary_root/failure.log" || {
+    cat "$temporary_root/failure.log" >&2
+    fail "$description did not produce the expected diagnostic"
+  }
+}
+
+fixture_repo="$temporary_root/repository"
+mkdir -p "$fixture_repo/scripts"
+cp "$SOURCE_SCRIPT_DIR/build-libvlc.sh" "$fixture_repo/scripts/build-libvlc.sh"
+git -C "$fixture_repo" init -q
+ROOT_DIR=$(cd "$fixture_repo" && pwd -P)
+BUILD_SCRIPT="$ROOT_DIR/scripts/build-libvlc.sh"
+
+external_root="$temporary_root/external-root"
+mkdir -p "$external_root"
+external_root=$(cd "$external_root" && pwd -P)
+managed_child="$external_root/swiftvlc-libvlc-build"
+lock_directory="$external_root/.swiftvlc-libvlc-build.lock"
+marker="$managed_child/.swiftvlc-managed-libvlc-build-v1"
+checkout_lock=$(git -C "$ROOT_DIR" rev-parse --git-path swiftvlc-libvlc-output.lock)
+case "$checkout_lock" in
+  /*) ;;
+  *) checkout_lock="$ROOT_DIR/$checkout_lock" ;;
+esac
+
+expect_failure \
+  "relative external build root" \
+  "--build-root must be an absolute directory path" \
+  --build-root=relative --clean
+
+expect_failure \
+  "empty external build root" \
+  "--build-root requires an absolute directory path" \
+  --build-root= --clean
+
+expect_failure \
+  "missing external build root" \
+  "External build root does not exist" \
+  --build-root="$temporary_root/missing" --clean
+
+expect_failure \
+  "build root inside the checkout" \
+  "--build-root must be outside the SwiftVLC checkout" \
+  --build-root="$ROOT_DIR" --clean
+
+root_alias="$temporary_root/root-alias"
+ln -s "$external_root" "$root_alias"
+expect_failure \
+  "non-canonical external build root" \
+  "--build-root must use its canonical physical path" \
+  --build-root="$root_alias" --clean
+
+mkdir -p "$managed_child"
+printf 'user data\n' > "$managed_child/keep.txt"
+expect_failure \
+  "unowned external build directory" \
+  "Refusing unowned external build directory" \
+  --build-root="$external_root" --clean
+[[ -f "$managed_child/keep.txt" ]] || \
+  fail "unowned external data was removed"
+
+rm -rf "$managed_child"
+mkdir -p "$temporary_root/symlink-target"
+printf 'user data\n' > "$temporary_root/symlink-target/keep.txt"
+ln -s "$temporary_root/symlink-target" "$managed_child"
+expect_failure \
+  "symlinked managed build directory" \
+  "Refusing symlinked managed build directory" \
+  --build-root="$external_root" --clean
+[[ -f "$temporary_root/symlink-target/keep.txt" ]] || \
+  fail "symlink target data was removed"
+
+rm "$managed_child"
+ln -s "$temporary_root/missing-symlink-target" "$managed_child"
+expect_failure \
+  "dangling managed build-directory symlink" \
+  "Refusing symlinked managed build directory" \
+  --build-root="$external_root" --clean
+rm "$managed_child"
+
+mkdir -p "$managed_child"
+printf 'wrong marker\n' > "$marker"
+expect_failure \
+  "incorrect managed-directory marker" \
+  "Refusing unowned external build directory" \
+  --build-root="$external_root" --clean
+
+printf 'SwiftVLC managed libVLC build directory v1\n\n' > "$marker"
+expect_failure \
+  "managed-directory marker with extra bytes" \
+  "Refusing unowned external build directory" \
+  --build-root="$external_root" --clean
+
+marker_target="$temporary_root/marker-target"
+printf 'SwiftVLC managed libVLC build directory v1\n' > "$marker_target"
+rm "$marker"
+ln -s "$marker_target" "$marker"
+expect_failure \
+  "symlinked managed-directory marker" \
+  "Refusing unowned external build directory" \
+  --build-root="$external_root" --clean
+rm "$marker"
+
+printf 'SwiftVLC managed libVLC build directory v1\n' > "$marker"
+printf 'managed data\n' > "$managed_child/remove.txt"
+printf 'sibling data\n' > "$external_root/preserve.txt"
+"$BUILD_SCRIPT" --clean --build-root="$external_root" \
+  > "$temporary_root/clean.log" 2>&1
+[[ ! -e "$managed_child" ]] || fail "managed build child was not removed"
+[[ -f "$external_root/preserve.txt" ]] || fail "build-root sibling was removed"
+[[ ! -e "$lock_directory" ]] || fail "successful cleanup left its lock behind"
+[[ ! -e "$checkout_lock" ]] || fail "successful cleanup left checkout lock behind"
+
+# If another writer replaces the managed directory between removal attempts,
+# the second attempt must not inherit the first marker's authorization.
+mkdir -p "$managed_child"
+printf 'SwiftVLC managed libVLC build directory v1\n' > "$marker"
+fake_bin="$temporary_root/fake-bin"
+mkdir "$fake_bin"
+cat > "$fake_bin/rm" <<'EOF'
+#!/bin/bash
+set -eu
+target="${@: -1}"
+if [ ! -e "$SWIFTVLC_RM_RACE_STATE" ] &&
+   [ "$target" = "$SWIFTVLC_RM_RACE_TARGET" ]; then
+  : > "$SWIFTVLC_RM_RACE_STATE"
+  /bin/rm "$@"
+  mkdir -p "$target"
+  printf 'replacement data\n' > "$target/do-not-delete"
+  exit 1
+fi
+exec /bin/rm "$@"
+EOF
+chmod +x "$fake_bin/rm"
+if PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  SWIFTVLC_RM_RACE_STATE="$temporary_root/rm-race-state" \
+  SWIFTVLC_RM_RACE_TARGET="$managed_child" \
+  "$BUILD_SCRIPT" --build-root="$external_root" --clean \
+  > "$temporary_root/rm-race.log" 2>&1; then
+  fail "replacement external build directory was deleted on retry"
+fi
+grep -Fq "Refusing unowned external build directory" \
+  "$temporary_root/rm-race.log" || \
+  fail "replacement build directory did not fail closed"
+[[ -f "$managed_child/do-not-delete" ]] || \
+  fail "replacement build-directory data was deleted"
+/bin/rm -rf "$managed_child"
+
+mkdir "$lock_directory"
+printf 'pid=12345\nhost=test-host\n' > "$lock_directory/owner"
+expect_failure \
+  "locked external build root" \
+  "External build root is locked" \
+  --build-root="$external_root" --clean
+[[ -f "$lock_directory/owner" ]] || fail "contended lock was modified"
+rm "$lock_directory/owner"
+rmdir "$lock_directory"
+
+expect_failure \
+  "duplicate external build root" \
+  "--build-root may be specified only once" \
+  --build-root="$external_root" --build-root="$external_root" --clean
+
+expect_failure \
+  "unknown option after locking" \
+  "Unknown argument '--definitely-unknown'" \
+  --build-root="$external_root" --definitely-unknown
+[[ ! -e "$lock_directory" ]] || fail "failed invocation left its lock behind"
+
+mkdir "$checkout_lock"
+printf 'pid=67890\nhost=test-host\n' > "$checkout_lock/owner"
+expect_failure \
+  "locked checkout artifact output" \
+  "This checkout already has a native build or cleanup in progress" \
+  --build-root="$external_root" --clean
+[[ ! -e "$lock_directory" ]] || \
+  fail "checkout-lock contention left the external-root lock behind"
+rm "$checkout_lock/owner"
+rmdir "$checkout_lock"
+
+# A normal build acquires the checkout lock before resolving HEAD. This fixture
+# intentionally has no commit, so the later provenance preflight fails and
+# proves the EXIT trap releases the already-acquired lock.
+if "$BUILD_SCRIPT" > "$temporary_root/post-lock-failure.log" 2>&1; then
+  fail "commitless build fixture unexpectedly passed"
+fi
+[[ ! -e "$checkout_lock" ]] || fail "post-lock failure left checkout lock behind"
+
+overlap_root="$temporary_root/overlap-root"
+mkdir -p "$overlap_root"
+overlap_root=$(cd "$overlap_root" && pwd -P)
+overlap_checkout="$overlap_root/swiftvlc-libvlc-build/checkout"
+mkdir -p "$overlap_checkout/scripts"
+cp "$SOURCE_SCRIPT_DIR/build-libvlc.sh" \
+  "$overlap_checkout/scripts/build-libvlc.sh"
+printf 'SwiftVLC managed libVLC build directory v1\n' > \
+  "$overlap_root/swiftvlc-libvlc-build/.swiftvlc-managed-libvlc-build-v1"
+printf 'preserve checkout\n' > "$overlap_checkout/preserve.txt"
+overlap_alias="$temporary_root/overlap-checkout-alias"
+ln -s "$overlap_checkout" "$overlap_alias"
+if "$overlap_alias/scripts/build-libvlc.sh" \
+  --build-root="$overlap_root" --clean \
+  > "$temporary_root/overlap.log" 2>&1; then
+  fail "managed build directory containing its checkout was accepted"
+fi
+grep -Fq "external build directory that contains the SwiftVLC checkout" \
+  "$temporary_root/overlap.log" || \
+  fail "checkout-ancestor rejection did not produce the expected diagnostic"
+[[ -f "$overlap_checkout/preserve.txt" ]] || \
+  fail "checkout was removed through its logical symlink path"
+
+expect_failure \
+  "clean build without external root" \
+  "--clean-build requires a canonical external --build-root" \
+  --clean-build --all
+
+dirty_repo="$temporary_root/dirty-repository"
+mkdir -p "$dirty_repo/scripts"
+cp "$SOURCE_SCRIPT_DIR/build-libvlc.sh" "$dirty_repo/scripts/build-libvlc.sh"
+git -C "$dirty_repo" init -q
+git -C "$dirty_repo" add scripts/build-libvlc.sh
+git -C "$dirty_repo" \
+  -c user.name=SwiftVLC -c user.email=swiftvlc@example.invalid \
+  commit -qm fixture
+printf 'untracked input\n' > "$dirty_repo/untracked"
+dirty_root="$temporary_root/dirty-external-root"
+mkdir -p "$dirty_root/swiftvlc-libvlc-build"
+dirty_root=$(cd "$dirty_root" && pwd -P)
+printf 'SwiftVLC managed libVLC build directory v1\n' > \
+  "$dirty_root/swiftvlc-libvlc-build/.swiftvlc-managed-libvlc-build-v1"
+printf 'preserve native cache\n' > \
+  "$dirty_root/swiftvlc-libvlc-build/preserve.txt"
+if "$dirty_repo/scripts/build-libvlc.sh" \
+  --build-root="$dirty_root" --clean-build --all \
+  > "$temporary_root/dirty-checkout.log" 2>&1; then
+  fail "dirty checkout was accepted for a clean native build"
+fi
+grep -Fq "requires a clean SwiftVLC checkout" \
+  "$temporary_root/dirty-checkout.log" || \
+  fail "dirty checkout did not produce the expected diagnostic"
+[[ -f "$dirty_root/swiftvlc-libvlc-build/preserve.txt" ]] || \
+  fail "clean build deleted its cache before rejecting a dirty checkout"
+[[ ! -e "$dirty_root/.swiftvlc-libvlc-build.lock" ]] || \
+  fail "dirty-checkout failure left external build lock behind"
+
+help_output=$("$BUILD_SCRIPT" --help)
+grep -Fq -- '--build-root=DIR' <<< "$help_output" || \
+  fail "help does not document the external build root"
+
+echo "libVLC build-root tests passed."

--- a/scripts/tests/build-libvlc-build-root.sh
+++ b/scripts/tests/build-libvlc-build-root.sh
@@ -26,9 +26,13 @@ expect_failure() {
 fixture_repo="$temporary_root/repository"
 mkdir -p "$fixture_repo/scripts"
 cp "$SOURCE_SCRIPT_DIR/build-libvlc.sh" "$fixture_repo/scripts/build-libvlc.sh"
+cp "$SOURCE_SCRIPT_DIR/detach-managed-build-directory.py" \
+  "$fixture_repo/scripts/detach-managed-build-directory.py"
 git -C "$fixture_repo" init -q
 ROOT_DIR=$(cd "$fixture_repo" && pwd -P)
 BUILD_SCRIPT="$ROOT_DIR/scripts/build-libvlc.sh"
+DETACH_HELPER="$ROOT_DIR/scripts/detach-managed-build-directory.py"
+real_python3=$(python3 -c 'import os, sys; print(os.path.realpath(sys.executable))')
 
 external_root="$temporary_root/external-root"
 mkdir -p "$external_root"
@@ -122,57 +126,306 @@ rm "$marker"
 
 printf 'SwiftVLC managed libVLC build directory v1\n' > "$marker"
 printf 'managed data\n' > "$managed_child/remove.txt"
+cleanup_symlink_target="$temporary_root/cleanup-symlink-target"
+mkdir "$cleanup_symlink_target"
+printf 'outside data\n' > "$cleanup_symlink_target/preserve.txt"
+ln -s "$cleanup_symlink_target" "$managed_child/outside-link"
 printf 'sibling data\n' > "$external_root/preserve.txt"
 "$BUILD_SCRIPT" --clean --build-root="$external_root" \
   > "$temporary_root/clean.log" 2>&1
 [[ ! -e "$managed_child" ]] || fail "managed build child was not removed"
 [[ -f "$external_root/preserve.txt" ]] || fail "build-root sibling was removed"
+[[ -f "$cleanup_symlink_target/preserve.txt" ]] || \
+  fail "cleanup followed a nested symlink outside the managed directory"
 [[ ! -e "$lock_directory" ]] || fail "successful cleanup left its lock behind"
 [[ ! -e "$checkout_lock" ]] || fail "successful cleanup left checkout lock behind"
 
-# If another writer replaces the managed directory between removal attempts,
-# the second attempt must not inherit the first marker's authorization.
-mkdir -p "$managed_child"
-printf 'SwiftVLC managed libVLC build directory v1\n' > "$marker"
-fake_bin="$temporary_root/fake-bin"
-mkdir "$fake_bin"
-cat > "$fake_bin/rm" <<'EOF'
+# Renaming and replacing the absolute external-root pathname after the script
+# has entered it must not redirect either cleanup or EXIT lock release. The
+# helper receives --root . and therefore remains anchored to the original CWD.
+root_swap_public="$temporary_root/root-swap-public"
+root_swap_state="$temporary_root/root-swap-state"
+root_swap_bin="$temporary_root/root-swap-bin"
+mkdir "$root_swap_public" "$root_swap_bin"
+root_swap_public=$(cd "$root_swap_public" && pwd -P)
+root_swap_original="$(dirname "$root_swap_public")/root-swap-original"
+"$real_python3" -B "$DETACH_HELPER" initialize \
+  --root "$root_swap_public" \
+  --child swiftvlc-libvlc-build \
+  --marker-name .swiftvlc-managed-libvlc-build-v1 \
+  --marker-content 'SwiftVLC managed libVLC build directory v1'
+printf 'original managed data\n' > \
+  "$root_swap_public/swiftvlc-libvlc-build/remove.txt"
+printf 'original root sibling\n' > "$root_swap_public/preserve.txt"
+cat > "$root_swap_bin/python3" <<'EOF'
 #!/bin/bash
 set -eu
-target="${@: -1}"
-if [ ! -e "$SWIFTVLC_RM_RACE_STATE" ] &&
-   [ "$target" = "$SWIFTVLC_RM_RACE_TARGET" ]; then
-  : > "$SWIFTVLC_RM_RACE_STATE"
-  /bin/rm "$@"
-  mkdir -p "$target"
-  printf 'replacement data\n' > "$target/do-not-delete"
-  exit 1
+if [ "${1:-}" = "$SWIFTVLC_DETACH_HELPER" ] &&
+   [ "${2:-}" = clean ] &&
+   [ ! -e "$SWIFTVLC_RACE_STATE" ]; then
+  : > "$SWIFTVLC_RACE_STATE"
+  /bin/mv "$SWIFTVLC_PUBLIC_ROOT" "$SWIFTVLC_ORIGINAL_ROOT"
+  /bin/mkdir "$SWIFTVLC_PUBLIC_ROOT"
+  /bin/mkdir "$SWIFTVLC_PUBLIC_ROOT/swiftvlc-libvlc-build"
+  printf 'SwiftVLC managed libVLC build directory v1\n' > \
+    "$SWIFTVLC_PUBLIC_ROOT/swiftvlc-libvlc-build/.swiftvlc-managed-libvlc-build-v1"
+  printf 'replacement managed data\n' > \
+    "$SWIFTVLC_PUBLIC_ROOT/swiftvlc-libvlc-build/do-not-delete"
+  printf 'replacement root data\n' > \
+    "$SWIFTVLC_PUBLIC_ROOT/do-not-delete"
 fi
-exec /bin/rm "$@"
+exec "$SWIFTVLC_REAL_PYTHON3" "$@"
 EOF
-chmod +x "$fake_bin/rm"
-if PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
-  SWIFTVLC_RM_RACE_STATE="$temporary_root/rm-race-state" \
-  SWIFTVLC_RM_RACE_TARGET="$managed_child" \
-  "$BUILD_SCRIPT" --build-root="$external_root" --clean \
-  > "$temporary_root/rm-race.log" 2>&1; then
-  fail "replacement external build directory was deleted on retry"
+chmod +x "$root_swap_bin/python3"
+PATH="$root_swap_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  SWIFTVLC_REAL_PYTHON3="$real_python3" \
+  SWIFTVLC_DETACH_HELPER="$DETACH_HELPER" \
+  SWIFTVLC_PUBLIC_ROOT="$root_swap_public" \
+  SWIFTVLC_ORIGINAL_ROOT="$root_swap_original" \
+  SWIFTVLC_RACE_STATE="$root_swap_state" \
+  "$BUILD_SCRIPT" --build-root="$root_swap_public" --clean \
+  > "$temporary_root/root-swap.log" 2>&1
+[[ -e "$root_swap_state" ]] || fail "external-root pathname race did not execute"
+[[ ! -e "$root_swap_original/swiftvlc-libvlc-build" ]] || \
+  fail "cleanup did not remove the managed child from the anchored root"
+[[ -f "$root_swap_original/preserve.txt" ]] || \
+  fail "cleanup removed an anchored-root sibling"
+[[ -f "$root_swap_public/do-not-delete" ]] || \
+  fail "cleanup touched the replacement external root"
+[[ -f "$root_swap_public/swiftvlc-libvlc-build/do-not-delete" ]] || \
+  fail "cleanup followed the replaced root pathname into unrelated data"
+[[ -f "$root_swap_public/swiftvlc-libvlc-build/.swiftvlc-managed-libvlc-build-v1" ]] || \
+  fail "cleanup removed the replacement directory's ownership marker"
+[[ ! -e "$root_swap_original/.swiftvlc-libvlc-build.lock" ]] || \
+  fail "root-path replacement redirected lock cleanup away from the anchored root"
+[[ ! -e "$root_swap_public/.swiftvlc-libvlc-build.lock" ]] || \
+  fail "root-path replacement created a lock in the replacement root"
+[[ ! -e "$checkout_lock" ]] || \
+  fail "root-path replacement left the checkout lock behind"
+/bin/rm -rf "$root_swap_original" "$root_swap_public"
+
+# Checkout-local cleanup must anchor the scripts directory itself. If a
+# worktree move replaces that public pathname after startup, --root . must
+# still remove only the build child beneath the original live CWD.
+default_swap_repo="$temporary_root/default-swap-repository"
+default_swap_bin="$temporary_root/default-swap-bin"
+default_swap_state="$temporary_root/default-swap-state"
+default_helper_source="$temporary_root/default-helper-source.py"
+mkdir -p "$default_swap_repo/scripts/.build-libvlc" "$default_swap_bin"
+default_swap_repo=$(cd "$default_swap_repo" && pwd -P)
+cp "$SOURCE_SCRIPT_DIR/build-libvlc.sh" \
+  "$default_swap_repo/scripts/build-libvlc.sh"
+cp "$SOURCE_SCRIPT_DIR/detach-managed-build-directory.py" \
+  "$default_swap_repo/scripts/detach-managed-build-directory.py"
+cp "$SOURCE_SCRIPT_DIR/detach-managed-build-directory.py" \
+  "$default_helper_source"
+git -C "$default_swap_repo" init -q
+printf 'SwiftVLC managed libVLC build directory v1\n' > \
+  "$default_swap_repo/scripts/.build-libvlc/.swiftvlc-managed-libvlc-build-v1"
+printf 'original managed data\n' > \
+  "$default_swap_repo/scripts/.build-libvlc/remove.txt"
+printf 'original scripts sibling\n' > \
+  "$default_swap_repo/scripts/preserve.txt"
+cat > "$default_swap_bin/python3" <<'EOF'
+#!/bin/bash
+set -eu
+if [ "${1:-}" = "$SWIFTVLC_PUBLIC_HELPER" ] &&
+   [ "${2:-}" = clean ] &&
+   [ ! -e "$SWIFTVLC_RACE_STATE" ]; then
+  : > "$SWIFTVLC_RACE_STATE"
+  /bin/mv "$SWIFTVLC_PUBLIC_SCRIPTS" "$SWIFTVLC_ORIGINAL_SCRIPTS"
+  /bin/mkdir -p "$SWIFTVLC_PUBLIC_SCRIPTS/.build-libvlc"
+  /bin/cp "$SWIFTVLC_HELPER_SOURCE" "$SWIFTVLC_PUBLIC_HELPER"
+  printf 'SwiftVLC managed libVLC build directory v1\n' > \
+    "$SWIFTVLC_PUBLIC_SCRIPTS/.build-libvlc/.swiftvlc-managed-libvlc-build-v1"
+  printf 'replacement managed data\n' > \
+    "$SWIFTVLC_PUBLIC_SCRIPTS/.build-libvlc/do-not-delete"
 fi
-grep -Fq "Refusing unowned external build directory" \
-  "$temporary_root/rm-race.log" || \
-  fail "replacement build directory did not fail closed"
+exec "$SWIFTVLC_REAL_PYTHON3" "$@"
+EOF
+chmod +x "$default_swap_bin/python3"
+default_public_scripts="$default_swap_repo/scripts"
+default_original_scripts="$default_swap_repo/scripts-original"
+default_checkout_lock=$(git -C "$default_swap_repo" \
+  rev-parse --git-path swiftvlc-libvlc-output.lock)
+case "$default_checkout_lock" in
+  /*) ;;
+  *) default_checkout_lock="$default_swap_repo/$default_checkout_lock" ;;
+esac
+PATH="$default_swap_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  SWIFTVLC_REAL_PYTHON3="$real_python3" \
+  SWIFTVLC_PUBLIC_HELPER="$default_public_scripts/detach-managed-build-directory.py" \
+  SWIFTVLC_PUBLIC_SCRIPTS="$default_public_scripts" \
+  SWIFTVLC_ORIGINAL_SCRIPTS="$default_original_scripts" \
+  SWIFTVLC_HELPER_SOURCE="$default_helper_source" \
+  SWIFTVLC_RACE_STATE="$default_swap_state" \
+  "$default_public_scripts/build-libvlc.sh" --clean \
+  > "$temporary_root/default-swap.log" 2>&1
+[[ -e "$default_swap_state" ]] || {
+  cat "$temporary_root/default-swap.log" >&2
+  fail "checkout-local scripts-path race did not execute"
+}
+[[ ! -e "$default_original_scripts/.build-libvlc" ]] || \
+  fail "checkout-local cleanup missed the anchored original build child"
+[[ -f "$default_original_scripts/preserve.txt" ]] || \
+  fail "checkout-local cleanup removed an original scripts sibling"
+[[ -f "$default_public_scripts/.build-libvlc/do-not-delete" ]] || \
+  fail "checkout-local cleanup followed the replaced scripts pathname"
+[[ -f "$default_public_scripts/.build-libvlc/.swiftvlc-managed-libvlc-build-v1" ]] || \
+  fail "checkout-local cleanup removed the replacement ownership marker"
+[[ ! -e "$default_checkout_lock" ]] || \
+  fail "checkout-local scripts-path race left the output lock behind"
+/bin/rm -rf "$default_original_scripts" "$default_public_scripts"
+
+# A crash after detachment can preserve a full native tree under a hidden
+# quarantine. Never silently start another large build while that recovery
+# state consumes the external volume; report it and leave it untouched.
+stale_quarantine=".swiftvlc-libvlc-build.removing-stale-test"
+"$real_python3" -B "$DETACH_HELPER" initialize \
+  --root "$external_root" \
+  --child swiftvlc-libvlc-build \
+  --marker-name .swiftvlc-managed-libvlc-build-v1 \
+  --marker-content 'SwiftVLC managed libVLC build directory v1'
+printf 'recoverable native data\n' > "$managed_child/recover.txt"
+"$real_python3" -B "$DETACH_HELPER" detach \
+  --root "$external_root" \
+  --child swiftvlc-libvlc-build \
+  --quarantine "$stale_quarantine" \
+  --marker-name .swiftvlc-managed-libvlc-build-v1 \
+  --marker-content 'SwiftVLC managed libVLC build directory v1'
+if "$BUILD_SCRIPT" --build-root="$external_root" --clean \
+  > "$temporary_root/stale-quarantine.log" 2>&1; then
+  fail "stale quarantine was silently ignored"
+fi
+grep -Fq "Found preserved managed-build state" \
+  "$temporary_root/stale-quarantine.log" || \
+  fail "stale quarantine did not produce recovery guidance"
+[[ -f "$external_root/$stale_quarantine/payload/recover.txt" ]] || \
+  fail "stale quarantine data was modified"
+[[ ! -e "$lock_directory" ]] || fail "stale quarantine failure left root lock"
+[[ ! -e "$checkout_lock" ]] || fail "stale quarantine failure left output lock"
+"$real_python3" -B "$DETACH_HELPER" remove \
+  --root "$external_root" \
+  --child swiftvlc-libvlc-build \
+  --quarantine "$stale_quarantine" \
+  --marker-name .swiftvlc-managed-libvlc-build-v1 \
+  --marker-content 'SwiftVLC managed libVLC build directory v1'
+
+# An absent result is safe only if the public name is still absent when the
+# shell receives it. Simulate a writer creating unrelated data after the
+# helper's final absence observation but before it returns to the caller.
+absent_race_bin="$temporary_root/absent-race-bin"
+absent_race_state="$temporary_root/absent-race-state"
+mkdir "$absent_race_bin"
+cat > "$absent_race_bin/python3" <<'EOF'
+#!/bin/bash
+set -u
+"$SWIFTVLC_REAL_PYTHON3" "$@"
+status=$?
+if [ "${1:-}" = "$SWIFTVLC_DETACH_HELPER" ] &&
+   [ "${2:-}" = clean ] &&
+   [ "$status" -eq 3 ] &&
+   [ ! -e "$SWIFTVLC_RACE_STATE" ]; then
+  : > "$SWIFTVLC_RACE_STATE"
+  /bin/mkdir "$SWIFTVLC_PUBLIC_BUILD_DIR"
+  printf 'unrelated late arrival\n' > \
+    "$SWIFTVLC_PUBLIC_BUILD_DIR/do-not-delete"
+fi
+exit "$status"
+EOF
+chmod +x "$absent_race_bin/python3"
+if PATH="$absent_race_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  SWIFTVLC_REAL_PYTHON3="$real_python3" \
+  SWIFTVLC_DETACH_HELPER="$DETACH_HELPER" \
+  SWIFTVLC_PUBLIC_BUILD_DIR="$managed_child" \
+  SWIFTVLC_RACE_STATE="$absent_race_state" \
+  "$BUILD_SCRIPT" --build-root="$external_root" --clean \
+  > "$temporary_root/absent-race.log" 2>&1; then
+  fail "late-arriving unowned build directory produced a false clean success"
+fi
+[[ -e "$absent_race_state" ]] || fail "absent-result race did not execute"
+grep -Fq "Managed build path appeared during cleanup and was left untouched" \
+  "$temporary_root/absent-race.log" || \
+  fail "late-arriving build directory did not fail closed"
 [[ -f "$managed_child/do-not-delete" ]] || \
-  fail "replacement build-directory data was deleted"
+  fail "late-arriving build-directory data was deleted"
+[[ ! -e "$lock_directory" ]] || fail "absent-result race left root lock"
+[[ ! -e "$checkout_lock" ]] || fail "absent-result race left output lock"
 /bin/rm -rf "$managed_child"
 
+# Reproduce the original check/use race exactly: the script's initial marker
+# verification succeeds, then a non-cooperating writer replaces the public
+# child immediately before the descriptor-safe cleanup helper starts. Neither
+# the original directory nor the unrelated replacement may be deleted.
+mkdir -p "$managed_child"
+printf 'SwiftVLC managed libVLC build directory v1\n' > "$marker"
+printf 'original managed data\n' > "$managed_child/original.txt"
+pre_clean_bin="$temporary_root/pre-clean-bin"
+pre_clean_original="$temporary_root/pre-clean-original"
+pre_clean_state="$temporary_root/pre-clean-state"
+pre_clean_rm_log="$temporary_root/pre-clean-rm.log"
+mkdir "$pre_clean_bin"
+: > "$pre_clean_rm_log"
+cat > "$pre_clean_bin/python3" <<'EOF'
+#!/bin/bash
+set -eu
+if [ "${1:-}" = "$SWIFTVLC_DETACH_HELPER" ] &&
+   [ "${2:-}" = clean ] &&
+   [ ! -e "$SWIFTVLC_RACE_STATE" ]; then
+  : > "$SWIFTVLC_RACE_STATE"
+  /bin/mv "$SWIFTVLC_PUBLIC_BUILD_DIR" "$SWIFTVLC_ORIGINAL_BUILD_DIR"
+  /bin/mkdir "$SWIFTVLC_PUBLIC_BUILD_DIR"
+  printf 'unrelated replacement\n' > \
+    "$SWIFTVLC_PUBLIC_BUILD_DIR/do-not-delete"
+fi
+exec "$SWIFTVLC_REAL_PYTHON3" "$@"
+EOF
+cat > "$pre_clean_bin/rm" <<'EOF'
+#!/bin/bash
+set -eu
+target=
+for argument in "$@"; do
+  target="$argument"
+done
+printf '%s\n' "$target" >> "$SWIFTVLC_RM_LOG"
+exec /bin/rm "$@"
+EOF
+chmod +x "$pre_clean_bin/python3" "$pre_clean_bin/rm"
+if PATH="$pre_clean_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  SWIFTVLC_REAL_PYTHON3="$real_python3" \
+  SWIFTVLC_DETACH_HELPER="$DETACH_HELPER" \
+  SWIFTVLC_PUBLIC_BUILD_DIR="$managed_child" \
+  SWIFTVLC_ORIGINAL_BUILD_DIR="$pre_clean_original" \
+  SWIFTVLC_RACE_STATE="$pre_clean_state" \
+  SWIFTVLC_RM_LOG="$pre_clean_rm_log" \
+  "$BUILD_SCRIPT" --build-root="$external_root" --clean \
+  > "$temporary_root/pre-clean-race.log" 2>&1; then
+  fail "pre-clean replacement was accepted"
+fi
+[[ -e "$pre_clean_state" ]] || fail "pre-clean race did not execute"
+grep -Fq "Could not safely clean managed build directory" \
+  "$temporary_root/pre-clean-race.log" || \
+  fail "pre-clean race did not fail closed"
+[[ -f "$pre_clean_original/original.txt" ]] || \
+  fail "original managed directory was lost"
+[[ -f "$managed_child/do-not-delete" ]] || \
+  fail "unrelated public replacement was deleted"
+if grep -Fqx -- "$managed_child" "$pre_clean_rm_log"; then
+  fail "recursive rm targeted the public managed path"
+fi
+[[ ! -e "$lock_directory" ]] || fail "pre-clean race left root lock"
+[[ ! -e "$checkout_lock" ]] || fail "pre-clean race left output lock"
+/bin/rm -rf "$pre_clean_original" "$managed_child"
+
 mkdir "$lock_directory"
-printf 'pid=12345\nhost=test-host\n' > "$lock_directory/owner"
+printf 'foreign lock data\n' > "$lock_directory/do-not-delete"
 expect_failure \
   "locked external build root" \
-  "External build root is locked" \
+  "External build root is locked or has preserved lock state; verify no build is active and inspect this exact managed lock: $lock_directory" \
   --build-root="$external_root" --clean
-[[ -f "$lock_directory/owner" ]] || fail "contended lock was modified"
-rm "$lock_directory/owner"
+[[ -f "$lock_directory/do-not-delete" ]] || \
+  fail "contended external-root lock was modified"
+rm "$lock_directory/do-not-delete"
 rmdir "$lock_directory"
 
 expect_failure \
@@ -187,14 +440,16 @@ expect_failure \
 [[ ! -e "$lock_directory" ]] || fail "failed invocation left its lock behind"
 
 mkdir "$checkout_lock"
-printf 'pid=67890\nhost=test-host\n' > "$checkout_lock/owner"
+printf 'foreign lock data\n' > "$checkout_lock/do-not-delete"
 expect_failure \
   "locked checkout artifact output" \
-  "This checkout already has a native build or cleanup in progress" \
+  "This checkout already has a native build or cleanup in progress, or preserved lock state; verify no build is active and inspect this exact managed lock: $checkout_lock" \
   --build-root="$external_root" --clean
 [[ ! -e "$lock_directory" ]] || \
   fail "checkout-lock contention left the external-root lock behind"
-rm "$checkout_lock/owner"
+[[ -f "$checkout_lock/do-not-delete" ]] || \
+  fail "contended checkout lock was modified"
+rm "$checkout_lock/do-not-delete"
 rmdir "$checkout_lock"
 
 # A normal build acquires the checkout lock before resolving HEAD. This fixture
@@ -205,6 +460,59 @@ if "$BUILD_SCRIPT" > "$temporary_root/post-lock-failure.log" 2>&1; then
 fi
 [[ ! -e "$checkout_lock" ]] || fail "post-lock failure left checkout lock behind"
 
+# A failure while releasing one lock must not short-circuit the composed EXIT
+# cleanup before the independent external-root lock is attempted.
+lock_failure_bin="$temporary_root/lock-failure-bin"
+lock_failure_helper_log="$temporary_root/lock-failure-helper.log"
+mkdir "$lock_failure_bin"
+: > "$lock_failure_helper_log"
+cat > "$lock_failure_bin/python3" <<'EOF'
+#!/bin/bash
+set -eu
+if [ "${1:-}" = "$SWIFTVLC_DETACH_HELPER" ] &&
+   [ "${2:-}" = lock-release ]; then
+  child=
+  previous=
+  for argument in "$@"; do
+    if [ "$previous" = --child ]; then
+      child=$argument
+    fi
+    previous=$argument
+  done
+  printf '%s\n' "$child" >> "$SWIFTVLC_HELPER_LOG"
+  if [ "$child" = swiftvlc-libvlc-output.lock ]; then
+    exit 73
+  fi
+fi
+exec "$SWIFTVLC_REAL_PYTHON3" "$@"
+EOF
+chmod +x "$lock_failure_bin/python3"
+if PATH="$lock_failure_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  SWIFTVLC_REAL_PYTHON3="$real_python3" \
+  SWIFTVLC_DETACH_HELPER="$DETACH_HELPER" \
+  SWIFTVLC_HELPER_LOG="$lock_failure_helper_log" \
+  "$BUILD_SCRIPT" --build-root="$external_root" --macos-only \
+  > "$temporary_root/lock-cleanup-failure.log" 2>&1; then
+  fail "commitless fixture unexpectedly passed with forced lock cleanup failure"
+fi
+grep -Fq "Could not remove checkout artifact lock: $checkout_lock" \
+  "$temporary_root/lock-cleanup-failure.log" || \
+  fail "output lock removal failure was not reported"
+grep -Fqx -- "swiftvlc-libvlc-output.lock" "$lock_failure_helper_log" || \
+  fail "output lock cleanup did not use the descriptor-safe helper"
+grep -Fqx -- ".swiftvlc-libvlc-build.lock" "$lock_failure_helper_log" || \
+  fail "root-lock cleanup was not attempted after output cleanup failed"
+[[ ! -e "$lock_directory" ]] || \
+  fail "output cleanup failure prevented root-lock release"
+[[ -d "$checkout_lock" ]] || \
+  fail "forced output lock removal failure did not preserve the lock"
+[[ -f "$checkout_lock/.swiftvlc-lock-generation-v1" ]] || \
+  fail "preserved checkout lock lost its generation token"
+[[ "$(find "$checkout_lock" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')" = 1 ]] || \
+  fail "preserved checkout lock contains unexpected state"
+/bin/rm "$checkout_lock/.swiftvlc-lock-generation-v1"
+/bin/rmdir "$checkout_lock"
+
 overlap_root="$temporary_root/overlap-root"
 mkdir -p "$overlap_root"
 overlap_root=$(cd "$overlap_root" && pwd -P)
@@ -212,6 +520,9 @@ overlap_checkout="$overlap_root/swiftvlc-libvlc-build/checkout"
 mkdir -p "$overlap_checkout/scripts"
 cp "$SOURCE_SCRIPT_DIR/build-libvlc.sh" \
   "$overlap_checkout/scripts/build-libvlc.sh"
+cp "$SOURCE_SCRIPT_DIR/detach-managed-build-directory.py" \
+  "$overlap_checkout/scripts/detach-managed-build-directory.py"
+git -C "$overlap_checkout" init -q
 printf 'SwiftVLC managed libVLC build directory v1\n' > \
   "$overlap_root/swiftvlc-libvlc-build/.swiftvlc-managed-libvlc-build-v1"
 printf 'preserve checkout\n' > "$overlap_checkout/preserve.txt"
@@ -233,11 +544,441 @@ expect_failure \
   "--clean-build requires a canonical external --build-root" \
   --clean-build --all
 
+# Reach real initialization without cloning VLC. The wrapper creates an
+# unrelated public child after the script's early absence check but before the
+# helper's exclusive staged publish. The helper must neither reuse nor mark it.
+git -C "$ROOT_DIR" add scripts
+git -C "$ROOT_DIR" \
+  -c user.name=SwiftVLC -c user.email=swiftvlc@example.invalid \
+  commit -qm fixture
+
+# Vendor authority must be minted while the original checkout is still the
+# shell's anchored parent. Move the checkout immediately after output-lock
+# acquisition: the physical parent check must reject the public replacement,
+# and descriptor-relative EXIT cleanup must still release the original lock.
+checkout_swap_bin="$temporary_root/checkout-swap-bin"
+checkout_swap_state="$temporary_root/checkout-swap-state"
+checkout_swap_original="$temporary_root/repository-bound-original"
+checkout_swap_helper_source="$temporary_root/checkout-swap-helper.py"
+mkdir "$checkout_swap_bin"
+cp "$SOURCE_SCRIPT_DIR/detach-managed-build-directory.py" \
+  "$checkout_swap_helper_source"
+cat > "$checkout_swap_bin/python3" <<'EOF'
+#!/bin/bash
+set -eu
+"$SWIFTVLC_REAL_PYTHON3" "$@"
+status=$?
+if [ "$status" -eq 0 ] &&
+   [ "${1:-}" = "$SWIFTVLC_PUBLIC_HELPER" ] &&
+   [ "${2:-}" = lock-acquire ] &&
+   [ ! -e "$SWIFTVLC_RACE_STATE" ]; then
+  : > "$SWIFTVLC_RACE_STATE"
+  /bin/mv "$SWIFTVLC_PUBLIC_REPO" "$SWIFTVLC_ORIGINAL_REPO"
+  /bin/mkdir -p "$SWIFTVLC_PUBLIC_REPO/scripts" \
+    "$SWIFTVLC_PUBLIC_REPO/Vendor"
+  /bin/cp "$SWIFTVLC_HELPER_SOURCE" "$SWIFTVLC_PUBLIC_HELPER"
+  printf 'replacement checkout data\n' > \
+    "$SWIFTVLC_PUBLIC_REPO/Vendor/do-not-delete"
+fi
+exit "$status"
+EOF
+chmod +x "$checkout_swap_bin/python3"
+if PATH="$checkout_swap_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  SWIFTVLC_REAL_PYTHON3="$real_python3" \
+  SWIFTVLC_PUBLIC_HELPER="$DETACH_HELPER" \
+  SWIFTVLC_PUBLIC_REPO="$ROOT_DIR" \
+  SWIFTVLC_ORIGINAL_REPO="$checkout_swap_original" \
+  SWIFTVLC_HELPER_SOURCE="$checkout_swap_helper_source" \
+  SWIFTVLC_RACE_STATE="$checkout_swap_state" \
+  "$BUILD_SCRIPT" --build-root="$external_root" --macos-only \
+  > "$temporary_root/checkout-swap.log" 2>&1; then
+  fail "checkout replacement before Vendor bind was accepted"
+fi
+[[ -e "$checkout_swap_state" ]] || \
+  fail "checkout replacement before Vendor bind did not execute"
+grep -Fq "checkout path changed before Vendor could be anchored" \
+  "$temporary_root/checkout-swap.log" || {
+  cat "$temporary_root/checkout-swap.log" >&2
+  fail "checkout replacement did not fail at the original-parent gate"
+}
+[[ -f "$ROOT_DIR/Vendor/do-not-delete" ]] || \
+  fail "Vendor binding mutated the replacement checkout"
+if find "$ROOT_DIR/Vendor" -maxdepth 1 \
+  -name '.swiftvlc-managed-output-binding-*' -print -quit | grep -q .; then
+  fail "replacement checkout inherited original Vendor authority"
+fi
+[[ ! -e "$checkout_swap_original/.git/swiftvlc-libvlc-output.lock" ]] || \
+  fail "checkout replacement redirected descriptor-safe output-lock cleanup"
+/bin/rm -rf "$ROOT_DIR"
+/bin/mv "$checkout_swap_original" "$ROOT_DIR"
+
+initialize_bin="$temporary_root/initialize-bin"
+initialize_state="$temporary_root/initialize-race-state"
+mkdir "$initialize_bin"
+cat > "$initialize_bin/tool-ok" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+chmod +x "$initialize_bin/tool-ok"
+for tool in xcode-select xcodebuild autoconf automake libtool \
+  autopoint pkg-config cmake; do
+  ln -s tool-ok "$initialize_bin/$tool"
+done
+cat > "$initialize_bin/df" <<'EOF'
+#!/bin/bash
+printf '%s\n' \
+  'Filesystem 1024-blocks Used Available Capacity Mounted on' \
+  'fixture 999999999 0 999999999 0% /'
+EOF
+chmod +x "$initialize_bin/df"
+cat > "$initialize_bin/python3" <<'EOF'
+#!/bin/bash
+set -eu
+if [ "${1:-}" = "$SWIFTVLC_ASSET_VALIDATOR" ]; then
+  exit 0
+fi
+if [ "${1:-}" = "$SWIFTVLC_DETACH_HELPER" ] &&
+   [ "${2:-}" = initialize ] &&
+   [ ! -e "$SWIFTVLC_RACE_STATE" ]; then
+  : > "$SWIFTVLC_RACE_STATE"
+  /bin/mkdir "$SWIFTVLC_PUBLIC_BUILD_DIR"
+  printf 'unrelated initialization winner\n' > \
+    "$SWIFTVLC_PUBLIC_BUILD_DIR/do-not-delete"
+fi
+exec "$SWIFTVLC_REAL_PYTHON3" "$@"
+EOF
+chmod +x "$initialize_bin/python3"
+if PATH="$initialize_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  MAKEFLAGS=-j1 TERM=dumb LC_ALL=C \
+  SWIFTVLC_REAL_PYTHON3="$real_python3" \
+  SWIFTVLC_ASSET_VALIDATOR="$ROOT_DIR/scripts/verify-native-validator-assets.py" \
+  SWIFTVLC_DETACH_HELPER="$DETACH_HELPER" \
+  SWIFTVLC_PUBLIC_BUILD_DIR="$managed_child" \
+  SWIFTVLC_RACE_STATE="$initialize_state" \
+  "$BUILD_SCRIPT" --build-root="$external_root" --macos-only \
+  > "$temporary_root/initialize-race.log" 2>&1; then
+  fail "racing unowned build directory was initialized"
+fi
+[[ -e "$initialize_state" ]] || fail "initialization race did not execute"
+grep -Fq "Could not safely initialize managed build directory" \
+  "$temporary_root/initialize-race.log" || \
+  fail "initialization race did not fail closed"
+[[ -f "$managed_child/do-not-delete" ]] || \
+  fail "initialization removed the racing directory"
+[[ ! -e "$marker" && ! -L "$marker" ]] || \
+  fail "initialization blessed a racing unowned directory"
+[[ ! -e "$lock_directory" ]] || fail "initialization race left root lock"
+[[ ! -e "$checkout_lock" ]] || fail "initialization race left output lock"
+/bin/rm -rf "$managed_child" "$ROOT_DIR/Vendor"
+
+# Even a replacement carrying the normal ownership marker must not inherit the
+# authority of a directory that this invocation just initialized. Swap the
+# child only after the real helper has published its invocation-unique binding;
+# the build body must reject the replacement before attempting to clone VLC.
+binding_root="$temporary_root/binding-root"
+binding_state="$temporary_root/binding-race-state"
+binding_clone_log="$temporary_root/binding-clone-attempted"
+binding_bin="$temporary_root/binding-bin"
+mkdir "$binding_root" "$binding_bin"
+binding_root=$(cd "$binding_root" && pwd -P)
+binding_original="$binding_root/initialized-original"
+binding_replacement="$binding_root/swiftvlc-libvlc-build"
+for tool in xcode-select xcodebuild autoconf automake libtool \
+  autopoint pkg-config cmake; do
+  ln -s "$initialize_bin/tool-ok" "$binding_bin/$tool"
+done
+ln -s "$initialize_bin/df" "$binding_bin/df"
+cat > "$binding_bin/python3" <<'EOF'
+#!/bin/bash
+set -u
+if [ "${1:-}" = "$SWIFTVLC_ASSET_VALIDATOR" ]; then
+  exit 0
+fi
+"$SWIFTVLC_REAL_PYTHON3" "$@"
+status=$?
+if [ "$status" -eq 0 ] &&
+   [ "${1:-}" = "$SWIFTVLC_DETACH_HELPER" ] &&
+   [ "${2:-}" = initialize ] &&
+   [ ! -e "$SWIFTVLC_RACE_STATE" ]; then
+  : > "$SWIFTVLC_RACE_STATE"
+  /bin/mv swiftvlc-libvlc-build initialized-original
+  printf 'preserve initialized directory\n' > \
+    initialized-original/do-not-delete
+  /bin/mkdir swiftvlc-libvlc-build
+  printf 'SwiftVLC managed libVLC build directory v1\n' > \
+    swiftvlc-libvlc-build/.swiftvlc-managed-libvlc-build-v1
+  printf 'preserve replacement directory\n' > \
+    swiftvlc-libvlc-build/do-not-delete
+fi
+exit "$status"
+EOF
+cat > "$binding_bin/git" <<'EOF'
+#!/bin/bash
+set -eu
+if [ "${1:-}" = clone ]; then
+  : > "$SWIFTVLC_CLONE_LOG"
+  exit 79
+fi
+exec "$SWIFTVLC_REAL_GIT" "$@"
+EOF
+chmod +x "$binding_bin/python3" "$binding_bin/git"
+if PATH="$binding_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  MAKEFLAGS=-j1 TERM=dumb LC_ALL=C \
+  SWIFTVLC_REAL_PYTHON3="$real_python3" \
+  SWIFTVLC_REAL_GIT="$(command -v git)" \
+  SWIFTVLC_ASSET_VALIDATOR="$ROOT_DIR/scripts/verify-native-validator-assets.py" \
+  SWIFTVLC_DETACH_HELPER="$DETACH_HELPER" \
+  SWIFTVLC_RACE_STATE="$binding_state" \
+  SWIFTVLC_CLONE_LOG="$binding_clone_log" \
+  "$BUILD_SCRIPT" --build-root="$binding_root" --macos-only \
+  > "$temporary_root/binding-race.log" 2>&1; then
+  fail "marker-only replacement bypassed the invocation binding"
+fi
+[[ -e "$binding_state" ]] || fail "post-initialize binding race did not execute"
+grep -Fq "Managed build directory changed before it could be anchored" \
+  "$temporary_root/binding-race.log" || \
+  fail "marker-only replacement did not fail at the binding gate"
+[[ ! -e "$binding_clone_log" ]] || \
+  fail "binding mismatch reached the VLC clone step"
+[[ -f "$binding_original/.swiftvlc-managed-libvlc-build-v1" ]] || \
+  fail "initialized directory lost its ownership marker"
+if ! find "$binding_original" -maxdepth 1 -type f \
+  -name '.swiftvlc-managed-build-binding-*' -print -quit | grep -q .; then
+  fail "initialized directory lost its invocation binding"
+fi
+[[ -f "$binding_original/do-not-delete" ]] || \
+  fail "initialized directory was mutated after being swapped aside"
+[[ -f "$binding_replacement/do-not-delete" ]] || \
+  fail "marker-only replacement was mutated"
+[[ -f "$binding_replacement/.swiftvlc-managed-libvlc-build-v1" ]] || \
+  fail "marker-only replacement lost its ownership marker"
+if find "$binding_replacement" -maxdepth 1 \
+  -name '.swiftvlc-managed-build-binding-*' -print -quit | grep -q .; then
+  fail "replacement unexpectedly received an invocation binding"
+fi
+[[ ! -e "$binding_original/vlc" && ! -e "$binding_replacement/vlc" ]] || \
+  fail "binding mismatch mutated a build directory before rejection"
+[[ ! -e "$binding_root/.swiftvlc-libvlc-build.lock" ]] || \
+  fail "binding mismatch left the external-root lock behind"
+[[ ! -e "$checkout_lock" ]] || \
+  fail "binding mismatch left the checkout lock behind"
+/bin/rm -rf "$binding_root" "$ROOT_DIR/Vendor"
+
+# Exercise the source and checkout-output handoffs without reaching a native
+# build. Direct Git commands are blocked so a missing guard cannot reset,
+# clean, or clone a fixture before the test reports the regression.
+handoff_bin="$temporary_root/handoff-bin"
+handoff_git_log="$temporary_root/handoff-direct-git.log"
+handoff_race_state="$temporary_root/handoff-race-state"
+mkdir "$handoff_bin"
+for tool in xcode-select xcodebuild autoconf automake libtool \
+  autopoint pkg-config cmake; do
+  ln -s "$initialize_bin/tool-ok" "$handoff_bin/$tool"
+done
+ln -s "$initialize_bin/df" "$handoff_bin/df"
+cat > "$handoff_bin/git" <<'EOF'
+#!/bin/bash
+set -eu
+if [ "${1:-}" != -C ]; then
+  printf '%s\n' "$*" >> "$SWIFTVLC_GIT_LOG"
+  exit 79
+fi
+exec "$SWIFTVLC_REAL_GIT" "$@"
+EOF
+cat > "$handoff_bin/python3" <<'EOF'
+#!/bin/bash
+set -u
+if [ "${1:-}" = "$SWIFTVLC_ASSET_VALIDATOR" ]; then
+  exit 0
+fi
+"$SWIFTVLC_REAL_PYTHON3" "$@"
+status=$?
+if [ "$status" -ne 0 ]; then
+  exit "$status"
+fi
+child=
+next_is_child=no
+for argument in "$@"; do
+  if [ "$next_is_child" = yes ]; then
+    child="$argument"
+    next_is_child=no
+  elif [ "$argument" = --child ]; then
+    next_is_child=yes
+  fi
+done
+if [ "${1:-}" = "$SWIFTVLC_DETACH_HELPER" ] &&
+   [ "${2:-}" = bind ] &&
+   [ "${SWIFTVLC_RACE_MODE:-none}" = source ] &&
+   [ "$child" = vlc ] &&
+   [ ! -e "$SWIFTVLC_RACE_STATE" ]; then
+  : > "$SWIFTVLC_RACE_STATE"
+  /bin/mv vlc vlc-bound-original
+  /bin/mkdir vlc
+  printf 'preserve replacement source\n' > vlc/do-not-delete
+fi
+exit 0
+EOF
+chmod +x "$handoff_bin/git" "$handoff_bin/python3"
+
+# A managed build directory does not authorize a symlink at its top-level
+# `vlc` entry. Reject it before binding or running any source Git mutation, and
+# leave the outside target and the public symlink exactly as they were.
+source_symlink_root="$temporary_root/source-symlink-root"
+source_symlink_target="$temporary_root/source-symlink-target"
+source_symlink_log="$temporary_root/source-symlink.log"
+mkdir -p "$source_symlink_root/swiftvlc-libvlc-build" \
+  "$source_symlink_target"
+source_symlink_root=$(cd "$source_symlink_root" && pwd -P)
+printf 'SwiftVLC managed libVLC build directory v1\n' > \
+  "$source_symlink_root/swiftvlc-libvlc-build/.swiftvlc-managed-libvlc-build-v1"
+printf 'outside source data\n' > "$source_symlink_target/do-not-delete"
+ln -s "$source_symlink_target" \
+  "$source_symlink_root/swiftvlc-libvlc-build/vlc"
+: > "$handoff_git_log"
+if PATH="$handoff_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  MAKEFLAGS=-j1 TERM=dumb LC_ALL=C \
+  SWIFTVLC_REAL_PYTHON3="$real_python3" \
+  SWIFTVLC_REAL_GIT="$(command -v git)" \
+  SWIFTVLC_ASSET_VALIDATOR="$ROOT_DIR/scripts/verify-native-validator-assets.py" \
+  SWIFTVLC_DETACH_HELPER="$DETACH_HELPER" \
+  SWIFTVLC_GIT_LOG="$handoff_git_log" \
+  SWIFTVLC_RACE_MODE=none \
+  SWIFTVLC_RACE_STATE="$handoff_race_state" \
+  "$BUILD_SCRIPT" --build-root="$source_symlink_root" --macos-only \
+  > "$source_symlink_log" 2>&1; then
+  fail "symlinked VLC source directory was accepted"
+fi
+grep -Fq \
+  "Refusing a symlinked VLC source directory: $source_symlink_root/swiftvlc-libvlc-build/vlc" \
+  "$source_symlink_log" || \
+  fail "symlinked VLC source did not produce the expected diagnostic"
+[[ -L "$source_symlink_root/swiftvlc-libvlc-build/vlc" ]] || \
+  fail "symlinked VLC source entry was mutated before rejection"
+[[ -f "$source_symlink_target/do-not-delete" ]] || \
+  fail "symlinked VLC source target was mutated before rejection"
+if find "$source_symlink_target" -maxdepth 1 \
+  -name '.swiftvlc-managed-vlc-binding-*' -print -quit | grep -q .; then
+  fail "VLC source handoff followed a symlink and bound its outside target"
+fi
+[[ ! -s "$handoff_git_log" ]] || \
+  fail "symlinked VLC source reached a direct Git command"
+[[ ! -e "$source_symlink_root/.swiftvlc-libvlc-build.lock" ]] || \
+  fail "symlinked VLC source failure left the external-root lock behind"
+[[ ! -e "$checkout_lock" ]] || \
+  fail "symlinked VLC source failure left the checkout lock behind"
+/bin/rm -rf "$source_symlink_root" "$source_symlink_target" "$ROOT_DIR/Vendor"
+
+# Vendor is an independent checkout output boundary. Its descriptor-safe bind
+# must reject a symlink without deleting prior evidence through the link.
+vendor_symlink_root="$temporary_root/vendor-symlink-root"
+vendor_symlink_target="$temporary_root/vendor-symlink-target"
+vendor_symlink_log="$temporary_root/vendor-symlink.log"
+mkdir "$vendor_symlink_root" "$vendor_symlink_target"
+vendor_symlink_root=$(cd "$vendor_symlink_root" && pwd -P)
+printf 'outside output data\n' > \
+  "$vendor_symlink_target/libvlc-provenance.json"
+printf 'outside output sentinel\n' > "$vendor_symlink_target/do-not-delete"
+ln -s "$vendor_symlink_target" "$ROOT_DIR/Vendor"
+: > "$handoff_git_log"
+if PATH="$handoff_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  MAKEFLAGS=-j1 TERM=dumb LC_ALL=C \
+  SWIFTVLC_REAL_PYTHON3="$real_python3" \
+  SWIFTVLC_REAL_GIT="$(command -v git)" \
+  SWIFTVLC_ASSET_VALIDATOR="$ROOT_DIR/scripts/verify-native-validator-assets.py" \
+  SWIFTVLC_DETACH_HELPER="$DETACH_HELPER" \
+  SWIFTVLC_GIT_LOG="$handoff_git_log" \
+  SWIFTVLC_RACE_MODE=none \
+  SWIFTVLC_RACE_STATE="$handoff_race_state" \
+  "$BUILD_SCRIPT" --build-root="$vendor_symlink_root" --macos-only \
+  > "$vendor_symlink_log" 2>&1; then
+  fail "symlinked checkout Vendor directory was accepted"
+fi
+grep -Fq "binding child Vendor is not a directory" \
+  "$vendor_symlink_log" || \
+  fail "symlinked Vendor was not rejected by the descriptor-safe bind"
+grep -Fq "Could not safely anchor the original checkout Vendor output directory" \
+  "$vendor_symlink_log" || \
+  fail "symlinked Vendor did not produce the expected build diagnostic"
+[[ -L "$ROOT_DIR/Vendor" ]] || \
+  fail "symlinked Vendor entry was mutated before rejection"
+[[ -f "$vendor_symlink_target/do-not-delete" ]] || \
+  fail "symlinked Vendor target was mutated before rejection"
+grep -Fqx 'outside output data' \
+  "$vendor_symlink_target/libvlc-provenance.json" || \
+  fail "symlinked Vendor target lost prior provenance evidence"
+if find "$vendor_symlink_target" -maxdepth 1 \
+  -name '.swiftvlc-managed-output-binding-*' -print -quit | grep -q .; then
+  fail "Vendor handoff followed a symlink and bound its outside target"
+fi
+[[ ! -s "$handoff_git_log" ]] || \
+  fail "symlinked Vendor rejection reached a direct Git command"
+[[ ! -e "$vendor_symlink_root/.swiftvlc-libvlc-build.lock" ]] || \
+  fail "symlinked Vendor failure left the external-root lock behind"
+[[ ! -e "$checkout_lock" ]] || \
+  fail "symlinked Vendor failure left the checkout lock behind"
+/bin/rm "$ROOT_DIR/Vendor"
+/bin/rm -rf "$vendor_symlink_root" "$vendor_symlink_target"
+
+# The real helper can bind an existing source directory, after which a
+# non-cooperating writer can still replace its public name. The one-use binding
+# must make that replacement fail before Git sees either directory.
+source_swap_root="$temporary_root/source-swap-root"
+source_swap_log="$temporary_root/source-swap.log"
+mkdir -p "$source_swap_root/swiftvlc-libvlc-build/vlc"
+source_swap_root=$(cd "$source_swap_root" && pwd -P)
+printf 'SwiftVLC managed libVLC build directory v1\n' > \
+  "$source_swap_root/swiftvlc-libvlc-build/.swiftvlc-managed-libvlc-build-v1"
+printf 'preserve original source\n' > \
+  "$source_swap_root/swiftvlc-libvlc-build/vlc/do-not-delete"
+/bin/rm -f "$handoff_race_state"
+: > "$handoff_git_log"
+if PATH="$handoff_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  MAKEFLAGS=-j1 TERM=dumb LC_ALL=C \
+  SWIFTVLC_REAL_PYTHON3="$real_python3" \
+  SWIFTVLC_REAL_GIT="$(command -v git)" \
+  SWIFTVLC_ASSET_VALIDATOR="$ROOT_DIR/scripts/verify-native-validator-assets.py" \
+  SWIFTVLC_DETACH_HELPER="$DETACH_HELPER" \
+  SWIFTVLC_GIT_LOG="$handoff_git_log" \
+  SWIFTVLC_RACE_MODE=source \
+  SWIFTVLC_RACE_STATE="$handoff_race_state" \
+  "$BUILD_SCRIPT" --build-root="$source_swap_root" --macos-only \
+  > "$source_swap_log" 2>&1; then
+  fail "post-bind VLC source replacement was accepted"
+fi
+[[ -e "$handoff_race_state" ]] || \
+  fail "post-bind VLC source replacement race did not execute"
+grep -Fq "Managed VLC source directory changed before it could be anchored" \
+  "$source_swap_log" || \
+  fail "post-bind VLC source replacement did not fail at the binding gate"
+[[ -f "$source_swap_root/swiftvlc-libvlc-build/vlc-bound-original/do-not-delete" ]] || \
+  fail "bound original VLC source directory was mutated"
+if ! find "$source_swap_root/swiftvlc-libvlc-build/vlc-bound-original" \
+  -maxdepth 1 -type f -name '.swiftvlc-managed-vlc-binding-*' \
+  -print -quit | grep -q .; then
+  fail "bound original VLC source directory lost its one-use binding"
+fi
+[[ -f "$source_swap_root/swiftvlc-libvlc-build/vlc/do-not-delete" ]] || \
+  fail "replacement VLC source directory was mutated"
+if find "$source_swap_root/swiftvlc-libvlc-build/vlc" -maxdepth 1 \
+  -name '.swiftvlc-managed-vlc-binding-*' -print -quit | grep -q .; then
+  fail "replacement VLC source directory inherited the original binding"
+fi
+[[ ! -s "$handoff_git_log" ]] || \
+  fail "post-bind VLC source replacement reached a direct Git command"
+[[ ! -e "$source_swap_root/.swiftvlc-libvlc-build.lock" ]] || \
+  fail "post-bind VLC source replacement left the external-root lock behind"
+[[ ! -e "$checkout_lock" ]] || \
+  fail "post-bind VLC source replacement left the checkout lock behind"
+/bin/rm -rf "$source_swap_root" "$ROOT_DIR/Vendor"
+
 dirty_repo="$temporary_root/dirty-repository"
 mkdir -p "$dirty_repo/scripts"
 cp "$SOURCE_SCRIPT_DIR/build-libvlc.sh" "$dirty_repo/scripts/build-libvlc.sh"
+cp "$SOURCE_SCRIPT_DIR/detach-managed-build-directory.py" \
+  "$dirty_repo/scripts/detach-managed-build-directory.py"
 git -C "$dirty_repo" init -q
-git -C "$dirty_repo" add scripts/build-libvlc.sh
+git -C "$dirty_repo" add \
+  scripts/build-libvlc.sh scripts/detach-managed-build-directory.py
 git -C "$dirty_repo" \
   -c user.name=SwiftVLC -c user.email=swiftvlc@example.invalid \
   commit -qm fixture

--- a/scripts/tests/release-integrity.sh
+++ b/scripts/tests/release-integrity.sh
@@ -2504,6 +2504,10 @@ headless_runtime_gate = build.index(
 final_archive_mutation = build.index(
     'find "${OUTPUT_DIR}/libvlc.xcframework" -name \'*.a\' -exec xcrun ranlib -D {} \\;'
 )
+checkout_path_gate = build.index(
+    'if [ "${EXTERNAL_BUILD_ROOT}" = yes ]; then\n'
+    '    info "Verifying that the release artifact contains no checkout-local paths..."'
+)
 native_archive_contract_setup = build.index(
     'native_archive_contract_args=('
 )
@@ -2518,6 +2522,7 @@ if not (
     < headless_runtime_selection
     < headless_runtime_gate
     < final_archive_mutation
+    < checkout_path_gate
     < native_archive_contract_setup
     < native_archive_contract
     < archive_metadata_gate
@@ -2526,6 +2531,36 @@ if not (
         "exact linked native extension validation is not after the final "
         "archive mutation and before artifact metadata/provenance gates"
     )
+checkout_path_gate_region = build[
+    checkout_path_gate:native_archive_contract_setup
+]
+checkout_path_function_start = build.index(
+    'verify_checkout_path_not_embedded() {'
+)
+checkout_path_function = build[
+    checkout_path_function_start:build.index(
+        '\n}\n\ntrap release_build_locks EXIT', checkout_path_function_start
+    )
+]
+for marker in (
+    '"${SCRIPT_DIR}/verify-libvlc-build-paths.py"',
+    '--xcframework "${OUTPUT_DIR}/libvlc.xcframework"',
+    '--forbidden-path "${REPO_ROOT}"',
+):
+    if checkout_path_function.count(marker) != 1:
+        sys.exit(f"checkout-path verifier invocation is incomplete: {marker}")
+for marker in (
+    'if [ "${EXTERNAL_BUILD_ROOT}" = yes ]; then',
+    'verify_checkout_path_not_embedded',
+):
+    if checkout_path_gate_region.count(marker) != 1:
+        sys.exit(f"checkout-path gate is not ordered after archive normalization: {marker}")
+if (
+    'if [ "${CLEAN_BUILD}" = yes ] && [ "${EXTERNAL_BUILD_ROOT}" != yes ]; then'
+    not in build
+    or '--clean-build requires a canonical external --build-root' not in build
+):
+    sys.exit("clean provenance builds do not require the canonical external root")
 headless_runtime_region = build[headless_runtime_selection:final_archive_mutation]
 for marker in (
     'if [ "$headless_vout_teardown_patch_listed" = yes ] && [ "$BUILD_MACOS" = "yes" ]; then',
@@ -2567,6 +2602,7 @@ expected_configurations = {
     "native-extension-version-probe.c",
     "pip_extension_version.py",
     "validate-libvlc-macho-metadata.py",
+    "verify-libvlc-build-paths.py",
     "validate-apple-assembly-metadata-patch.sh",
     "validate-aom-nasm3-detection.sh",
     "validate-headless-vout-teardown.sh",
@@ -5173,6 +5209,7 @@ release_flow_pushes_before=$(wc -l < "$release_flow_git_log" | tr -d ' ')
   fail "completed finalize repeated a candidate or cleanup ref write"
 cd "$ROOT_DIR"
 bash -n \
+  scripts/build-libvlc.sh \
   scripts/canonical-libvlc-artifact.sh \
   scripts/check-engine-coverage.sh \
   scripts/check-qualification.sh \

--- a/scripts/tests/release-integrity.sh
+++ b/scripts/tests/release-integrity.sh
@@ -2190,11 +2190,42 @@ for retained_evidence in (
     if post_pin_validator.count(retained_evidence) != 1:
         sys.exit(f"post-pin linked/native evidence was dropped: {retained_evidence}")
 
-artifact_replacement = build.index('rm -rf "${OUTPUT_DIR}/libvlc.xcframework"')
-metadata_report_removal = build.index('    "${MACHO_METADATA_REPORT}"')
+staged_output_setup = build.index(
+    'STAGED_OUTPUT_CHILD=".swiftvlc-native-output"'
+)
+staged_output_initialization = build.index(
+    '"${SCRIPT_DIR}/detach-managed-build-directory.py" initialize \\\n',
+    staged_output_setup,
+)
+staged_output_require_new = build.index(
+    '    --require-new; then', staged_output_initialization
+)
+staged_output_anchor = build.index(
+    'cd "${STAGED_OUTPUT_CHILD}"', staged_output_require_new
+)
 artifact_creation = build.index('\nxcodebuild -create-xcframework \\\n')
-if not metadata_report_removal < artifact_replacement < artifact_creation:
-    sys.exit("artifact replacement can retain a stale Mach-O metadata report")
+if not (
+    staged_output_setup
+    < staged_output_initialization
+    < staged_output_require_new
+    < staged_output_anchor
+    < artifact_creation
+):
+    sys.exit("native artifact is not assembled in a fresh bound staging directory")
+if 'rm -rf "${OUTPUT_DIR}/libvlc.xcframework"' in build:
+    sys.exit("native artifact replacement regressed to pathname-recursive deletion")
+stage_phase = build[staged_output_anchor:]
+if (
+    'retire_directory_binding \\\n'
+    '    "${STAGED_OUTPUT_BINDING_NAME}" "${STAGED_OUTPUT_BINDING_CONTENT}"'
+    in stage_phase
+):
+    sys.exit("native output stage retires its generation binding before cleanup")
+if stage_phase.count(
+    'verify_directory_binding \\\n'
+    '    "${STAGED_OUTPUT_BINDING_NAME}" "${STAGED_OUTPUT_BINDING_CONTENT}"'
+) != 2:
+    sys.exit("native output stage is not generation-verified at entry and publication")
 
 build_metadata_verification = build.index(
     'info "Verifying per-object Mach-O platform metadata and section alignment..."'
@@ -2202,21 +2233,199 @@ build_metadata_verification = build.index(
 provenance = build.index('python3 "${SCRIPT_DIR}/libvlc-provenance.py" create')
 if provenance < build_metadata_verification:
     sys.exit("provenance is written before per-object Mach-O verification")
-startup_evidence_invalidation = (
-    'rm -f "${OUTPUT_DIR}/libvlc-provenance-a.json" \\\n'
-    '    "${OUTPUT_DIR}/libvlc-provenance.json" \\\n'
-    '    "${OUTPUT_DIR}/libvlc-reproducibility.json" \\\n'
-    '    "${OUTPUT_DIR}/libvlc-macho-metadata.json"'
+evidence_invalidation = (
+    'rm -f ./libvlc-provenance-a.json \\\n'
+    '    ./libvlc-provenance.json \\\n'
+    '    ./libvlc-reproducibility.json \\\n'
+    '    ./libvlc-macho-metadata.json'
 )
-if build.count(startup_evidence_invalidation) != 1:
+if build.count(evidence_invalidation) != 2:
     sys.exit(
-        "native build startup does not invalidate A/B provenance, proof, and "
-        "Mach-O evidence as one exact set"
+        "native build does not invalidate A/B provenance, proof, and Mach-O "
+        "evidence as one exact set at startup and final publication"
     )
-if build.index(startup_evidence_invalidation) > build.index(
+startup_evidence_invalidation = build.index(evidence_invalidation)
+if startup_evidence_invalidation > build.index(
     'info "Setting up VLC source..."'
 ):
     sys.exit("native build invalidates stale two-build evidence after source setup")
+
+output_lock_call = build.index('\nacquire_output_lock\n')
+original_vendor_bind = build.index(
+    'if ! bind_directory_for_handoff \\\n'
+    '            . Vendor \\\n',
+    output_lock_call,
+)
+external_root_reanchor = build.index(
+    'configure_external_build_root "${BUILD_ROOT_OVERRIDE}"',
+    original_vendor_bind,
+)
+if not (
+    output_lock_call
+    < original_vendor_bind
+    < external_root_reanchor
+    < startup_evidence_invalidation
+):
+    sys.exit("checkout lock/Vendor continuity is established after external re-anchor")
+if (
+    'cd -P ..\n'
+    '        if [ "$(/bin/pwd -P)" != "${REPO_ROOT}" ]; then'
+    not in build[output_lock_call:original_vendor_bind]
+):
+    sys.exit("original Vendor bind is not rooted in the physical checkout parent")
+if '$(pwd -P)' in build:
+    sys.exit("native path identity relies on Bash 3.2's stale cached pwd builtin")
+
+output_lock_function_start = build.index('acquire_output_lock() {')
+output_lock_function_end = build.index(
+    '\n}\n\ninitialize_managed_build_directory()', output_lock_function_start
+)
+output_lock_function = build[output_lock_function_start:output_lock_function_end]
+for lock_marker in (
+    'lock-acquire',
+    '--root-fd "${OUTPUT_LOCK_PARENT_FD}"',
+    '--child "${OUTPUT_LOCK_NAME}"',
+    '--token-name "${LOCK_TOKEN_NAME}"',
+    '--token-content "${OUTPUT_LOCK_TOKEN_CONTENT}"',
+):
+    if output_lock_function.count(lock_marker) != 1:
+        sys.exit(f"checkout output lock is not descriptor-anchored: {lock_marker}")
+release_output_lock_start = build.index('release_output_lock() {')
+release_output_lock_end = build.index(
+    '\n}\n\nclose_output_lock_parent()', release_output_lock_start
+)
+release_output_lock_function = build[
+    release_output_lock_start:release_output_lock_end
+]
+for lock_marker in (
+    'lock-release',
+    '--root-fd "${OUTPUT_LOCK_PARENT_FD}"',
+    '--child "${OUTPUT_LOCK_NAME}"',
+    '--token-name "${LOCK_TOKEN_NAME}"',
+    '--token-content "${OUTPUT_LOCK_TOKEN_CONTENT}"',
+):
+    if release_output_lock_function.count(lock_marker) != 1:
+        sys.exit(f"checkout output lock release is not descriptor-safe: {lock_marker}")
+if 'rmdir "${OUTPUT_LOCK_DIR}"' in build:
+    sys.exit("checkout output lock release regressed to an absolute pathname")
+
+build_lock_function_start = build.index('acquire_build_root_lock() {')
+build_lock_function_end = build.index(
+    '\n}\n\nreject_stale_managed_build_state()', build_lock_function_start
+)
+build_lock_function = build[build_lock_function_start:build_lock_function_end]
+for lock_marker in (
+    'exec 8<.',
+    'lock-acquire',
+    '--root-fd "${BUILD_LOCK_PARENT_FD}"',
+    '--child "${BUILD_LOCK_DIR}"',
+    '--token-name "${LOCK_TOKEN_NAME}"',
+    '--token-content "${BUILD_LOCK_TOKEN_CONTENT}"',
+):
+    if build_lock_function.count(lock_marker) != 1:
+        sys.exit(f"external build-root lock is not generation-bound: {lock_marker}")
+release_build_lock_start = build.index('release_build_root_lock() {')
+release_build_lock_end = build.index(
+    '\n}\n\nclose_build_lock_parent()', release_build_lock_start
+)
+release_build_lock_function = build[
+    release_build_lock_start:release_build_lock_end
+]
+for lock_marker in (
+    'lock-release',
+    '--root-fd "${BUILD_LOCK_PARENT_FD}"',
+    '--child "${BUILD_LOCK_DIR}"',
+    '--token-name "${LOCK_TOKEN_NAME}"',
+    '--token-content "${BUILD_LOCK_TOKEN_CONTENT}"',
+):
+    if release_build_lock_function.count(lock_marker) != 1:
+        sys.exit(f"external build-root lock release is not generation-safe: {lock_marker}")
+if 'mkdir "${BUILD_LOCK_DIR}"' in build or 'rmdir "${BUILD_LOCK_DIR}"' in build:
+    sys.exit("external build-root lock regressed to pathname-only mkdir/rmdir")
+
+publication_binding = build.index(
+    '    "${PUBLISHING_BINDING_NAME}" "${PUBLISHING_BINDING_CONTENT}" \\\n'
+    '    --create; then'
+)
+publication_copy = build.index(
+    '    "${STAGED_OUTPUT_DIRECTORY}/libvlc.xcframework" \\\n'
+    '    ./libvlc.xcframework',
+    publication_binding,
+)
+published_tree_verification = build.index(
+    'module.verify_recorded_artifact(record, published_path, "published XCFramework")',
+    publication_copy,
+)
+old_artifact_cleanup = build.index(
+    '"${SCRIPT_DIR}/detach-managed-build-directory.py" clean \\\n'
+    '        --root . \\\n'
+    '        --child libvlc.xcframework',
+    published_tree_verification,
+)
+final_evidence_invalidation = build.index(
+    evidence_invalidation, old_artifact_cleanup
+)
+publication = build.index(
+    '"${SCRIPT_DIR}/detach-managed-build-directory.py" publish \\\n',
+    final_evidence_invalidation,
+)
+publication_command_end = build.index(
+    '; then', publication
+)
+publication_command = build[publication:publication_command_end]
+expected_publication_entries = (
+    '    --entry libvlc.xcframework \\\n'
+    '    --entry libvlc-macho-metadata.json \\\n'
+    '    --entry libvlc-provenance.json'
+)
+if publication_command.count(expected_publication_entries) != 1:
+    sys.exit("native publication does not move provenance last as its commit marker")
+if not (
+    provenance
+    < publication_binding
+    < publication_copy
+    < published_tree_verification
+    < old_artifact_cleanup
+    < final_evidence_invalidation
+    < publication
+):
+    sys.exit("native publication is not bound, verified, invalidated, and committed in order")
+for unsafe_publication in (
+    'mkdir "${PUBLISHING_CHILD}"',
+    'mv "${PUBLISHING_CHILD}/',
+    'rmdir "${PUBLISHING_CHILD}"',
+):
+    if unsafe_publication in build:
+        sys.exit(f"native publication bypasses the fd-safe helper: {unsafe_publication}")
+stage_cleanup = build.index(
+    '"${SCRIPT_DIR}/detach-managed-build-directory.py" clean \\\n'
+    '    --root . \\\n'
+    '    --child "${STAGED_OUTPUT_CHILD}"',
+    publication,
+)
+stage_cleanup_end = build.index('; then', stage_cleanup)
+stage_cleanup_command = build[stage_cleanup:stage_cleanup_end]
+for generation_marker in (
+    '--marker-name "${STAGED_OUTPUT_BINDING_NAME}"',
+    '--marker-content "${STAGED_OUTPUT_BINDING_CONTENT}"',
+):
+    if stage_cleanup_command.count(generation_marker) != 1:
+        sys.exit(
+            "native output cleanup is not authorized by its invocation binding: "
+            f"{generation_marker}"
+        )
+for preserved_state in (
+    'for preserved_checkout_state in \\\n'
+    '            ./.swiftvlc-managed-build.initializing-*',
+    './.swiftvlc-native-output-publishing-* \\\n'
+    '    ./.swiftvlc-published-artifact.removing-* \\\n'
+    '    ./.swiftvlc-managed-build.initializing-*',
+    './.swiftvlc-native-output \\\n'
+    '    ./.swiftvlc-native-output.removing-* \\\n'
+    '    ./.swiftvlc-managed-build.initializing-*',
+):
+    if build.count(preserved_state) != 1:
+        sys.exit(f"native build does not surface preserved helper state: {preserved_state}")
 
 build_validator_asset_verification = build.index(
     'if ! python3 "${SCRIPT_DIR}/verify-native-validator-assets.py"; then'
@@ -2556,7 +2765,7 @@ for marker in (
     if checkout_path_gate_region.count(marker) != 1:
         sys.exit(f"checkout-path gate is not ordered after archive normalization: {marker}")
 if (
-    'if [ "${CLEAN_BUILD}" = yes ] && [ "${EXTERNAL_BUILD_ROOT}" != yes ]; then'
+    'if [ "${CLEAN_BUILD}" = yes ] && [ "${BUILD_ROOT_OVERRIDE_SET}" != yes ]; then'
     not in build
     or '--clean-build requires a canonical external --build-root' not in build
 ):
@@ -2597,6 +2806,7 @@ if release_validator_asset_verification > release_provenance_verification:
 
 expected_configurations = {
     "build-libvlc.sh",
+    "detach-managed-build-directory.py",
     "fix-duplicate-symbols.sh",
     "native-validator-assets.sha256",
     "native-extension-version-probe.c",

--- a/scripts/tests/test_detach_managed_build_directory.py
+++ b/scripts/tests/test_detach_managed_build_directory.py
@@ -1,0 +1,1045 @@
+import errno
+import importlib.util
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Optional
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "detach-managed-build-directory.py"
+MODULE_NAME = "swiftvlc_detach_managed_build_directory"
+SPEC = importlib.util.spec_from_file_location(MODULE_NAME, SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Could not load {SCRIPT}")
+HELPER = importlib.util.module_from_spec(SPEC)
+sys.modules[MODULE_NAME] = HELPER
+SPEC.loader.exec_module(HELPER)
+
+
+class ManagedBuildDirectoryTests(unittest.TestCase):
+    child_name = "swiftvlc-libvlc-build"
+    quarantine_name = ".swiftvlc-libvlc-build.removing-test"
+    marker_name = ".swiftvlc-managed-libvlc-build-v1"
+    marker_content = "SwiftVLC managed libVLC build directory v1"
+    binding_name = ".swiftvlc-source-binding"
+    binding_content = "invocation=test"
+    lock_token_name = ".swiftvlc-lock-generation-v1"
+    lock_token_content = "SwiftVLC lock generation test"
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name).resolve()
+        self.child = self.root / self.child_name
+        self.marker = self.child / self.marker_name
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def initialize(self, *, require_new: bool = False) -> None:
+        HELPER.initialize(
+            str(self.root),
+            self.child_name,
+            self.marker_name,
+            self.marker_content,
+            require_new,
+        )
+
+    def clean(self) -> None:
+        HELPER.clean(
+            str(self.root),
+            self.child_name,
+            self.quarantine_name,
+            self.marker_name,
+            self.marker_content,
+        )
+
+    def test_empty_lock_is_scoped_to_inherited_root_descriptor(self) -> None:
+        anchor = self.root / "lock-anchor"
+        moved = self.root / "lock-anchor-original"
+        anchor.mkdir()
+        root_fd = os.open(anchor, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try:
+            HELPER.acquire_generation_lock(
+                root_fd,
+                "native.lock",
+                self.lock_token_name,
+                self.lock_token_content,
+            )
+            anchor.rename(moved)
+            anchor.mkdir()
+            (anchor / "native.lock").mkdir()
+
+            HELPER.release_generation_lock(
+                root_fd,
+                "native.lock",
+                self.lock_token_name,
+                self.lock_token_content,
+            )
+        finally:
+            os.close(root_fd)
+
+        self.assertFalse((moved / "native.lock").exists())
+        self.assertTrue((anchor / "native.lock").is_dir())
+
+    def test_empty_lock_acquire_preserves_contended_directory(self) -> None:
+        lock = self.root / "native.lock"
+        lock.mkdir()
+        (lock / "owner-data").write_text("preserve\n")
+        root_fd = os.open(self.root, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try:
+            with self.assertRaisesRegex(HELPER.SafetyError, "lock already exists"):
+                HELPER.acquire_generation_lock(
+                    root_fd,
+                    "native.lock",
+                    self.lock_token_name,
+                    self.lock_token_content,
+                )
+        finally:
+            os.close(root_fd)
+
+        self.assertEqual((lock / "owner-data").read_text(), "preserve\n")
+
+    def test_empty_lock_release_refuses_populated_lock(self) -> None:
+        root_fd = os.open(self.root, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try:
+            HELPER.acquire_generation_lock(
+                root_fd,
+                "native.lock",
+                self.lock_token_name,
+                self.lock_token_content,
+            )
+            (self.root / "native.lock" / "foreign-data").write_text("preserve\n")
+            with self.assertRaisesRegex(HELPER.SafetyError, "unexpectedly populated"):
+                HELPER.release_generation_lock(
+                    root_fd,
+                    "native.lock",
+                    self.lock_token_name,
+                    self.lock_token_content,
+                )
+        finally:
+            os.close(root_fd)
+
+        self.assertEqual(
+            (self.root / "native.lock" / "foreign-data").read_text(),
+            "preserve\n",
+        )
+
+    def test_generation_lock_release_never_removes_a_successor_lock(self) -> None:
+        root_fd = os.open(self.root, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try:
+            HELPER.acquire_generation_lock(
+                root_fd,
+                "native.lock",
+                self.lock_token_name,
+                self.lock_token_content,
+            )
+            (self.root / "native.lock").rename(self.root / "first-generation")
+            successor_content = "SwiftVLC lock generation next"
+            HELPER.acquire_generation_lock(
+                root_fd,
+                "native.lock",
+                self.lock_token_name,
+                successor_content,
+            )
+
+            with self.assertRaisesRegex(
+                HELPER.SafetyError, "belongs to a different invocation"
+            ):
+                HELPER.release_generation_lock(
+                    root_fd,
+                    "native.lock",
+                    self.lock_token_name,
+                    self.lock_token_content,
+                )
+        finally:
+            os.close(root_fd)
+
+        self.assertEqual(
+            (self.root / "native.lock" / self.lock_token_name).read_text(),
+            "SwiftVLC lock generation next\n",
+        )
+        self.assertTrue((self.root / "first-generation").is_dir())
+
+    def test_generation_lock_release_rmdir_window_preserves_successor(self) -> None:
+        root_fd = os.open(self.root, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        original_rmdir = HELPER.os.rmdir
+        race_triggered = False
+        successor_content = "SwiftVLC lock generation next"
+
+        def replace_immediately_before_rmdir(path, *args, **kwargs):
+            nonlocal race_triggered
+            if (
+                not race_triggered
+                and path == "native.lock"
+                and kwargs.get("dir_fd") is not None
+                and HELPER.same_identity(
+                    os.fstat(kwargs["dir_fd"]), os.fstat(root_fd)
+                )
+            ):
+                race_triggered = True
+                (self.root / "native.lock").rename(
+                    self.root / "first-generation"
+                )
+                HELPER.acquire_generation_lock(
+                    root_fd,
+                    "native.lock",
+                    self.lock_token_name,
+                    successor_content,
+                )
+            return original_rmdir(path, *args, **kwargs)
+
+        try:
+            HELPER.acquire_generation_lock(
+                root_fd,
+                "native.lock",
+                self.lock_token_name,
+                self.lock_token_content,
+            )
+            with mock.patch.object(
+                HELPER.os, "rmdir", side_effect=replace_immediately_before_rmdir
+            ):
+                with self.assertRaisesRegex(
+                    HELPER.SafetyError, "cannot retire generation lock"
+                ):
+                    HELPER.release_generation_lock(
+                        root_fd,
+                        "native.lock",
+                        self.lock_token_name,
+                        self.lock_token_content,
+                    )
+        finally:
+            os.close(root_fd)
+
+        self.assertTrue(race_triggered)
+        self.assertEqual(
+            (self.root / "native.lock" / self.lock_token_name).read_text(),
+            successor_content + "\n",
+        )
+        self.assertEqual(
+            (self.root / "first-generation" / self.lock_token_name).read_text(),
+            self.lock_token_content + "\n",
+        )
+
+    @staticmethod
+    def create_file_at(parent_fd: int, name: str, payload: bytes) -> None:
+        descriptor = os.open(
+            name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+            dir_fd=parent_fd,
+        )
+        try:
+            os.write(descriptor, payload)
+        finally:
+            os.close(descriptor)
+
+    def test_initialize_publishes_exact_marker_and_require_new_rejects_reuse(
+        self,
+    ) -> None:
+        self.initialize()
+
+        self.assertEqual(
+            self.marker.read_bytes(), (self.marker_content + "\n").encode()
+        )
+        self.initialize()
+        with self.assertRaisesRegex(HELPER.SafetyError, "new directory was required"):
+            self.initialize(require_new=True)
+
+        self.assertEqual(
+            sorted(path.name for path in self.root.iterdir()), [self.child_name]
+        )
+
+    def test_initialize_never_blesses_unowned_publish_winner(self) -> None:
+        original_rename = HELPER.rename_noreplace
+        raced = False
+
+        def publish_race(
+            source_parent_fd: int,
+            source_name: str,
+            destination_parent_fd: int,
+            destination_name: str,
+        ) -> None:
+            nonlocal raced
+            self.assertFalse(raced)
+            raced = True
+            os.mkdir(destination_name, 0o700, dir_fd=destination_parent_fd)
+            self.create_file_at(
+                destination_parent_fd,
+                f"{destination_name}/do-not-delete",
+                b"unrelated data\n",
+            )
+            original_rename(
+                source_parent_fd,
+                source_name,
+                destination_parent_fd,
+                destination_name,
+            )
+
+        with mock.patch.object(HELPER, "rename_noreplace", side_effect=publish_race):
+            with self.assertRaises(HELPER.SafetyError):
+                self.initialize()
+
+        self.assertTrue(raced)
+        self.assertEqual((self.child / "do-not-delete").read_text(), "unrelated data\n")
+        self.assertFalse(self.marker.exists())
+        self.assertFalse(self.marker.is_symlink())
+        self.assertFalse(
+            any(
+                path.name.startswith(HELPER.STAGING_PREFIX)
+                for path in self.root.iterdir()
+            )
+        )
+
+    def test_bind_exclusively_binds_existing_directory_without_initializing(
+        self,
+    ) -> None:
+        self.child.mkdir()
+        preserved = self.child / "preserved.txt"
+        preserved.write_text("source\n")
+
+        HELPER.bind(
+            str(self.root),
+            self.child_name,
+            self.binding_name,
+            self.binding_content,
+            create=True,
+        )
+
+        binding = self.child / self.binding_name
+        self.assertEqual(binding.read_bytes(), b"invocation=test\n")
+        self.assertEqual(preserved.read_text(), "source\n")
+        self.assertFalse(self.marker.exists())
+        with self.assertRaisesRegex(HELPER.SafetyError, "exclusively create"):
+            HELPER.bind(
+                str(self.root),
+                self.child_name,
+                self.binding_name,
+                self.binding_content,
+            )
+        self.assertEqual(binding.read_bytes(), b"invocation=test\n")
+
+    def test_bind_create_atomically_publishes_binding_only_directory(self) -> None:
+        HELPER.bind(
+            str(self.root),
+            self.child_name,
+            self.binding_name,
+            self.binding_content,
+            create=True,
+        )
+
+        self.assertEqual(
+            sorted(path.name for path in self.child.iterdir()), [self.binding_name]
+        )
+        self.assertEqual(
+            (self.child / self.binding_name).read_bytes(), b"invocation=test\n"
+        )
+        self.assertEqual(stat.S_IMODE(self.child.stat().st_mode), 0o700)
+        self.assertFalse(
+            any(
+                path.name.startswith(HELPER.STAGING_PREFIX)
+                for path in self.root.iterdir()
+            )
+        )
+
+    def test_bind_create_preserves_racing_publish_winner(self) -> None:
+        original_rename = HELPER.rename_noreplace
+        raced = False
+
+        def publish_race(
+            source_parent_fd: int,
+            source_name: str,
+            destination_parent_fd: int,
+            destination_name: str,
+        ) -> None:
+            nonlocal raced
+            self.assertFalse(raced)
+            raced = True
+            os.mkdir(destination_name, 0o700, dir_fd=destination_parent_fd)
+            self.create_file_at(
+                destination_parent_fd,
+                f"{destination_name}/do-not-delete",
+                b"unrelated\n",
+            )
+            original_rename(
+                source_parent_fd,
+                source_name,
+                destination_parent_fd,
+                destination_name,
+            )
+
+        with mock.patch.object(HELPER, "rename_noreplace", side_effect=publish_race):
+            with self.assertRaisesRegex(
+                HELPER.SafetyError, "cannot atomically publish binding child"
+            ):
+                HELPER.bind(
+                    str(self.root),
+                    self.child_name,
+                    self.binding_name,
+                    self.binding_content,
+                    create=True,
+                )
+
+        self.assertTrue(raced)
+        self.assertEqual((self.child / "do-not-delete").read_text(), "unrelated\n")
+        self.assertFalse((self.child / self.binding_name).exists())
+        self.assertFalse(
+            any(
+                path.name.startswith(HELPER.STAGING_PREFIX)
+                for path in self.root.iterdir()
+            )
+        )
+
+    def test_bind_rejects_absent_file_and_symlink_children(self) -> None:
+        with self.assertRaises(HELPER.SafetyError):
+            HELPER.bind(
+                str(self.root),
+                "absent",
+                self.binding_name,
+                self.binding_content,
+            )
+
+        file_child = self.root / "file-child"
+        file_child.write_text("preserve\n")
+        with self.assertRaisesRegex(HELPER.SafetyError, "is not a directory"):
+            HELPER.bind(
+                str(self.root),
+                file_child.name,
+                self.binding_name,
+                self.binding_content,
+                create=True,
+            )
+        self.assertEqual(file_child.read_text(), "preserve\n")
+
+        outside = self.root / "outside"
+        outside.mkdir()
+        symlink_child = self.root / "symlink-child"
+        symlink_child.symlink_to(outside, target_is_directory=True)
+        with self.assertRaisesRegex(HELPER.SafetyError, "is not a directory"):
+            HELPER.bind(
+                str(self.root),
+                symlink_child.name,
+                self.binding_name,
+                self.binding_content,
+                create=True,
+            )
+        self.assertFalse((outside / self.binding_name).exists())
+
+    def test_bind_rejects_filesystem_boundary_before_creating_binding(self) -> None:
+        self.child.mkdir()
+
+        def filesystem_identifier(_: int, description: str) -> int:
+            return 202 if description.startswith("binding child") else 101
+
+        with mock.patch.object(
+            HELPER,
+            "filesystem_identifier",
+            side_effect=filesystem_identifier,
+        ):
+            with self.assertRaisesRegex(
+                HELPER.SafetyError, "device/filesystem identity boundary"
+            ):
+                HELPER.bind(
+                    str(self.root),
+                    self.child_name,
+                    self.binding_name,
+                    self.binding_content,
+                )
+        self.assertFalse((self.child / self.binding_name).exists())
+
+    def test_bind_rejects_public_child_swap_at_final_revalidation(self) -> None:
+        self.child.mkdir()
+        (self.child / "original.txt").write_text("original\n")
+        saved_name = "original-source-child"
+        original_revalidate = HELPER.require_named_directory_identity
+        raced = False
+
+        def revalidate_with_swap(
+            parent_fd: int,
+            name: str,
+            metadata: os.stat_result,
+            description: str,
+        ) -> None:
+            nonlocal raced
+            try:
+                os.stat(
+                    f"{name}/{self.binding_name}",
+                    dir_fd=parent_fd,
+                    follow_symlinks=False,
+                )
+                binding_exists = True
+            except FileNotFoundError:
+                binding_exists = False
+            if description.startswith("binding child") and binding_exists and not raced:
+                raced = True
+                os.rename(
+                    name,
+                    saved_name,
+                    src_dir_fd=parent_fd,
+                    dst_dir_fd=parent_fd,
+                )
+                os.mkdir(name, 0o700, dir_fd=parent_fd)
+                self.create_file_at(
+                    parent_fd,
+                    f"{name}/do-not-delete",
+                    b"replacement\n",
+                )
+            original_revalidate(parent_fd, name, metadata, description)
+
+        with mock.patch.object(
+            HELPER,
+            "require_named_directory_identity",
+            side_effect=revalidate_with_swap,
+        ):
+            with self.assertRaisesRegex(HELPER.SafetyError, "identity changed"):
+                HELPER.bind(
+                    str(self.root),
+                    self.child_name,
+                    self.binding_name,
+                    self.binding_content,
+                )
+
+        self.assertTrue(raced)
+        moved_child = self.root / saved_name
+        self.assertEqual((moved_child / "original.txt").read_text(), "original\n")
+        self.assertEqual(
+            (moved_child / self.binding_name).read_bytes(), b"invocation=test\n"
+        )
+        self.assertEqual((self.child / "do-not-delete").read_text(), "replacement\n")
+        self.assertFalse((self.child / self.binding_name).exists())
+
+    def test_publish_moves_entries_in_order_and_retires_bound_child(self) -> None:
+        self.child.mkdir()
+        HELPER.bind(
+            str(self.root),
+            self.child_name,
+            self.binding_name,
+            self.binding_content,
+        )
+        artifact = self.child / "libvlc.xcframework"
+        artifact.mkdir()
+        (artifact / "binary").write_bytes(b"artifact")
+        (self.child / "macho-report.json").write_text("report\n")
+        (self.child / "provenance.json").write_text("provenance\n")
+        original_rename = HELPER.rename_noreplace
+        publication_order: list[str] = []
+
+        def record_rename(
+            source_parent_fd: int,
+            source_name: str,
+            destination_parent_fd: int,
+            destination_name: str,
+        ) -> None:
+            publication_order.append(source_name)
+            original_rename(
+                source_parent_fd,
+                source_name,
+                destination_parent_fd,
+                destination_name,
+            )
+
+        with mock.patch.object(HELPER, "rename_noreplace", side_effect=record_rename):
+            HELPER.publish(
+                str(self.root),
+                self.child_name,
+                self.binding_name,
+                self.binding_content,
+                [
+                    "libvlc.xcframework",
+                    "macho-report.json",
+                    "provenance.json",
+                ],
+            )
+
+        self.assertEqual(
+            publication_order,
+            ["libvlc.xcframework", "macho-report.json", "provenance.json"],
+        )
+        self.assertFalse(self.child.exists())
+        self.assertEqual(
+            (self.root / "libvlc.xcframework" / "binary").read_bytes(), b"artifact"
+        )
+        self.assertEqual((self.root / "macho-report.json").read_text(), "report\n")
+        self.assertEqual((self.root / "provenance.json").read_text(), "provenance\n")
+
+    def test_publish_destination_race_never_replaces_winner(self) -> None:
+        self.child.mkdir()
+        HELPER.bind(
+            str(self.root),
+            self.child_name,
+            self.binding_name,
+            self.binding_content,
+        )
+        (self.child / "artifact").mkdir()
+        original_rename = HELPER.rename_noreplace
+
+        def destination_race(
+            source_parent_fd: int,
+            source_name: str,
+            destination_parent_fd: int,
+            destination_name: str,
+        ) -> None:
+            os.mkdir(destination_name, 0o700, dir_fd=destination_parent_fd)
+            self.create_file_at(
+                destination_parent_fd,
+                f"{destination_name}/winner",
+                b"unrelated\n",
+            )
+            original_rename(
+                source_parent_fd,
+                source_name,
+                destination_parent_fd,
+                destination_name,
+            )
+
+        with mock.patch.object(
+            HELPER, "rename_noreplace", side_effect=destination_race
+        ):
+            with self.assertRaisesRegex(
+                HELPER.SafetyError, "cannot atomically publish entry artifact"
+            ):
+                HELPER.publish(
+                    str(self.root),
+                    self.child_name,
+                    self.binding_name,
+                    self.binding_content,
+                    ["artifact"],
+                )
+
+        self.assertEqual((self.root / "artifact" / "winner").read_text(), "unrelated\n")
+        self.assertTrue((self.child / "artifact").is_dir())
+        self.assertEqual(
+            (self.child / self.binding_name).read_bytes(), b"invocation=test\n"
+        )
+
+    def test_publish_public_child_swap_preserves_opened_child(self) -> None:
+        self.child.mkdir()
+        HELPER.bind(
+            str(self.root),
+            self.child_name,
+            self.binding_name,
+            self.binding_content,
+        )
+        (self.child / "artifact").write_text("artifact\n")
+        original_rename = HELPER.rename_noreplace
+        saved_name = "original-publication-child"
+
+        def child_swap(
+            source_parent_fd: int,
+            source_name: str,
+            destination_parent_fd: int,
+            destination_name: str,
+        ) -> None:
+            os.rename(
+                self.child_name,
+                saved_name,
+                src_dir_fd=destination_parent_fd,
+                dst_dir_fd=destination_parent_fd,
+            )
+            os.mkdir(self.child_name, 0o700, dir_fd=destination_parent_fd)
+            self.create_file_at(
+                destination_parent_fd,
+                f"{self.child_name}/do-not-delete",
+                b"replacement\n",
+            )
+            original_rename(
+                source_parent_fd,
+                source_name,
+                destination_parent_fd,
+                destination_name,
+            )
+
+        with mock.patch.object(HELPER, "rename_noreplace", side_effect=child_swap):
+            with self.assertRaisesRegex(
+                HELPER.SafetyError,
+                "publication stopped after moving: artifact.*no rollback",
+            ):
+                HELPER.publish(
+                    str(self.root),
+                    self.child_name,
+                    self.binding_name,
+                    self.binding_content,
+                    ["artifact"],
+                )
+
+        self.assertEqual((self.root / "artifact").read_text(), "artifact\n")
+        self.assertEqual(
+            (self.root / saved_name / self.binding_name).read_bytes(),
+            b"invocation=test\n",
+        )
+        self.assertEqual((self.child / "do-not-delete").read_text(), "replacement\n")
+
+    def test_publish_rejects_unexpected_entry_before_any_move(self) -> None:
+        self.child.mkdir()
+        HELPER.bind(
+            str(self.root),
+            self.child_name,
+            self.binding_name,
+            self.binding_content,
+        )
+        (self.child / "artifact").write_text("artifact\n")
+        (self.child / "unexpected").write_text("preserve\n")
+
+        with self.assertRaisesRegex(
+            HELPER.SafetyError, "unexpected or missing entries"
+        ):
+            HELPER.publish(
+                str(self.root),
+                self.child_name,
+                self.binding_name,
+                self.binding_content,
+                ["artifact"],
+            )
+
+        self.assertFalse((self.root / "artifact").exists())
+        self.assertEqual((self.child / "artifact").read_text(), "artifact\n")
+        self.assertEqual((self.child / "unexpected").read_text(), "preserve\n")
+        with self.assertRaisesRegex(HELPER.SafetyError, "duplicate publication entry"):
+            HELPER.publish(
+                str(self.root),
+                self.child_name,
+                self.binding_name,
+                self.binding_content,
+                ["artifact", "artifact"],
+            )
+        with self.assertRaisesRegex(HELPER.SafetyError, "non-special path component"):
+            HELPER.publish(
+                str(self.root),
+                self.child_name,
+                self.binding_name,
+                self.binding_content,
+                ["."],
+            )
+
+    def test_publish_partial_failure_keeps_published_and_remaining_state(self) -> None:
+        self.child.mkdir()
+        HELPER.bind(
+            str(self.root),
+            self.child_name,
+            self.binding_name,
+            self.binding_content,
+        )
+        (self.child / "artifact").write_text("artifact\n")
+        (self.child / "macho-report").write_text("original report\n")
+        (self.child / "provenance").write_text("original provenance\n")
+        original_rename = HELPER.rename_noreplace
+
+        def fail_second_move(
+            source_parent_fd: int,
+            source_name: str,
+            destination_parent_fd: int,
+            destination_name: str,
+        ) -> None:
+            if source_name == "macho-report":
+                self.create_file_at(
+                    destination_parent_fd,
+                    destination_name,
+                    b"racing report\n",
+                )
+            original_rename(
+                source_parent_fd,
+                source_name,
+                destination_parent_fd,
+                destination_name,
+            )
+
+        with mock.patch.object(
+            HELPER, "rename_noreplace", side_effect=fail_second_move
+        ):
+            with self.assertRaisesRegex(
+                HELPER.SafetyError,
+                "publication stopped after moving: artifact.*no rollback",
+            ):
+                HELPER.publish(
+                    str(self.root),
+                    self.child_name,
+                    self.binding_name,
+                    self.binding_content,
+                    ["artifact", "macho-report", "provenance"],
+                )
+
+        self.assertEqual((self.root / "artifact").read_text(), "artifact\n")
+        self.assertEqual((self.root / "macho-report").read_text(), "racing report\n")
+        self.assertFalse((self.root / "provenance").exists())
+        self.assertEqual((self.child / "macho-report").read_text(), "original report\n")
+        self.assertEqual(
+            (self.child / "provenance").read_text(), "original provenance\n"
+        )
+        self.assertEqual(
+            (self.child / self.binding_name).read_bytes(), b"invocation=test\n"
+        )
+
+    def test_clean_removes_nested_tree_without_following_symlink(self) -> None:
+        self.initialize()
+        nested = self.child / "unicode-ı" / "deeper"
+        nested.mkdir(parents=True)
+        (nested / "data.bin").write_bytes(b"managed")
+        os.mkfifo(self.child / "named-pipe")
+        outside = self.root / "outside"
+        outside.mkdir()
+        (outside / "preserve.txt").write_text("outside\n")
+        (nested / "outside-link").symlink_to(outside, target_is_directory=True)
+
+        self.clean()
+
+        self.assertFalse(self.child.exists())
+        self.assertFalse((self.root / self.quarantine_name).exists())
+        self.assertEqual((outside / "preserve.txt").read_text(), "outside\n")
+
+    def test_clean_fails_closed_when_marker_is_a_symlink(self) -> None:
+        self.child.mkdir()
+        outside_marker = self.root / "outside-marker"
+        outside_marker.write_text(self.marker_content + "\n")
+        self.marker.symlink_to(outside_marker)
+        (self.child / "preserve.txt").write_text("managed\n")
+
+        with self.assertRaises(HELPER.SafetyError):
+            self.clean()
+
+        self.assertEqual((self.child / "preserve.txt").read_text(), "managed\n")
+        self.assertEqual(outside_marker.read_text(), self.marker_content + "\n")
+
+    def test_detach_detects_swap_in_final_public_name_window(self) -> None:
+        self.initialize()
+        (self.child / "original.txt").write_text("original\n")
+        original_rename = HELPER.rename_noreplace
+        saved_name = "original-managed-child"
+        raced = False
+
+        def detach_race(
+            source_parent_fd: int,
+            source_name: str,
+            destination_parent_fd: int,
+            destination_name: str,
+        ) -> None:
+            nonlocal raced
+            self.assertFalse(raced)
+            raced = True
+            os.rename(
+                source_name,
+                saved_name,
+                src_dir_fd=source_parent_fd,
+                dst_dir_fd=source_parent_fd,
+            )
+            os.mkdir(source_name, 0o700, dir_fd=source_parent_fd)
+            self.create_file_at(
+                source_parent_fd,
+                f"{source_name}/do-not-delete",
+                b"replacement\n",
+            )
+            self.create_file_at(
+                source_parent_fd,
+                f"{source_name}/{self.marker_name}",
+                (self.marker_content + "\n").encode(),
+            )
+            original_rename(
+                source_parent_fd,
+                source_name,
+                destination_parent_fd,
+                destination_name,
+            )
+
+        with mock.patch.object(HELPER, "rename_noreplace", side_effect=detach_race):
+            with self.assertRaisesRegex(
+                HELPER.SafetyError,
+                "detached payload is not the verified managed child.*preserved at",
+            ):
+                self.clean()
+
+        self.assertTrue(raced)
+        self.assertEqual(
+            (self.root / saved_name / "original.txt").read_text(), "original\n"
+        )
+        self.assertEqual(
+            (
+                self.root / self.quarantine_name / "payload" / "do-not-delete"
+            ).read_text(),
+            "replacement\n",
+        )
+
+    def test_quarantine_path_swap_cannot_redirect_recursive_cleanup(self) -> None:
+        self.initialize()
+        (self.child / "managed.txt").write_text("managed\n")
+        context = HELPER.detach_open(
+            str(self.root),
+            self.child_name,
+            self.quarantine_name,
+            self.marker_name,
+            self.marker_content,
+        )
+        moved_quarantine = self.root / "moved-quarantine"
+        outside = self.root / "outside"
+        outside.mkdir()
+        (outside / "preserve.txt").write_text("outside\n")
+        (self.root / self.quarantine_name).rename(moved_quarantine)
+        (self.root / self.quarantine_name).symlink_to(outside, target_is_directory=True)
+        try:
+            with self.assertRaises(HELPER.SafetyError):
+                HELPER.remove_detached_context(context)
+        finally:
+            context.close()
+
+        self.assertEqual((outside / "preserve.txt").read_text(), "outside\n")
+        self.assertEqual(
+            (moved_quarantine / "payload" / "managed.txt").read_text(), "managed\n"
+        )
+
+    def test_nested_directory_swap_is_rejected_before_descent(self) -> None:
+        parent = self.root / "parent"
+        target = parent / "target"
+        target.mkdir(parents=True)
+        (target / "original.txt").write_text("original\n")
+        parent_fd = os.open(parent, HELPER.directory_open_flags())
+        original_open = HELPER.open_named_directory
+        raced = False
+
+        def open_race(
+            supplied_parent_fd: int, name: str, description: str
+        ) -> tuple[int, os.stat_result]:
+            nonlocal raced
+            if name == "target" and not raced:
+                raced = True
+                os.rename(
+                    name,
+                    "target-original",
+                    src_dir_fd=supplied_parent_fd,
+                    dst_dir_fd=supplied_parent_fd,
+                )
+                os.mkdir(name, 0o700, dir_fd=supplied_parent_fd)
+                self.create_file_at(
+                    supplied_parent_fd,
+                    f"{name}/do-not-delete",
+                    b"replacement\n",
+                )
+            return original_open(supplied_parent_fd, name, description)
+
+        try:
+            with mock.patch.object(
+                HELPER, "open_named_directory", side_effect=open_race
+            ):
+                with self.assertRaisesRegex(
+                    HELPER.SafetyError, "identity changed before recursive descent"
+                ):
+                    HELPER.remove_entry(
+                        parent_fd,
+                        "target",
+                        os.fstat(parent_fd).st_dev,
+                        "target",
+                    )
+        finally:
+            os.close(parent_fd)
+
+        self.assertTrue(raced)
+        self.assertEqual(
+            (parent / "target-original" / "original.txt").read_text(), "original\n"
+        )
+        self.assertEqual(
+            (parent / "target" / "do-not-delete").read_text(), "replacement\n"
+        )
+
+    def test_opened_directory_rejects_distinct_filesystem_id_on_same_device(
+        self,
+    ) -> None:
+        child = self.root / "child"
+        child.mkdir()
+        parent_fd = os.open(self.root, HELPER.directory_open_flags())
+        self.assertEqual(os.fstat(parent_fd).st_dev, child.stat().st_dev)
+
+        def distinct_filesystems(directory_fd: int) -> SimpleNamespace:
+            identifier = 101 if directory_fd == parent_fd else 202
+            return SimpleNamespace(f_fsid=identifier)
+
+        try:
+            with mock.patch.object(
+                HELPER.os, "fstatvfs", side_effect=distinct_filesystems
+            ):
+                with self.assertRaisesRegex(
+                    HELPER.SafetyError,
+                    "device/filesystem identity boundary.*parent filesystem=101.*"
+                    "child filesystem=202",
+                ):
+                    HELPER.open_named_directory(parent_fd, "child", "mounted child")
+        finally:
+            os.close(parent_fd)
+
+    def test_non_darwin_without_filesystem_id_falls_back_to_device_identity(
+        self,
+    ) -> None:
+        child = self.root / "child"
+        child.mkdir()
+        parent_fd = os.open(self.root, HELPER.directory_open_flags())
+        child_fd = -1
+        try:
+            with mock.patch.object(HELPER.sys, "platform", "linux"), mock.patch.object(
+                HELPER.os, "fstatvfs", None
+            ):
+                self.assertIsNone(
+                    HELPER.filesystem_identifier(parent_fd, "portable parent")
+                )
+            with mock.patch.object(HELPER.sys, "platform", "linux"), mock.patch.object(
+                HELPER.os,
+                "fstatvfs",
+                return_value=SimpleNamespace(),
+            ):
+                child_fd, metadata = HELPER.open_named_directory(
+                    parent_fd, "child", "portable child"
+                )
+            self.assertEqual(os.fstat(parent_fd).st_dev, metadata.st_dev)
+        finally:
+            if child_fd >= 0:
+                os.close(child_fd)
+            os.close(parent_fd)
+
+    def test_darwin_requires_exposed_filesystem_id(self) -> None:
+        directory_fd = os.open(self.root, HELPER.directory_open_flags())
+        try:
+            with mock.patch.object(HELPER.sys, "platform", "darwin"), mock.patch.object(
+                HELPER.os,
+                "fstatvfs",
+                return_value=SimpleNamespace(),
+            ):
+                with self.assertRaisesRegex(
+                    HELPER.SafetyError, "f_fsid is unavailable"
+                ):
+                    HELPER.filesystem_identifier(directory_fd, "test directory")
+        finally:
+            os.close(directory_fd)
+
+    def test_final_removal_repopulation_restores_marker_and_retries(self) -> None:
+        self.initialize()
+        (self.child / "managed.txt").write_text("managed\n")
+        original_rmdir = HELPER.os.rmdir
+        injected = False
+
+        def rmdir_with_late_writer(name: str, *, dir_fd: Optional[int] = None) -> None:
+            nonlocal injected
+            if name == HELPER.PAYLOAD_NAME and not injected:
+                self.assertIsNotNone(dir_fd)
+                injected = True
+                payload_fd = os.open(name, HELPER.directory_open_flags(), dir_fd=dir_fd)
+                try:
+                    self.create_file_at(payload_fd, "late-file", b"late\n")
+                finally:
+                    os.close(payload_fd)
+                raise OSError(errno.ENOTEMPTY, "simulated late writer")
+            if dir_fd is None:
+                original_rmdir(name)
+            else:
+                original_rmdir(name, dir_fd=dir_fd)
+
+        with mock.patch.object(
+            HELPER.os, "rmdir", side_effect=rmdir_with_late_writer
+        ), mock.patch.object(HELPER.time, "sleep"):
+            self.clean()
+
+        self.assertTrue(injected)
+        self.assertFalse(self.child.exists())
+        self.assertFalse((self.root / self.quarantine_name).exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_libvlc_feature_contract.py
+++ b/scripts/tests/test_libvlc_feature_contract.py
@@ -93,7 +93,7 @@ class LibVLCFeatureContractTests(unittest.TestCase):
             failures.extend(VALIDATOR.validate_contract(manifest.stem, manifest))
         self.assertEqual(failures, [])
 
-    def test_clean_retries_when_metadata_repopulates_the_build_directory(self) -> None:
+    def test_checkout_local_clean_uses_descriptor_safe_helper(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             scripts = root / "scripts"
@@ -101,6 +101,12 @@ class LibVLCFeatureContractTests(unittest.TestCase):
             build_script = scripts / "build-libvlc.sh"
             build_script.write_bytes(
                 (REPO_ROOT / "scripts" / "build-libvlc.sh").read_bytes()
+            )
+            helper = scripts / "detach-managed-build-directory.py"
+            helper.write_bytes(
+                (
+                    REPO_ROOT / "scripts" / "detach-managed-build-directory.py"
+                ).read_bytes()
             )
             subprocess.run(
                 ["git", "init", "-q"],
@@ -112,22 +118,18 @@ class LibVLCFeatureContractTests(unittest.TestCase):
             build_directory = scripts / ".build-libvlc"
             (build_directory / "vlc").mkdir(parents=True)
             (build_directory / "vlc" / "stale").write_text("stale")
+            (build_directory / ".swiftvlc-managed-libvlc-build-v1").write_text(
+                "SwiftVLC managed libVLC build directory v1\n"
+            )
 
             fake_bin = root / "bin"
             fake_bin.mkdir()
-            state = root / "rm-was-raced"
+            state = root / "unsafe-rm-was-called"
             (fake_bin / "rm").write_text("""#!/bin/bash
 set -eu
-target="${@: -1}"
-if [ ! -e "$SWIFTVLC_RM_TEST_STATE" ]; then
-  : > "$SWIFTVLC_RM_TEST_STATE"
-  /bin/rm "$@"
-  mkdir -p "$target"
-  : > "$target/.DS_Store"
-  echo "rm: $target: Directory not empty" >&2
-  exit 1
-fi
-exec /bin/rm "$@"
+: > "$SWIFTVLC_RM_TEST_STATE"
+echo "unsafe pathname rm was called" >&2
+exit 99
 """)
             (fake_bin / "rm").chmod(0o755)
             environment = dict(
@@ -146,9 +148,8 @@ exec /bin/rm "$@"
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertTrue(state.is_file())
+            self.assertFalse(state.exists())
             self.assertFalse(build_directory.exists())
-            self.assertIn("cleanup did not settle", result.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_libvlc_feature_contract.py
+++ b/scripts/tests/test_libvlc_feature_contract.py
@@ -102,6 +102,13 @@ class LibVLCFeatureContractTests(unittest.TestCase):
             build_script.write_bytes(
                 (REPO_ROOT / "scripts" / "build-libvlc.sh").read_bytes()
             )
+            subprocess.run(
+                ["git", "init", "-q"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
             build_directory = scripts / ".build-libvlc"
             (build_directory / "vlc").mkdir(parents=True)
             (build_directory / "vlc" / "stale").write_text("stale")

--- a/scripts/tests/test_verify_libvlc_build_paths.py
+++ b/scripts/tests/test_verify_libvlc_build_paths.py
@@ -1,0 +1,254 @@
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "verify-libvlc-build-paths.py"
+CHUNK_SIZE = 1024 * 1024
+
+
+class BuildPathVerifierTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name).resolve()
+        self.artifact = self.root / "libvlc.xcframework"
+        self.library = self.artifact / "ios-arm64" / "libvlc.a"
+        self.library.parent.mkdir(parents=True)
+        self.forbidden = self.root / "checkout-with-a-long-name"
+        self.forbidden.mkdir()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def run_verifier(self, *extra_arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--xcframework",
+                str(self.artifact),
+                "--forbidden-path",
+                str(self.forbidden),
+                *extra_arguments,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_accepts_artifact_without_forbidden_path(self) -> None:
+        self.library.write_bytes(b"deterministic native archive")
+
+        result = self.run_verifier()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("no forbidden build paths embedded", result.stdout)
+
+    def test_rejects_path_split_across_read_chunks(self) -> None:
+        encoded = str(self.forbidden.resolve()).encode()
+        prefix_size = CHUNK_SIZE - len(encoded) // 2
+        self.library.write_bytes(b"x" * prefix_size + encoded + b"tail")
+
+        result = self.run_verifier()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("release artifact embeds forbidden build path", result.stderr)
+        self.assertIn("ios-arm64/libvlc.a", result.stderr)
+
+    def test_reports_each_leaking_file_and_root(self) -> None:
+        second_library = self.artifact / "macos-arm64_x86_64" / "libvlc.a"
+        second_library.parent.mkdir()
+        payload = str(self.forbidden.resolve()).encode()
+        self.library.write_bytes(payload)
+        second_library.write_bytes(b"prefix" + payload)
+
+        result = self.run_verifier()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(str(self.forbidden.resolve()), result.stderr)
+        self.assertIn("ios-arm64/libvlc.a", result.stderr)
+        self.assertIn("macos-arm64_x86_64/libvlc.a", result.stderr)
+
+    def test_rejects_duplicate_canonical_forbidden_path(self) -> None:
+        self.library.write_bytes(b"clean")
+
+        result = self.run_verifier(
+            "--forbidden-path",
+            str(self.forbidden),
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("duplicate forbidden build path", result.stderr)
+
+    def test_rejects_lexically_noncanonical_forbidden_path(self) -> None:
+        self.library.write_bytes(b"clean")
+        raw_alias = f"{self.forbidden.parent}/./{self.forbidden.name}"
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--xcframework",
+                str(self.artifact),
+                "--forbidden-path",
+                raw_alias,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must use its canonical physical path", result.stderr)
+
+    def test_rejects_noncanonical_forbidden_path_alias(self) -> None:
+        self.library.write_bytes(b"clean")
+        alias = self.root / "checkout-alias"
+        alias.symlink_to(self.forbidden, target_is_directory=True)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--xcframework",
+                str(self.artifact),
+                "--forbidden-path",
+                str(alias),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must use its canonical physical path", result.stderr)
+
+    def test_rejects_wrong_case_alias_on_case_insensitive_filesystem(self) -> None:
+        self.library.write_bytes(b"clean")
+        wrong_case = self.forbidden.with_name(self.forbidden.name.upper())
+        if not wrong_case.exists() or not wrong_case.samefile(self.forbidden):
+            self.skipTest("test volume is case-sensitive")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--xcframework",
+                str(self.artifact),
+                "--forbidden-path",
+                str(wrong_case),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must use its canonical physical path", result.stderr)
+
+    def test_rejects_relative_and_nondirectory_forbidden_paths(self) -> None:
+        self.library.write_bytes(b"clean")
+        relative = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--xcframework",
+                str(self.artifact),
+                "--forbidden-path",
+                "relative-checkout",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(relative.returncode, 0)
+        self.assertIn("must be an absolute path", relative.stderr)
+
+        regular_file = self.root / "not-a-directory"
+        regular_file.write_bytes(b"path")
+        nondirectory = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--xcframework",
+                str(self.artifact),
+                "--forbidden-path",
+                str(regular_file),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(nondirectory.returncode, 0)
+        self.assertIn("is not a directory", nondirectory.stderr)
+
+    def test_scans_multiple_roots_and_binary_payloads(self) -> None:
+        second_forbidden = self.root / "second-root-with-different-length"
+        second_forbidden.mkdir()
+        self.library.write_bytes(
+            b"\x00\xffbinary\x00" + str(second_forbidden).encode() + b"\x00tail"
+        )
+
+        result = self.run_verifier(
+            "--forbidden-path",
+            str(second_forbidden),
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(str(second_forbidden), result.stderr)
+
+    def test_rejects_empty_artifact_tree(self) -> None:
+        self.library.unlink(missing_ok=True)
+
+        result = self.run_verifier()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("XCFramework contains no files or symlinks", result.stderr)
+
+    def test_rejects_forbidden_path_in_symlink_target(self) -> None:
+        artifact = self.forbidden / "Vendor" / "libvlc.xcframework"
+        target = artifact / "ios-arm64" / "libvlc.a"
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"clean archive")
+        link = artifact / "current-library"
+        link.symlink_to(target)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--xcframework",
+                str(artifact),
+                "--forbidden-path",
+                str(self.forbidden),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("current-library (symlink target)", result.stderr)
+
+    @unittest.skipIf(os.geteuid() == 0, "root can traverse mode-zero directories")
+    def test_fails_closed_when_an_artifact_subtree_is_unreadable(self) -> None:
+        self.library.write_bytes(b"clean")
+        unreadable = self.artifact / "unreadable"
+        unreadable.mkdir()
+        (unreadable / "hidden").write_bytes(str(self.forbidden).encode())
+        unreadable.chmod(0)
+        try:
+            result = self.run_verifier()
+        finally:
+            unreadable.chmod(0o700)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("cannot enumerate XCFramework", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify-libvlc-build-paths.py
+++ b/scripts/verify-libvlc-build-paths.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Reject host checkout paths embedded in a release XCFramework."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+import sys
+from pathlib import Path
+
+CHUNK_SIZE = 1024 * 1024
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"Error: {message}")
+
+
+def contains_bytes(path: Path, needle: bytes) -> bool:
+    overlap = b""
+    carry = len(needle) - 1
+    try:
+        with path.open("rb") as source:
+            while chunk := source.read(CHUNK_SIZE):
+                payload = overlap + chunk
+                if needle in payload:
+                    return True
+                overlap = payload[-carry:] if carry else b""
+    except OSError as error:
+        fail(f"cannot scan artifact file {path}: {error}")
+    return False
+
+
+def canonical_directory(
+    raw_path: str | Path, description: str, *, require_canonical: bool = False
+) -> Path:
+    raw_text = os.fspath(raw_path)
+    if not os.path.isabs(raw_text):
+        fail(f"{description} must be an absolute path: {raw_text}")
+    saved_directory = -1
+    try:
+        saved_directory = os.open(".", os.O_RDONLY)
+        os.chdir(raw_text)
+        # getcwd asks the filesystem for the physical spelling. Unlike
+        # Path.resolve(), this also canonicalizes case and Unicode aliases on
+        # the default case-insensitive Apple filesystems.
+        resolved = Path(os.getcwd())
+    except NotADirectoryError:
+        fail(f"{description} is not a directory: {raw_text}")
+    except OSError as error:
+        fail(f"cannot resolve {description} {raw_text}: {error}")
+    finally:
+        if saved_directory >= 0:
+            try:
+                os.fchdir(saved_directory)
+            finally:
+                os.close(saved_directory)
+    if require_canonical and raw_text != str(resolved):
+        fail(f"{description} must use its canonical physical path: {resolved}")
+    return resolved
+
+
+def verify(xcframework: str | Path, forbidden_paths: list[str | Path]) -> None:
+    artifact = canonical_directory(xcframework, "XCFramework")
+    forbidden: list[tuple[Path, bytes]] = []
+    seen: set[Path] = set()
+    for raw_path in forbidden_paths:
+        path = canonical_directory(
+            raw_path, "forbidden build path", require_canonical=True
+        )
+        if path in seen:
+            fail(f"duplicate forbidden build path: {path}")
+        seen.add(path)
+        forbidden.append((path, os.fsencode(path)))
+
+    files: list[Path] = []
+    symlinks: list[tuple[Path, bytes]] = []
+
+    def raise_walk_error(error: OSError) -> None:
+        raise error
+
+    try:
+        for raw_directory, directory_names, file_names in os.walk(
+            artifact,
+            topdown=True,
+            followlinks=False,
+            onerror=raise_walk_error,
+        ):
+            directory = Path(raw_directory)
+            for name in sorted(directory_names + file_names):
+                candidate = directory / name
+                metadata = candidate.lstat()
+                if stat.S_ISLNK(metadata.st_mode):
+                    symlinks.append(
+                        (candidate, os.fsencode(os.readlink(candidate)))
+                    )
+                elif stat.S_ISREG(metadata.st_mode):
+                    files.append(candidate)
+                elif not stat.S_ISDIR(metadata.st_mode):
+                    fail(f"unsupported artifact entry type: {candidate}")
+    except OSError as error:
+        fail(f"cannot enumerate XCFramework {artifact}: {error}")
+    if not files and not symlinks:
+        fail(f"XCFramework contains no files or symlinks: {artifact}")
+
+    leaks: list[tuple[Path, list[str]]] = []
+    for forbidden_path, needle in forbidden:
+        matches = [
+            candidate.relative_to(artifact).as_posix()
+            for candidate in sorted(files)
+            if contains_bytes(candidate, needle)
+        ]
+        matches.extend(
+            f"{candidate.relative_to(artifact).as_posix()} (symlink target)"
+            for candidate, target in sorted(symlinks)
+            if needle in target
+        )
+        if matches:
+            leaks.append((forbidden_path, matches))
+
+    if leaks:
+        details = "; ".join(
+            f"{path}: {', '.join(matches)}" for path, matches in leaks
+        )
+        fail(f"release artifact embeds forbidden build path(s): {details}")
+
+    print(
+        f"Verified {len(files)} file(s) and {len(symlinks)} symlink(s): "
+        "no forbidden build paths embedded."
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Reject absolute checkout/build paths in a release XCFramework."
+    )
+    parser.add_argument("--xcframework", required=True)
+    parser.add_argument(
+        "--forbidden-path",
+        action="append",
+        required=True,
+        help="Absolute directory whose encoded path must not occur in artifact bytes.",
+    )
+    arguments = parser.parse_args()
+    verify(arguments.xcframework, arguments.forbidden_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

The first native v9 reproducibility proof correctly failed. Across all eight XCFramework slices, every one of the 8,052 differing bytes was the A versus B character from the two checkout paths embedded in live object strings. Archive order, headers, timestamps, symbol indexes, toolchain inputs, and Mach-O metadata were otherwise deterministic.

The documented release process required separate checkouts while build-libvlc.sh placed VLC beneath each checkout, so the process itself introduced a different undeclared path input.

## What

- Add a canonical external build-root option whose fixed managed child is shared by sequential release builds.
- Require that external root for every clean build eligible for provenance.
- Refuse noncanonical, checkout-overlapping, symlinked, or unowned cleanup targets.
- Serialize both the shared native root and each checkout Vendor output with fail-closed ownership locks.
- Reject dirty clean-build inputs before deleting an existing native cache.
- Scan the final post-strip, post-ranlib artifact bytes and symlink payloads for checkout-path leakage.
- Bind the scanner itself into release provenance and verify its placement in the release-integrity contract.
- Update all release instructions and diagnostics.

## Validation

- Release-integrity fault matrix passes.
- Full native source replay passes: 42 of 42 patches and 37 validator assets.
- Build-root safety suite passes, including deletion authorization, symlink, race, lock, physical-path, dirty-checkout, and ancestor cases.
- Artifact path scanner suite passes under Apple Python 3.9 and current Python.
- Existing libVLC feature-contract suite passes.
- The new scanner rejects every slice from both failed real native builds.
- Independent review found no remaining blocker.

The two complete native builds must be rerun after merge because provenance binds the exact merged source commit. This PR does not publish a beta or stable release.