### PR TITLE
Release v1.1.0-beta.12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
   targets: [
     .binaryTarget(
       name: "libvlc",
-      url: "https://github.com/harflabs/SwiftVLC/releases/download/v1.1.0-beta.11/libvlc.xcframework.zip",
-      checksum: "e9dd7febd2f762725ef80066384ca3cc54870cc49f36cd8d54191e996521dc68"
+      url: "https://github.com/harflabs/SwiftVLC/releases/download/v1.1.0-beta.12/libvlc.xcframework.zip",
+      checksum: "e1c9686b5e9e2b1c3906afdf51ce7ee01c40738eaadee295b6e86c3d1758f97f"
     ),
     .target(
       name: "CLibVLC",

--- a/Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj
+++ b/Showcase/SwiftVLCShowcase.xcodeproj/project.pbxproj
@@ -1026,7 +1026,7 @@
 			repositoryURL = "https://github.com/harflabs/SwiftVLC";
 			requirement = {
 				kind = exactVersion;
-				version = 1.1.0-beta.11;
+				version = 1.1.0-beta.12;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
Publishes the already-prepared libVLC candidate for **v1.1.0-beta.12**.

- Exact release commit: **8a54d1e44df87d2a6a4efe2d16e847ebd3564703**
- Artifact checksum: **e1c9686b5e9e2b1c3906afdf51ce7ee01c40738eaadee295b6e86c3d1758f97f**
- The final SemVer tag remains absent until candidate CI and this PR are green.