### PR TITLE
Release v1.1.0-beta.10

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
   targets: [
     .binaryTarget(
       name: "libvlc",
-      url: "https://github.com/harflabs/SwiftVLC/releases/download/v1.1.0-beta.9/libvlc.xcframework.zip",
-      checksum: "26db53b9d21112dfafd7de747a43409a9575229e0c8176b4af903655cb3ad722"
+      url: "https://github.com/harflabs/SwiftVLC/releases/download/v1.1.0-beta.10/libvlc.xcframework.zip",
+      checksum: "d4e662541553dbc49a5452d79ef379888e5abd3da81efc28eb128a4fc6476d54"
     ),
     .target(
       name: "CLibVLC",

--- a/Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj
+++ b/Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj
@@ -1026,7 +1026,7 @@
 			repositoryURL = "https://github.com/harflabs/SwiftVLC";
 			requirement = {
 				kind = exactVersion;
-				version = 1.1.0-beta.9;
+				version = 1.1.0-beta.10;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
Publishes the rebuilt and reproducibility-verified libVLC candidate for **v1.1.0-beta.10**.\n\n- Exact release commit: **d51df92746fb54e84e44d069fb05ac15820a69a4**\n- Artifact checksum: **d4e662541553dbc49a5452d79ef379888e5abd3da81efc28eb128a4fc6476d54**\n- Rebuilt from merged fix commit: **fd8d77a863d7eb4e57700be07abbbb8913fcead8**\n- The final SemVer tag remains absent until candidate CI and this PR are green.