### PR TITLE
Fix playback and media ownership bugs

### DIFF
--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -156,4 +156,4 @@ jobs:
             xcrun --toolchain "$TOOLCHAINS" swift test \
               --sanitize=${{ matrix.sanitizer }} \
               --no-parallel \
-              --filter "RaceTests|StressTests|MemoryAndRetainTests|MemoryPressureTests|LifecycleStressTests|OwnershipTests|DialogIDTests|DialogStreamLosslessnessTests|ThumbnailAliasTests"
+              --filter "RaceTests|StressTests|MemoryAndRetainTests|MemoryPressureTests|LifecycleStressTests|OwnershipTests|Dialog|ThumbnailAliasTests"

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -156,4 +156,4 @@ jobs:
             xcrun --toolchain "$TOOLCHAINS" swift test \
               --sanitize=${{ matrix.sanitizer }} \
               --no-parallel \
-              --filter "RaceTests|StressTests|MemoryAndRetainTests|MemoryPressureTests|LifecycleStressTests"
+              --filter "RaceTests|StressTests|MemoryAndRetainTests|MemoryPressureTests|LifecycleStressTests|OwnershipTests|DialogIDTests|DialogStreamLosslessnessTests|ThumbnailAliasTests"

--- a/Sources/SwiftVLC/Audio/Equalizer.swift
+++ b/Sources/SwiftVLC/Audio/Equalizer.swift
@@ -4,8 +4,8 @@ import Observation
 /// A 10-band audio equalizer with preamp and preset support.
 ///
 /// `Equalizer` is `@Observable` and `@MainActor`. SwiftUI views that
-/// read ``preamp`` or ``bands`` update automatically, and the player
-/// it is attached to re-applies its audio output on every change.
+/// read ``preamp`` or ``bands`` update automatically, and each attached
+/// player re-applies its audio output on every change.
 ///
 /// ```swift
 /// let eq = Equalizer()
@@ -19,12 +19,36 @@ public final class Equalizer {
   @ObservationIgnored
   let pointer: OpaquePointer // libvlc_equalizer_t*
 
-  /// Fires on the main actor after any observable change. `Player`
-  /// installs a handler here on assignment to re-apply the equalizer to
-  /// its audio output, since libVLC copies settings on
-  /// `libvlc_media_player_set_equalizer` and does not retain the reference.
+  /// Internal observation hook, independent of the attached players.
   @ObservationIgnored
   var onChange: (@MainActor () -> Void)?
+  private struct Attachment {
+    weak var player: Player?
+  }
+
+  @ObservationIgnored private var attachments: [ObjectIdentifier: Attachment] = [:]
+
+  func attach(to player: Player) {
+    attachments = attachments.filter { $0.value.player != nil }
+    attachments[ObjectIdentifier(player)] = Attachment(player: player)
+  }
+
+  func detach(from player: Player) {
+    attachments.removeValue(forKey: ObjectIdentifier(player))
+  }
+
+  private func notifyChange() {
+    attachments = attachments.filter { $0.value.player != nil }
+    for attachment in Array(attachments.values) {
+      guard let player = attachment.player, player._equalizer === self, !player.isShutdown else { continue }
+      #if DEBUG
+      player.recordObservableControlNativeDispatch(.equalizer(ObjectIdentifier(self)), pointer: player.pointer)
+      #endif
+      libvlc_media_player_set_equalizer(player.pointer, pointer)
+    }
+    onChange?()
+  }
+
   /// Separate causal identities for controls that mutate the same native
   /// value through more than one public API. Observation calls app code before
   /// the mutation body, so a newer reentrant command must invalidate the older
@@ -127,7 +151,7 @@ public final class Equalizer {
       didPerform = true
     }
     if didPerform {
-      onChange?()
+      notifyChange()
     }
   }
 
@@ -162,7 +186,7 @@ public final class Equalizer {
     guard result == 0 else {
       throw .operationFailed("Set equalizer amplification for band \(band)")
     }
-    onChange?()
+    notifyChange()
   }
 
   // MARK: - Presets
@@ -245,7 +269,7 @@ extension Equalizer {
       didPerform = true
     }
     if didPerform {
-      onChange?()
+      notifyChange()
     }
   }
 

--- a/Sources/SwiftVLC/Core/DialogEventBroadcaster.swift
+++ b/Sources/SwiftVLC/Core/DialogEventBroadcaster.swift
@@ -1,0 +1,96 @@
+import Dispatch
+import Foundation
+
+/// Serializes subscription with prompt publication so late consumers cannot
+/// miss a request between reading outstanding prompts and subscribing.
+final class DialogEventBroadcaster: @unchecked Sendable {
+  private let queue = DispatchQueue(label: "swiftvlc.dialog-events")
+  // All mutable state belongs to queue. Termination handlers enqueue their
+  // removal asynchronously: yielding can never wait on a cancellation handler
+  // that is itself waiting to enter this queue.
+  private var subscribers: [UUID: AsyncStream<DialogEvent>.Continuation] = [:]
+  private var outstanding: [DialogEvent] = []
+  private var terminated = false
+
+  func subscribe() -> AsyncStream<DialogEvent> {
+    let (stream, continuation) = AsyncStream<DialogEvent>.makeStream(bufferingPolicy: .unbounded)
+    let id = UUID()
+    queue.sync {
+      guard !terminated else {
+        continuation.finish()
+        return
+      }
+      outstanding.removeAll { $0.dialogID?.pointer == nil }
+      for event in outstanding {
+        continuation.yield(event)
+      }
+      subscribers[id] = continuation
+    }
+    continuation.onTermination = { [weak self] _ in
+      self?.queue.async { [weak self] in
+        self?.subscribers.removeValue(forKey: id)
+      }
+    }
+    return stream
+  }
+
+  func broadcast(_ event: DialogEvent) {
+    queue.sync {
+      guard !terminated else { return }
+      outstanding.removeAll { $0.dialogID?.pointer == nil }
+      switch event {
+      case .login, .question, .progress:
+        if let id = event.dialogID, id.pointer != nil {
+          outstanding.removeAll { $0.dialogID?.identity == id.identity }
+          outstanding.append(event)
+        }
+      case .cancel(let id):
+        outstanding.removeAll { $0.dialogID?.identity == id.identity }
+      case .progressUpdated(let update):
+        if
+          let index = outstanding.firstIndex(where: { $0.dialogID?.identity == update.dialogId.identity }),
+          case .progress(let info) = outstanding[index] {
+          outstanding[index] = .progress(ProgressInfo(
+            dialogId: info.dialogId,
+            title: info.title,
+            text: update.text,
+            isIndeterminate: info.isIndeterminate,
+            position: update.position,
+            cancelText: info.cancelText
+          ))
+        }
+      case .error:
+        break
+      }
+      for continuation in subscribers.values {
+        continuation.yield(event)
+      }
+    }
+  }
+
+  func terminate() {
+    let continuations = queue.sync {
+      terminated = true
+      outstanding.removeAll()
+      let continuations = Array(subscribers.values)
+      subscribers.removeAll()
+      return continuations
+    }
+    for continuation in continuations {
+      continuation.finish()
+    }
+  }
+}
+
+extension DialogEvent {
+  fileprivate var dialogID: DialogID? {
+    switch self {
+    case .login(let request): request.dialogId
+    case .question(let request): request.dialogId
+    case .progress(let info): info.dialogId
+    case .progressUpdated(let update): update.dialogId
+    case .cancel(let id): id
+    case .error: nil
+    }
+  }
+}

