### PR TITLE
Pass anchored path to native artifact verifier

### DIFF
--- a/scripts/build-libvlc.sh
+++ b/scripts/build-libvlc.sh
@@ -506,7 +506,7 @@ verify_checkout_path_not_embedded() {
     fi
     PYTHONDONTWRITEBYTECODE=1 python3 \
         "${SCRIPT_DIR}/verify-libvlc-build-paths.py" \
-        --xcframework "${OUTPUT_DIR}/libvlc.xcframework" \
+        --xcframework "${STAGED_OUTPUT_DIRECTORY}/libvlc.xcframework" \
         --forbidden-path "${REPO_ROOT}"
 }
 

--- a/scripts/build-libvlc.sh
+++ b/scripts/build-libvlc.sh
@@ -504,10 +504,15 @@ verify_checkout_path_not_embedded() {
     if [ "${EXTERNAL_BUILD_ROOT}" != yes ]; then
         return
     fi
+    # Open the already-anchored output CWD only for this command. The verifier
+    # resolves and walks the XCFramework below FD 7 without re-entering a
+    # replaceable external-root pathname.
     PYTHONDONTWRITEBYTECODE=1 python3 \
         "${SCRIPT_DIR}/verify-libvlc-build-paths.py" \
-        --xcframework "${STAGED_OUTPUT_DIRECTORY}/libvlc.xcframework" \
-        --forbidden-path "${REPO_ROOT}"
+        --xcframework-parent-fd 7 \
+        --xcframework-child "libvlc.xcframework" \
+        --forbidden-path "${REPO_ROOT}" \
+        7<.
 }
 
 trap release_build_locks EXIT

--- a/scripts/tests/release-integrity.sh
+++ b/scripts/tests/release-integrity.sh
@@ -2753,11 +2753,19 @@ checkout_path_function = build[
 ]
 for marker in (
     '"${SCRIPT_DIR}/verify-libvlc-build-paths.py"',
-    '--xcframework "${STAGED_OUTPUT_DIRECTORY}/libvlc.xcframework"',
+    '--xcframework-parent-fd 7',
+    '--xcframework-child "libvlc.xcframework"',
     '--forbidden-path "${REPO_ROOT}"',
+    '7<.',
 ):
     if checkout_path_function.count(marker) != 1:
         sys.exit(f"checkout-path verifier invocation is incomplete: {marker}")
+for stale_path in (
+    '${STAGED_OUTPUT_DIRECTORY}/libvlc.xcframework',
+    '${OUTPUT_DIR}/libvlc.xcframework',
+):
+    if stale_path in checkout_path_function:
+        sys.exit(f"checkout-path verifier re-entered pathname resolution: {stale_path}")
 for marker in (
     'if [ "${EXTERNAL_BUILD_ROOT}" = yes ]; then',
     'verify_checkout_path_not_embedded',

--- a/scripts/tests/release-integrity.sh
+++ b/scripts/tests/release-integrity.sh
@@ -2753,7 +2753,7 @@ checkout_path_function = build[
 ]
 for marker in (
     '"${SCRIPT_DIR}/verify-libvlc-build-paths.py"',
-    '--xcframework "${OUTPUT_DIR}/libvlc.xcframework"',
+    '--xcframework "${STAGED_OUTPUT_DIRECTORY}/libvlc.xcframework"',
     '--forbidden-path "${REPO_ROOT}"',
 ):
     if checkout_path_function.count(marker) != 1:

--- a/scripts/tests/test_verify_libvlc_build_paths.py
+++ b/scripts/tests/test_verify_libvlc_build_paths.py
@@ -40,6 +40,28 @@ class BuildPathVerifierTests(unittest.TestCase):
             check=False,
         )
 
+    def run_descriptor_verifier(
+        self,
+        parent_fd: int,
+        child: str = "libvlc.xcframework",
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--xcframework-parent-fd",
+                str(parent_fd),
+                "--xcframework-child",
+                child,
+                "--forbidden-path",
+                str(self.forbidden),
+            ],
+            pass_fds=(parent_fd,),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
     def test_accepts_artifact_without_forbidden_path(self) -> None:
         self.library.write_bytes(b"deterministic native archive")
 
