### PR TITLE
Fix release candidate artifact CI

### DIFF
--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Set up Vendor + local Swift package
         timeout-minutes: 12
         env:
-          GH_TOKEN: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && secrets.GITHUB_TOKEN || '' }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SWIFTVLC_ALLOW_DRAFT_RELEASE: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}
         run: ./scripts/setup-dev.sh
 

--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -36,10 +36,16 @@ jobs:
     # Xcode 26.4+, hence macos-26 (same rationale as the showcase job in
     # test.yml).
     runs-on: macos-26
+    # GitHub hides draft releases from read-only installation tokens. The
+    # resolver below separately authenticates and binds the exact candidate.
+    permissions:
+      contents: write
     timeout-minutes: 55
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         timeout-minutes: 2
+        with:
+          persist-credentials: false
 
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         timeout-minutes: 5
@@ -66,7 +72,7 @@ jobs:
       - name: Set up Vendor + local Swift package
         timeout-minutes: 12
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && secrets.GITHUB_TOKEN || '' }}
           SWIFTVLC_ALLOW_DRAFT_RELEASE: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}
         run: ./scripts/setup-dev.sh
 

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -95,7 +95,7 @@ jobs:
         id: xcf
         timeout-minutes: 12
         env:
-          GH_TOKEN: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && secrets.GITHUB_TOKEN || '' }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SWIFTVLC_ALLOW_DRAFT_RELEASE: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}
         run: ./scripts/ci-use-released-xcframework.sh
 

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -53,11 +53,17 @@ jobs:
       matrix:
         sanitizer: [thread, address]
     runs-on: macos-latest
+    # GitHub hides draft releases from read-only installation tokens. The
+    # resolver below separately authenticates and binds the exact candidate.
+    permissions:
+      contents: write
     timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         timeout-minutes: 2
+        with:
+          persist-credentials: false
 
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         timeout-minutes: 5
@@ -89,7 +95,7 @@ jobs:
         id: xcf
         timeout-minutes: 12
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && secrets.GITHUB_TOKEN || '' }}
           SWIFTVLC_ALLOW_DRAFT_RELEASE: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}
         run: ./scripts/ci-use-released-xcframework.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,7 @@ jobs:
         # startup. Keep a bounded ceiling without killing a healthy matrix.
         timeout-minutes: 5
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SWIFTVLC_RELEASE_CANDIDATE_LINT: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/')) && '1' || '' }}
         run: ./scripts/tests/release-integrity.sh
 
@@ -256,7 +257,7 @@ jobs:
       - name: Set up Vendor + local Swift package
         timeout-minutes: 12
         env:
-          GH_TOKEN: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && secrets.GITHUB_TOKEN || '' }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SWIFTVLC_ALLOW_DRAFT_RELEASE: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}
         run: ./scripts/setup-dev.sh
 
@@ -495,7 +496,7 @@ jobs:
         id: xcf
         timeout-minutes: 12
         env:
-          GH_TOKEN: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && secrets.GITHUB_TOKEN || '' }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SWIFTVLC_ALLOW_DRAFT_RELEASE: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}
         run: ./scripts/ci-use-released-xcframework.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,9 @@ on:
   push:
     branches: [main]
 
-# CI consumes source and immutable release artifacts only. Keep the workflow
-# token unable to tag, push, publish a release, or mutate repository state.
+# Default every job to immutable source/release reads. Jobs that consume an
+# exact same-repository release candidate opt into `contents: write` below:
+# GitHub deliberately hides draft releases from read-only installation tokens.
 permissions:
   contents: read
 
@@ -30,10 +31,17 @@ jobs:
   # warnings are treated as errors.
   lint:
     runs-on: macos-latest
+    # release-integrity resolves the current candidate after its isolated fault
+    # matrix. The resolver still binds the exact same-repository PR, SHA, tag,
+    # release metadata, asset URL, and digest before accepting draft bytes.
+    permissions:
+      contents: write
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         timeout-minutes: 2
+        with:
+          persist-credentials: false
 
       - name: Install pinned SwiftLint and SwiftFormat
         timeout-minutes: 3
@@ -92,7 +100,7 @@ jobs:
         # startup. Keep a bounded ceiling without killing a healthy matrix.
         timeout-minutes: 5
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && secrets.GITHUB_TOKEN || '' }}
           SWIFTVLC_ALLOW_DRAFT_RELEASE: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}
         run: ./scripts/tests/release-integrity.sh
 
@@ -115,7 +123,8 @@ jobs:
       - name: Engine patch coverage
         timeout-minutes: 2
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && secrets.GITHUB_TOKEN || '' }}
+          SWIFTVLC_ALLOW_DRAFT_RELEASE: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}
         run: ./scripts/check-engine-coverage.sh
 
       # The accounting parser is part of the PR gate, so test it independently
@@ -196,9 +205,6 @@ jobs:
       # the local SwiftVLC checkout so we compile against in-PR code.
       - name: Set up Vendor + local Swift package
         timeout-minutes: 12
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SWIFTVLC_ALLOW_DRAFT_RELEASE: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}
         run: ./scripts/setup-dev.sh
 
       - name: Build Showcase (${{ matrix.scheme }})
@@ -228,6 +234,11 @@ jobs:
     # must understand the manifest's Swift 6.3 tools-version — needs Xcode
     # 26.4+, hence macos-26 (same rationale as the showcase job above).
     runs-on: macos-26
+    # Reading a draft release requires push-level repository access. GitHub
+    # downgrades fork pull-request tokens to read-only, and draft authorization
+    # below independently requires the exact same-repository candidate PR.
+    permissions:
+      contents: write
     # Pull requests have 67 minutes of explicit per-step ceilings below. Keep
     # one provisioned runner, but leave enough job-level headroom for every
     # bounded step to complete instead of cutting the job off at 30 minutes.
@@ -235,6 +246,8 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         timeout-minutes: 2
+        with:
+          persist-credentials: false
 
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         timeout-minutes: 5
@@ -252,7 +265,7 @@ jobs:
       - name: Set up Vendor + local Swift package
         timeout-minutes: 12
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && secrets.GITHUB_TOKEN || '' }}
           SWIFTVLC_ALLOW_DRAFT_RELEASE: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}
         run: ./scripts/setup-dev.sh
 