--- a/Sources/SwiftVLC/Core/DialogHandler.swift
+++ b/Sources/SwiftVLC/Core/DialogHandler.swift
@@ -25,7 +25,7 @@ public final class DialogHandler: Sendable {
   private let instance: VLCInstance
   /// Internal, not private: the losslessness tests drive it directly, since
   /// VLC dialog callbacks cannot be raised from a test process.
-  let broadcaster: Broadcaster<DialogEvent>
+  let broadcaster: DialogEventBroadcaster
   /// Token returned by `VLCInstance.claimDialogRegistration` on
   /// successful registration. `nil` when this handler lost the race
   /// to another `DialogHandler` that owns the slot.
@@ -33,6 +33,8 @@ public final class DialogHandler: Sendable {
 
   /// Stream of dialog events from VLC. A new independent stream is
   /// returned per access; subscribers don't compete for events.
+  /// Outstanding login, question, and progress prompts replay to late
+  /// subscribers. Answered or cancelled prompts are not replayed.
   ///
   /// Unbounded, and that is load-bearing rather than generous. Most of
   /// ``DialogEvent`` is one-shot and *demands a reply*: VLC blocks until a
@@ -51,7 +53,7 @@ public final class DialogHandler: Sendable {
   /// updates for the life of the operation. That is the better failure: the
   /// alternative is a player that stops and cannot say why.
   public var dialogs: AsyncStream<DialogEvent> {
-    broadcaster.subscribe(policy: .unbounded)
+    broadcaster.subscribe()
   }
 
   /// Registers dialog callbacks with the given VLC instance.
@@ -63,7 +65,7 @@ public final class DialogHandler: Sendable {
   public init(instance: VLCInstance = .shared) {
     self.instance = instance
 
-    let broadcaster = Broadcaster<DialogEvent>(defaultBufferSize: 16)
+    let broadcaster = DialogEventBroadcaster()
     self.broadcaster = broadcaster
 
     let box = Unmanaged.passRetained(broadcaster).toOpaque()
@@ -89,7 +91,7 @@ public final class DialogHandler: Sendable {
       // Release our box and terminate the broadcaster so any
       // `dialogs` access on this handler returns an immediately-
       // finished stream.
-      Unmanaged<Broadcaster<DialogEvent>>.fromOpaque(box).release()
+      Unmanaged<DialogEventBroadcaster>.fromOpaque(box).release()
       registrationToken = nil
       broadcaster.terminate()
     }
@@ -114,7 +116,7 @@ public final class DialogHandler: Sendable {
           libvlc_dialog_set_error_callback(pointer, nil, nil)
         }
       ) {
-      Unmanaged<Broadcaster<DialogEvent>>.fromOpaque(box).release()
+      Unmanaged<DialogEventBroadcaster>.fromOpaque(box).release()
     }
     broadcaster.terminate()
   }
@@ -213,6 +215,18 @@ public struct DialogID: Sendable {
     storage = DialogIDStorage.shared(for: pointer)
   }
 
+  private init(storage: DialogIDStorage) {
+    self.storage = storage
+  }
+
+  static func existing(pointer: OpaquePointer) -> DialogID? {
+    DialogIDStorage.existing(for: pointer).map(Self.init(storage:))
+  }
+
+  var identity: ObjectIdentifier {
+    ObjectIdentifier(storage)
+  }
+
   /// Dismisses the dialog without responding.
   ///
   /// Safe to call on an already-closed dialog; the return value
@@ -251,12 +265,11 @@ public struct DialogID: Sendable {
 
   @discardableResult
   func _consumeForTesting() -> OpaquePointer? {
-    storage.consumePointer()
+    storage.consume { $0 }
   }
 
-  private func consume(_ operation: (OpaquePointer) -> Bool) -> Bool {
-    guard let pointer = storage.consumePointer() else { return false }
-    return operation(pointer)
+  func consume(_ operation: (OpaquePointer) -> Bool) -> Bool {
+    storage.consume(operation) ?? false
   }
 }
 
@@ -384,7 +397,7 @@ private func dialogLoginCallback(
   _ askStore: Bool
 ) {
   guard let data, let dialogId, let title, let text else { return }
-  let broadcaster = Unmanaged<Broadcaster<DialogEvent>>.fromOpaque(data).takeUnretainedValue()
+  let broadcaster = Unmanaged<DialogEventBroadcaster>.fromOpaque(data).takeUnretainedValue()
   broadcaster.broadcast(.login(LoginRequest(
     dialogId: DialogID(pointer: dialogId),
     title: String(cString: title),
@@ -405,7 +418,7 @@ private func dialogQuestionCallback(
   _ action2: UnsafePointer<CChar>?
 ) {
   guard let data, let dialogId, let title, let text, let cancel else { return }
-  let broadcaster = Unmanaged<Broadcaster<DialogEvent>>.fromOpaque(data).takeUnretainedValue()
+  let broadcaster = Unmanaged<DialogEventBroadcaster>.fromOpaque(data).takeUnretainedValue()
 
   let qType: QuestionType = switch type {
   case LIBVLC_DIALOG_QUESTION_WARNING: .warning
@@ -434,7 +447,7 @@ private func dialogProgressCallback(
   _ cancel: UnsafePointer<CChar>?
 ) {
   guard let data, let dialogId, let title, let text else { return }
-  let broadcaster = Unmanaged<Broadcaster<DialogEvent>>.fromOpaque(data).takeUnretainedValue()
+  let broadcaster = Unmanaged<DialogEventBroadcaster>.fromOpaque(data).takeUnretainedValue()
   broadcaster.broadcast(.progress(ProgressInfo(
     dialogId: DialogID(pointer: dialogId),
     title: String(cString: title),
@@ -450,8 +463,8 @@ private func dialogCancelCallback(
   _ dialogId: OpaquePointer?
 ) {
   guard let data, let dialogId else { return }
-  let broadcaster = Unmanaged<Broadcaster<DialogEvent>>.fromOpaque(data).takeUnretainedValue()
-  let dialog = DialogID(pointer: dialogId)
+  let broadcaster = Unmanaged<DialogEventBroadcaster>.fromOpaque(data).takeUnretainedValue()
+  guard let dialog = DialogID.existing(pointer: dialogId) else { return }
   broadcaster.broadcast(.cancel(dialog))
   _ = dialog.dismiss()
 }
@@ -463,9 +476,10 @@ private func dialogUpdateProgressCallback(
   _ text: UnsafePointer<CChar>?
 ) {
   guard let data, let dialogId, let text else { return }
-  let broadcaster = Unmanaged<Broadcaster<DialogEvent>>.fromOpaque(data).takeUnretainedValue()
+  let broadcaster = Unmanaged<DialogEventBroadcaster>.fromOpaque(data).takeUnretainedValue()
+  guard let dialog = DialogID.existing(pointer: dialogId), dialog.pointer != nil else { return }
   broadcaster.broadcast(.progressUpdated(ProgressUpdate(
-    dialogId: DialogID(pointer: dialogId),
+    dialogId: dialog,
     position: position,
     text: String(cString: text)
   )))
@@ -477,7 +491,7 @@ private func dialogErrorCallback(
   _ text: UnsafePointer<CChar>?
 ) {
   guard let data, let title, let text else { return }
-  let broadcaster = Unmanaged<Broadcaster<DialogEvent>>.fromOpaque(data).takeUnretainedValue()
+  let broadcaster = Unmanaged<DialogEventBroadcaster>.fromOpaque(data).takeUnretainedValue()
   broadcaster.broadcast(.error(
     title: String(cString: title),
     message: String(cString: text)
@@ -512,6 +526,10 @@ private final class DialogIDStorage: @unchecked Sendable {
     }
   }
 
+  static func existing(for pointer: OpaquePointer) -> DialogIDStorage? {
+    registryQueue.sync { registry[pointer]?.value }
+  }
+
   private let key: OpaquePointer
   private let state: Mutex<State>
 
@@ -524,22 +542,25 @@ private final class DialogIDStorage: @unchecked Sendable {
     state.withLock { $0.pointer }
   }
 
-  func consumePointer() -> OpaquePointer? {
-    Self.registryQueue.sync {
-      let pointer = state.withLock { state -> OpaquePointer? in
+  func consume<Result>(_ operation: (OpaquePointer) -> Result) -> Result? {
+    let pointer = Self.registryQueue.sync {
+      state.withLock { state -> OpaquePointer? in
         let pointer = state.pointer
         state.pointer = nil
         return pointer
       }
-
-      if pointer != nil {
+    }
+    guard let pointer else { return nil }
+    // Keep this consumed authority discoverable through the entire native
+    // call: a concurrent cancellation must not manufacture another owner.
+    defer {
+      Self.registryQueue.sync {
         if Self.registry[key]?.value === self {
           Self.registry.removeValue(forKey: key)
         }
       }
-
-      return pointer
     }
+    return operation(pointer)
   }
 
   deinit {

--- a/Sources/SwiftVLC/Media/Media.swift
+++ b/Sources/SwiftVLC/Media/Media.swift
@@ -99,7 +99,7 @@ public struct MediaSlave: Sendable, Hashable {
 /// `@MainActor` ``Player`` via `player.load(media)`.
 public final class Media: Sendable {
   nonisolated(unsafe) let pointer: OpaquePointer // libvlc_media_t*
-  let thumbnailCoordinator = ThumbnailCoordinator()
+  let thumbnailCoordinator: ThumbnailCoordinator
 
   /// Creates media from a URL.
   ///
@@ -118,6 +118,7 @@ public final class Media: Sendable {
       throw .mediaCreationFailed(source: url.absoluteString)
     }
     pointer = media
+    thumbnailCoordinator = ThumbnailCoordinator.shared(for: media)
   }
 
   /// Creates media from a URL with per-media HTTP identity headers.
@@ -151,6 +152,7 @@ public final class Media: Sendable {
       throw .mediaCreationFailed(source: path)
     }
     pointer = media
+    thumbnailCoordinator = ThumbnailCoordinator.shared(for: media)
   }
 
   /// Parses the media's metadata and track list, awaiting the result.
@@ -176,15 +178,6 @@ public final class Media: Sendable {
     let em = libvlc_media_event_manager(media)!
     let instancePtr = instance.pointer
     let operationRef = ParseOperationRef()
-
-    // `onCancel` is a `@Sendable` closure and `OpaquePointer` isn't
-    // Sendable, so bind the pointers to `nonisolated(unsafe)` locals —
-    // the same pattern used elsewhere for libVLC pointer captures
-    // (Player.deinit, PixelBufferRenderer). The pointers stay valid for
-    // the duration of this call because `self` (Media) and `instance`
-    // (VLCInstance) are retained by the surrounding `async` frame.
-    nonisolated(unsafe) let cancelMedia = media
-    nonisolated(unsafe) let cancelInstance = instancePtr
 
     let result: Result<Metadata, VLCError> = await withTaskCancellationHandler {
       await withCheckedContinuation { cont in
@@ -242,13 +235,10 @@ public final class Media: Sendable {
         }
       }
     } onCancel: {
-      // Stop the in-progress parse. VLC will fire MediaParsedChanged
-      // with a failed status, which resumes the continuation.
-      if let operation = operationRef.value() {
-        operation.cancel()
-      } else {
-        libvlc_media_parse_stop(cancelInstance, cancelMedia)
-      }
+      // Only this operation can own a request. Before installation, the
+      // cancellation checks above settle this caller without stopping a
+      // different caller's active parse on the same native media.
+      operationRef.value()?.cancel()
     }
     operationRef.value()?.cleanupAfterCompletion()
     return try result.get()
@@ -349,6 +339,7 @@ public final class Media: Sendable {
   /// `Media` will call `libvlc_media_release` on deinit.
   init(retaining ptr: OpaquePointer) {
     pointer = ptr
+    thumbnailCoordinator = ThumbnailCoordinator.shared(for: ptr)
   }
 
   /// Creates media from an open file descriptor.
@@ -363,6 +354,7 @@ public final class Media: Sendable {
       throw .mediaCreationFailed(source: "fd:\(fd)")
     }
     pointer = media
+    thumbnailCoordinator = ThumbnailCoordinator.shared(for: media)
   }
 
   /// Applies a libVLC option to this media before playback starts.

--- a/Sources/SwiftVLC/Media/ThumbnailRequest.swift
+++ b/Sources/SwiftVLC/Media/ThumbnailRequest.swift
@@ -186,8 +186,44 @@ func checkedThumbnailRequestMilliseconds(
 // MARK: - Internals
 
 actor ThumbnailCoordinator {
+  /// Accessed only while the registry mutex is held.
+  private final class WeakCoordinator: @unchecked Sendable {
+    weak var value: ThumbnailCoordinator?
+
+    init(_ value: ThumbnailCoordinator) {
+      self.value = value
+    }
+  }
+
+  private static let registry = Mutex<[UInt: WeakCoordinator]>([:])
+  private let nativeIdentity: UInt?
   private var isBusy = false
   private var waiters: [ThumbnailGate] = []
+
+  init(nativeIdentity: UInt? = nil) {
+    self.nativeIdentity = nativeIdentity
+  }
+
+  static func shared(for media: OpaquePointer) -> ThumbnailCoordinator {
+    let key = UInt(bitPattern: media)
+    return registry.withLock { registry in
+      if let existing = registry[key]?.value {
+        return existing
+      }
+      let coordinator = ThumbnailCoordinator(nativeIdentity: key)
+      registry[key] = WeakCoordinator(coordinator)
+      return coordinator
+    }
+  }
+
+  deinit {
+    guard let nativeIdentity else { return }
+    Self.registry.withLock { registry in
+      if registry[nativeIdentity]?.value == nil {
+        registry.removeValue(forKey: nativeIdentity)
+      }
+    }
+  }
 
   func acquire() async throws(VLCError) {
     guard !Task.isCancelled else {

--- a/Sources/SwiftVLC/Player/Player+Audio.swift
+++ b/Sources/SwiftVLC/Player/Player+Audio.swift
@@ -12,6 +12,8 @@ extension Player {
   /// handler. libVLC copies settings on each
   /// `libvlc_media_player_set_equalizer` call and does not retain the
   /// reference.
+  /// The same equalizer may be shared by multiple players; detaching it from
+  /// one player leaves the others subscribed to future changes.
   public var equalizer: Equalizer? {
     get {
       access(keyPath: \.equalizer)
@@ -28,8 +30,9 @@ extension Player {
         identity: identity,
         revision: \PlayerIntentRevisions.equalizer
       ) { pointer in
-        _equalizer?.onChange = nil
+        _equalizer?.detach(from: self)
         _equalizer = newValue
+        newValue?.attach(to: self)
         #if DEBUG
         recordObservableControlNativeDispatch(
           .equalizer(newValue.map(ObjectIdentifier.init)),
@@ -37,15 +40,6 @@ extension Player {
         )
         #endif
         libvlc_media_player_set_equalizer(pointer, newValue?.pointer)
-        newValue?.onChange = { [weak self, weak newValue] in
-          guard
-            let self,
-            let newValue,
-            _equalizer === newValue,
-            !isShutdown
-          else { return }
-          libvlc_media_player_set_equalizer(self.pointer, newValue.pointer)
-        }
       }
     }
   }

--- a/Sources/SwiftVLC/Player/Player+Drawable.swift
+++ b/Sources/SwiftVLC/Player/Player+Drawable.swift
@@ -358,12 +358,16 @@ extension Player {
       throw .operationFailed("Set renderer")
     }
     let newLifetime = NativePlayerHandleLifetime(pointer: newPointer)
+    var preparedSubtitleGeneration: UInt64?
     func releaseUncommittedCandidate() {
+      if let preparedSubtitleGeneration {
+        subtitleTextBridge.cancelAttachment(preparedSubtitleGeneration)
+      }
       libvlc_media_player_release(newPointer)
       newLifetime.initialOwnerDidRelease()
     }
     do {
-      try reattachTextSubtitleCaptureIfEnabled(to: newLifetime)
+      preparedSubtitleGeneration = try prepareTextSubtitleCaptureIfEnabled(to: newLifetime)
     } catch {
       releaseUncommittedCandidate()
       throw error
@@ -506,6 +510,9 @@ extension Player {
     // as B.
     pointer = newPointer
     nativeHandleLifetime = newLifetime
+    if let preparedSubtitleGeneration {
+      subtitleTextBridge.commitAttachment(preparedSubtitleGeneration)
+    }
     supersedeAllSeekWorkForCausalBoundary()
     let drainedFrameResults = nativeSeekMonitor.reattach(
       to: newPointer,

--- a/Sources/SwiftVLC/Player/Player+Events.swift
+++ b/Sources/SwiftVLC/Player/Player+Events.swift
@@ -662,17 +662,45 @@ extension Player {
         break
       }
 
-    // Computed properties read fresh state from libVLC in their getter.
+    case .volumeChanged:
+      let revision = intentRevisions.audioVolume
+      #if DEBUG
+      let value = _nativeVolumeOverrideForTesting ?? libvlc_audio_get_volume(pointer)
+      #else
+      let value = libvlc_audio_get_volume(pointer)
+      #endif
+      performObservableMutation(
+        keyPath: \.volume,
+        ifPlaybackGeneration: sourcePlaybackGeneration ?? sessionGeneration,
+        nativeHandleGeneration: sourceNativeHandleGeneration ?? eventBridge.currentNativeHandleGeneration,
+        lifecycleControlEpoch: sourceLifecycleControlEpoch ?? eventBridge.currentLifecycleControlEpoch
+      ) {
+        guard value >= 0, intentRevisions.audioVolume == revision else { return }
+        _volume = Float(value) / 100
+      }
+
+    case .muted, .unmuted:
+      let revision = intentRevisions.mute
+      #if DEBUG
+      let value = _nativeMuteOverrideForTesting ?? libvlc_audio_get_mute(pointer)
+      #else
+      let value = libvlc_audio_get_mute(pointer)
+      #endif
+      performObservableMutation(
+        keyPath: \.isMuted,
+        ifPlaybackGeneration: sourcePlaybackGeneration ?? sessionGeneration,
+        nativeHandleGeneration: sourceNativeHandleGeneration ?? eventBridge.currentNativeHandleGeneration,
+        lifecycleControlEpoch: sourceLifecycleControlEpoch ?? eventBridge.currentLifecycleControlEpoch
+      ) {
+        guard value >= 0, intentRevisions.mute == revision else { return }
+        _isMuted = value != 0
+      }
+
+    // These computed properties read fresh state from libVLC in their getter.
     // An empty `withMutation` is what re-triggers SwiftUI when the
     // underlying C state changes externally (hardware keys, system controls,
     // renderer-initiated chapter/title moves). Without this
     // the observers stay pinned to their last read.
-    case .volumeChanged:
-      withMutation(keyPath: \.volume) {}
-
-    case .muted, .unmuted:
-      withMutation(keyPath: \.isMuted) {}
-
     case .chapterChanged:
       withMutation(keyPath: \.currentChapter) {}
 

--- a/Sources/SwiftVLC/Player/Player+PlaybackControl.swift
+++ b/Sources/SwiftVLC/Player/Player+PlaybackControl.swift
@@ -29,10 +29,9 @@ extension Player {
         successorPlaybackGeneration: requestedPlaybackGeneration
       )
       let mediaPublicationGeneration = sessionGeneration
-      precondition(
-        mediaPublicationGeneration == requestedPlaybackGeneration.value,
-        "Fresh-handle playback must commit its requested generation"
-      )
+      // Replacement publishes observables synchronously. A newer load/play
+      // from an observer owns the successor and must win this transaction.
+      guard mediaPublicationGeneration == requestedPlaybackGeneration.value else { return }
       self.mediaPublicationGeneration = mediaPublicationGeneration
       defer {
         if self.mediaPublicationGeneration == mediaPublicationGeneration {

--- a/Sources/SwiftVLC/Player/Player+TextSubtitles.swift
+++ b/Sources/SwiftVLC/Player/Player+TextSubtitles.swift
@@ -59,21 +59,24 @@ extension Player {
     return subtitleTextBridge.subscribe()
   }
 
-  /// Reattaches an already-enabled capture bridge to a replacement native
-  /// player. Called while the candidate handle is still private, before it can
-  /// start playback or replace the outgoing pointer.
-  func reattachTextSubtitleCaptureIfEnabled(
+  /// Prepares capture on a private candidate. The caller must commit the
+  /// returned generation with the native handle swap or cancel it on rollback.
+  func prepareTextSubtitleCaptureIfEnabled(
     to lifetime: NativePlayerHandleLifetime
   )
-    throws(VLCError) {
-    guard isTextSubtitleCaptureEnabled else { return }
+    throws(VLCError) -> UInt64? {
+    guard isTextSubtitleCaptureEnabled else { return nil }
     let native = subtitleTextNativeOperations
     guard native.isAvailable() else {
       throw .operationFailed("Reattach text subtitle capture")
     }
-    guard attachTextSubtitleCapture(to: lifetime, using: native) else {
+    guard
+      let generation = subtitleTextBridge.prepareAttachment(to: lifetime, using: { callback, opaque in
+        native.register(lifetime.pointer, callback, opaque)
+      }) else {
       throw .operationFailed("Reattach text subtitle capture")
     }
+    return generation
   }
 
   private func attachTextSubtitleCapture(

--- a/Sources/SwiftVLC/Player/SubtitleTextBridge.swift
+++ b/Sources/SwiftVLC/Player/SubtitleTextBridge.swift
@@ -88,7 +88,17 @@ final class SubtitleTextBridge: Sendable {
     to lifetime: NativePlayerHandleLifetime,
     using registration: Registration
   ) -> Bool {
-    guard !lifetime.isReleased else { return false }
+    guard let generation = prepareAttachment(to: lifetime, using: registration) else { return false }
+    return commitAttachment(generation)
+  }
+
+  /// Registers a candidate without replacing the active subtitle source.
+  /// The enclosing native-player transaction must commit or cancel it.
+  func prepareAttachment(
+    to lifetime: NativePlayerHandleLifetime,
+    using registration: Registration
+  ) -> UInt64? {
+    guard !lifetime.isReleased else { return nil }
 
     guard
       let generation = state.withLock({ state -> UInt64? in
@@ -97,7 +107,7 @@ final class SubtitleTextBridge: Sendable {
         let generation = state.nextGeneration
         state.pendingSnapshots[generation] = PendingSnapshot()
         return generation
-      }) else { return false }
+      }) else { return nil }
 
     let attachment = SubtitleTextCallbackAttachment(
       bridge: self,
@@ -108,22 +118,28 @@ final class SubtitleTextBridge: Sendable {
       _ = state.withLock {
         $0.pendingSnapshots.removeValue(forKey: generation)
       }
-      return false
+      return nil
     }
 
     // Registration latches the opaque into the native handle. Establish its
     // lifetime before publishing the generation as current.
     lifetime.retainUntilReleased([attachment])
+    return generation
+  }
 
-    return state.withLock { state in
+  func cancelAttachment(_ generation: UInt64) {
+    _ = state.withLock { $0.pendingSnapshots.removeValue(forKey: generation) }
+  }
+
+  @discardableResult
+  func commitAttachment(_ generation: UInt64) -> Bool {
+    state.withLock { state in
       guard !state.isTerminated else {
         state.pendingSnapshots.removeValue(forKey: generation)
         return false
       }
       let pendingSnapshot = state.pendingSnapshots.removeValue(forKey: generation)
-      // Termination is the only operation that can remove a pending entry,
-      // and that state was handled above while holding this same lock.
-      precondition(pendingSnapshot != nil)
+      guard pendingSnapshot != nil else { return false }
       if let currentGeneration = state.currentGeneration {
         guard generation > currentGeneration else { return false }
       }

--- a/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
+++ b/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
@@ -207,6 +207,7 @@ public final class MediaListPlayer {
 
   /// Starts playing the media list from the beginning.
   public func play() {
+    guard (try? prepareAttachedPlayerForPlayback()) == true else { return }
     guard
       attachedPlayerHandleIsCurrent,
       let reservation = reservePlaybackStart()
@@ -231,6 +232,10 @@ public final class MediaListPlayer {
   /// `src/audio_output/dec.c:876`, killing the process. Mirror the
   /// guard in ``Player/togglePlayPause()``.
   public func togglePause() {
+    if _mediaPlayer?.nativePlayerNeedsReplacementBeforePlayback == true {
+      play()
+      return
+    }
     guard attachedPlayerHandleIsCurrent else { return }
     switch state {
     case .playing:
@@ -262,6 +267,10 @@ public final class MediaListPlayer {
 
   /// Resumes playback.
   public func resume() {
+    if _mediaPlayer?.nativePlayerNeedsReplacementBeforePlayback == true {
+      play()
+      return
+    }
     guard attachedPlayerHandleIsCurrent else { return }
     if let mediaPlayer = _mediaPlayer {
       mediaPlayer.resume()
@@ -287,7 +296,7 @@ public final class MediaListPlayer {
   ///   ``VLCError/invalidInput(_:)`` if the index is out of range for the
   ///   attached list, or ``VLCError/operationFailed(_:)`` if libVLC rejects it.
   public func play(at requestedIndex: Int) throws(VLCError) {
-    guard attachedPlayerHandleIsCurrent else {
+    guard try prepareAttachedPlayerForPlayback() else {
       throw .invalidState("The attached Player is waiting for a fresh native handle")
     }
     let index = try checkedNonnegativeInt32(requestedIndex, parameter: "index")
@@ -314,7 +323,7 @@ public final class MediaListPlayer {
   /// - Throws: ``VLCError/invalidState(_:)`` if no media list is attached,
   ///   or ``VLCError/operationFailed(_:)`` if the item is not in the list.
   public func play(_ media: borrowing Media) throws(VLCError) {
-    guard attachedPlayerHandleIsCurrent else {
+    guard try prepareAttachedPlayerForPlayback() else {
       throw .invalidState("The attached Player is waiting for a fresh native handle")
     }
     guard _mediaList != nil else {
@@ -357,7 +366,7 @@ public final class MediaListPlayer {
   /// Advances to the next item in the list.
   /// - Throws: `VLCError.operationFailed` if there is no next item.
   public func next() throws(VLCError) {
-    guard attachedPlayerHandleIsCurrent else {
+    guard try prepareAttachedPlayerForPlayback() else {
       throw .invalidState("The attached Player is waiting for a fresh native handle")
     }
     guard let reservation = reservePlaybackStart() else {
@@ -373,7 +382,7 @@ public final class MediaListPlayer {
   /// Goes back to the previous item in the list.
   /// - Throws: `VLCError.operationFailed` if there is no previous item.
   public func previous() throws(VLCError) {
-    guard attachedPlayerHandleIsCurrent else {
+    guard try prepareAttachedPlayerForPlayback() else {
       throw .invalidState("The attached Player is waiting for a fresh native handle")
     }
     guard let reservation = reservePlaybackStart() else {
@@ -568,6 +577,37 @@ public final class MediaListPlayer {
       libvlc_media_list_player_stop_async(oldPointer)
       libvlc_media_list_player_release(oldPointer)
     }
+  }
+
+  /// A drawable-hosted stop retires the handle before the next transport.
+  /// Preparing the replacement also rebinds this list player's native owner.
+  /// Observation during preparation can install a newer command or owner;
+  /// that takeover must prevent this older transport from being dispatched.
+  private func prepareAttachedPlayerForPlayback() throws(VLCError) -> Bool {
+    guard let player = _mediaPlayer else { return true }
+    guard
+      !player.isShutdown,
+      player.attachedMediaListPlayer === self,
+      player.eventBridge.currentPlaybackGeneration == player.sessionGeneration
+    else { return false }
+    guard player.nativePlayerNeedsReplacementBeforePlayback else {
+      return attachedPlayerHandleIsCurrent
+    }
+    let listPlayer = pointer
+    let list = _mediaList
+    let ownership = player.mediaListOwnershipEpoch
+    let generation = player.sessionGeneration
+    let control = player.playbackControlIntentRevision
+    try player.prepareDrawableForPlayback()
+    return pointer == listPlayer
+      && _mediaList === list
+      && _mediaPlayer === player
+      && player.attachedMediaListPlayer === self
+      && player.mediaListOwnershipEpoch == ownership
+      && player.sessionGeneration == generation
+      && player.playbackControlIntentRevision == control
+      && !player.isShutdown
+      && attachedPlayerHandleIsCurrent
   }
 
   private var attachedPlayerHandleIsCurrent: Bool {

--- a/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
+++ b/Sources/SwiftVLC/Playlist/MediaListPlayer.swift
@@ -232,8 +232,15 @@ public final class MediaListPlayer {
   /// `src/audio_output/dec.c:876`, killing the process. Mirror the
   /// guard in ``Player/togglePlayPause()``.
   public func togglePause() {
-    if _mediaPlayer?.nativePlayerNeedsReplacementBeforePlayback == true {
-      play()
+    if let player = _mediaPlayer, player.nativePlayerNeedsReplacementBeforePlayback {
+      // The list's state deliberately hides a retired handle as idle. Use
+      // the attached player's observed state until its stop has settled.
+      switch player.state {
+      case .idle, .stopped:
+        play()
+      case .playing, .paused, .opening, .buffering, .stopping, .error:
+        break
+      }
       return
     }
     guard attachedPlayerHandleIsCurrent else { return }

--- a/Sources/SwiftVLC/Video/VideoAdjustments.swift
+++ b/Sources/SwiftVLC/Video/VideoAdjustments.swift
@@ -13,11 +13,15 @@ import CLibVLC
 /// ```
 @MainActor
 public struct VideoAdjustments: ~Copyable, ~Escapable {
-  private let pointer: OpaquePointer
+  private let player: Player
 
   @_lifetime(borrow player)
   init(player: borrowing Player) {
-    pointer = player.pointer
+    self.player = copy player
+  }
+
+  private var pointer: OpaquePointer {
+    player.pointer
   }
 
   /// Whether video adjustments are enabled.

--- a/Tests/SwiftVLCTests/Core/DialogIDTests.swift
+++ b/Tests/SwiftVLCTests/Core/DialogIDTests.swift
@@ -17,6 +17,39 @@ import Testing
 /// and consumption tokens.
 extension Logic {
   struct DialogIDTests {
+    @Test
+    func `Cancellation during an answer shares the consumed native authority`() {
+      let pointer = SyntheticDialogPointer.next()
+      let answer = DialogID(pointer: pointer)
+      var nativeCalls = 0
+      let answered = answer.consume { pointer in
+        nativeCalls += 1
+        guard let cancellation = DialogID.existing(pointer: pointer) else {
+          Issue.record("In-flight consumption lost its registry authority")
+          return false
+        }
+        #expect(!cancellation.consume { _ in nativeCalls += 1; return true })
+        return true
+      }
+      #expect(answered)
+      #expect(nativeCalls == 1)
+      #expect(DialogID.existing(pointer: pointer) == nil)
+    }
+
+    @Test
+    func `Finishing an old answer cannot remove a new allocation at its address`() {
+      let pointer = SyntheticDialogPointer.next()
+      let answer = DialogID(pointer: pointer)
+      var successor: DialogID?
+      #expect(answer.consume { pointer in
+        successor = DialogID(pointer: pointer)
+        return true
+      })
+      #expect(successor?._isValidForTesting == true)
+      #expect(DialogID.existing(pointer: pointer)?.identity == successor?.identity)
+      #expect(successor?._consumeForTesting() == pointer)
+    }
+
     /// A fresh DialogID reports itself valid until it's consumed.
     @Test
     func `New DialogID is valid before consume`() {

--- a/Tests/SwiftVLCTests/Core/DialogStreamLosslessnessTests.swift
+++ b/Tests/SwiftVLCTests/Core/DialogStreamLosslessnessTests.swift
@@ -35,6 +35,62 @@ struct DialogStreamLosslessnessTests {
     )
   }
 
+  @Test
+  func `Every late subscriber receives outstanding prompts`() async {
+    let handler = DialogHandler(instance: TestInstance.makeAudioOnly())
+    let first = loginRequest()
+    let second = loginRequest()
+    handler.broadcaster.broadcast(.login(first))
+    handler.broadcaster.broadcast(.login(second))
+    let one = handler.dialogs
+    let two = handler.dialogs
+    handler.broadcaster.terminate()
+    for stream in [one, two] {
+      var ids: [ObjectIdentifier] = []
+      for await event in stream {
+        if let request = event.login {
+          ids.append(request.dialogId.identity)
+        }
+      }
+      #expect(ids == [first.dialogId.identity, second.dialogId.identity])
+    }
+    _ = first.dialogId._consumeForTesting()
+    _ = second.dialogId._consumeForTesting()
+  }
+
+  @Test
+  func `Answered and cancelled prompts are not replayed`() async {
+    let handler = DialogHandler(instance: TestInstance.makeAudioOnly())
+    let answered = loginRequest()
+    let cancelled = loginRequest()
+    handler.broadcaster.broadcast(.login(answered))
+    handler.broadcaster.broadcast(.login(cancelled))
+    _ = answered.dialogId._consumeForTesting()
+    handler.broadcaster.broadcast(.cancel(cancelled.dialogId))
+    var stream = handler.dialogs.makeAsyncIterator()
+    handler.broadcaster.terminate()
+    #expect(await stream.next() == nil)
+    _ = cancelled.dialogId._consumeForTesting()
+  }
+
+  @Test
+  func `Late progress subscribers receive the latest presentation`() async {
+    let handler = DialogHandler(instance: TestInstance.makeAudioOnly())
+    let id = Self.syntheticDialogID()
+    handler.broadcaster.broadcast(.progress(ProgressInfo(
+      dialogId: id, title: "Download", text: "Starting", isIndeterminate: false,
+      position: 0, cancelText: "Cancel"
+    )))
+    handler.broadcaster.broadcast(.progressUpdated(ProgressUpdate(dialogId: id, position: 0.75, text: "Almost done")))
+    var values = handler.dialogs.makeAsyncIterator()
+    handler.broadcaster.terminate()
+    let latest = await values.next()?.progress
+    #expect(latest?.text == "Almost done")
+    #expect(latest?.position == 0.75)
+    #expect(await values.next() == nil)
+    _ = id._consumeForTesting()
+  }
+
   @Test(.timeLimit(.minutes(1)))
   func `A progress burst cannot evict a login prompt`() async {
     // A fresh instance per test: DialogHandler finishes its stream immediately

--- a/Tests/SwiftVLCTests/Media/ParseOwnershipTests.swift
+++ b/Tests/SwiftVLCTests/Media/ParseOwnershipTests.swift
@@ -1,0 +1,112 @@
+@testable import SwiftVLC
+import CLibVLC
+import Foundation
+import Network
+import Synchronization
+import Testing
+
+extension Integration {
+  @Suite(.tags(.media, .async), .timeLimit(.minutes(1)))
+  @MainActor struct ParseOwnershipTests {
+    @Test
+    func `A pre-cancelled caller does not stop the active native parse`() async throws {
+      let server = try DelayedParseServer(body: Data(contentsOf: TestMedia.twosecURL))
+      defer { server.stop() }
+      let media = try Media(url: server.url)
+      let instance = TestInstance.makeAudioOnly()
+      let first = Task { try await media.parse(timeout: .seconds(10), instance: instance) }
+      let deadline = ContinuousClock.now + .seconds(5)
+      while !server.hasRequest && ContinuousClock.now < deadline {
+        try await Task.sleep(for: .milliseconds(10))
+      }
+      try #require(server.hasRequest)
+      #expect(libvlc_media_get_parsed_status(media.pointer) == libvlc_media_parsed_status_pending)
+      // The task inherits MainActor, so cancellation precedes its first step.
+      let second = Task { try await media.parse(timeout: .seconds(10), instance: instance) }
+      second.cancel()
+      if case .success = await second.result {
+        Issue.record("Expected cancellation")
+      }
+      #expect(libvlc_media_get_parsed_status(media.pointer) == libvlc_media_parsed_status_pending)
+      server.releaseResponse()
+      _ = try await first.value
+      #expect(libvlc_media_get_parsed_status(media.pointer) == libvlc_media_parsed_status_done)
+    }
+  }
+}
+
+/// A loopback HTTP fixture whose response is explicitly released by the test.
+private final class DelayedParseServer: @unchecked Sendable {
+  private let listener: NWListener
+  private let queue = DispatchQueue(label: "swiftvlc.delayed-parse-fixture")
+  private let received = Mutex(false)
+  private let response: Data
+  // Only queue accesses these fields.
+  private var pending: [NWConnection] = []
+  private var released = false
+  var url: URL {
+    URL(string: "http://127.0.0.1:\(listener.port!.rawValue)/twosec.mp4")!
+  }
+
+  var hasRequest: Bool {
+    received.withLock { $0 }
+  }
+
+  init(body: Data) throws {
+    let parameters = NWParameters.tcp
+    parameters.requiredLocalEndpoint = .hostPort(host: "127.0.0.1", port: .any)
+    listener = try NWListener(using: parameters)
+    let ready = DispatchSemaphore(value: 0)
+    listener.stateUpdateHandler = { state in
+      if case .ready = state {
+        ready.signal()
+      }
+      if case .failed = state {
+        ready.signal()
+      }
+    }
+    response = Data("HTTP/1.1 200 OK\r\nContent-Type: video/mp4\r\nContent-Length: \(body.count)\r\nConnection: close\r\n\r\n".utf8) + body
+    listener.newConnectionHandler = { [weak self] connection in
+      guard let self else { connection.cancel(); return }
+      connection.start(queue: queue)
+      connection.receive(minimumIncompleteLength: 1, maximumLength: 16384) { [weak self] data, _, _, _ in
+        guard let self, data?.isEmpty == false else { connection.cancel(); return }
+        received.withLock { $0 = true }
+        if released {
+          send(to: connection)
+        } else {
+          pending.append(connection)
+        }
+      }
+    }
+    listener.start(queue: queue)
+    guard ready.wait(timeout: .now() + 5) == .success, listener.port != nil else {
+      listener.cancel()
+      throw VLCError.operationFailed("Start loopback parse fixture")
+    }
+  }
+
+  func releaseResponse() {
+    queue.async {
+      self.released = true
+      for connection in self.pending {
+        self.send(to: connection)
+      }
+      self.pending.removeAll()
+    }
+  }
+
+  func stop() {
+    listener.cancel()
+    queue.async {
+      for connection in self.pending {
+        connection.cancel()
+      }
+      self.pending.removeAll()
+    }
+  }
+
+  private func send(to connection: NWConnection) {
+    connection.send(content: response, completion: .contentProcessed { _ in connection.cancel() })
+  }
+}

--- a/Tests/SwiftVLCTests/Media/ThumbnailAliasTests.swift
+++ b/Tests/SwiftVLCTests/Media/ThumbnailAliasTests.swift
@@ -1,0 +1,26 @@
+@testable import SwiftVLC
+import Foundation
+import Testing
+
+extension Integration {
+  @Suite(.tags(.media, .async), .timeLimit(.minutes(1)))
+  struct ThumbnailAliasTests {
+    @Test
+    func `Native media aliases return their own requested thumbnail dimensions`() async throws {
+      let list = MediaList()
+      try list.append(Media(url: TestMedia.twosecURL))
+      let first = try #require(list[0])
+      let second = try #require(list[0])
+      #expect(first !== second)
+      #expect(first.pointer == second.pointer)
+      let instance = try VLCInstance(arguments: VLCInstance.defaultArguments + ["--no-audio", "--codec=avcodec"])
+      async let small = first.thumbnail(at: .milliseconds(100), width: 64, height: 36, instance: instance)
+      async let large = second.thumbnail(at: .milliseconds(500), width: 128, height: 72, instance: instance)
+      let (smallPNG, largePNG) = try await (small, large)
+      try #require(smallPNG.count >= 24 && largePNG.count >= 24)
+      #expect(smallPNG[16..<20].reduce(UInt32(0)) { $0 << 8 | UInt32($1) } == 64)
+      #expect(largePNG[16..<20].reduce(UInt32(0)) { $0 << 8 | UInt32($1) } == 128)
+      #expect(smallPNG != largePNG)
+    }
+  }
+}

--- a/Tests/SwiftVLCTests/Player/PlayerBehaviorOwnershipTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlayerBehaviorOwnershipTests.swift
@@ -1,0 +1,131 @@
+@testable import SwiftVLC
+import CLibVLC
+import Foundation
+import Observation
+import Testing
+
+extension Integration {
+  @Suite(.tags(.mainActor), .timeLimit(.minutes(1)))
+  @MainActor struct PlayerBehaviorOwnershipTests {
+    @Test
+    func `Reentrant load supersedes active play without starting the newer media`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      try player.load(Media(url: TestMedia.silenceURL))
+      player._setStateForTesting(state: .playing)
+      player.activeVideoOutputs = 1
+      let newest = try Media(url: TestMedia.twosecURL)
+      let action = BehaviorObservationAction { player.load(newest) }
+      withObservationTracking { _ = player.activeVideoOutputs } onChange: {
+        MainActor.assumeIsolated { action.run() }
+      }
+
+      try player.play(Media(url: TestMedia.silenceURL))
+
+      #expect(action.didRun)
+      #expect(player.currentMedia === newest)
+      #expect(player.state == .idle)
+      #expect(!player.nativePlayerHasStartedPlayback)
+    }
+
+    @Test
+    func `Scoped adjustments follow replacement and leave the retired handle untouched`() throws {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      let old = player.pointer
+      let lease = player.nativeHandleLifetime.acquireNativeOwnerLease()
+      _ = libvlc_media_player_retain(old)
+      defer {
+        libvlc_media_player_release(old)
+        lease.endAfterNativeOwnerRelease()
+      }
+      try player.withAdjustments { adjustments in
+        try player.replaceNativePlayerForDrawablePlayback(target: nil)
+        adjustments.contrast = 1.5
+        adjustments.brightness = 0.7
+        #expect(adjustments.contrast == 1.5)
+      }
+      #expect(player.adjustments.contrast == 1.5)
+      #expect(player.adjustments.brightness == 0.7)
+      #expect(libvlc_video_get_adjust_float(old, UInt32(libvlc_adjust_Contrast.rawValue)) == 1)
+    }
+
+    @Test
+    func `Shared equalizer updates both players and detaches only its owner`() throws {
+      let first = Player(instance: TestInstance.makeAudioOnly())
+      let second = Player(instance: TestInstance.makeAudioOnly())
+      let equalizer = Equalizer()
+      first.equalizer = equalizer
+      second.equalizer = equalizer
+      var firstUpdates = 0
+      var secondUpdates = 0
+      first._observableControlNativeDispatchHookForTesting = { _, dispatch in
+        if case .equalizer(.some) = dispatch {
+          firstUpdates += 1
+        }
+      }
+      second._observableControlNativeDispatchHookForTesting = { _, dispatch in
+        if case .equalizer(.some) = dispatch {
+          secondUpdates += 1
+        }
+      }
+      equalizer.preampGain = 5.0
+      #expect(firstUpdates == 1)
+      #expect(secondUpdates == 1)
+      first.equalizer = nil
+      try equalizer.setAmplification(6, forBand: 0)
+      #expect(firstUpdates == 1)
+      #expect(secondUpdates == 2)
+      try second.replaceNativePlayerForDrawablePlayback(target: nil)
+      equalizer.preampGain = 7.0
+      #expect(secondUpdates == 3)
+      #expect(second.equalizer === equalizer)
+    }
+
+    @Test
+    func `Native audio events update shadows and ignore unavailable native values`() {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._nativeVolumeOverrideForTesting = 20
+      player._nativeMuteOverrideForTesting = 1
+      player.handleEvent(.volumeChanged(0.2))
+      player.handleEvent(.muted)
+      #expect(player.volume == 0.2)
+      #expect(player.isMuted)
+      player._nativeMuteOverrideForTesting = 0
+      player.handleEvent(.unmuted)
+      #expect(!player.isMuted)
+      player._nativeVolumeOverrideForTesting = -100
+      player._nativeMuteOverrideForTesting = -1
+      player.handleEvent(.volumeChanged(-1))
+      #expect(player.volume == 0.2)
+      #expect(!player.isMuted)
+    }
+
+    @Test
+    func `A newer volume command wins over an event refresh`() {
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      player._nativeVolumeOverrideForTesting = 20
+      let action = BehaviorObservationAction { try! player.setAudioVolume(Volume(0.8)) }
+      withObservationTracking { _ = player.volume } onChange: {
+        MainActor.assumeIsolated { action.run() }
+      }
+      player.handleEvent(.volumeChanged(0.2))
+      #expect(action.didRun)
+      #expect(player.volume == 0.8)
+    }
+  }
+}
+
+@MainActor
+private final class BehaviorObservationAction {
+  private(set) var didRun = false
+  private let action: @MainActor () -> Void
+
+  init(_ action: @escaping @MainActor () -> Void) {
+    self.action = action
+  }
+
+  func run() {
+    guard !didRun else { return }
+    didRun = true
+    action()
+  }
+}

--- a/Tests/SwiftVLCTests/Player/PlaylistRestartOwnershipTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlaylistRestartOwnershipTests.swift
@@ -49,6 +49,30 @@ extension Integration {
       await player.shutdown()
     }
 
+    @Test(arguments: [PlayerState.playing, .paused, .opening, .buffering, .stopping, .error])
+    func `Toggle does not restart a retired handle before stop settles`(_ state: PlayerState) async throws {
+      let instance = TestInstance.makeAudioOnly()
+      let player = Player(instance: instance)
+      let playlist = MediaListPlayer(instance: instance)
+      playlist.mediaPlayer = player
+      player.setDrawable(NSObject())
+      playlist.stop()
+      let outgoing = player.pointer
+      try #require(player.nativePlayerNeedsReplacementBeforePlayback)
+      player._setStateForTesting(state: state)
+      var starts = 0
+      playlist._nativeTransportDispatchOverrideForTesting = { _ in
+        starts += 1
+        return 0
+      }
+      playlist.togglePause()
+      #expect(starts == 0)
+      #expect(player.pointer == outgoing)
+      #expect(player.nativePlayerNeedsReplacementBeforePlayback)
+      playlist.mediaPlayer = nil
+      await player.shutdown()
+    }
+
     @Test
     func `An ownership change during preparation supersedes the older playlist command`() async throws {
       let instance = TestInstance.makeAudioOnly()

--- a/Tests/SwiftVLCTests/Player/PlaylistRestartOwnershipTests.swift
+++ b/Tests/SwiftVLCTests/Player/PlaylistRestartOwnershipTests.swift
@@ -1,0 +1,116 @@
+@testable import SwiftVLC
+import CLibVLC
+import Foundation
+import Observation
+import Testing
+
+extension Integration {
+  @Suite(.tags(.mainActor), .timeLimit(.minutes(1)))
+  @MainActor struct PlaylistRestartOwnershipTests {
+    @Test(arguments: ["play", "index", "media", "next", "previous", "resume", "toggle"])
+    func `Playlist transport prepares and rebinds a stopped drawable handle`(_ command: String) async throws {
+      let instance = TestInstance.makeAudioOnly()
+      let player = Player(instance: instance)
+      let media = try Media(url: TestMedia.silenceURL)
+      player.load(media)
+      let list = MediaList()
+      try list.append(media)
+      let playlist = MediaListPlayer(instance: instance)
+      playlist.mediaList = list
+      playlist.mediaPlayer = player
+      player.setDrawable(NSObject())
+      var starts = 0
+      playlist._nativeTransportDispatchOverrideForTesting = { command in
+        if case .stop = command {} else {
+          starts += 1
+        }
+        return 0
+      }
+      playlist.play()
+      playlist.stop()
+      let outgoing = player.pointer
+      try #require(player.nativePlayerNeedsReplacementBeforePlayback)
+      switch command {
+      case "play": playlist.play()
+      case "index": try playlist.play(at: 0)
+      case "media": try playlist.play(media)
+      case "next": try playlist.next()
+      case "previous": try playlist.previous()
+      case "resume": playlist.resume()
+      default: playlist.togglePause()
+      }
+      #expect(starts == 2)
+      #expect(player.pointer != outgoing)
+      #expect(!player.nativePlayerNeedsReplacementBeforePlayback)
+      let bound = try #require(libvlc_media_list_player_get_media_player(playlist.pointer))
+      #expect(bound == player.pointer)
+      libvlc_media_player_release(bound)
+      playlist.mediaPlayer = nil
+      await player.shutdown()
+    }
+
+    @Test
+    func `An ownership change during preparation supersedes the older playlist command`() async throws {
+      let instance = TestInstance.makeAudioOnly()
+      let player = Player(instance: instance)
+      let takeover = Player(instance: instance)
+      let list = MediaList()
+      try list.append(Media(url: TestMedia.silenceURL))
+      let playlist = MediaListPlayer(instance: instance)
+      playlist.mediaList = list
+      playlist.mediaPlayer = player
+      player.setDrawable(NSObject())
+      var starts = 0
+      playlist._nativeTransportDispatchOverrideForTesting = { command in
+        if case .play = command {
+          starts += 1
+        }
+        return 0
+      }
+      playlist.play()
+      playlist.stop()
+      player.activeVideoOutputs = 1
+      withObservationTracking { _ = player.activeVideoOutputs } onChange: {
+        MainActor.assumeIsolated { playlist.mediaPlayer = takeover }
+      }
+      playlist.play()
+      #expect(playlist.mediaPlayer === takeover)
+      #expect(starts == 1)
+      playlist.mediaPlayer = nil
+      await player.shutdown()
+      await takeover.shutdown()
+    }
+
+    @Test
+    func `Failed playlist preparation can retry without dispatching the rejected candidate`() async throws {
+      let instance = TestInstance.makeAudioOnly()
+      let player = Player(instance: instance)
+      let list = MediaList()
+      try list.append(Media(url: TestMedia.silenceURL))
+      let playlist = MediaListPlayer(instance: instance)
+      playlist.mediaList = list
+      playlist.mediaPlayer = player
+      player.setDrawable(NSObject())
+      var starts = 0
+      playlist._nativeTransportDispatchOverrideForTesting = { command in
+        if case .play = command {
+          starts += 1
+        }
+        return 0
+      }
+      playlist.play()
+      playlist.stop()
+      let outgoing = player.pointer
+      player.eventBridge._forcePreparedAttachmentFailureForTesting(afterAttachedCount: 1)
+      playlist.play()
+      #expect(starts == 1)
+      #expect(player.pointer == outgoing)
+      #expect(player.nativePlayerNeedsReplacementBeforePlayback)
+      player.eventBridge._forcePreparedAttachmentFailureForTesting(afterAttachedCount: nil)
+      playlist.play()
+      #expect(starts == 2)
+      playlist.mediaPlayer = nil
+      await player.shutdown()
+    }
+  }
+}

--- a/Tests/SwiftVLCTests/Player/SubtitleTextBridgeTests.swift
+++ b/Tests/SwiftVLCTests/Player/SubtitleTextBridgeTests.swift
@@ -565,7 +565,8 @@ extension Integration {
       #expect(await values.next()?.text == "outgoing")
 
       let successorLifetime = makeLifetime(12)
-      try player.reattachTextSubtitleCaptureIfEnabled(to: successorLifetime)
+      let prepared = try #require(try player.prepareTextSubtitleCaptureIfEnabled(to: successorLifetime))
+      #expect(player.subtitleTextBridge.commitAttachment(prepared))
       #expect(harness.registrationCount == 2)
       #expect(await values.next()?.text == "")
 
@@ -612,6 +613,29 @@ extension Integration {
       harness.send("stale", registrationAt: 0)
       harness.send("still successor", registrationAt: 1)
       #expect(await values.next()?.text == "still successor")
+    }
+
+    @Test
+    func `Later event attachment failure preserves outgoing subtitle capture`() async throws {
+      let harness = SubtitleTextCallbackHarness()
+      let player = Player(instance: TestInstance.makeAudioOnly())
+      _ = try player.textSubtitleStream(using: makeNativeOperations(harness: harness))
+      harness.send("outgoing", registrationAt: 0)
+      player.eventBridge._forcePreparedAttachmentFailureForTesting(afterAttachedCount: 2)
+      let outgoing = player.pointer
+      do {
+        try player.replaceNativePlayerForDrawablePlayback(target: nil)
+        Issue.record("Expected event attachment failure")
+      } catch {
+        #expect(error == .operationFailed("Attach player events"))
+      }
+      #expect(player.pointer == outgoing)
+      #expect(harness.registrationAttempts == 2)
+      var initial = player.subtitleTextBridge.subscribe().makeAsyncIterator()
+      #expect(await initial.next()?.text == "outgoing")
+      harness.send("still outgoing", registrationAt: 0)
+      var latest = player.subtitleTextBridge.subscribe().makeAsyncIterator()
+      #expect(await latest.next()?.text == "still outgoing")
     }
 
     @Test

--- a/Tests/SwiftVLCTests/Player/SubtitleTextCoverageTests.swift
+++ b/Tests/SwiftVLCTests/Player/SubtitleTextCoverageTests.swift
@@ -65,7 +65,7 @@ extension Integration {
       defer { successorLifetime.initialOwnerDidRelease() }
 
       do {
-        try player.reattachTextSubtitleCaptureIfEnabled(to: successorLifetime)
+        try player.prepareTextSubtitleCaptureIfEnabled(to: successorLifetime)
         Issue.record("Expected unavailable capture reattachment to fail")
       } catch {
         #expect(error == .operationFailed("Reattach text subtitle capture"))


### PR DESCRIPTION
Fix 10 ownership and state bugs from the library audit.

- Let newer loads supersede an in-flight play, keep scoped video adjustments on the current handle, and preserve subtitle capture when replacement fails.
- Prepare and rebind stopped drawable players before playlist transport, while respecting a newer command or ownership change. Toggle waits for a retired player to settle before restarting.
- Keep pre-cancelled parsing from stopping another request and serialize thumbnails across aliases of the same native media.
- Keep dialog answer/cancellation on one consumption record and replay outstanding prompts to late subscribers.
- Refresh native volume/mute values without overwriting newer commands, and update every player sharing an equalizer.

Validation: [hosted macOS tests](https://github.com/harflabs/SwiftVLC/actions/runs/34028125176) pass against the verified beta.10 artifact: 2,259 passed, 176 accounted-for skips, zero failures. Lint, release-tooling, documentation, test-accounting, and both coverage checks pass. iOS Simulator, Mac Catalyst, tvOS Simulator, and visionOS build-for-testing pass, along with Showcase and qualification UI-test compilation for both iOS SDKs.

[Address Sanitizer and Thread Sanitizer](https://github.com/harflabs/SwiftVLC/actions/runs/34028122836) pass on the final commit, each running 172 tests across 23 suites, including ownership regressions and native authentication callbacks. Regression runs against the old code reproduce the reentrant playback crash and the parse, thumbnail, adjustment, audio-state, equalizer, playlist restart, and premature toggle failures.

This builds on merged #239.

Live surface migration (#227) and the two native patch issues (#233, #234) remain separate.

Closes #223, closes #224, closes #225, closes #226, closes #228, closes #229, closes #230, closes #231, closes #232, closes #235.