@@ -47,6 +69,95 @@ class BuildPathVerifierTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("no forbidden build paths embedded", result.stdout)
+
+    def test_accepts_descriptor_anchored_artifact(self) -> None:
+        self.library.write_bytes(b"deterministic native archive")
+        parent_fd = os.open(self.root, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            result = self.run_descriptor_verifier(parent_fd)
+        finally:
+            os.close(parent_fd)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("no forbidden build paths embedded", result.stdout)
+
+    def test_descriptor_anchor_cannot_be_redirected_by_parent_path_replacement(
+        self,
+    ) -> None:
+        source = self.root / "native-source"
+        stage = source / "vlc" / ".swiftvlc-native-output"
+        original_library = (
+            stage / "libvlc.xcframework" / "ios-arm64" / "libvlc.a"
+        )
+        original_library.parent.mkdir(parents=True)
+        original_library.write_bytes(os.fsencode(self.forbidden))
+        stage_fd = os.open(stage, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            source.rename(self.root / "native-source-moved")
+            replacement_library = (
+                source
+                / "vlc"
+                / ".swiftvlc-native-output"
+                / "libvlc.xcframework"
+                / "ios-arm64"
+                / "libvlc.a"
+            )
+            replacement_library.parent.mkdir(parents=True)
+            replacement_library.write_bytes(b"clean replacement")
+
+            result = self.run_descriptor_verifier(stage_fd)
+        finally:
+            os.close(stage_fd)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("release artifact embeds forbidden build path", result.stderr)
+        self.assertIn("ios-arm64/libvlc.a", result.stderr)
+
+    def test_descriptor_mode_rejects_noncomponent_child(self) -> None:
+        self.library.write_bytes(b"clean")
+        parent_fd = os.open(self.root, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            result = self.run_descriptor_verifier(
+                parent_fd, "nested/libvlc.xcframework"
+            )
+        finally:
+            os.close(parent_fd)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must be one non-special path component", result.stderr)
+
+    def test_descriptor_mode_rejects_symlink_child(self) -> None:
+        self.library.write_bytes(b"clean")
+        real_artifact = self.root / "real-libvlc.xcframework"
+        self.artifact.rename(real_artifact)
+        self.artifact.symlink_to(real_artifact, target_is_directory=True)
+        parent_fd = os.open(self.root, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            result = self.run_descriptor_verifier(parent_fd)
+        finally:
+            os.close(parent_fd)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("XCFramework child libvlc.xcframework is not a directory", result.stderr)
+
+    def test_absolute_mode_still_rejects_relative_xcframework(self) -> None:
+        self.library.write_bytes(b"clean")
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--xcframework",
+                "libvlc.xcframework",
+                "--forbidden-path",
+                str(self.forbidden),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("XCFramework must be an absolute path", result.stderr)
 
     def test_rejects_path_split_across_read_chunks(self) -> None:
         encoded = str(self.forbidden.resolve()).encode()

--- a/scripts/verify-libvlc-build-paths.py
+++ b/scripts/verify-libvlc-build-paths.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Reject host checkout paths embedded in a release XCFramework."""
+"""Reject host checkout paths embedded in a release XCFramework.
+
+The native build supplies an anchored parent directory descriptor so replacing
+an external-root pathname cannot redirect the audit. Artifact entries are then
+enumerated, opened, and revalidated relative to retained directory descriptors.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +13,7 @@ import os
 import stat
 import sys
 from pathlib import Path
+from typing import Iterable
 
 CHUNK_SIZE = 1024 * 1024
 
@@ -16,19 +22,319 @@ def fail(message: str) -> None:
     raise SystemExit(f"Error: {message}")
 
 
-def contains_bytes(path: Path, needle: bytes) -> bool:
-    overlap = b""
-    carry = len(needle) - 1
+def required_flag(name: str) -> int:
+    value = getattr(os, name, None)
+    if value is None:
+        fail(f"this platform does not provide required {name} support")
+    return int(value)
+
+
+def directory_open_flags() -> int:
+    return (
+        os.O_RDONLY
+        | required_flag("O_DIRECTORY")
+        | required_flag("O_NOFOLLOW")
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+
+
+def regular_read_flags() -> int:
+    return (
+        os.O_RDONLY
+        | required_flag("O_NOFOLLOW")
+        | required_flag("O_NONBLOCK")
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+
+
+def validate_component(value: str, description: str) -> None:
+    if not value or value in (".", "..") or "/" in value or "\0" in value:
+        fail(f"{description} must be one non-special path component: {value!r}")
+
+
+def stability_signature(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_nlink,
+        metadata.st_uid,
+        metadata.st_gid,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def require_directory(metadata: os.stat_result, description: str) -> None:
+    if not stat.S_ISDIR(metadata.st_mode):
+        fail(f"{description} is not a directory")
+
+
+def require_regular(metadata: os.stat_result, description: str) -> None:
+    if not stat.S_ISREG(metadata.st_mode):
+        fail(f"{description} is not a regular file")
+
+
+def stat_at(parent_fd: int, name: str, description: str) -> os.stat_result:
     try:
-        with path.open("rb") as source:
-            while chunk := source.read(CHUNK_SIZE):
-                payload = overlap + chunk
-                if needle in payload:
-                    return True
-                overlap = payload[-carry:] if carry else b""
+        return os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
     except OSError as error:
-        fail(f"cannot scan artifact file {path}: {error}")
-    return False
+        fail(f"cannot inspect {description}: {error}")
+
+
+def filesystem_identifier(directory_fd: int, description: str) -> int | None:
+    fstatvfs = getattr(os, "fstatvfs", None)
+    if fstatvfs is None:
+        if sys.platform == "darwin":
+            fail(f"cannot verify filesystem identity for {description}")
+        return None
+    try:
+        metadata = fstatvfs(directory_fd)
+    except OSError as error:
+        fail(f"cannot inspect filesystem identity for {description}: {error}")
+    identifier = getattr(metadata, "f_fsid", None)
+    if identifier is None:
+        if sys.platform == "darwin":
+            fail(f"cannot verify filesystem identity for {description}")
+        return None
+    try:
+        return int(identifier)
+    except (TypeError, ValueError) as error:
+        fail(f"filesystem identity for {description} is invalid: {error}")
+
+
+def require_opened_directory_containment(
+    parent_fd: int,
+    parent_metadata: os.stat_result,
+    directory_fd: int,
+    directory_metadata: os.stat_result,
+    description: str,
+) -> None:
+    if parent_metadata.st_dev != directory_metadata.st_dev:
+        fail(f"artifact directory crosses a device boundary: {description}")
+    parent_filesystem = filesystem_identifier(parent_fd, "artifact parent")
+    child_filesystem = filesystem_identifier(directory_fd, description)
+    if parent_filesystem is None and child_filesystem is None:
+        return
+    if parent_filesystem is None or child_filesystem is None:
+        fail(f"cannot consistently verify filesystem identity for {description}")
+    if parent_filesystem != child_filesystem:
+        fail(f"artifact directory crosses a filesystem boundary: {description}")
+
+
+def open_named_directory(
+    parent_fd: int, name: str, description: str
+) -> tuple[int, os.stat_result]:
+    named_before = stat_at(parent_fd, name, description)
+    require_directory(named_before, description)
+    try:
+        directory_fd = os.open(name, directory_open_flags(), dir_fd=parent_fd)
+    except OSError as error:
+        fail(
+            f"cannot enumerate XCFramework {description}: "
+            f"cannot open without following symlinks: {error}"
+        )
+    try:
+        opened = os.fstat(directory_fd)
+        require_directory(opened, description)
+        if stability_signature(named_before) != stability_signature(opened):
+            fail(f"{description} changed while it was being opened")
+        try:
+            parent_metadata = os.fstat(parent_fd)
+        except OSError as error:
+            fail(f"cannot inspect parent directory for {description}: {error}")
+        require_directory(parent_metadata, f"parent directory for {description}")
+        require_opened_directory_containment(
+            parent_fd,
+            parent_metadata,
+            directory_fd,
+            opened,
+            description,
+        )
+        named_after = stat_at(parent_fd, name, description)
+        if stability_signature(opened) != stability_signature(named_after):
+            fail(f"{description} changed while it was being opened")
+        return directory_fd, opened
+    except BaseException:
+        os.close(directory_fd)
+        raise
+
+
+def open_absolute_directory(
+    path: Path, description: str
+) -> tuple[int, os.stat_result]:
+    try:
+        named_before = os.stat(path, follow_symlinks=False)
+    except OSError as error:
+        fail(f"cannot inspect {description} {path}: {error}")
+    require_directory(named_before, description)
+    try:
+        directory_fd = os.open(path, directory_open_flags())
+    except OSError as error:
+        fail(f"cannot open {description} without following symlinks {path}: {error}")
+    try:
+        opened = os.fstat(directory_fd)
+        require_directory(opened, description)
+        if stability_signature(named_before) != stability_signature(opened):
+            fail(f"{description} changed while it was being opened: {path}")
+        try:
+            named_after = os.stat(path, follow_symlinks=False)
+        except OSError as error:
+            fail(f"cannot revalidate {description} {path}: {error}")
+        if stability_signature(opened) != stability_signature(named_after):
+            fail(f"{description} changed while it was being opened: {path}")
+        return directory_fd, opened
+    except BaseException:
+        os.close(directory_fd)
+        raise
+
+
+def list_directory(directory_fd: int, description: str) -> list[str]:
+    try:
+        with os.scandir(directory_fd) as entries:
+            # DirEntry metadata is intentionally ignored. Every decision uses
+            # a fresh descriptor-relative, no-follow stat and open below.
+            return sorted(entry.name for entry in entries)
+    except OSError as error:
+        fail(f"cannot enumerate XCFramework {description}: {error}")
+
+
+def scan_regular(
+    parent_fd: int,
+    name: str,
+    relative_path: str,
+    named_before: os.stat_result,
+    needles: list[bytes],
+) -> list[int]:
+    try:
+        file_fd = os.open(name, regular_read_flags(), dir_fd=parent_fd)
+    except OSError as error:
+        fail(f"cannot open artifact file {relative_path} without following symlinks: {error}")
+    try:
+        opened_before = os.fstat(file_fd)
+        require_regular(opened_before, f"artifact file {relative_path}")
+        if stability_signature(named_before) != stability_signature(opened_before):
+            fail(f"artifact file changed while opening: {relative_path}")
+
+        found: set[int] = set()
+        carry_size = max((len(needle) - 1 for needle in needles), default=0)
+        overlap = b""
+        try:
+            while True:
+                try:
+                    chunk = os.read(file_fd, CHUNK_SIZE)
+                except InterruptedError:
+                    continue
+                if not chunk:
+                    break
+                payload = overlap + chunk
+                for index, needle in enumerate(needles):
+                    if index not in found and needle in payload:
+                        found.add(index)
+                overlap = payload[-carry_size:] if carry_size else b""
+        except OSError as error:
+            fail(f"cannot scan artifact file {relative_path}: {error}")
+
+        opened_after = os.fstat(file_fd)
+        if stability_signature(opened_before) != stability_signature(opened_after):
+            fail(f"artifact file changed while it was being scanned: {relative_path}")
+        named_after = stat_at(parent_fd, name, f"artifact file {relative_path}")
+        require_regular(named_after, f"artifact file {relative_path}")
+        if stability_signature(opened_after) != stability_signature(named_after):
+            fail(f"artifact file changed while it was being validated: {relative_path}")
+        return sorted(found)
+    finally:
+        os.close(file_fd)
+
+
+def scan_symlink(
+    parent_fd: int,
+    name: str,
+    relative_path: str,
+    named_before: os.stat_result,
+    needles: list[bytes],
+) -> list[int]:
+    try:
+        target = os.readlink(name, dir_fd=parent_fd)
+    except OSError as error:
+        fail(f"cannot read artifact symlink {relative_path}: {error}")
+    named_after = stat_at(parent_fd, name, f"artifact symlink {relative_path}")
+    if stability_signature(named_before) != stability_signature(named_after):
+        fail(f"artifact symlink changed while it was being read: {relative_path}")
+    encoded_target = os.fsencode(target)
+    return [index for index, needle in enumerate(needles) if needle in encoded_target]
+
+
+def scan_directory(
+    directory_fd: int,
+    relative_directory: str,
+    needles: list[bytes],
+    matches: list[list[str]],
+) -> tuple[int, int]:
+    description = relative_directory or "."
+    try:
+        directory_before = os.fstat(directory_fd)
+    except OSError as error:
+        fail(f"cannot inspect artifact directory {description}: {error}")
+    require_directory(directory_before, f"artifact directory {description}")
+    names_before = list_directory(directory_fd, description)
+    file_count = 0
+    symlink_count = 0
+
+    for name in names_before:
+        relative_path = f"{relative_directory}/{name}" if relative_directory else name
+        named_before = stat_at(directory_fd, name, f"artifact entry {relative_path}")
+        if stat.S_ISDIR(named_before.st_mode):
+            child_fd, child_metadata = open_named_directory(
+                directory_fd, name, f"artifact directory {relative_path}"
+            )
+            try:
+                child_files, child_symlinks = scan_directory(
+                    child_fd, relative_path, needles, matches
+                )
+            finally:
+                os.close(child_fd)
+            named_after = stat_at(
+                directory_fd, name, f"artifact directory {relative_path}"
+            )
+            if stability_signature(child_metadata) != stability_signature(named_after):
+                fail(f"artifact directory changed while it was scanned: {relative_path}")
+            file_count += child_files
+            symlink_count += child_symlinks
+        elif stat.S_ISREG(named_before.st_mode):
+            for index in scan_regular(
+                directory_fd,
+                name,
+                relative_path,
+                named_before,
+                needles,
+            ):
+                matches[index].append(relative_path)
+            file_count += 1
+        elif stat.S_ISLNK(named_before.st_mode):
+            for index in scan_symlink(
+                directory_fd,
+                name,
+                relative_path,
+                named_before,
+                needles,
+            ):
+                matches[index].append(f"{relative_path} (symlink target)")
+            symlink_count += 1
+        else:
+            fail(f"unsupported artifact entry type: {relative_path}")
+
+    names_after = list_directory(directory_fd, description)
+    if names_before != names_after:
+        fail(f"artifact directory changed while it was scanned: {description}")
+    try:
+        directory_after = os.fstat(directory_fd)
+    except OSError as error:
+        fail(f"cannot revalidate artifact directory {description}: {error}")
+    if stability_signature(directory_before) != stability_signature(directory_after):
+        fail(f"artifact directory changed while it was scanned: {description}")
+    return file_count, symlink_count
 
 
 def canonical_directory(
@@ -60,8 +366,9 @@ def canonical_directory(
     return resolved
 
 
-def verify(xcframework: str | Path, forbidden_paths: list[str | Path]) -> None:
-    artifact = canonical_directory(xcframework, "XCFramework")
+def canonical_forbidden_paths(
+    forbidden_paths: Iterable[str | Path],
+) -> list[tuple[Path, bytes]]:
     forbidden: list[tuple[Path, bytes]] = []
     seen: set[Path] = set()
     for raw_path in forbidden_paths:
@@ -72,51 +379,29 @@ def verify(xcframework: str | Path, forbidden_paths: list[str | Path]) -> None:
             fail(f"duplicate forbidden build path: {path}")
         seen.add(path)
         forbidden.append((path, os.fsencode(path)))
+    return forbidden
 
-    files: list[Path] = []
-    symlinks: list[tuple[Path, bytes]] = []
 
-    def raise_walk_error(error: OSError) -> None:
-        raise error
+def verify_opened_artifact(
+    artifact_fd: int,
+    artifact_display: str,
+    forbidden: list[tuple[Path, bytes]],
+) -> None:
+    matches: list[list[str]] = [[] for _ in forbidden]
+    file_count, symlink_count = scan_directory(
+        artifact_fd,
+        "",
+        [needle for _, needle in forbidden],
+        matches,
+    )
+    if file_count == 0 and symlink_count == 0:
+        fail(f"XCFramework contains no files or symlinks: {artifact_display}")
 
-    try:
-        for raw_directory, directory_names, file_names in os.walk(
-            artifact,
-            topdown=True,
-            followlinks=False,
-            onerror=raise_walk_error,
-        ):
-            directory = Path(raw_directory)
-            for name in sorted(directory_names + file_names):
-                candidate = directory / name
-                metadata = candidate.lstat()
-                if stat.S_ISLNK(metadata.st_mode):
-                    symlinks.append(
-                        (candidate, os.fsencode(os.readlink(candidate)))
-                    )
-                elif stat.S_ISREG(metadata.st_mode):
-                    files.append(candidate)
-                elif not stat.S_ISDIR(metadata.st_mode):
-                    fail(f"unsupported artifact entry type: {candidate}")
-    except OSError as error:
-        fail(f"cannot enumerate XCFramework {artifact}: {error}")
-    if not files and not symlinks:
-        fail(f"XCFramework contains no files or symlinks: {artifact}")
-
-    leaks: list[tuple[Path, list[str]]] = []
-    for forbidden_path, needle in forbidden:
-        matches = [
-            candidate.relative_to(artifact).as_posix()
-            for candidate in sorted(files)
-            if contains_bytes(candidate, needle)
-        ]
-        matches.extend(
-            f"{candidate.relative_to(artifact).as_posix()} (symlink target)"
-            for candidate, target in sorted(symlinks)
-            if needle in target
-        )
-        if matches:
-            leaks.append((forbidden_path, matches))
+    leaks = [
+        (forbidden_path, sorted(path_matches))
+        for (forbidden_path, _), path_matches in zip(forbidden, matches)
+        if path_matches
+    ]
 
     if leaks:
         details = "; ".join(
@@ -125,16 +410,96 @@ def verify(xcframework: str | Path, forbidden_paths: list[str | Path]) -> None:
         fail(f"release artifact embeds forbidden build path(s): {details}")
 
     print(
-        f"Verified {len(files)} file(s) and {len(symlinks)} symlink(s): "
+        f"Verified {file_count} file(s) and {symlink_count} symlink(s): "
         "no forbidden build paths embedded."
     )
+
+
+def verify(xcframework: str | Path, forbidden_paths: list[str | Path]) -> None:
+    artifact = canonical_directory(xcframework, "XCFramework")
+    artifact_fd, artifact_metadata = open_absolute_directory(artifact, "XCFramework")
+    try:
+        verify_opened_artifact(
+            artifact_fd,
+            str(artifact),
+            canonical_forbidden_paths(forbidden_paths),
+        )
+        try:
+            named_after = os.stat(artifact, follow_symlinks=False)
+        except OSError as error:
+            fail(f"cannot revalidate XCFramework {artifact}: {error}")
+        if stability_signature(artifact_metadata) != stability_signature(named_after):
+            fail(f"XCFramework changed while it was scanned: {artifact}")
+    finally:
+        os.close(artifact_fd)
+
+
+def verify_from_parent_descriptor(
+    parent_descriptor: int,
+    xcframework_child: str,
+    forbidden_paths: list[str | Path],
+) -> None:
+    if parent_descriptor < 0:
+        fail("XCFramework parent descriptor must be non-negative")
+    validate_component(xcframework_child, "XCFramework child")
+    try:
+        parent_fd = os.dup(parent_descriptor)
+    except OSError as error:
+        fail(f"cannot duplicate XCFramework parent descriptor: {error}")
+    try:
+        try:
+            parent_before = os.fstat(parent_fd)
+        except OSError as error:
+            fail(f"cannot inspect XCFramework parent descriptor: {error}")
+        require_directory(parent_before, "XCFramework parent descriptor")
+        artifact_fd, artifact_metadata = open_named_directory(
+            parent_fd,
+            xcframework_child,
+            f"XCFramework child {xcframework_child}",
+        )
+        try:
+            verify_opened_artifact(
+                artifact_fd,
+                f"<parent-fd>/{xcframework_child}",
+                canonical_forbidden_paths(forbidden_paths),
+            )
+        finally:
+            os.close(artifact_fd)
+
+        named_after = stat_at(
+            parent_fd,
+            xcframework_child,
+            f"XCFramework child {xcframework_child}",
+        )
+        if stability_signature(artifact_metadata) != stability_signature(named_after):
+            fail(f"XCFramework child changed while it was scanned: {xcframework_child}")
+        try:
+            parent_after = os.fstat(parent_fd)
+        except OSError as error:
+            fail(f"cannot revalidate XCFramework parent descriptor: {error}")
+        if stability_signature(parent_before) != stability_signature(parent_after):
+            fail("XCFramework parent directory changed while artifact was scanned")
+    finally:
+        os.close(parent_fd)
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Reject absolute checkout/build paths in a release XCFramework."
     )
-    parser.add_argument("--xcframework", required=True)
+    parser.add_argument(
+        "--xcframework",
+        help="Absolute path to an XCFramework for a standalone audit.",
+    )
+    parser.add_argument(
+        "--xcframework-parent-fd",
+        type=int,
+        help="Inherited descriptor for an anchored XCFramework parent directory.",
+    )
+    parser.add_argument(
+        "--xcframework-child",
+        help="One-component XCFramework child below --xcframework-parent-fd.",
+    )
     parser.add_argument(
         "--forbidden-path",
         action="append",
@@ -142,7 +507,31 @@ def main() -> None:
         help="Absolute directory whose encoded path must not occur in artifact bytes.",
     )
     arguments = parser.parse_args()
-    verify(arguments.xcframework, arguments.forbidden_path)
+    absolute_mode = arguments.xcframework is not None
+    descriptor_mode = (
+        arguments.xcframework_parent_fd is not None
+        or arguments.xcframework_child is not None
+    )
+    if absolute_mode == descriptor_mode:
+        fail(
+            "provide either --xcframework or both --xcframework-parent-fd and "
+            "--xcframework-child"
+        )
+    if absolute_mode:
+        verify(arguments.xcframework, arguments.forbidden_path)
+        return
+    if (
+        arguments.xcframework_parent_fd is None
+        or arguments.xcframework_child is None
+    ):
+        fail(
+            "--xcframework-parent-fd and --xcframework-child must be provided together"
+        )
+    verify_from_parent_descriptor(
+        arguments.xcframework_parent_fd,
+        arguments.xcframework_child,
+        arguments.forbidden_path,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- keep the standalone `--xcframework` interface absolute-only
- add a build-only parent-descriptor plus one-component child mode
- open every artifact directory and file without following symlinks
- traverse only below retained directory descriptors
- bind pre-open, opened, post-read, and named-after filesystem identity and stability
- reject device/filesystem crossings, unsupported entry types, concurrent directory changes, and raced FIFO/symlink substitutions
- pin the descriptor call contract in release-integrity tests

## Root cause

The first full clean native rebuild after PR #213 compiled all 13 architecture builds, assembled and normalized the XCFramework, and passed the runtime gates. It then failed after 69m49s because the staged-output subshell intentionally sets `OUTPUT_DIR=.` while the standalone verifier intentionally rejects relative artifact paths.

The initial repair passed the cached absolute `STAGED_OUTPUT_DIRECTORY`. Review then exposed a deeper false-negative: if the external source tree is renamed and a replacement appears at its old pathname, the cached string can scan the replacement even though the output shell remains anchored in the original staging inode.

The build now opens FD 7 from its already-anchored output CWD for the verifier command. The verifier duplicates that authority, opens only the direct `libvlc.xcframework` child with no-follow semantics, scans through retained descriptors, and revalidates the tree. It never re-enters the replaceable external-root pathname.

A deterministic regression recreates the attack: the original anchored artifact embeds a forbidden path, its old absolute location is replaced by a clean artifact, and the verifier must still reject the original.

The completed real artifact from the failed build also passes the corrected scan: 129 files, 0 symlinks, no checkout-local path embedded.

## Verification

- 17 verifier tests on Apple Python 3.9 and Python 3.14
- 44 combined verifier and managed-filesystem tests
- build-root shell race suite
- shell syntax, Python compilation, and diff hygiene
- complete release-integrity suite, including candidate and uncertain-merge recovery paths
- real 129-file XCFramework in standalone and descriptor modes
- repeated descriptor scans with no FD growth
- independent path-continuity, attack reproduction, and filesystem implementation reviews

This fixes the late build integration failure and its review-discovered false-negative without weakening the verifier.