### PR TITLE
Authenticate main-only artifact consumers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,6 +197,8 @@ jobs:
       # the local SwiftVLC checkout so we compile against in-PR code.
       - name: Set up Vendor + local Swift package
         timeout-minutes: 12
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/setup-dev.sh
 
       - name: Build Showcase (${{ matrix.scheme }})
@@ -386,6 +388,8 @@ jobs:
 
       - name: Set up Vendor + local Swift package
         timeout-minutes: 12
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/setup-dev.sh
 
       # TEST_RUNNER_CI=true is load-bearing: xcodebuild strips the

--- a/scripts/resolve-release-artifact.sh
+++ b/scripts/resolve-release-artifact.sh
@@ -210,10 +210,9 @@ if [[ "$ALLOW_DRAFT" == "1" || -n "${GH_TOKEN:-}" ]]; then
     --json url,tagName,targetCommitish,isDraft,isImmutable,isPrerelease,assets \
     > "$temp_dir/release.json"
 else
-  # Public release metadata does not need a repository token. Keeping ordinary
-  # PRs anonymous means their checked-out scripts never receive the candidate
-  # job's write-capable token. Normalize REST names to the gh JSON contract so
-  # the verifier below has one fail-closed implementation.
+  # Local public release resolution can work without a repository token.
+  # Normalize REST names to the gh JSON contract so authenticated CI and
+  # anonymous local callers share one fail-closed verifier.
   curl --disable --fail --location --retry 3 --retry-all-errors \
     --silent --show-error \
     -H 'Accept: application/vnd.github+json' \

--- a/scripts/tests/release-integrity.sh
+++ b/scripts/tests/release-integrity.sh
@@ -698,7 +698,8 @@ chmod +x "$resolver_bin/gh" "$resolver_bin/curl"
 
 (
   cd "$resolver_repo"
-  PATH="$resolver_bin:$PATH" \
+  GH_TOKEN= GITHUB_TOKEN= \
+    PATH="$resolver_bin:$PATH" \
     RESOLVER_RELEASE_DRAFT=0 \
     ./scripts/resolve-release-artifact.sh >/dev/null
 )

--- a/scripts/tests/release-integrity.sh
+++ b/scripts/tests/release-integrity.sh
@@ -172,6 +172,7 @@ python3 - \
   "$ROOT_DIR/.github/workflows/native-source-contracts.yml" <<'PY'
 import re
 import sys
+from pathlib import Path
 
 workflow = open(sys.argv[1]).read()
 draft_authorization = (
@@ -184,7 +185,7 @@ draft_authorization = (
 )
 workflow_token = "          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n"
 expected_draft_counts = (2, 1, 1, 1, 0)
-expected_token_counts = (3, 1, 1, 1, 0)
+expected_token_counts = (5, 1, 1, 1, 0)
 if len(sys.argv[1:]) != len(expected_draft_counts):
     sys.exit("release workflow integrity invocation is incomplete")
 for path, expected_draft_count, expected_token_count in zip(
@@ -224,6 +225,18 @@ for path, expected_draft_count, expected_token_count in zip(
     for action in re.findall(r"(?m)^\s*-?\s*uses:\s*([^\s#]+)", source):
         if not re.fullmatch(r"[^@]+@[0-9a-f]{40}", action):
             sys.exit(f"{path} contains an unpinned authorizing action: {action}")
+
+# Audit consumers, not only the candidate jobs: main-only Showcase/tvOS lanes
+# also call GitHub's API and can exhaust the shared anonymous runner quota.
+for path in Path(sys.argv[1]).parent.glob("*.yml"):
+    source = path.read_text()
+    for step in re.split(r"(?m)^      - ", source)[1:]:
+        if re.search(
+            r"(?m)^\s+run: \./scripts/(?:setup-dev|ci-use-released-xcframework)\.sh\s*$",
+            step,
+        ) and workflow_token not in step:
+            sys.exit(f"{path} has an unauthenticated release-artifact consumer")
+
 candidate_lint_marker = (
     "          SWIFTVLC_RELEASE_CANDIDATE_LINT: "
     "${{ (github.event_name == 'pull_request' && "


### PR DESCRIPTION
## Fix
The post-merge visionOS Showcase job exposed two artifact consumers omitted from the earlier authentication fix. Showcase and tvOS jobs now use their existing read-only ephemeral token for public release metadata and downloads. Draft authorization and job permissions are unchanged.

## Regression coverage
The integrity suite now inspects every workflow artifact-selection step, including main-only lanes, and rejects a missing token. It also keeps the exact token and draft-authorization counts.

## Validation
- Full release-integrity suite passed.
- Shell syntax, YAML parsing, and git diff checks passed.
- No runtime, native patch, or package API changes.