### PR TITLE
Update subtitle tests for native capture

### DIFF
--- a/Sources/SwiftVLC/Player/SubtitleTextBridge.swift
+++ b/Sources/SwiftVLC/Player/SubtitleTextBridge.swift
@@ -4,8 +4,7 @@ import Synchronization
 /// The native operations behind text-subtitle capture.
 ///
 /// Keeping these calls injectable lets the callback bridge and the `Player`
-/// lifecycle be tested with the released libVLC artifact, which deliberately
-/// does not export SwiftVLC's subtitle callback extension.
+/// lifecycle be tested independently from the released libVLC artifact.
 struct SubtitleTextNativeOperations {
   typealias Registration = @MainActor @Sendable (
     OpaquePointer,

--- a/Tests/SwiftVLCTests/PiP/DecodedFrameHarnessTests.swift
+++ b/Tests/SwiftVLCTests/PiP/DecodedFrameHarnessTests.swift
@@ -177,6 +177,7 @@ extension Integration {
       async throws -> TextSubtitleSnapshot {
       let player = Player(instance: TestInstance.makeVideoDecoding())
       let harness = Harness(attachedTo: player)
+      defer { withExtendedLifetime(harness) {} }
       let stream = try player.textSubtitleStream()
       let snapshots = Mutex<[TextSubtitleSnapshot]>([])
       let collector = Task.detached { @Sendable in
@@ -213,8 +214,7 @@ extension Integration {
         player.selectedSubtitleTrack = subtitleTrack
 
         let capturedExpectedSnapshot = try await poll(timeout: .seconds(30), until: {
-          harness.drained > 0
-            && snapshots.withLock { $0.contains(where: match.matches) }
+          snapshots.withLock { $0.contains(where: match.matches) }
         })
         let observedRegionTexts = snapshots.withLock { values in
           values.map { $0.regions.map(\.text) }

--- a/Tests/SwiftVLCTests/Player/SubtitleTextCoverageTests.swift
+++ b/Tests/SwiftVLCTests/Player/SubtitleTextCoverageTests.swift
@@ -28,35 +28,26 @@ extension Integration {
   @Suite(.tags(.mainActor))
   @MainActor struct PlayerTextSubtitleCoverageTests {
     @Test
-    func `Public API reports the released artifact lacks text capture`() throws {
+    func `Public API matches the released artifact text capture capability`() throws {
       let player = Player(instance: TestInstance.makeAudioOnly())
-      let callback: swiftvlc_subtitle_text_snapshot_cb = { _, _, _ in }
-      let opaque = Unmanaged.passUnretained(player).toOpaque()
 
-      #expect(
-        !SubtitleTextNativeOperations.live.register(
-          player.pointer,
-          callback,
-          opaque
-        )
-      )
-      do {
+      if SubtitleTextNativeOperations.live.isAvailable() {
         _ = try player.textSubtitleStream()
-        Issue.record("Expected the released libVLC artifact to lack text capture")
-      } catch {
-        #expect(
-          error
-            == .operationFailed(
-              "Enable text subtitle capture (custom libVLC build required)"
-            )
-        )
+        #expect(player.isTextSubtitleCaptureEnabled)
+      } else {
+        do {
+          _ = try player.textSubtitleStream()
+          Issue.record("Expected text capture to reject an artifact without the native extension")
+        } catch {
+          #expect(
+            error
+              == .operationFailed(
+                "Enable text subtitle capture (custom libVLC build required)"
+              )
+          )
+        }
+        #expect(!player.isTextSubtitleCaptureEnabled)
       }
-
-      let harness = SubtitleTextCallbackHarness()
-      _ = try player.textSubtitleStream(using: makeCoverageNativeOperations(harness: harness))
-      _ = try player.textSubtitleStream()
-      #expect(harness.availabilityProbeCount == 1)
-      #expect(harness.registrationAttempts == 1)
     }
 
     @Test


### PR DESCRIPTION
Updates the subtitle tests for the native text-capture ABI introduced by the next beta artifact. Snapshot matching now waits on the subtitle callback itself instead of an unrelated sparse-video drain counter, and the public API coverage test adapts to both the current beta.9 artifact and the beta.10 candidate. Focused suites pass against both artifact capability states.