@@ -381,9 +394,6 @@ jobs:
 
       - name: Set up Vendor + local Swift package
         timeout-minutes: 12
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SWIFTVLC_ALLOW_DRAFT_RELEASE: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}
         run: ./scripts/setup-dev.sh
 
       # TEST_RUNNER_CI=true is load-bearing: xcodebuild strips the
@@ -430,6 +440,10 @@ jobs:
     # can lag, so we install the Swift 6.3.1 open-source toolchain from
     # swift.org and activate it via the TOOLCHAINS env var.
     runs-on: macos-latest
+    # See ios-build: write-level contents permission makes the draft visible;
+    # it does not replace the resolver's exact candidate identity checks.
+    permissions:
+      contents: write
     # Absolute ceiling — the job CANNOT run longer than this. The wrapper
     # script and step timeouts below enforce tighter bounds; this is the
     # last line of defense if those fail.
@@ -438,6 +452,8 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         timeout-minutes: 2
+        with:
+          persist-credentials: false
 
       # Pin Xcode for SDKs / linker / simulators. Current GHA runners
       # can lag behind the package's tools-version 6.3 manifest, so we
@@ -488,7 +504,7 @@ jobs:
         id: xcf
         timeout-minutes: 12
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && secrets.GITHUB_TOKEN || '' }}
           SWIFTVLC_ALLOW_DRAFT_RELEASE: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}
         run: ./scripts/ci-use-released-xcframework.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,11 +31,6 @@ jobs:
   # warnings are treated as errors.
   lint:
     runs-on: macos-latest
-    # release-integrity resolves the current candidate after its isolated fault
-    # matrix. The resolver still binds the exact same-repository PR, SHA, tag,
-    # release metadata, asset URL, and digest before accepting draft bytes.
-    permissions:
-      contents: write
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -100,8 +95,7 @@ jobs:
         # startup. Keep a bounded ceiling without killing a healthy matrix.
         timeout-minutes: 5
         env:
-          GH_TOKEN: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && secrets.GITHUB_TOKEN || '' }}
-          SWIFTVLC_ALLOW_DRAFT_RELEASE: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}
+          SWIFTVLC_RELEASE_CANDIDATE_LINT: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/')) && '1' || '' }}
         run: ./scripts/tests/release-integrity.sh
 
       - name: Test native filesystem safety helpers
@@ -122,9 +116,6 @@ jobs:
       # regression that made this worth surfacing.
       - name: Engine patch coverage
         timeout-minutes: 2
-        env:
-          GH_TOKEN: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && secrets.GITHUB_TOKEN || '' }}
-          SWIFTVLC_ALLOW_DRAFT_RELEASE: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}
         run: ./scripts/check-engine-coverage.sh
 
       # The accounting parser is part of the PR gate, so test it independently

--- a/.github/workflows/vendor-manifest.yml
+++ b/.github/workflows/vendor-manifest.yml
@@ -48,10 +48,16 @@ jobs:
     # which must understand the manifest's Swift 6.3 tools-version —
     # needs Xcode 26.4+, hence macos-26 (same rationale as test.yml).
     runs-on: macos-26
+    # GitHub hides draft releases from read-only installation tokens. The
+    # resolver below separately authenticates and binds the exact candidate.
+    permissions:
+      contents: write
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         timeout-minutes: 2
+        with:
+          persist-credentials: false
 
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         timeout-minutes: 5
@@ -72,7 +78,7 @@ jobs:
       - name: Set up Vendor + local Swift package
         timeout-minutes: 12
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && secrets.GITHUB_TOKEN || '' }}
           SWIFTVLC_ALLOW_DRAFT_RELEASE: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}
         run: ./scripts/setup-dev.sh
 

--- a/.github/workflows/vendor-manifest.yml
+++ b/.github/workflows/vendor-manifest.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Vendor + local Swift package
         timeout-minutes: 12
         env:
-          GH_TOKEN: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && secrets.GITHUB_TOKEN || '' }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SWIFTVLC_ALLOW_DRAFT_RELEASE: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-candidates/')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}
         run: ./scripts/setup-dev.sh
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1392,7 +1392,7 @@ verify_github_release() {
   local metadata="$WORK_DIR/github-release-${release_tag}.json"
 
   gh release view "$release_tag" --repo "$REPO" \
-    --json tagName,targetCommitish,isDraft,isImmutable,isPrerelease,name,body,assets \
+    --json url,tagName,targetCommitish,isDraft,isImmutable,isPrerelease,name,body,assets \
     > "$metadata"
   EXPECTED_PRERELEASE="$UNQUALIFIED" \
   EXPECTED_RELEASE_NAME="$expected_name" \
@@ -1403,6 +1403,7 @@ verify_github_release() {
 import hashlib
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -1433,6 +1434,22 @@ if release.get("name") != os.environ["EXPECTED_RELEASE_NAME"]:
 if release.get("body") != os.environ["EXPECTED_RELEASE_BODY"]:
     sys.exit("Error: GitHub release notes drifted")
 
+release_url = release.get("url")
+release_url_prefix = f"https://github.com/{repository}/releases/tag/"
+if visibility == "draft":
+    if not isinstance(release_url, str) or not release_url.startswith(
+        release_url_prefix
+    ):
+        sys.exit("Error: draft release URL does not belong to the exact repository")
+    download_ref = release_url[len(release_url_prefix) :]
+    if re.fullmatch(r"untagged-[0-9A-Za-z._-]+", download_ref) is None:
+        sys.exit("Error: draft release URL has an unsafe GitHub locator")
+else:
+    expected_release_url = f"{release_url_prefix}{url_tag}"
+    if release_url != expected_release_url:
+        sys.exit("Error: published release URL does not match its exact tag")
+    download_ref = url_tag
+
 expected = {Path(path).name: Path(path) for path in asset_paths}
 actual_assets = release.get("assets")
 if not isinstance(actual_assets, list):
@@ -1457,7 +1474,7 @@ for name, path in expected.items():
     if asset.get("digest") != f"sha256:{digest}":
         sys.exit(f"Error: GitHub release asset digest drifted: {name}")
     expected_url = (
-        f"https://github.com/{repository}/releases/download/{url_tag}/{name}"
+        f"https://github.com/{repository}/releases/download/{download_ref}/{name}"
     )
     if asset.get("url") != expected_url:
         sys.exit(f"Error: GitHub release asset URL drifted: {name}")
@@ -1512,17 +1529,36 @@ candidate_asset_status() {
   local asset_path=$1
   local metadata="$WORK_DIR/candidate-assets.json"
   gh release view "$CANDIDATE_TAG" --repo "$REPO" \
-    --json tagName,targetCommitish,isDraft,isImmutable,isPrerelease,assets \
+    --json url,tagName,targetCommitish,isDraft,isImmutable,isPrerelease,assets \
     > "$metadata"
-  python3 - "$metadata" "$asset_path" "$REPO" "$CANDIDATE_TAG" <<'PY'
+  python3 - "$metadata" "$asset_path" "$REPO" "$CANDIDATE_TAG" \
+    "$STAGED_COMMIT" "$UNQUALIFIED" <<'PY'
 import hashlib
 import json
+import re
 import sys
 from pathlib import Path
 
-metadata_path, asset_path, repository, tag = sys.argv[1:]
+metadata_path, asset_path, repository, tag, commit, prerelease = sys.argv[1:]
 path = Path(asset_path)
 release = json.load(open(metadata_path))
+if release.get("tagName") != tag:
+    raise SystemExit("Error: candidate release tag drifted")
+if release.get("targetCommitish") != commit:
+    raise SystemExit("Error: candidate release target drifted")
+if release.get("isDraft") is not True or release.get("isImmutable") is not False:
+    raise SystemExit("Error: candidate release must remain a mutable draft")
+if bool(release.get("isPrerelease")) != (prerelease == "true"):
+    raise SystemExit("Error: candidate pre-release classification drifted")
+release_url_prefix = f"https://github.com/{repository}/releases/tag/"
+release_url = release.get("url")
+if not isinstance(release_url, str) or not release_url.startswith(
+    release_url_prefix
+):
+    raise SystemExit("Error: draft release URL does not belong to the exact repository")
+download_ref = release_url[len(release_url_prefix) :]
+if re.fullmatch(r"untagged-[0-9A-Za-z._-]+", download_ref) is None:
+    raise SystemExit("Error: draft release URL has an unsafe GitHub locator")
 matches = [asset for asset in release.get("assets", []) if asset.get("name") == path.name]
 if not matches:
     print("missing")
@@ -1541,7 +1577,9 @@ if state == "starter":
 if state != "uploaded":
     raise SystemExit(f"Error: candidate asset has unsupported state {state!r}: {path.name}")
 digest = hashlib.sha256(path.read_bytes()).hexdigest()
-expected_url = f"https://github.com/{repository}/releases/download/{tag}/{path.name}"
+expected_url = (
+    f"https://github.com/{repository}/releases/download/{download_ref}/{path.name}"
+)
 if asset.get("digest") != f"sha256:{digest}" or asset.get("url") != expected_url:
     raise SystemExit(f"Error: existing candidate asset conflicts with local bytes: {path.name}")
 print("exact")

--- a/scripts/resolve-release-artifact.sh
+++ b/scripts/resolve-release-artifact.sh
@@ -49,15 +49,6 @@ if [[ -n "$ALLOW_DRAFT" && "$ALLOW_DRAFT" != "1" ]]; then
   echo "Error: SWIFTVLC_ALLOW_DRAFT_RELEASE must be exactly 1 when enabled." >&2
   exit 1
 fi
-if ! command -v gh >/dev/null 2>&1; then
-  echo "Error: GitHub CLI (gh) is required to verify release metadata." >&2
-  exit 1
-fi
-if ! gh auth status >/dev/null 2>&1; then
-  echo "Error: GitHub CLI authentication is required to verify release metadata." >&2
-  exit 1
-fi
-
 CHECKOUT_COMMIT=$(git rev-parse HEAD)
 RELEASE_TAG="$TAG"
 RELEASE_REF="refs/swiftvlc-release/$TAG"
@@ -74,6 +65,14 @@ CANDIDATE_EVENT=""
 # the unqualified final version. The tag is deterministic and bound to all 40
 # bits of the checkout commit; callers cannot supply or redirect it.
 if [[ "$ALLOW_DRAFT" == "1" ]]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "Error: GitHub CLI (gh) is required to verify draft release metadata." >&2
+    exit 1
+  fi
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "Error: GitHub CLI authentication is required to verify draft release metadata." >&2
+    exit 1
+  fi
   if [[ "${GITHUB_ACTIONS:-}" != "true" \
       || "${GITHUB_REPOSITORY:-}" != "$REPO" ]]; then
     echo "Error: draft releases are available only to authenticated candidate CI in $REPO." >&2
@@ -152,7 +151,6 @@ PY
 
   RELEASE_TAG="swiftvlc-candidate-${TAG}-${CANDIDATE_COMMIT}"
   RELEASE_REF="refs/swiftvlc-release/$RELEASE_TAG"
-  EXPECTED_ASSET_URL="https://github.com/$REPO/releases/download/$RELEASE_TAG/$ASSET_NAME"
 
   # A final SemVer tag before publication would make this still-draft package
   # selectable by normal SwiftPM clients. Candidate CI treats that as a P0.
@@ -196,15 +194,59 @@ git show "$RELEASE_REF:Package.swift" > "$temp_dir/Package.swift"
 python3 "$SCRIPT_DIR/release-artifact-info.py" \
   "$temp_dir/Package.swift" --expect-tag "$TAG" > "$temp_dir/manifest.json"
 
-gh release view "$RELEASE_TAG" --repo "$REPO" \
-  --json tagName,targetCommitish,isDraft,isPrerelease,assets \
-  > "$temp_dir/release.json"
+if [[ "$ALLOW_DRAFT" == "1" ]]; then
+  gh release view "$RELEASE_TAG" --repo "$REPO" \
+    --json url,tagName,targetCommitish,isDraft,isImmutable,isPrerelease,assets \
+    > "$temp_dir/release.json"
+else
+  # Public release metadata does not need a repository token. Keeping ordinary
+  # PRs anonymous means their checked-out scripts never receive the candidate
+  # job's write-capable token. Normalize REST names to the gh JSON contract so
+  # the verifier below has one fail-closed implementation.
+  curl --disable --fail --location --retry 3 --retry-all-errors \
+    --silent --show-error \
+    -H 'Accept: application/vnd.github+json' \
+    -H 'X-GitHub-Api-Version: 2022-11-28' \
+    "https://api.github.com/repos/$REPO/releases/tags/$RELEASE_TAG" \
+    > "$temp_dir/release-rest.json"
+  python3 - "$temp_dir/release-rest.json" "$temp_dir/release.json" <<'PY'
+import json
+import sys
+
+input_path, output_path = sys.argv[1:]
+release = json.load(open(input_path))
+assets = []
+for asset in release.get("assets", []):
+    assets.append(
+        {
+            "name": asset.get("name"),
+            "digest": asset.get("digest"),
+            "url": asset.get("browser_download_url"),
+            "size": asset.get("size"),
+            "state": asset.get("state"),
+        }
+    )
+normalized = {
+    "url": release.get("html_url"),
+    "tagName": release.get("tag_name"),
+    "targetCommitish": release.get("target_commitish"),
+    "isDraft": release.get("draft"),
+    "isImmutable": release.get("immutable"),
+    "isPrerelease": release.get("prerelease"),
+    "assets": assets,
+}
+with open(output_path, "w") as output:
+    json.dump(normalized, output)
+    output.write("\n")
+PY
+fi
 
 EXPECTED_RELEASE_TAG="$RELEASE_TAG" \
 EXPECTED_TAG_COMMIT="$TAG_COMMIT" \
 EXPECTED_CHECKOUT_COMMIT="$CHECKOUT_COMMIT" \
 EXPECTED_CANDIDATE_COMMIT="$CANDIDATE_COMMIT" \
 EXPECTED_ASSET_URL="$EXPECTED_ASSET_URL" \
+EXPECTED_REPOSITORY="$REPO" \
 python3 - \
   "$temp_dir/manifest.json" \
   "$temp_dir/release.json" \
@@ -212,6 +254,7 @@ python3 - \
   "$ALLOW_DRAFT" > "$temp_dir/resolved.json" <<'PY'
 import json
 import os
+import re
 import sys
 
 manifest_path, release_path, asset_name, allow_draft = sys.argv[1:5]
@@ -221,6 +264,7 @@ release_tag = os.environ["EXPECTED_RELEASE_TAG"]
 tag_commit = os.environ["EXPECTED_TAG_COMMIT"]
 checkout_commit = os.environ["EXPECTED_CHECKOUT_COMMIT"]
 candidate_commit = os.environ["EXPECTED_CANDIDATE_COMMIT"]
+repository = os.environ["EXPECTED_REPOSITORY"]
 
 if release.get("tagName") != release_tag:
     sys.exit(
@@ -231,6 +275,8 @@ is_draft = release.get("isDraft") is True
 if allow_draft == "1":
     if not is_draft:
         sys.exit("Error: candidate authorization may resolve only a draft release.")
+    if release.get("isImmutable") is not False:
+        sys.exit("Error: candidate release must remain mutable while it is a draft.")
     if tag_commit != candidate_commit:
         sys.exit(
             "Error: candidate tag and authenticated release commit differ.\n"
@@ -259,7 +305,27 @@ if asset.get("digest") != expected_digest:
         f"  manifest: {expected_digest}\n"
         f"  asset:    {asset.get('digest')}"
     )
-expected_url = os.environ["EXPECTED_ASSET_URL"] or manifest["url"]
+release_url = release.get("url")
+if allow_draft == "1":
+    release_url_prefix = f"https://github.com/{repository}/releases/tag/"
+    if not isinstance(release_url, str) or not release_url.startswith(
+        release_url_prefix
+    ):
+        sys.exit("Error: draft release URL does not belong to the exact repository.")
+    draft_locator = release_url[len(release_url_prefix) :]
+    if re.fullmatch(r"untagged-[0-9A-Za-z._-]+", draft_locator) is None:
+        sys.exit("Error: draft release URL has an unsafe GitHub locator.")
+    expected_url = (
+        f"https://github.com/{repository}/releases/download/"
+        f"{draft_locator}/{asset_name}"
+    )
+else:
+    expected_release_url = (
+        f"https://github.com/{repository}/releases/tag/{release_tag}"
+    )
+    if release_url != expected_release_url:
+        sys.exit("Error: public release URL does not match its exact tag.")
+    expected_url = os.environ["EXPECTED_ASSET_URL"] or manifest["url"]
 if asset.get("url") != expected_url:
     sys.exit(
         "Error: release asset URL does not match its exact release identity.\n"

--- a/scripts/resolve-release-artifact.sh
+++ b/scripts/resolve-release-artifact.sh
@@ -194,7 +194,18 @@ git show "$RELEASE_REF:Package.swift" > "$temp_dir/Package.swift"
 python3 "$SCRIPT_DIR/release-artifact-info.py" \
   "$temp_dir/Package.swift" --expect-tag "$TAG" > "$temp_dir/manifest.json"
 
-if [[ "$ALLOW_DRAFT" == "1" ]]; then
+if [[ "$ALLOW_DRAFT" == "1" || -n "${GH_TOKEN:-}" ]]; then
+  # GitHub-hosted runners share a small anonymous API quota. Use the job's
+  # ephemeral token for public metadata when available; draft acceptance stays
+  # independently gated by the exact candidate identity checks above.
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "Error: GitHub CLI (gh) is required for authenticated release metadata." >&2
+    exit 1
+  fi
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "Error: GitHub CLI authentication is required for release metadata." >&2
+    exit 1
+  fi
   gh release view "$RELEASE_TAG" --repo "$REPO" \
     --json url,tagName,targetCommitish,isDraft,isImmutable,isPrerelease,assets \
     > "$temp_dir/release.json"

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -260,13 +260,15 @@ PYEOF
 
     echo "Downloading $ZIP_NAME from $RESOLVED_DOWNLOAD_TAG..."
     rm -f "Vendor/$ZIP_NAME"
-    if [[ "$RESOLVED_IS_DRAFT" == true ]]; then
+    if [[ "$RESOLVED_IS_DRAFT" == true || -n "${GH_TOKEN:-}" ]]; then
+      # Authenticated gh downloads avoid the shared anonymous runner quota and
+      # refresh GitHub's short-lived signed asset URL. The checksum below still
+      # authenticates the exact bytes declared by Package.swift.
       require_gh
       gh release download "$RESOLVED_DOWNLOAD_TAG" \
         --repo "$REPO" --pattern "$ZIP_NAME" --dir Vendor/
     else
-      # Published assets are public and checksum-bound by Package.swift. Avoid
-      # passing any repository token through ordinary PR-controlled scripts.
+      # Local public installs remain usable without GitHub authentication.
       curl --disable --fail --location --retry 3 --retry-all-errors \
         --output "Vendor/$ZIP_NAME" "$RESOLVED_URL"
     fi

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -260,12 +260,15 @@ PYEOF
 
     echo "Downloading $ZIP_NAME from $RESOLVED_DOWNLOAD_TAG..."
     rm -f "Vendor/$ZIP_NAME"
-    if [[ "$MANIFEST_ONLY" == true ]]; then
-      curl --fail --location --retry 3 --output "Vendor/$ZIP_NAME" "$RESOLVED_URL"
-    else
+    if [[ "$RESOLVED_IS_DRAFT" == true ]]; then
       require_gh
       gh release download "$RESOLVED_DOWNLOAD_TAG" \
         --repo "$REPO" --pattern "$ZIP_NAME" --dir Vendor/
+    else
+      # Published assets are public and checksum-bound by Package.swift. Avoid
+      # passing any repository token through ordinary PR-controlled scripts.
+      curl --disable --fail --location --retry 3 --retry-all-errors \
+        --output "Vendor/$ZIP_NAME" "$RESOLVED_URL"
     fi
 
     downloaded_checksum=$(swift package compute-checksum "Vendor/$ZIP_NAME")

--- a/scripts/tests/release-integrity.sh
+++ b/scripts/tests/release-integrity.sh
@@ -6,6 +6,11 @@ export PYTHONDONTWRITEBYTECODE=1
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Candidate CI authorizes the final live-checkout resolver probe. Keep that
+# ambient capability out of the isolated adversarial fixtures below; each
+# fixture supplies its own complete candidate context when it intends one.
+outer_allow_draft_release=${SWIFTVLC_ALLOW_DRAFT_RELEASE:-}
+unset SWIFTVLC_ALLOW_DRAFT_RELEASE
 temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/swiftvlc-release-tests.XXXXXX")
 trap 'rm -rf "$temp_dir"' EXIT
 
@@ -171,7 +176,16 @@ draft_authorization = (
     "github.event.pull_request.head.repo.full_name == github.repository && "
     "startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}\n"
 )
-expected_counts = (5, 1, 1, 1, 0)
+candidate_token = (
+    "          GH_TOKEN: "
+    "${{ ((github.event_name == 'push' && "
+    "startsWith(github.ref, 'refs/heads/release-candidates/')) || "
+    "(github.event_name == 'pull_request' && "
+    "github.event.pull_request.head.repo.full_name == github.repository && "
+    "startsWith(github.head_ref, 'release-candidates/'))) && "
+    "secrets.GITHUB_TOKEN || '' }}\n"
+)
+expected_counts = (4, 1, 1, 1, 0)
 if len(sys.argv[1:]) != len(expected_counts):
     sys.exit("release workflow integrity invocation is incomplete")
 for path, expected_count in zip(sys.argv[1:], expected_counts):
@@ -182,6 +196,16 @@ for path, expected_count in zip(sys.argv[1:], expected_counts):
             f"{path} must scope draft authorization to each of its "
             f"{expected_count} release-asset steps; found {count}"
         )
+    token_count = source.count(candidate_token)
+    if token_count != expected_count:
+        sys.exit(
+            f"{path} must expose the ephemeral token only to its "
+            f"{expected_count} candidate steps; found {token_count}"
+        )
+    if source.count(candidate_token + draft_authorization) != expected_count:
+        sys.exit(f"{path} candidate token and authorization are not inseparable")
+    if "GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}" in source:
+        sys.exit(f"{path} exposes a repository token outside candidate CI")
     if "  pull_request:\n    branches: [main]\n" not in source:
         sys.exit(f"{path} does not run protected release-candidate PR CI")
     if "  push:\n    branches: [main]\n" not in source:
@@ -241,16 +265,47 @@ for cache_workflow in (workflow, open(sys.argv[4]).read()):
             sys.exit("candidate PR cache isolation still relies only on github.ref")
 
 
-def job(name):
+def job_in(workflow_source, name, path):
     matches = list(
         re.finditer(
             rf"(?ms)^  {re.escape(name)}:\n.*?(?=^  [A-Za-z0-9_-]+:\n|\Z)",
-            workflow,
+            workflow_source,
         )
     )
     if len(matches) != 1:
-        sys.exit(f"expected exactly one {name} workflow job, found {len(matches)}")
+        sys.exit(
+            f"expected exactly one {name} workflow job in {path}, "
+            f"found {len(matches)}"
+        )
     return matches[0].group(0)
+
+
+def job(name):
+    return job_in(workflow, name, sys.argv[1])
+
+
+privileged_jobs = (
+    (workflow, sys.argv[1], ("lint", "ios-build", "test")),
+    (open(sys.argv[2]).read(), sys.argv[2], ("dynamic-host",)),
+    (vendor_manifest, sys.argv[3], ("check",)),
+    (open(sys.argv[4]).read(), sys.argv[4], ("sanitize",)),
+    (native_contracts, sys.argv[5], ()),
+)
+permission_marker = "    permissions:\n      contents: write\n"
+for source, path, names in privileged_jobs:
+    if source.count("permissions:\n  contents: read\n") != 1:
+        sys.exit(f"{path} must keep read-only workflow-level permissions")
+    if source.count(permission_marker) != len(names):
+        sys.exit(
+            f"{path} must grant draft visibility only to {list(names)}"
+        )
+    for name in names:
+        candidate_job = job_in(source, name, path)
+        header = candidate_job.split("\n    steps:\n", 1)[0]
+        if header.count(permission_marker.rstrip("\n")) != 1:
+            sys.exit(f"{path} job {name} lost draft-readable contents permission")
+        if candidate_job.count("          persist-credentials: false\n") != 1:
+            sys.exit(f"{path} job {name} persists its write-capable Git credential")
 
 
 def named_step(job_source, name):
@@ -531,12 +586,24 @@ checksum = "03a57454a6159c455406889c7867e0b284db028d2734a10bdf85a6a7285c862f"
 digest = os.environ.get("RESOLVER_RELEASE_DIGEST", checksum)
 requested_tag, commit = sys.argv[1:]
 tag = os.environ.get("RESOLVER_RELEASE_TAG", requested_tag)
+draft = os.environ.get("RESOLVER_RELEASE_DRAFT") == "1"
+release_locator = (
+    os.environ.get("RESOLVER_RELEASE_LOCATOR", "untagged-0123456789abcdef")
+    if draft
+    else tag
+)
+asset_locator = os.environ.get("RESOLVER_ASSET_LOCATOR", release_locator)
 print(
     json.dumps(
         {
+            "url": (
+                "https://github.com/harflabs/SwiftVLC/releases/"
+                f"tag/{release_locator}"
+            ),
             "tagName": tag,
             "targetCommitish": os.environ.get("RESOLVER_RELEASE_TARGET", commit),
-            "isDraft": os.environ.get("RESOLVER_RELEASE_DRAFT") == "1",
+            "isDraft": draft,
+            "isImmutable": False,
             "isPrerelease": True,
             "assets": [
                 {
@@ -544,7 +611,7 @@ print(
                     "digest": f"sha256:{digest}",
                     "url": (
                         "https://github.com/harflabs/SwiftVLC/releases/"
-                        f"download/{requested_tag}/libvlc.xcframework.zip"
+                        f"download/{asset_locator}/libvlc.xcframework.zip"
                     ),
                     "size": 1,
                 }
@@ -557,7 +624,54 @@ PY
 fi
 exit 2
 SH
-chmod +x "$resolver_bin/gh"
+cat > "$resolver_bin/curl" <<'SH'
+#!/bin/sh
+set -eu
+
+request_url=""
+for argument in "$@"; do
+  request_url=$argument
+done
+requested_tag=${request_url##*/}
+commit=$(/usr/bin/git rev-parse HEAD)
+python3 - "$requested_tag" "$commit" <<'PY'
+import json
+import os
+import sys
+
+checksum = "03a57454a6159c455406889c7867e0b284db028d2734a10bdf85a6a7285c862f"
+requested_tag, commit = sys.argv[1:]
+tag = os.environ.get("RESOLVER_RELEASE_TAG", requested_tag)
+print(
+    json.dumps(
+        {
+            "html_url": (
+                "https://github.com/harflabs/SwiftVLC/releases/"
+                f"tag/{tag}"
+            ),
+            "tag_name": tag,
+            "target_commitish": os.environ.get("RESOLVER_RELEASE_TARGET", commit),
+            "draft": False,
+            "immutable": False,
+            "prerelease": True,
+            "assets": [
+                {
+                    "name": "libvlc.xcframework.zip",
+                    "digest": f"sha256:{checksum}",
+                    "browser_download_url": (
+                        "https://github.com/harflabs/SwiftVLC/releases/"
+                        f"download/{tag}/libvlc.xcframework.zip"
+                    ),
+                    "size": 1,
+                    "state": "uploaded",
+                }
+            ],
+        }
+    )
+)
+PY
+SH
+chmod +x "$resolver_bin/gh" "$resolver_bin/curl"
 
 (
   cd "$resolver_repo"
@@ -668,6 +782,15 @@ if (
     ./scripts/resolve-release-artifact.sh >/dev/null 2>&1
 ); then
   fail "draft release resolved after asset digest drift"
+fi
+if (
+  cd "$resolver_repo"
+  env "${resolver_ci_env[@]}" \
+    RESOLVER_ASSET_LOCATOR=untagged-fedcba9876543210 \
+    PATH="$resolver_bin:$PATH" \
+    ./scripts/resolve-release-artifact.sh >/dev/null 2>&1
+); then
+  fail "draft release resolved an asset from a different untagged locator"
 fi
 if (
   cd "$resolver_repo"
@@ -4491,12 +4614,21 @@ if [ "${1:-}" = release ] && [ "${2:-}" = view ]; then
         "${SWIFTVLC_RELEASE_TEST_METADATA_DRIFT:-}" <<'PY'
 import hashlib
 import json
+import os
 import sys
 from pathlib import Path
 
 state_path, capture_path, tag, drift, immutable_drift, metadata_drift = sys.argv[1:]
 state = Path(state_path).read_text().strip()
 capture = Path(capture_path)
+release_locator = (
+    "untagged-0123456789abcdef" if state == "draft" else tag
+)
+asset_locator = (
+    "untagged-fedcba9876543210"
+    if os.environ.get("SWIFTVLC_RELEASE_TEST_ASSET_URL_DRIFT") == "1"
+    else release_locator
+)
 assets = []
 for path in sorted((capture / "uploaded").iterdir()):
     digest = hashlib.sha256(path.read_bytes()).hexdigest()
@@ -4508,7 +4640,7 @@ for path in sorted((capture / "uploaded").iterdir()):
             "digest": f"sha256:{digest}",
             "url": (
                 "https://github.com/harflabs/SwiftVLC/releases/download/"
-                f"{tag}/{path.name}"
+                f"{asset_locator}/{path.name}"
             ),
             "apiUrl": (
                 "https://api.github.com/repos/harflabs/SwiftVLC/"
@@ -4525,7 +4657,7 @@ for path in sorted((capture / "starters").iterdir()):
             "digest": None,
             "url": (
                 "https://github.com/harflabs/SwiftVLC/releases/download/"
-                f"{tag}/{path.name}"
+                f"{asset_locator}/{path.name}"
             ),
             "apiUrl": (
                 "https://api.github.com/repos/harflabs/SwiftVLC/"
@@ -4538,6 +4670,10 @@ for path in sorted((capture / "starters").iterdir()):
 print(
     json.dumps(
         {
+            "url": (
+                "https://github.com/harflabs/SwiftVLC/releases/"
+                f"tag/{release_locator}"
+            ),
             "tagName": tag,
             "targetCommitish": (capture / "release.commit").read_text().strip(),
             "isDraft": state == "draft",
@@ -5140,6 +5276,24 @@ for release_flow_asset in "${expected_release_assets[@]}"; do
     "$release_flow_candidate/$release_flow_asset"
 done
 
+# GitHub represents mutable draft downloads with an opaque `untagged-*`
+# locator. It must come from the exact release's top-level URL; a matching
+# digest at another draft locator is not the staged candidate.
+if (
+  cd "$release_flow_repo"
+  env "${release_flow_common_env[@]}" \
+    SWIFTVLC_RELEASE_TEST_ASSET_URL_DRIFT=1 \
+    ./scripts/release.sh 1.1.0 --candidate "$release_flow_candidate" \
+      > "$release_flow_root/draft-asset-url-drift.log" 2>&1
+); then
+  fail "release accepted a candidate asset from a different draft locator"
+fi
+grep -q 'existing candidate asset conflicts with local bytes' \
+  "$release_flow_root/draft-asset-url-drift.log" || \
+  fail "candidate draft-locator drift did not produce a fail-closed diagnostic"
+[[ $(tr -d '\n' < "$release_flow_gh_state") == draft ]] || \
+  fail "candidate draft-locator drift changed release visibility"
+
 # A checksum-looking staged Package.swift is not sufficient. Move the mutable
 # candidate anchors to a one-parent commit containing the canonical release
 # files plus an unrelated Package.swift edit; fresh finalize must reconstruct
@@ -5545,7 +5699,10 @@ if grep -En '\$\{[A-Za-z_][A-Za-z0-9_]*\[@\]\}' scripts/setup-dev.sh >/dev/null;
   fail "setup-dev.sh contains an array expansion that is unsafe under Bash 3.2 nounset"
 fi
 
-artifact_info=$(./scripts/resolve-release-artifact.sh)
+artifact_info=$(
+  SWIFTVLC_ALLOW_DRAFT_RELEASE="$outer_allow_draft_release" \
+    ./scripts/resolve-release-artifact.sh
+)
 actual_tag=$(printf '%s' "$artifact_info" \
   | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag"])')
 showcase_version=$(sed -n \

--- a/scripts/tests/release-integrity.sh
+++ b/scripts/tests/release-integrity.sh
@@ -6,11 +6,17 @@ export PYTHONDONTWRITEBYTECODE=1
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-# Candidate CI authorizes the final live-checkout resolver probe. Keep that
-# ambient capability out of the isolated adversarial fixtures below; each
-# fixture supplies its own complete candidate context when it intends one.
-outer_allow_draft_release=${SWIFTVLC_ALLOW_DRAFT_RELEASE:-}
+# Keep ambient candidate capability out of the isolated adversarial fixtures;
+# each fixture supplies its own complete context when it intends one. The lint
+# workflow uses a non-authorizing marker to avoid duplicating authenticated
+# artifact resolution already performed by both candidate build jobs.
+candidate_lint=${SWIFTVLC_RELEASE_CANDIDATE_LINT:-}
+if [[ -n "$candidate_lint" && "$candidate_lint" != "1" ]]; then
+  echo "Error: SWIFTVLC_RELEASE_CANDIDATE_LINT must be exactly 1 when enabled." >&2
+  exit 1
+fi
 unset SWIFTVLC_ALLOW_DRAFT_RELEASE
+unset SWIFTVLC_RELEASE_CANDIDATE_LINT
 temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/swiftvlc-release-tests.XXXXXX")
 trap 'rm -rf "$temp_dir"' EXIT
 
@@ -185,7 +191,7 @@ candidate_token = (
     "startsWith(github.head_ref, 'release-candidates/'))) && "
     "secrets.GITHUB_TOKEN || '' }}\n"
 )
-expected_counts = (4, 1, 1, 1, 0)
+expected_counts = (2, 1, 1, 1, 0)
 if len(sys.argv[1:]) != len(expected_counts):
     sys.exit("release workflow integrity invocation is incomplete")
 for path, expected_count in zip(sys.argv[1:], expected_counts):
@@ -225,6 +231,17 @@ for path, expected_count in zip(sys.argv[1:], expected_counts):
     for action in re.findall(r"(?m)^\s*-?\s*uses:\s*([^\s#]+)", source):
         if not re.fullmatch(r"[^@]+@[0-9a-f]{40}", action):
             sys.exit(f"{path} contains an unpinned authorizing action: {action}")
+candidate_lint_marker = (
+    "          SWIFTVLC_RELEASE_CANDIDATE_LINT: "
+    "${{ (github.event_name == 'pull_request' && "
+    "github.event.pull_request.head.repo.full_name == github.repository && "
+    "startsWith(github.head_ref, 'release-candidates/')) && '1' || '' }}\n"
+)
+if workflow.count(candidate_lint_marker) != 1:
+    sys.exit("release-integrity candidate lint marker is not exactly scoped")
+for path in sys.argv[2:]:
+    if candidate_lint_marker in open(path).read():
+        sys.exit(f"{path} unexpectedly grants the candidate lint marker")
 native_contracts = open(sys.argv[5]).read()
 vendor_manifest = open(sys.argv[3]).read()
 for marker, expected_count in (
@@ -285,7 +302,7 @@ def job(name):
 
 
 privileged_jobs = (
-    (workflow, sys.argv[1], ("lint", "ios-build", "test")),
+    (workflow, sys.argv[1], ("ios-build", "test")),
     (open(sys.argv[2]).read(), sys.argv[2], ("dynamic-host",)),
     (vendor_manifest, sys.argv[3], ("check",)),
     (open(sys.argv[4]).read(), sys.argv[4], ("sanitize",)),
@@ -5699,10 +5716,14 @@ if grep -En '\$\{[A-Za-z_][A-Za-z0-9_]*\[@\]\}' scripts/setup-dev.sh >/dev/null;
   fail "setup-dev.sh contains an array expansion that is unsafe under Bash 3.2 nounset"
 fi
 
-artifact_info=$(
-  SWIFTVLC_ALLOW_DRAFT_RELEASE="$outer_allow_draft_release" \
-    ./scripts/resolve-release-artifact.sh
-)
+if [[ "$candidate_lint" == "1" ]]; then
+  # Candidate build jobs perform the authenticated live download. Keep this
+  # broad fault-matrix/lint job read-only while still checking that its release
+  # and Showcase declarations agree.
+  artifact_info=$(python3 scripts/release-artifact-info.py Package.swift)
+else
+  artifact_info=$(./scripts/resolve-release-artifact.sh)
+fi
 actual_tag=$(printf '%s' "$artifact_info" \
   | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag"])')
 showcase_version=$(sed -n \

--- a/scripts/tests/release-integrity.sh
+++ b/scripts/tests/release-integrity.sh
@@ -182,36 +182,29 @@ draft_authorization = (
     "github.event.pull_request.head.repo.full_name == github.repository && "
     "startsWith(github.head_ref, 'release-candidates/'))) && '1' || '' }}\n"
 )
-candidate_token = (
-    "          GH_TOKEN: "
-    "${{ ((github.event_name == 'push' && "
-    "startsWith(github.ref, 'refs/heads/release-candidates/')) || "
-    "(github.event_name == 'pull_request' && "
-    "github.event.pull_request.head.repo.full_name == github.repository && "
-    "startsWith(github.head_ref, 'release-candidates/'))) && "
-    "secrets.GITHUB_TOKEN || '' }}\n"
-)
-expected_counts = (2, 1, 1, 1, 0)
-if len(sys.argv[1:]) != len(expected_counts):
+workflow_token = "          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n"
+expected_draft_counts = (2, 1, 1, 1, 0)
+expected_token_counts = (3, 1, 1, 1, 0)
+if len(sys.argv[1:]) != len(expected_draft_counts):
     sys.exit("release workflow integrity invocation is incomplete")
-for path, expected_count in zip(sys.argv[1:], expected_counts):
+for path, expected_draft_count, expected_token_count in zip(
+    sys.argv[1:], expected_draft_counts, expected_token_counts
+):
     source = open(path).read()
     count = source.count(draft_authorization)
-    if count != expected_count:
+    if count != expected_draft_count:
         sys.exit(
             f"{path} must scope draft authorization to each of its "
-            f"{expected_count} release-asset steps; found {count}"
+            f"{expected_draft_count} release-asset steps; found {count}"
         )
-    token_count = source.count(candidate_token)
-    if token_count != expected_count:
+    token_count = source.count(workflow_token)
+    if token_count != expected_token_count:
         sys.exit(
-            f"{path} must expose the ephemeral token only to its "
-            f"{expected_count} candidate steps; found {token_count}"
+            f"{path} must expose the ephemeral token to exactly "
+            f"{expected_token_count} release-asset steps; found {token_count}"
         )
-    if source.count(candidate_token + draft_authorization) != expected_count:
+    if source.count(workflow_token + draft_authorization) != expected_draft_count:
         sys.exit(f"{path} candidate token and authorization are not inseparable")
-    if "GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}" in source:
-        sys.exit(f"{path} exposes a repository token outside candidate CI")
     if "  pull_request:\n    branches: [main]\n" not in source:
         sys.exit(f"{path} does not run protected release-candidate PR CI")
     if "  push:\n    branches: [main]\n" not in source:
@@ -222,7 +215,7 @@ for path, expected_count in zip(sys.argv[1:], expected_counts):
         re.MULTILINE,
     ):
         sys.exit(f"{path} grants unconditional draft release access")
-    if expected_count and (
+    if expected_draft_count and (
         "github.event.pull_request.head.repo.full_name == github.repository"
         not in source
         or "startsWith(github.head_ref, 'release-candidates/')" not in source
@@ -697,6 +690,25 @@ chmod +x "$resolver_bin/gh" "$resolver_bin/curl"
     ./scripts/resolve-release-artifact.sh >/dev/null
 )
 
+# GitHub-hosted runners must use their ephemeral token instead of the shared
+# anonymous API quota, without broadening which releases may be drafts.
+(
+  cd "$resolver_repo"
+  GH_TOKEN=fixture-token \
+    PATH="$resolver_bin:$PATH" \
+    RESOLVER_RELEASE_DRAFT=0 \
+    ./scripts/resolve-release-artifact.sh >/dev/null
+)
+if (
+  cd "$resolver_repo"
+  GH_TOKEN=fixture-token \
+    PATH="$resolver_bin:$PATH" \
+    RESOLVER_RELEASE_DRAFT=1 \
+    ./scripts/resolve-release-artifact.sh >/dev/null 2>&1
+); then
+  fail "public authenticated resolution accepted a draft without candidate authorization"
+fi
+
 # Candidate staging removes the final SemVer tag from the equation entirely.
 # Install only the deterministic candidate tag and exact candidate branch.
 git -C "$resolver_repo" tag -d v1.1.0-beta.1 >/dev/null
@@ -1067,6 +1079,24 @@ grep -q '^trusted release bytes$' \
 )
 [[ $(wc -l < "$cache_downloads" | tr -d ' ') == 1 ]] || \
   fail "verified public Vendor cache lost its non-candidate fast path"
+
+rm -rf "$cache_repo/Vendor/libvlc.xcframework"
+rm -f "$cache_repo/Vendor/.swiftvlc-release.json"
+(
+  cd "$cache_repo"
+  GH_TOKEN=fixture-token \
+    PATH="$cache_bin:$PATH" \
+    CACHE_IS_DRAFT=0 \
+    CACHE_ZIP_CHECKSUM="$cache_zip_checksum" \
+    CACHE_ASSET="$cache_zip" \
+    CACHE_DOWNLOADS="$cache_downloads" \
+    ./scripts/setup-dev.sh --artifact-only >/dev/null
+)
+[[ $(wc -l < "$cache_downloads" | tr -d ' ') == 2 ]] || \
+  fail "authenticated public setup did not use the reliable gh download path"
+grep -q '^trusted release bytes$' \
+  "$cache_repo/Vendor/libvlc.xcframework/payload.txt" || \
+  fail "authenticated public setup installed unexpected Vendor bytes"
 
 mkdir -p "$temp_dir/tree-a/Headers" "$temp_dir/tree-b/Headers"
 printf 'binary' > "$temp_dir/tree-a/libvlc.a"


### PR DESCRIPTION
Fixes the release-candidate failures exposed by beta 9 staging.

- handle GitHub's real `untagged-*` draft URLs while binding every asset to the exact release
- let exact same-repository candidate jobs read draft releases, without persisting checkout credentials
- keep tokens out of ordinary PR scripts by resolving/downloading public releases anonymously
- isolate ambient candidate authorization from the release-integrity fault fixtures
- add fail-closed URL and workflow permission regressions

Validated locally with the full `scripts/tests/release-integrity.sh` suite, Bash syntax checks, YAML parsing, a tokenless live beta.8 resolution, and two adversarial reviews.